### PR TITLE
PP-111: Citizen user sees summary of their service and charge before payment steps

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/LinksResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/LinksResponse.java
@@ -17,6 +17,11 @@ public abstract class LinksResponse {
         return this;
     }
 
+    public LinksResponse addLink(String rel, String method, String href) {
+        links.add(new JsonLink(rel, method, href));
+        return this;
+    }
+
     public List<JsonLink> getLinks() {
         return links;
     }

--- a/src/main/java/uk/gov/pay/api/utils/ResponseUtil.java
+++ b/src/main/java/uk/gov/pay/api/utils/ResponseUtil.java
@@ -8,8 +8,7 @@ import org.slf4j.Logger;
 import javax.ws.rs.core.Response;
 import java.util.List;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.*;
 
 public class ResponseUtil {
 
@@ -27,15 +26,23 @@ public class ResponseUtil {
         return messageResponse(logger, message, BAD_REQUEST);
     }
 
+    public static Response internalServerErrorResponse(Logger logger, String internalMessage, String externalMessage) {
+        return messageResponse(logger, internalMessage, externalMessage, INTERNAL_SERVER_ERROR);
+    }
+
     public static Response fieldsMissingResponse(Logger logger, List<String> missingFields) {
         String message = String.format("Field(s) missing: [%s]", COMMA_JOINER.join(missingFields));
         return messageResponse(logger, message, BAD_REQUEST);
     }
 
     private static Response messageResponse(Logger logger, String message, Response.Status status) {
-        logger.error(message);
+        return messageResponse(logger, message, message, status);
+    }
+
+    private static Response messageResponse(Logger logger, String internalMessage, String externalMessage, Response.Status status) {
+        logger.error(internalMessage);
         return Response.status(status)
-                .entity(ImmutableMap.of("message", message))
+                .entity(ImmutableMap.of("message", externalMessage))
                 .build();
     }
 

--- a/src/test/java/uk/gov/pay/api/utils/LinksAssert.java
+++ b/src/test/java/uk/gov/pay/api/utils/LinksAssert.java
@@ -6,8 +6,8 @@ import static javax.ws.rs.HttpMethod.GET;
 import static org.hamcrest.Matchers.is;
 
 public class LinksAssert {
-    public static void assertSelfLink(ValidatableResponse response, String paymentUrl) {
-        response.body("links.find {links -> links.rel == 'self' }.href", is(paymentUrl));
-        response.body("links.find {links -> links.rel == 'self' }.method", is(GET));
+    public static void assertLink(ValidatableResponse response, String paymentUrl, String linkRel) {
+        response.body("links.find {links -> links.rel == '" + linkRel + "' }.href", is(paymentUrl));
+        response.body("links.find {links -> links.rel == '" + linkRel + "' }.method", is(GET));
     }
 }


### PR DESCRIPTION
Upon successful creation of the payment, PublicApi includes the next_url link in the response (acquired from connector) so that clients can locate the fulfilment URL

see https://payments-platform.atlassian.net/browse/PP-111
