### PR TITLE
Fix swagger endpoints to point at new integration environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,8 +221,8 @@
                         <apiSource>
                             <springmvc>false</springmvc>
                             <locations>uk.gov.pay.api.resources</locations>
-                            <schemes>http,https</schemes>
-                            <host>www-flow-0.pymnt.uk</host>
+                            <schemes>https</schemes>
+                            <host>publicapi-integration-1.pymnt.uk</host>
                             <basePath>/</basePath>
                             <info>
                                 <title>GOV.UK Pay Api</title>

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -5,9 +5,9 @@
     "version" : "1.0.0",
     "title" : "GOV.UK Pay Api"
   },
-  "host" : "www-flow-0.pymnt.uk",
+  "host" : "publicapi-integration-1.pymnt.uk",
   "basePath" : "/",
-  "schemes" : [ "http", "https" ],
+  "schemes" : [ "https" ],
   "paths" : {
     "/v1/payments" : {
       "post" : {


### PR DESCRIPTION
Fix swagger endpoints to point at new integration environment, and only do HTTPS now.
