### PR TITLE
PP-451 Make publicapi URL obvious in the documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
                             <springmvc>false</springmvc>
                             <locations>uk.gov.pay.api.resources</locations>
                             <schemes>https</schemes>
-                            <host>publicapi-integration-1.pymnt.uk</host>
+                            <host>publicapi.pymnt.uk</host>
                             <!--<basePath>/</basePath>-->
                             <info>
                                 <title>GOV.UK Pay Api</title>

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -5,7 +5,7 @@
     "version" : "1.0.0",
     "title" : "GOV.UK Pay Api"
   },
-  "host" : "publicapi-integration-1.pymnt.uk",
+  "host" : "publicapi.pymnt.uk",
   "schemes" : [ "https" ],
   "paths" : {
     "/v1/payments" : {


### PR DESCRIPTION
- Changing the publicapi to a consistent endpoint, that doesn't include an
  environment name
