### PR TITLE
PP-455 api docs generation for Links structure

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/Link.java
+++ b/src/main/java/uk/gov/pay/api/model/Link.java
@@ -4,7 +4,7 @@ import io.dropwizard.jackson.JsonSnakeCase;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
-@ApiModel(value = "paymentLinks", description = "Resource links of a Payment")
+@ApiModel(value = "paymentLink", description = "A link related to a payment")
 @JsonSnakeCase
 public class Link {
     private String href;
@@ -19,7 +19,7 @@ public class Link {
         return new Link(url, "GET");
     }
 
-    @ApiModelProperty(example = "https://publicapi-integration-1.pymnt.uk/v1/payments/12345")
+    @ApiModelProperty(example = "https://an.example.link/from/payment/platform")
     public String getHref() {
         return href;
     }

--- a/src/main/java/uk/gov/pay/api/model/Links.java
+++ b/src/main/java/uk/gov/pay/api/model/Links.java
@@ -19,12 +19,12 @@ public class Links {
         this.nextUrl = Link.get(url);
     }
 
-    @ApiModelProperty(example = "https://publicapi-integration-1.pymnt.uk/v1/payments/12345")
+    @ApiModelProperty(value = "selfUrl", dataType = "uk.gov.pay.api.model.Link")
     public Link getSelf() {
         return self;
     }
 
-    @ApiModelProperty(example = "https://www-integration-1.pymnt.uk/charge/12345?chargeTokenId=3671c717-2a0c-4655-92d3-348c7c7b04fb")
+    @ApiModelProperty(value = "nextUrl", dataType = "uk.gov.pay.api.model.Link")
     public Link getNextUrl() {
         return nextUrl;
     }

--- a/src/main/java/uk/gov/pay/api/model/Payment.java
+++ b/src/main/java/uk/gov/pay/api/model/Payment.java
@@ -49,6 +49,7 @@ public class Payment {
         this.createdDate = createdDate;
     }
 
+    @ApiModelProperty(example = "2016-01-21T17:15:00Z")
     public String getCreatedDate() {
         return createdDate;
     }
@@ -83,8 +84,14 @@ public class Payment {
         return reference;
     }
 
+    @ApiModelProperty(example = "worldpay")
     public String getPaymentProvider() {
         return paymentProvider;
+    }
+
+    @ApiModelProperty(dataType = "uk.gov.pay.api.model.Links")
+    public Links getLinks() {
+        return links;
     }
 
     @Override

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -215,28 +215,45 @@
         },
         "payment_provider" : {
           "type" : "string",
+          "example" : "worldpay",
           "readOnly" : true
         },
         "_links" : {
+          "readOnly" : true,
           "$ref" : "#/definitions/paymentLinks"
         },
         "created_date" : {
           "type" : "string",
+          "example" : "2016-01-21T17:15:00Z",
           "readOnly" : true
         }
       },
       "description" : "A Payment description"
     },
+    "paymentLink" : {
+      "type" : "object",
+      "properties" : {
+        "href" : {
+          "type" : "string",
+          "example" : "https://an.example.link/from/payment/platform"
+        },
+        "method" : {
+          "type" : "string",
+          "example" : "GET"
+        }
+      },
+      "description" : "A link related to a payment"
+    },
     "paymentLinks" : {
       "type" : "object",
       "properties" : {
         "self" : {
-          "example" : "https://publicapi-integration-1.pymnt.uk/v1/payments/12345",
-          "$ref" : "#/definitions/paymentLinks"
+          "description" : "selfUrl",
+          "$ref" : "#/definitions/paymentLink"
         },
         "nextUrl" : {
-          "example" : "https://www-integration-1.pymnt.uk/charge/12345?chargeTokenId=3671c717-2a0c-4655-92d3-348c7c7b04fb",
-          "$ref" : "#/definitions/paymentLinks"
+          "description" : "nextUrl",
+          "$ref" : "#/definitions/paymentLink"
         }
       },
       "description" : "Resource links of a Payment"


### PR DESCRIPTION
- Managed to get swagger to generate Jsons for Links sub structures 
  (must make sure the @ApiModel(value ="{a-unique-name}"))
- Gelato however, doesn't seem to generate the correct documentation if two attributes return the same substructure. Only generates the last one at the moment (following up with Gelato)
