### PR TITLE
PP-539 Making the create payment payload restrictive.

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
@@ -13,7 +13,6 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 @ApiModel(value = "CreatePaymentRequest", description = "The Payment Request Payload")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class CreatePaymentRequest {
 
     private Integer amount;


### PR DESCRIPTION
* Removing the ignore unknown properties capability when parsing a json
payload to create a payment.
* If the payload has an attribute that we don't know about, the request
will response with a 400.