### PR TITLE
PP 618 fix cert loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ hs_err_pid*
 target
 
 bin
+
+.DS_Store

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -1,35 +1,7 @@
 #!/usr/bin/env bash
 
-#create keystore and import certs if necessary properties present
-function configure_keystore {
-    if [ -z "${CERTS_DIR}" -a \
-         -z "${KEYSTORE_DIR}" -a \
-         -z "${KEYSTORE_PASSWORD}" -a \
-         -z "${KEYSTORE_FILE}" -a \
-         -z "${CERT_FILE}" -a \
-         -z "${KEY_FILE}" ];
-         then
-           echo "not all variables needed for keystore creation are available";
-         else
-           if [ -d "${CERTS_DIR}" -a -d "${KEYSTORE_DIR}" ];
-           then
-                #replace correct filenames
-                openssl pkcs12 -export -out ${KEYSTORE_DIR}/${KEYSTORE_FILE} -inkey ${CERTS_DIR}/${KEY_FILE} -in ${CERTS_DIR}/${CERT_FILE} -passout pass:${KEYSTORE_PASSWORD};
-                if [ $? -eq 0 ]; then
-                    echo "keystore created successfully at \"${KEYSTORE_DIR}/${KEYSTORE_FILE}\" ";
-                else
-                    echo "keystore creation failed";
-                fi
-           else
-                echo "KEYSTORE_DIR and CERTS_DIR does not exist";
-           fi
-    fi
-}
-
 if [ "${ENABLE_NEWRELIC}" == "yes" ]; then
   NEWRELIC_JVM_FLAG="-javaagent:/app/newrelic/newrelic.jar"
 fi
 
-## TODO enable this after figuring out the failure during `openssl` above
-# configure_keystore
 java ${NEWRELIC_JVM_FLAG} -jar *-allinone.jar server *.yaml

--- a/src/main/java/uk/gov/pay/api/config/RestClientConfig.java
+++ b/src/main/java/uk/gov/pay/api/config/RestClientConfig.java
@@ -3,23 +3,7 @@ package uk.gov.pay.api.config;
 import io.dropwizard.Configuration;
 
 public class RestClientConfig extends Configuration {
-
     private String disabledSecureConnection;
-    private String keyStoreDir;
-    private String keyStoreFile;
-    private String keyStorePassword;
-
-    public String getKeyStoreDir() {
-        return keyStoreDir.endsWith("/") ? keyStoreDir : keyStoreDir.concat("/");
-    }
-
-    public String getKeyStoreFile() {
-        return keyStoreFile;
-    }
-
-    public String getKeyStorePassword() {
-        return keyStorePassword;
-    }
 
     public Boolean isDisabledSecureConnection() {
         return "true".equals(disabledSecureConnection);

--- a/src/main/java/uk/gov/pay/api/resources/RestClientFactory.java
+++ b/src/main/java/uk/gov/pay/api/resources/RestClientFactory.java
@@ -7,6 +7,9 @@ import javax.net.ssl.SSLContext;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 
+import static uk.gov.pay.api.utils.TrustStoreLoader.getTrustStore;
+import static uk.gov.pay.api.utils.TrustStoreLoader.getTrustStorePassword;
+
 public class RestClientFactory {
     public static final String TLSV1_2 = "TLSv1.2";
 
@@ -14,10 +17,9 @@ public class RestClientFactory {
         if (clientConfig.isDisabledSecureConnection()) {
             return ClientBuilder.newBuilder().build();
         } else {
-            String keyStoreFile = clientConfig.getKeyStoreDir() + clientConfig.getKeyStoreFile();
             SslConfigurator sslConfig = SslConfigurator.newInstance()
-                    .keyStoreFile(keyStoreFile)
-                    .keyPassword(clientConfig.getKeyStorePassword())
+                    .trustStore(getTrustStore())
+                    .trustStorePassword(getTrustStorePassword())
                     .securityProtocol(TLSV1_2);
 
             SSLContext sslContext = sslConfig.createSSLContext();

--- a/src/main/java/uk/gov/pay/api/utils/TrustStoreLoader.java
+++ b/src/main/java/uk/gov/pay/api/utils/TrustStoreLoader.java
@@ -1,0 +1,65 @@
+package uk.gov.pay.api.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Paths;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+
+public class TrustStoreLoader {
+    private static final Logger logger = LoggerFactory.getLogger(TrustStoreLoader.class);
+
+    private static final String CERTS_PATH;
+    private static final String TRUST_STORE_PASSWORD = "";
+
+    private static final KeyStore TRUST_STORE;
+
+    static {
+        CERTS_PATH = System.getenv("CERTS_PATH");
+
+        try {
+            TRUST_STORE = KeyStore.getInstance(KeyStore.getDefaultType());
+            TRUST_STORE.load(null, TRUST_STORE_PASSWORD.toCharArray());
+        } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {
+            throw new RuntimeException("Could not create a keystore", e);
+        }
+
+        if (CERTS_PATH != null) {
+            try {
+                Files.walk(Paths.get(CERTS_PATH)).forEach(certPath -> {
+                    if (Files.isRegularFile(certPath)) {
+                        try {
+                            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+                            Certificate cert = cf.generateCertificate(new ByteArrayInputStream(Files.readAllBytes(certPath)));
+                            TRUST_STORE.setCertificateEntry(certPath.getFileName().toString(), cert);
+                            logger.info("Loaded cert " + certPath);
+                        } catch (SecurityException | KeyStoreException | CertificateException | IOException e) {
+                            logger.error("Could not load " + certPath, e);
+                        }
+                    }
+                });
+            } catch (NoSuchFileException nsfe) {
+                logger.warn("Did not find any certificates to load");
+            } catch (IOException ioe) {
+                logger.error("Error walking certs directory", ioe);
+            }
+        }
+    }
+
+    public static KeyStore getTrustStore() {
+        return TRUST_STORE;
+    }
+
+    public static String getTrustStorePassword() {
+        return new String(TRUST_STORE_PASSWORD);
+    }
+}

--- a/src/main/java/uk/gov/pay/api/validation/URLValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/URLValidator.java
@@ -6,7 +6,7 @@ import static org.apache.commons.validator.routines.UrlValidator.*;
 
 public enum URLValidator {
     SECURITY_ENABLED {
-        private final UrlValidator URL_VALIDATOR = new UrlValidator(new String[]{"https"});
+        private final UrlValidator URL_VALIDATOR = new UrlValidator(new String[]{"https"}, ALLOW_LOCAL_URLS);
 
         @Override
         public boolean isValid(String value) {

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -14,6 +14,3 @@ publicAuthUrl: ${PUBLIC_AUTH_URL}
 
 jerseyClientConfig:
   disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS}
-  keyStoreDir: "/etc/ssl/"
-  keyStoreFile: "keystore.pfx" # TODO need to replace with the exact file name
-  keyStorePassword: ${KEY_STORE_PASSWORD}

--- a/src/test/java/uk/gov/pay/api/resources/RestClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/RestClientFactoryTest.java
@@ -42,9 +42,6 @@ public class RestClientFactoryTest {
         //given
         RestClientConfig clientConfiguration = mock(RestClientConfig.class);
         when(clientConfiguration.isDisabledSecureConnection()).thenReturn(false);
-        when(clientConfiguration.getKeyStoreDir()).thenReturn(keyStoreDir.getAbsolutePath() + "/");
-        when(clientConfiguration.getKeyStoreFile()).thenReturn(keyStoreFile);
-        when(clientConfiguration.getKeyStorePassword()).thenReturn(keyStorePassword);
 
         //when
         Client client = RestClientFactory.buildClient(clientConfiguration);
@@ -65,9 +62,6 @@ public class RestClientFactoryTest {
         Client client = RestClientFactory.buildClient(clientConfiguration);
 
         //then
-        verify(clientConfiguration, times(0)).getKeyStoreDir();
-        verify(clientConfiguration, times(0)).getKeyStoreFile();
-        verify(clientConfiguration, times(0)).getKeyStorePassword();
         assertThat(client.getSslContext().getProtocol(), is(not("TLSv1.2")));
     }
 

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -20,6 +20,3 @@ publicAuthUrl: http://publicauth.url/v1/auth
 
 jerseyClientConfig:
   disabledSecureConnection: "true"
-  keyStoreDir: "./"
-  keyStoreFile: "./keystore_file.pfx"
-  keyStorePassword: "test-key-store-password"


### PR DESCRIPTION
There is no need for the private keys.
cacerts is a truststore, not a keystore.

Move to a programmatic approach for creating a truststore from the pem directory, to avoid the need for bash scripting inside the containers. 