### PR TITLE
PP-539 Selectively including links in the payment responses

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/Payment.java
+++ b/src/main/java/uk/gov/pay/api/model/Payment.java
@@ -1,30 +1,19 @@
 package uk.gov.pay.api.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 
-@ApiModel(value="Payment information", description = "A Payment description")
-public class Payment {
-    @JsonProperty("payment_id")
+public class Payment implements PaymentJSON {
     private final String paymentId;
     
-    @JsonProperty("payment_provider")
     private final String paymentProvider;
     private final long amount;
     private final String status;
     private final String description;
     
-    @JsonProperty("return_url")
     private final String returnUrl;
     
     private final String reference;
-    
-    @JsonProperty("_links")
-    private final Links links = new Links();
 
-    @JsonProperty("created_date")
     private final String createdDate;
 
     public static Payment createPaymentResponse(JsonNode payload) {
@@ -52,49 +41,36 @@ public class Payment {
         this.createdDate = createdDate;
     }
 
-    @ApiModelProperty(example = "2016-01-21T17:15:00Z")
     public String getCreatedDate() {
         return createdDate;
     }
 
-    @ApiModelProperty(example = "hu20sqlact5260q2nanm0q8u93")
     public String getPaymentId() {
         return paymentId;
     }
 
-    @ApiModelProperty(example = "1200")
     public long getAmount() {
         return amount;
     }
 
-    @ApiModelProperty(example = "CREATED")
     public String getStatus() {
         return status;
     }
 
-    @ApiModelProperty(example = "http://your.service.domain/your-reference")
     public String getReturnUrl() {
         return returnUrl;
     }
 
-    @ApiModelProperty(example = "Your Service Description")
     public String getDescription() {
         return description;
     }
 
-    @ApiModelProperty(example = "your-reference")
     public String getReference() {
         return reference;
     }
 
-    @ApiModelProperty(example = "worldpay")
     public String getPaymentProvider() {
         return paymentProvider;
-    }
-
-    @ApiModelProperty(dataType = "uk.gov.pay.api.model.Links")
-    public Links getLinks() {
-        return links;
     }
 
     @Override
@@ -108,17 +84,6 @@ public class Payment {
                 ", description='" + description + '\'' +
                 ", reference='" + reference + '\'' +
                 ", createdDate='" + createdDate + '\'' +
-                ", links=" + links +
                 '}';
-    }
-
-    public Payment withSelfLink(String url) {
-        this.links.setSelf(url);
-        return this;
-    }
-
-    public Payment withNextLink(String url) {
-        this.links.setNextUrl(url);
-        return this;
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/PaymentJSON.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentJSON.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(description = "A Payment")
+interface PaymentJSON {
+
+    @JsonProperty("created_date")
+    @ApiModelProperty(example = "2016-01-21T17:15:00Z")
+    String getCreatedDate();
+
+    @JsonProperty("payment_id")
+    @ApiModelProperty(example = "hu20sqlact5260q2nanm0q8u93")
+    String getPaymentId();
+
+    @JsonProperty("amount")
+    @ApiModelProperty(example = "1200")
+    long getAmount();
+
+    @JsonProperty("status")
+    @ApiModelProperty(example = "CREATED")
+    String getStatus();
+
+    @JsonProperty("return_url")
+    @ApiModelProperty(example = "http://your.service.domain/your-reference")
+    String getReturnUrl();
+
+    @JsonProperty("description")
+    @ApiModelProperty(example = "Your Service Description")
+    String getDescription();
+
+    @JsonProperty("reference")
+    @ApiModelProperty(example = "your-reference")
+    String getReference();
+
+    @JsonProperty("payment_provider")
+    @ApiModelProperty(example = "worldpay")
+    String getPaymentProvider();
+}

--- a/src/main/java/uk/gov/pay/api/model/PaymentWithLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentWithLinks.java
@@ -1,0 +1,86 @@
+package uk.gov.pay.api.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.Iterator;
+import java.util.Optional;
+
+public class PaymentWithLinks implements PaymentWithLinksJSON {
+    Payment payment;
+
+    private final Links links = new Links();
+
+    public Links getLinks() {
+        return links;
+    }
+
+    public static PaymentWithLinks createPaymentResponseWithLinks(JsonNode payload, String selfLink) {
+        Payment payment = Payment.createPaymentResponse(payload);
+        PaymentWithLinks paymentWithLinks = new PaymentWithLinks(payment);
+        paymentWithLinks.withSelfLink(selfLink);
+        Optional<JsonNode> nextLinkMaybe = getNextLink(payload);
+
+        nextLinkMaybe.ifPresent(
+                (nextLink) -> paymentWithLinks.withNextLink(nextLink.get("href").asText()));
+
+        return paymentWithLinks;
+    }
+
+    private PaymentWithLinks(Payment payment) {
+        this.payment = payment;
+    }
+
+    public String getCreatedDate() {
+        return payment.getCreatedDate();
+    }
+
+    public String getPaymentId() {
+        return payment.getPaymentId();
+    }
+
+    public long getAmount() {
+        return payment.getAmount();
+    }
+
+    public String getStatus() {
+        return payment.getStatus();
+    }
+
+    public String getReturnUrl() {
+        return payment.getReturnUrl();
+    }
+
+    public String getDescription() {
+        return payment.getDescription();
+    }
+
+    public String getReference() {
+        return payment.getReference();
+    }
+
+    public String getPaymentProvider() {
+        return payment.getPaymentProvider();
+    }
+
+    public PaymentWithLinks withSelfLink(String url) {
+        this.links.setSelf(url);
+        return this;
+    }
+
+    public PaymentWithLinks withNextLink(String url) {
+        this.links.setNextUrl(url);
+        return this;
+    }
+
+    private static Optional<JsonNode> getNextLink(JsonNode payload) {
+        for (Iterator<JsonNode> it = payload.get("links").elements(); it.hasNext(); ) {
+            JsonNode node = it.next();
+            if ("next_url".equals(node.get("rel").asText())) {
+                return Optional.of(node);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+}

--- a/src/main/java/uk/gov/pay/api/model/PaymentWithLinksJSON.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentWithLinksJSON.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(description = "A Payment with links")
+public interface PaymentWithLinksJSON extends PaymentJSON {
+
+    String LINKS_JSON_ATTRIBUTE = "_links";
+
+    @JsonProperty(LINKS_JSON_ATTRIBUTE)
+    @ApiModelProperty(dataType = "uk.gov.pay.api.model.Links")
+    Links getLinks();
+
+}

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -44,7 +44,7 @@
           "200" : {
             "description" : "OK",
             "schema" : {
-              "$ref" : "#/definitions/Payment information"
+              "$ref" : "#/definitions/Payment"
             }
           },
           "401" : {
@@ -77,7 +77,7 @@
           "201" : {
             "description" : "Created",
             "schema" : {
-              "$ref" : "#/definitions/Payment information"
+              "$ref" : "#/definitions/PaymentWithLinks"
             }
           },
           "400" : {
@@ -105,7 +105,7 @@
           "200" : {
             "description" : "OK",
             "schema" : {
-              "$ref" : "#/definitions/Payment information"
+              "$ref" : "#/definitions/PaymentWithLinks"
             }
           },
           "401" : {
@@ -158,7 +158,7 @@
           "200" : {
             "description" : "OK",
             "schema" : {
-              "$ref" : "#/definitions/Payment information"
+              "$ref" : "#/definitions/Payment"
             }
           },
           "401" : {
@@ -208,26 +208,9 @@
       },
       "description" : "The Payment Request Payload"
     },
-    "Payment information" : {
+    "Payment" : {
       "type" : "object",
       "properties" : {
-        "amount" : {
-          "type" : "integer",
-          "format" : "int64",
-          "example" : "1200"
-        },
-        "status" : {
-          "type" : "string",
-          "example" : "CREATED"
-        },
-        "description" : {
-          "type" : "string",
-          "example" : "Your Service Description"
-        },
-        "reference" : {
-          "type" : "string",
-          "example" : "your-reference"
-        },
         "payment_id" : {
           "type" : "string",
           "example" : "hu20sqlact5260q2nanm0q8u93",
@@ -238,14 +221,31 @@
           "example" : "worldpay",
           "readOnly" : true
         },
+        "amount" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : "1200",
+          "readOnly" : true
+        },
+        "status" : {
+          "type" : "string",
+          "example" : "CREATED",
+          "readOnly" : true
+        },
+        "description" : {
+          "type" : "string",
+          "example" : "Your Service Description",
+          "readOnly" : true
+        },
         "return_url" : {
           "type" : "string",
           "example" : "http://your.service.domain/your-reference",
           "readOnly" : true
         },
-        "_links" : {
-          "readOnly" : true,
-          "$ref" : "#/definitions/paymentLinks"
+        "reference" : {
+          "type" : "string",
+          "example" : "your-reference",
+          "readOnly" : true
         },
         "created_date" : {
           "type" : "string",
@@ -253,7 +253,58 @@
           "readOnly" : true
         }
       },
-      "description" : "A Payment description"
+      "description" : "A Payment"
+    },
+    "PaymentWithLinks" : {
+      "type" : "object",
+      "properties" : {
+        "_links" : {
+          "readOnly" : true,
+          "$ref" : "#/definitions/paymentLinks"
+        },
+        "reference" : {
+          "type" : "string",
+          "example" : "your-reference",
+          "readOnly" : true
+        },
+        "description" : {
+          "type" : "string",
+          "example" : "Your Service Description",
+          "readOnly" : true
+        },
+        "status" : {
+          "type" : "string",
+          "example" : "CREATED",
+          "readOnly" : true
+        },
+        "amount" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : "1200",
+          "readOnly" : true
+        },
+        "return_url" : {
+          "type" : "string",
+          "example" : "http://your.service.domain/your-reference",
+          "readOnly" : true
+        },
+        "created_date" : {
+          "type" : "string",
+          "example" : "2016-01-21T17:15:00Z",
+          "readOnly" : true
+        },
+        "payment_id" : {
+          "type" : "string",
+          "example" : "hu20sqlact5260q2nanm0q8u93",
+          "readOnly" : true
+        },
+        "payment_provider" : {
+          "type" : "string",
+          "example" : "worldpay",
+          "readOnly" : true
+        }
+      },
+      "description" : "A Payment with links"
     },
     "paymentLink" : {
       "type" : "object",


### PR DESCRIPTION
This addresses the need to have separate response structures for
'create', 'find by payment id' and 'search payments'. Providing links in
the response for search payments doesn't make sense as it presents a
snapshot of each payment. However 'create' and 'find by payment id'
require links to be present in their responses.

* Introducing a concept of PaymentWithLinks to represent the fact that
its different from a Payment
* All JSON and API documentation annotations are moved to interfaces to
give the value objects json behaviors.
* The objects would just be value objects with the interfaces giving
them JSON and API documentation capabilities.
* Both create payments and find payment now uses the new PaymentWithLink
object as it makes sense to include links in these responses.
* Search payment will use the Payment object which doesn't include
links.