### PR TITLE
Fix cacerts generation from pem.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ hs_err_pid*
 target
 
 bin
+
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ EXPOSE 8080
 EXPOSE 8081
 
 WORKDIR /app
+RUN mkdir /app/ssl
 
 ADD target/*.yaml /app/
 ADD target/pay-*-allinone.jar /app/

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -4,11 +4,4 @@ if [ "${ENABLE_NEWRELIC}" == "yes" ]; then
   NEWRELIC_JVM_FLAG="-javaagent:/app/newrelic/newrelic.jar"
 fi
 
-# (re)create cacerts from supplied certificates
-rm /app/ssl/cacerts 
-for crt in `ls -1 $CA_FILEPATH/*.crt`; do
-  echo "Found $crt"
-  keytool -import -file $crt -alias $crt -keystore /app/ssl/cacerts -storepass password -noprompt
-done
-
 java ${NEWRELIC_JVM_FLAG} -jar *-allinone.jar server *.yaml

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -1,35 +1,14 @@
 #!/usr/bin/env bash
 
-#create keystore and import certs if necessary properties present
-function configure_keystore {
-    if [ -z "${CERTS_DIR}" -a \
-         -z "${KEYSTORE_DIR}" -a \
-         -z "${KEYSTORE_PASSWORD}" -a \
-         -z "${KEYSTORE_FILE}" -a \
-         -z "${CERT_FILE}" -a \
-         -z "${KEY_FILE}" ];
-         then
-           echo "not all variables needed for keystore creation are available";
-         else
-           if [ -d "${CERTS_DIR}" -a -d "${KEYSTORE_DIR}" ];
-           then
-                #replace correct filenames
-                openssl pkcs12 -export -out ${KEYSTORE_DIR}/${KEYSTORE_FILE} -inkey ${CERTS_DIR}/${KEY_FILE} -in ${CERTS_DIR}/${CERT_FILE} -passout pass:${KEYSTORE_PASSWORD};
-                if [ $? -eq 0 ]; then
-                    echo "keystore created successfully at \"${KEYSTORE_DIR}/${KEYSTORE_FILE}\" ";
-                else
-                    echo "keystore creation failed";
-                fi
-           else
-                echo "KEYSTORE_DIR and CERTS_DIR does not exist";
-           fi
-    fi
-}
-
 if [ "${ENABLE_NEWRELIC}" == "yes" ]; then
   NEWRELIC_JVM_FLAG="-javaagent:/app/newrelic/newrelic.jar"
 fi
 
-## TODO enable this after figuring out the failure during `openssl` above
-# configure_keystore
+# (re)create cacerts from supplied certificates
+rm /app/ssl/cacerts 
+for crt in `ls -1 $CA_FILEPATH/*.crt`; do
+  echo "Found $crt"
+  keytool -import -file $crt -alias $crt -keystore /app/ssl/cacerts -storepass password -noprompt
+done
+
 java ${NEWRELIC_JVM_FLAG} -jar *-allinone.jar server *.yaml

--- a/src/main/java/uk/gov/pay/api/resources/RestClientFactory.java
+++ b/src/main/java/uk/gov/pay/api/resources/RestClientFactory.java
@@ -7,6 +7,9 @@ import javax.net.ssl.SSLContext;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 
+import static uk.gov.pay.api.utils.TrustStoreLoader.getTrustStore;
+import static uk.gov.pay.api.utils.TrustStoreLoader.getTrustStorePassword;
+
 public class RestClientFactory {
     public static final String TLSV1_2 = "TLSv1.2";
 
@@ -17,7 +20,8 @@ public class RestClientFactory {
             String keyStoreFile = clientConfig.getKeyStoreDir() + clientConfig.getKeyStoreFile();
             SslConfigurator sslConfig = SslConfigurator.newInstance()
                     .trustStoreFile(keyStoreFile)
-                    .trustStorePassword(clientConfig.getKeyStorePassword())
+                    .trustStore(getTrustStore())
+                    .trustStorePassword(getTrustStorePassword())
                     .securityProtocol(TLSV1_2);
 
             SSLContext sslContext = sslConfig.createSSLContext();

--- a/src/main/java/uk/gov/pay/api/resources/RestClientFactory.java
+++ b/src/main/java/uk/gov/pay/api/resources/RestClientFactory.java
@@ -16,8 +16,8 @@ public class RestClientFactory {
         } else {
             String keyStoreFile = clientConfig.getKeyStoreDir() + clientConfig.getKeyStoreFile();
             SslConfigurator sslConfig = SslConfigurator.newInstance()
-                    .keyStoreFile(keyStoreFile)
-                    .keyPassword(clientConfig.getKeyStorePassword())
+                    .trustStoreFile(keyStoreFile)
+                    .trustStorePassword(clientConfig.getKeyStorePassword())
                     .securityProtocol(TLSV1_2);
 
             SSLContext sslContext = sslConfig.createSSLContext();

--- a/src/main/java/uk/gov/pay/api/utils/TrustStoreLoader.java
+++ b/src/main/java/uk/gov/pay/api/utils/TrustStoreLoader.java
@@ -1,0 +1,65 @@
+package uk.gov.pay.api.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Paths;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+
+public class TrustStoreLoader {
+    private static final Logger logger = LoggerFactory.getLogger(TrustStoreLoader.class);
+
+    private static final String CERTS_PATH;
+    private static final String TRUST_STORE_PASSWORD = "";
+
+    private static final KeyStore TRUST_STORE;
+
+    static {
+        CERTS_PATH = System.getenv("CERTS_PATH");
+
+        try {
+            TRUST_STORE = KeyStore.getInstance(KeyStore.getDefaultType());
+            TRUST_STORE.load(null, TRUST_STORE_PASSWORD.toCharArray());
+        } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {
+            throw new RuntimeException("Could not create a keystore", e);
+        }
+
+        if (CERTS_PATH != null) {
+            try {
+                Files.walk(Paths.get(CERTS_PATH)).forEach(certPath -> {
+                    if (Files.isRegularFile(certPath)) {
+                        try {
+                            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+                            Certificate cert = cf.generateCertificate(new ByteArrayInputStream(Files.readAllBytes(certPath)));
+                            TRUST_STORE.setCertificateEntry(certPath.getFileName().toString(), cert);
+                            logger.info("Loaded cert " + certPath);
+                        } catch (SecurityException | KeyStoreException | CertificateException | IOException e) {
+                            logger.error("Could not load " + certPath, e);
+                        }
+                    }
+                });
+            } catch (NoSuchFileException nsfe) {
+                logger.warn("Did not find any certificates to load");
+            } catch (IOException ioe) {
+                logger.error("Error walking certs directory", ioe);
+            }
+        }
+    }
+
+    public static KeyStore getTrustStore() {
+        return TRUST_STORE;
+    }
+
+    public static String getTrustStorePassword() {
+        return new String(TRUST_STORE_PASSWORD);
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -14,6 +14,6 @@ publicAuthUrl: ${PUBLIC_AUTH_URL}
 
 jerseyClientConfig:
   disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS}
-  keyStoreDir: "/etc/ssl/"
-  keyStoreFile: "keystore.pfx" # TODO need to replace with the exact file name
-  keyStorePassword: ${KEY_STORE_PASSWORD}
+  keyStoreDir: "/app/ssl/"
+  keyStoreFile: "cacerts"
+  keyStorePassword: password


### PR DESCRIPTION
There is no need for the private keys.
cacerts is a truststore, not a keystore.