### PR TITLE
pp-221 removed invalid validation

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -84,10 +84,6 @@ public class PaymentsResource {
         if (missingFields.isPresent()) {
             return fieldsMissingResponse(logger, missingFields.get());
         }
-        Optional<String> fieldFormatError = checkFieldFormat(requestPayload);
-        if (fieldFormatError.isPresent()) {
-            return badRequestResponse(logger, fieldFormatError.get());
-        }
 
         Response connectorResponse = client.target(chargeUrl)
                 .request()
@@ -173,16 +169,6 @@ public class PaymentsResource {
         return missing.isEmpty()
                 ? Optional.<List<String>>empty()
                 : Optional.of(missing);
-    }
-
-    private Optional<String> checkFieldFormat(JsonNode requestPayload) {
-        String returnUrl = requestPayload.get(SERVICE_RETURN_URL).asText();
-        if (negate(containsIgnoreCase(returnUrl, PAYMENTS_ID_PLACEHOLDER))) {
-            String errorMessage = format("Payment-id placeholder is missing: '%s' does not contain a '%s' placeholder."
-                    , returnUrl, PAYMENTS_ID_PLACEHOLDER);
-            return Optional.of(errorMessage);
-        }
-        return Optional.empty();
     }
 
     private Entity buildChargeRequestPayload(String accountId, JsonNode requestPayload) {

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
@@ -113,18 +113,6 @@ public class PaymentsResourceITest {
     }
 
     @Test
-    public void createPayment_responseWith4xx_forInvalidReturnUrl() {
-        String invalidReturnUrl = "http://no.payment.id/inpath";
-
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
-
-        postPaymentResponse(BEARER_TOKEN, paymentPayload(TEST_AMOUNT, invalidReturnUrl))
-                .statusCode(400)
-                .contentType(JSON)
-                .body("message", is(format("Payment-id placeholder is missing: '%s' does not contain a '{paymentId}' placeholder.", invalidReturnUrl)));
-    }
-
-    @Test
     public void createPayment_responseWith4xx_whenFieldsMissing() {
         publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
 


### PR DESCRIPTION
- removed checking for {paymentId} placeholder in return_url from a goverment service
  This seems to be from an incorrect assumption and should not be done, given a government service
  should be in control of what the return url should be rather than the payment platform manipulating it.

with @rahul-vinayak 
