### PR TITLE
Explicitly configure the ports.

### DIFF
--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -1,2 +1,17 @@
+server:
+  applicationConnectors:
+    - type: http
+      port: 9010
+  adminConnectors:
+    - type: http
+      port: 9011
+
 logging:
-  level: INFO
+    level: INFO
+    appenders:
+      - type: console
+        threshold: ALL
+        timeZone: UTC
+        target: stdout
+        logFormat: "[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+


### PR DESCRIPTION
Running the tests in Jenkins failed because the default Dropwizard port was the same as
the one Jenkins was running on.
Hardcoding the values for the moment. We should consider discovery of the next available
open port an use that instead for our tests.
