### PR TITLE
PP-421 fixing internal server error due to status case mismtach

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -32,6 +32,7 @@ import static javax.ws.rs.client.Entity.json;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.upperCase;
 import static org.apache.http.HttpStatus.SC_OK;
 import static uk.gov.pay.api.model.Payment.createPaymentResponse;
 import static uk.gov.pay.api.utils.JsonStringBuilder.jsonStringBuilder;
@@ -165,7 +166,7 @@ public class PaymentsResource {
                 .orElseGet(() -> {
                     List<Pair<String, String>> queryParams = Lists.newArrayList(
                             Pair.of(REFERENCE_KEY, reference),
-                            Pair.of(STATUS_KEY, status),
+                            Pair.of(STATUS_KEY, upperCase(status)),
                             Pair.of(FROM_DATE_KEY, fromDate),
                             Pair.of(TO_DATE_KEY, toDate)
                     );

--- a/src/test/java/uk/gov/pay/api/it/PaymentSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentSearchITest.java
@@ -67,6 +67,24 @@ public class PaymentSearchITest extends PaymentResourceITestBase {
     }
 
     @Test
+    public void searchPayments_filterByStatusLowercase() throws Exception {
+        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, TEST_STATUS, null, null,
+                aSuccessfulSearchResponse()
+                        .withMatchingStatus(TEST_STATUS)
+                        .build()
+        );
+
+        ValidatableResponse response = searchPayments(BEARER_TOKEN, ImmutableMap.of("status", TEST_STATUS.toLowerCase()))
+                .statusCode(200)
+                .contentType(JSON)
+                .body("results.size()", equalTo(3));
+
+        List<Map<String, Object>> results = response.extract().body().jsonPath().getList("results");
+        assertThat(results, matchesField("status", TEST_STATUS));
+    }
+
+    @Test
     public void searchPayments_filterFromAndToDates() throws Exception {
         publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
         connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, null, TEST_FROM_DATE, TEST_TO_DATE,


### PR DESCRIPTION
- Making sure we will not return error 500 in case if the status is not in uppercase.
  Now the search by status is case insensitive

Connector still responds only to uppercase, so making sure the connector interaction is always in upper case. 
