### PR TITLE
PP-307 Bug fix for required field check

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -26,6 +26,7 @@ import static java.lang.String.format;
 import static javax.ws.rs.client.Entity.json;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.http.HttpStatus.SC_OK;
 import static uk.gov.pay.api.model.CreatePaymentResponse.createPaymentResponse;
 import static uk.gov.pay.api.utils.JsonStringBuilder.jsonStringBuilder;
@@ -165,7 +166,7 @@ public class PaymentsResource {
     private Optional<List<String>> checkMissingFields(JsonNode node) {
         List<String> missing = new ArrayList<>();
         for (String field : REQUIRED_FIELDS) {
-            if (!node.hasNonNull(field)) {
+            if (!node.hasNonNull(field) || isEmpty(node.get(field).asText())) {
                 missing.add(field);
             }
         }

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
@@ -117,7 +117,7 @@ public class PaymentsResourceITest {
     public void createPayment_responseWith4xx_whenFieldsMissing() {
         publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
 
-        postPaymentResponse(BEARER_TOKEN, "{}")
+        postPaymentResponse(BEARER_TOKEN, "{\"description\":\"\", \"reference\":null}")
                 .statusCode(400)
                 .contentType(JSON)
                 .body("message", is("Field(s) missing: [description, amount, reference, return_url]"));


### PR DESCRIPTION
- We had a check for required fields that was checking
  only that the fields are missing as keys in the json payload
  but not whether an actual value was empty
