### PR TITLE
PP-490 Double escaping in Payment Reference

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 import static javax.ws.rs.client.Entity.json;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.upperCase;
 import static org.apache.http.HttpStatus.SC_OK;
@@ -333,8 +332,8 @@ public class PaymentsResource {
         String returnUrl = requestPayload.getReturnUrl();
         return json(jsonStringBuilder()
                 .add(AMOUNT_KEY, amount)
-                .add(REFERENCE_KEY, escapeHtml4(reference))
-                .add(DESCRIPTION_KEY, escapeHtml4(description))
+                .add(REFERENCE_KEY, reference)
+                .add(DESCRIPTION_KEY, description)
                 .add(SERVICE_RETURN_URL, returnUrl)
                 .build());
     }

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
@@ -16,7 +16,6 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
-import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -50,8 +49,8 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
                 .contentType(JSON)
                 .body("payment_id", is(TEST_CHARGE_ID))
                 .body("amount", is(TEST_AMOUNT))
-                .body("reference", is(escapeHtml4(TEST_REFERENCE)))
-                .body("description", is(escapeHtml4(TEST_DESCRIPTION)))
+                .body("reference", is(TEST_REFERENCE))
+                .body("description", is(TEST_DESCRIPTION))
                 .body("status", is(TEST_STATUS))
                 .body("return_url", is(TEST_RETURN_URL))
                 .body("payment_provider", is(TEST_PAYMENT_PROVIDER))
@@ -124,8 +123,8 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
                 .statusCode(200)
                 .contentType(JSON)
                 .body("payment_id", is(TEST_CHARGE_ID))
-                .body("reference", is(escapeHtml4(TEST_REFERENCE)))
-                .body("description", is(escapeHtml4(TEST_DESCRIPTION)))
+                .body("reference", is(TEST_REFERENCE))
+                .body("description", is(TEST_DESCRIPTION))
                 .body("amount", is(TEST_AMOUNT))
                 .body("status", is(TEST_STATUS))
                 .body("return_url", is(TEST_RETURN_URL))

--- a/src/test/java/uk/gov/pay/api/utils/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/ConnectorMockClient.java
@@ -17,7 +17,6 @@ import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.HttpHeaders.LOCATION;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.eclipse.jetty.http.HttpStatus.*;
 import static org.mockserver.model.HttpRequest.request;
@@ -46,8 +45,8 @@ public class ConnectorMockClient {
     private String createChargePayload(long amount, String returnUrl, String description, String reference) {
         return jsonStringBuilder()
                 .add("amount", amount)
-                .add("reference", escapeHtml4(reference))
-                .add("description", escapeHtml4(description))
+                .add("reference", reference)
+                .add("description", description)
                 .add("return_url", returnUrl)
                 .build();
     }
@@ -57,8 +56,8 @@ public class ConnectorMockClient {
         return jsonStringBuilder()
                 .add("charge_id", chargeId)
                 .add("amount", amount)
-                .add("reference", escapeHtml4(reference))
-                .add("description", escapeHtml4(description))
+                .add("reference", reference)
+                .add("description", description)
                 .add("status", status)
                 .add("return_url", returnUrl)
                 .add("payment_provider", paymentProvider)


### PR DESCRIPTION
- Putting '< &' in the payment description field on Demo Service
  was resulting in "&lt; &amp;" being displayed in frontend. This
  was due to pay-publicapi escaping the 'reference' and 'description'
  fields. This changes removes any escaping being done on pay-publicapi
  and rely on the template engine framework on frontend and selfservice
  to escape those two fields.
