### PR TITLE
PP-307 Add payment reference

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentResponse.java
@@ -3,6 +3,8 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.dropwizard.jackson.JsonSnakeCase;
 
+import static uk.gov.pay.api.utils.TolerantReaderUtil.tolerantGet;
+
 @JsonSnakeCase
 public class CreatePaymentResponse extends LinksResponse {
     private final String paymentId;
@@ -10,6 +12,7 @@ public class CreatePaymentResponse extends LinksResponse {
     private final String status;
     private final String returnUrl;
     private final String description;
+    private final String reference;
 
     public static CreatePaymentResponse createPaymentResponse(JsonNode payload) {
         return new CreatePaymentResponse(
@@ -17,16 +20,18 @@ public class CreatePaymentResponse extends LinksResponse {
                 payload.get("amount").asLong(),
                 payload.get("status").asText(),
                 payload.get("return_url").asText(),
-                payload.get("description").asText()
+                payload.get("description").asText(),
+                tolerantGet(payload, "reference")
                 );
     }
 
-    private CreatePaymentResponse(String chargeId, long amount, String status, String returnUrl, String description) {
+    private CreatePaymentResponse(String chargeId, long amount, String status, String returnUrl, String description, String reference) {
         this.paymentId = chargeId;
         this.amount = amount;
         this.status = status;
         this.returnUrl = returnUrl;
         this.description = description;
+        this.reference = reference;
     }
 
     public String getPaymentId() {
@@ -49,6 +54,10 @@ public class CreatePaymentResponse extends LinksResponse {
         return description;
     }
 
+    public String getReference() {
+        return reference;
+    }
+
     @Override
     public String toString() {
         return "CreatePaymentResponse{" +
@@ -57,6 +66,7 @@ public class CreatePaymentResponse extends LinksResponse {
                 ", status='" + status + '\'' +
                 ", returnUrl='" + returnUrl + '\'' +
                 ", description='" + description + '\'' +
+                ", reference='" + reference + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -6,6 +6,7 @@ import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.model.LinksResponse;
+import uk.gov.pay.api.utils.TolerantReaderUtil;
 
 import javax.ws.rs.*;
 import javax.ws.rs.client.Client;
@@ -24,6 +25,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import static java.lang.String.format;
+import static java.lang.String.valueOf;
 import static javax.ws.rs.client.Entity.json;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
@@ -31,10 +33,12 @@ import static org.apache.http.HttpStatus.SC_OK;
 import static uk.gov.pay.api.model.CreatePaymentResponse.createPaymentResponse;
 import static uk.gov.pay.api.utils.JsonStringBuilder.jsonStringBuilder;
 import static uk.gov.pay.api.utils.ResponseUtil.*;
+import static uk.gov.pay.api.utils.TolerantReaderUtil.tolerantGet;
 
 @Path("/")
 public class PaymentsResource {
     private static final String PAYMENT_KEY = "paymentId";
+    private static final String REFERENCE_KEY = "reference";
     private static final String DESCRIPTION_KEY = "description";
     private static final String AMOUNT_KEY = "amount";
     private static final String GATEWAY_ACCOUNT_KEY = "gateway_account_id";
@@ -176,14 +180,17 @@ public class PaymentsResource {
 
     private Entity buildChargeRequestPayload(String accountId, JsonNode requestPayload) {
         long amount = requestPayload.get(AMOUNT_KEY).asLong();
+        String reference = tolerantGet(requestPayload, REFERENCE_KEY);
         String description = requestPayload.get(DESCRIPTION_KEY).asText();
         String returnUrl = requestPayload.get(SERVICE_RETURN_URL).asText();
 
         return json(jsonStringBuilder()
                 .add(AMOUNT_KEY, amount)
+                .add(REFERENCE_KEY, escapeHtml4(reference))
                 .add(DESCRIPTION_KEY, escapeHtml4(description))
                 .add(GATEWAY_ACCOUNT_KEY, accountId)
                 .add(SERVICE_RETURN_URL, returnUrl)
                 .build());
     }
+
 }

--- a/src/main/java/uk/gov/pay/api/utils/TolerantReaderUtil.java
+++ b/src/main/java/uk/gov/pay/api/utils/TolerantReaderUtil.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.api.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class TolerantReaderUtil {
+    public static String tolerantGet(JsonNode node, String key) {
+        JsonNode value = node.get(key);
+        if (value != null) {
+            return value.asText();
+        } else {
+            return "null";
+        }
+    }
+}


### PR DESCRIPTION
https://payments-platform.atlassian.net/browse/PP-307

Added a payment reference field
Tolerates the field being absent for the moment on the idea that once the demo-service is going to send id, we will do proper checks
