### PR TITLE
PP-424 Add payment_provider and created_date

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ Content-Type: application/json
     "description": "Payment description",
     "status": "CREATED",
     "return_url": "https://example.service.gov.uk/some-reference-to-this-payment",
-    "reference": "some-reference-to-this-payment"
+    "reference": "some-reference-to-this-payment",
+    "payment_provider": "Sandbox",
+    "created_date": "2016-01-15 16:30:56"
 }
 ```
 
@@ -113,8 +115,10 @@ Content-Type: application/json
 | `amount`               | Amount to pay in pence                    |
 | `description`          | Payment description                       |
 | `status`               | Current status of the payment             |
-| `return_url`           | The URL where the user should be redirected to when the payment workflow is finished.         |
-| `reference`            | There reference issued by the government service for this payment          |
+| `return_url`           | The URL where the user should be redirected to when the payment workflow is finished.    |
+| `reference`            | The reference issued by the government service for this payment                          |
+| `payment_provider      | The payment provider for this payment                                                    |
+| `created_date`         | The payment creation date for this payment                                               |
 
 #### Payment creation failed
 
@@ -169,7 +173,9 @@ Content-Type: application/json
     "description": "Payment description",
     "status": "CREATED",
     "return_url": "https://example.service.gov.uk/some-reference-to-this-payment",
-    "reference" : "some-reference-to-this-payment"
+    "reference" : "some-reference-to-this-payment",
+    "payment_provider": "Sandbox",
+    "created_date": "2016-01-15 16:30:56"
 }
 ```
 

--- a/src/main/java/uk/gov/pay/api/model/Payment.java
+++ b/src/main/java/uk/gov/pay/api/model/Payment.java
@@ -11,6 +11,8 @@ import io.swagger.annotations.ApiModelProperty;
 public class Payment {
     @JsonProperty("payment_id")
     private final String paymentId;
+    @JsonProperty("payment_provider")
+    private final String paymentProvider;
     private final long amount;
     private final String status;
     private final String description;
@@ -19,6 +21,9 @@ public class Payment {
     @JsonProperty("_links")
     private final Links links = new Links();
 
+    @JsonProperty("created_date")
+    private final String createdDate;
+
     public static Payment createPaymentResponse(JsonNode payload) {
         return new Payment(
                 payload.get("charge_id").asText(),
@@ -26,17 +31,26 @@ public class Payment {
                 payload.get("status").asText(),
                 payload.get("return_url").asText(),
                 payload.get("description").asText(),
-                payload.get("reference").asText()
+                payload.get("reference").asText(),
+                payload.get("payment_provider").asText(),
+                payload.get("created_date").asText()
         );
     }
 
-    private Payment(String chargeId, long amount, String status, String returnUrl, String description, String reference) {
+    private Payment(String chargeId, long amount, String status, String returnUrl, String description,
+                    String reference, String paymentProvider, String createdDate) {
         this.paymentId = chargeId;
         this.amount = amount;
         this.status = status;
         this.returnUrl = returnUrl;
         this.description = description;
         this.reference = reference;
+        this.paymentProvider = paymentProvider;
+        this.createdDate = createdDate;
+    }
+
+    public String getCreatedDate() {
+        return createdDate;
     }
 
     @ApiModelProperty(example = "1122335")
@@ -69,15 +83,21 @@ public class Payment {
         return reference;
     }
 
+    public String getPaymentProvider() {
+        return paymentProvider;
+    }
+
     @Override
     public String toString() {
         return "Payment{" +
                 "paymentId='" + paymentId + '\'' +
+                ", paymentProvider='" + paymentProvider + '\'' +
                 ", amount=" + amount +
                 ", status='" + status + '\'' +
                 ", returnUrl='" + returnUrl + '\'' +
                 ", description='" + description + '\'' +
                 ", reference='" + reference + '\'' +
+                ", createdDate='" + createdDate + '\'' +
                 ", links=" + links +
                 '}';
     }

--- a/src/test/java/uk/gov/pay/api/utils/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/ConnectorMockClient.java
@@ -45,7 +45,8 @@ public class ConnectorMockClient {
                 .build();
     }
 
-    private String createChargeResponse(long amount, String chargeId, String status, String returnUrl, String description, String reference, ImmutableMap<?, ?>... links) {
+    private String createChargeResponse(long amount, String chargeId, String status, String returnUrl, String description,
+                                        String reference, String paymentProvider, String createdDate, ImmutableMap<?, ?>... links) {
         return jsonStringBuilder()
                 .add("charge_id", chargeId)
                 .add("amount", amount)
@@ -53,6 +54,8 @@ public class ConnectorMockClient {
                 .add("description", escapeHtml4(description))
                 .add("status", status)
                 .add("return_url", returnUrl)
+                .add("payment_provider", paymentProvider)
+                .add("created_date", createdDate)
                 .add("links", asList(links))
                 .build();
     }
@@ -85,7 +88,8 @@ public class ConnectorMockClient {
         return baseUrl + format(CONNECTOR_MOCK_CHARGE_EVENTS_PATH, accountId, chargeId);
     }
 
-    public void respondOk_whenCreateCharge(long amount, String gatewayAccountId, String chargeId, String status, String returnUrl, String description, String reference) {
+    public void respondOk_whenCreateCharge(long amount, String gatewayAccountId, String chargeId, String status, String returnUrl,
+                                           String description, String reference, String paymentProvider, String createdDate) {
         whenCreateCharge(amount, gatewayAccountId, returnUrl, description, reference)
                 .respond(response()
                         .withStatusCode(CREATED_201)
@@ -98,6 +102,8 @@ public class ConnectorMockClient {
                                 returnUrl,
                                 description,
                                 reference,
+                                paymentProvider,
+                                createdDate,
                                 validLink(chargeLocation(gatewayAccountId, chargeId), "self"),
                                 validLink(nextUrl(chargeId), "next_url"))));
     }
@@ -115,13 +121,14 @@ public class ConnectorMockClient {
                         .withHeader(LOCATION, chargeLocation(gatewayAccountId, chargeId)));
     }
 
-    public void respondWithChargeFound(long amount, String gatewayAccountId, String chargeId, String status, String returnUrl, String description, String reference) {
+    public void respondWithChargeFound(long amount, String gatewayAccountId, String chargeId, String status, String returnUrl,
+                                       String description, String reference, String paymentProvider, String createdDate) {
         whenGetCharge(gatewayAccountId, chargeId)
                 .respond(response()
                         .withStatusCode(OK_200)
                         .withHeader(CONTENT_TYPE, APPLICATION_JSON)
                         .withBody(createChargeResponse(amount, chargeId, status, returnUrl,
-                                description, reference, validLink(chargeLocation(gatewayAccountId, chargeId), "self"),
+                                description, reference, paymentProvider, createdDate, validLink(chargeLocation(gatewayAccountId, chargeId), "self"),
                                 validLink(nextUrl(chargeId), "next_url"))));
     }
 

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -190,8 +190,16 @@
           "example" : "1122335",
           "readOnly" : true
         },
+        "payment_provider" : {
+          "type" : "string",
+          "readOnly" : true
+        },
         "_links" : {
           "$ref" : "#/definitions/paymentLinks"
+        },
+        "created_date" : {
+          "type" : "string",
+          "readOnly" : true
         }
       },
       "description" : "A Payment description"


### PR DESCRIPTION
- As part of the PP-424 signoff Rory asked if we could return the
  created_date instead.
- 'payment_provider' and 'created_date' were added in and respective
  amended.
- **IMPORTANT:** **Depends on https://github.com/alphagov/pay-connector/pull/89**
