### PR TITLE
PP-497 Validate amount

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.app;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import io.dropwizard.Application;
 import io.dropwizard.auth.AuthFactory;
 import io.dropwizard.auth.oauth.OAuthFactory;
@@ -31,10 +32,10 @@ public class PublicApi extends Application<PublicApiConfig> {
     public void run(PublicApiConfig config, Environment environment) throws Exception {
         final Client client = RestClientFactory.from(config.getRestClientConfig()).getInstance();
 
+        environment.getObjectMapper().configure(DeserializationFeature.ACCEPT_FLOAT_AS_INT, false);
+
         environment.healthChecks().register("ping", new Ping());
-
         environment.jersey().register(new PaymentsResource(client, config.getConnectorUrl()));
-
         environment.jersey().register(AuthFactory.binder(new OAuthFactory<>(new AccountAuthenticator(client, config.getPublicAuthUrl()), "", String.class)));
     }
 

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
@@ -9,12 +9,11 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
-@ApiModel(value="CreatePaymentRequest", description = "The Payment Request Payload")
+@ApiModel(value = "CreatePaymentRequest", description = "The Payment Request Payload")
 public class CreatePaymentRequest {
     @JsonProperty("account_id")
     private String accountId;
-
-    private Long amount;
+    private Integer amount;
     @JsonProperty("return_url")
     private String returnUrl;
     private String reference;
@@ -38,7 +37,7 @@ public class CreatePaymentRequest {
     @NotNull
     @Min(1)
     @Max(10000000)
-    public Long getAmount() {
+    public Integer getAmount() {
         return amount;
     }
 

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
@@ -14,9 +14,9 @@ import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 
 public abstract class PaymentResourceITestBase {
 
-    public static final String BEARER_TOKEN = "TEST_BEARER_TOKEN";
-    public static final String GATEWAY_ACCOUNT_ID = "GATEWAY_ACCOUNT_ID";
-    public static final String PAYMENTS_PATH = "/v1/payments/";
+    protected static final String BEARER_TOKEN = "TEST_BEARER_TOKEN";
+    protected static final String GATEWAY_ACCOUNT_ID = "GATEWAY_ACCOUNT_ID";
+    protected static final String PAYMENTS_PATH = "/v1/payments/";
 
     @Rule
     public MockServerRule connectorMockRule = new MockServerRule(this);
@@ -24,15 +24,15 @@ public abstract class PaymentResourceITestBase {
     @Rule
     public MockServerRule publicAuthMockRule = new MockServerRule(this);
 
-    protected ConnectorMockClient connectorMock;
-    protected PublicAuthMockClient publicAuthMock;
-
     @Rule
     public DropwizardAppRule<PublicApiConfig> app = new DropwizardAppRule<>(
             PublicApi.class
             , resourceFilePath("config/test-config.yaml")
             , config("connectorUrl", connectorBaseUrl())
             , config("publicAuthUrl", publicAuthBaseUrl()));
+
+    protected ConnectorMockClient connectorMock;
+    protected PublicAuthMockClient publicAuthMock;
 
     @Before
     public void setup() {
@@ -47,5 +47,4 @@ public abstract class PaymentResourceITestBase {
     private String publicAuthBaseUrl() {
         return "http://localhost:" + publicAuthMockRule.getHttpPort() + "/v1/auth";
     }
-
 }

--- a/src/test/java/uk/gov/pay/api/it/PaymentSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentSearchITest.java
@@ -23,10 +23,10 @@ import static uk.gov.pay.api.it.fixtures.PaymentSearchResultBuilder.aSuccessfulS
 
 public class PaymentSearchITest extends PaymentResourceITestBase {
 
-    protected static final String TEST_REFERENCE = "test_reference";
-    protected static final String TEST_STATUS = "succeeded";
-    protected static final String TEST_FROM_DATE = "2016-01-28T00:00:00Z";
-    protected static final String TEST_TO_DATE = "2016-01-28T12:00:00Z";
+    private static final String TEST_REFERENCE = "test_reference";
+    private static final String TEST_STATUS = "succeeded";
+    private static final String TEST_FROM_DATE = "2016-01-28T00:00:00Z";
+    private static final String TEST_TO_DATE = "2016-01-28T12:00:00Z";
     private static final String SEARCH_PATH = "/v1/payments";
 
     @Test

--- a/src/test/java/uk/gov/pay/api/it/PaymentsCancelResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsCancelResourceITest.java
@@ -1,57 +1,17 @@
 package uk.gov.pay.api.it;
 
 import com.jayway.restassured.response.ValidatableResponse;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.mockserver.junit.MockServerRule;
-import uk.gov.pay.api.app.PublicApi;
-import uk.gov.pay.api.config.PublicApiConfig;
-import uk.gov.pay.api.utils.ConnectorMockClient;
-import uk.gov.pay.api.utils.PublicAuthMockClient;
 
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.http.ContentType.JSON;
-import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.hamcrest.Matchers.is;
 
 public class PaymentsCancelResourceITest extends PaymentResourceITestBase {
+
     private static final String TEST_CHARGE_ID = "ch_ab2341da231434";
-
     private static final String CANCEL_PAYMENTS_PATH = PAYMENTS_PATH + "%s/cancel";
-
-    @Rule
-    public MockServerRule connectorMockRule = new MockServerRule(this);
-
-    @Rule
-    public MockServerRule publicAuthMockRule = new MockServerRule(this);
-
-    private ConnectorMockClient connectorMock;
-    private PublicAuthMockClient publicAuthMock;
-
-    @Rule
-    public DropwizardAppRule<PublicApiConfig> app = new DropwizardAppRule<>(
-            PublicApi.class
-            , resourceFilePath("config/test-config.yaml")
-            , config("publicAuthUrl", publicAuthBaseUrl())
-            , config("connectorUrl", connectorBaseUrl()));
-
-    private String connectorBaseUrl() {
-        return "http://localhost:" + connectorMockRule.getHttpPort();
-    }
-
-    private String publicAuthBaseUrl() {
-        return "http://localhost:" + publicAuthMockRule.getHttpPort() + "/v1/auth";
-    }
-
-    @Before
-    public void setup() {
-        connectorMock = new ConnectorMockClient(connectorMockRule.getHttpPort(), connectorBaseUrl());
-        publicAuthMock = new PublicAuthMockClient(publicAuthMockRule.getHttpPort());
-    }
 
     @Test
     public void cancelPayment_Returns401_WhenUnauthorised() {

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceAmountValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceAmountValidationITest.java
@@ -1,0 +1,162 @@
+package uk.gov.pay.api.it;
+
+import com.jayway.restassured.response.ValidatableResponse;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.google.common.collect.Maps.newHashMap;
+import static com.jayway.restassured.RestAssured.given;
+import static com.jayway.restassured.http.ContentType.JSON;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+
+public class PaymentsResourceAmountValidationITest extends PaymentResourceITestBase {
+
+    @Before
+    public void setUpBearerToken() {
+        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+    }
+
+    @Test
+    public void createPayment_responseWith422_whenAmountIsNegative() {
+
+        postPaymentResponse(BEARER_TOKEN, paymentPayload(-123))
+                .statusCode(422)
+                .contentType(JSON)
+                .body("errors", hasSize(1))
+                .body("errors", hasItem("amount must be greater than or equal to 1 (was -123)"));
+    }
+
+    @Test
+    public void createPayment_responseWith422_whenAmountIsSmallerThanTheMinimumAllowed() {
+
+        postPaymentResponse(BEARER_TOKEN, paymentPayload(0))
+                .statusCode(422)
+                .contentType(JSON)
+                .body("errors", hasSize(1))
+                .body("errors", hasItem("amount must be greater than or equal to 1 (was 0)"));
+    }
+
+    @Test
+    public void createPayment_responseWith422_whenAmountIsBiggerThanTheMaximumAllowed() {
+
+        postPaymentResponse(BEARER_TOKEN, paymentPayload(10000001L))
+                .statusCode(422)
+                .contentType(JSON)
+                .body("errors", hasSize(1))
+                .body("errors", hasItem("amount must be less than or equal to 10000000 (was 10000001)"));
+    }
+
+    @Test
+    public void createPayment_responseWith422_whenAmountFieldHasNullValue() {
+
+        postPaymentResponse(BEARER_TOKEN, paymentPayload(null))
+                .statusCode(422)
+                .contentType(JSON)
+                .body("errors", hasSize(1))
+                .body("errors", hasItem("amount may not be null (was null)"));
+    }
+
+    @Test
+    public void createPayment_responseWith400_whenAmountFieldIsNotNumeric() {
+
+        postPaymentResponse(BEARER_TOKEN, paymentPayload("£%&dasg*??<>"))
+                .statusCode(400)
+                .contentType(JSON)
+                .body("message", is("Unable to process JSON"));
+    }
+
+    @Test
+    public void createPayment_responseWith400_whenAmountFieldIsNotAValidJsonField() {
+
+        postPaymentResponse(BEARER_TOKEN, paymentPayload(newHashMap()))
+                .statusCode(400)
+                .contentType(JSON)
+                .body("message", is("Unable to process JSON"));
+    }
+
+    @Test
+    public void createPayment_responseWith422_whenAmountFieldIsBlank() {
+
+        postPaymentResponse(BEARER_TOKEN, paymentPayload("\"    \""))
+                .statusCode(422)
+                .contentType(JSON)
+                .body("errors", hasSize(1))
+                .body("errors", hasItem("amount may not be null (was null)"));
+    }
+
+    @Test
+    public void createPayment_responseWith400_whenAmountIsHexadecimal() {
+
+        postPaymentResponse(BEARER_TOKEN, paymentPayload("0x1000"))
+                .statusCode(400)
+                .contentType(JSON)
+                .body("message", is("Unable to process JSON"));
+    }
+
+    @Test
+    public void createPayment_responseWith400_whenAmountIsBinary() {
+
+        postPaymentResponse(BEARER_TOKEN, paymentPayload("0B101"))
+                .statusCode(400)
+                .contentType(JSON)
+                .body("message", is("Unable to process JSON"));
+    }
+
+    @Test
+    public void createPayment_responseWith400_whenAmountIsOctal() {
+
+        postPaymentResponse(BEARER_TOKEN, paymentPayload("017"))
+                .statusCode(400)
+                .contentType(JSON)
+                .body("message", is("Unable to process JSON"));
+    }
+
+    @Test
+    public void createPayment_responseWith400_whenAmountIsFloat() {
+
+        postPaymentResponse(BEARER_TOKEN, paymentPayload(27.55))
+                .statusCode(400)
+                .contentType(JSON)
+                .body("message", is("Unable to process JSON"));
+    }
+
+    @Test
+    public void createPayment_responseWith400_whenAmountIsDouble() {
+
+        postPaymentResponse(BEARER_TOKEN, paymentPayload(27.55d))
+                .statusCode(400)
+                .contentType(JSON)
+                .body("message", is("Unable to process JSON"));
+    }
+
+    @Test
+    public void createPayment_responseWith400_whenAmountIsNullByteEncoded() {
+
+        postPaymentResponse(BEARER_TOKEN, paymentPayload("%00"))
+                .statusCode(400)
+                .contentType(JSON)
+                .body("message", is("Unable to process JSON"));
+    }
+
+    private String paymentPayload(Object amount) {
+        return "{" +
+                "  \"amount\" : " + amount + "," +
+                "  \"reference\" : \"Some reference\"," +
+                "  \"description\" : \"Some description\"," +
+                "  \"return_url\" : \"http://somewhere.over.the/rainbow/{paymentID}\"" +
+                "}";
+    }
+
+    private ValidatableResponse postPaymentResponse(String bearerToken, String payload) {
+        return given().port(app.getLocalPort())
+                .body(payload)
+                .accept(JSON)
+                .contentType(JSON)
+                .header(AUTHORIZATION, "Bearer " + bearerToken)
+                .post(PAYMENTS_PATH)
+                .then();
+    }
+}

--- a/src/test/java/uk/gov/pay/api/utils/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/ConnectorMockClient.java
@@ -93,7 +93,7 @@ public class ConnectorMockClient {
         return baseUrl + format(CONNECTOR_MOCK_CHARGE_EVENTS_PATH, accountId, chargeId);
     }
 
-    public void respondOk_whenCreateCharge(long amount, String gatewayAccountId, String chargeId, String status, String returnUrl,
+    public void respondOk_whenCreateCharge(int amount, String gatewayAccountId, String chargeId, String status, String returnUrl,
                                            String description, String reference, String paymentProvider, String createdDate) {
         whenCreateCharge(amount, gatewayAccountId, returnUrl, description, reference)
                 .respond(response()
@@ -253,7 +253,7 @@ public class ConnectorMockClient {
                 .withBody(jsonString("message", errorMsg));
     }
 
-    public void verifyCreateCharge(long amount, String gatewayAccountId, String returnUrl, String description, String reference) {
+    public void verifyCreateCharge(int amount, String gatewayAccountId, String returnUrl, String description, String reference) {
         mockClient.verify(request()
                         .withMethod(POST)
                         .withPath(format(CONNECTOR_MOCK_CHARGES_PATH, gatewayAccountId))

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -152,11 +152,12 @@
       "properties" : {
         "amount" : {
           "type" : "integer",
-          "format" : "int64",
+          "format" : "int32",
           "example" : "12000",
           "description" : "amount in pence",
           "readOnly" : true,
-          "minimum" : 0.0
+          "minimum" : 1.0,
+          "maximum" : 1.0E7
         },
         "reference" : {
           "type" : "string",


### PR DESCRIPTION
Improved amount validation:    
- Added new tests for failing validations (improve test coverage). Added tests for introducing amount as HEX, OCT and BIN values.
- Spotted issues and fixed to **reject** float or double values as amount (Before, the API was just ignoring the decimal part)
- Separated amount validation tests into a separated class.
