### PR TITLE
PP-611 500 Error mapping Creating a Charge when Gateway account does not exist

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -10,6 +10,7 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import uk.gov.pay.api.auth.AccountAuthenticator;
 import uk.gov.pay.api.config.PublicApiConfig;
+import uk.gov.pay.api.exception.CreateChargeConnectorErrorResponseExceptionMapper;
 import uk.gov.pay.api.healthcheck.Ping;
 import uk.gov.pay.api.resources.PaymentsResource;
 import uk.gov.pay.api.resources.RestClientFactory;
@@ -44,6 +45,7 @@ public class PublicApi extends Application<PublicApiConfig> {
 
         environment.jersey().register(new PaymentsResource(client, config.getConnectorUrl()));
         environment.jersey().register(AuthFactory.binder(new OAuthFactory<>(new AccountAuthenticator(client, config.getPublicAuthUrl()), "", String.class)));
+        environment.jersey().register(CreateChargeConnectorErrorResponseExceptionMapper.class);
     }
 
     public static void main(String[] args) throws Exception {

--- a/src/main/java/uk/gov/pay/api/exception/CreateChargeConnectorErrorResponseException.java
+++ b/src/main/java/uk/gov/pay/api/exception/CreateChargeConnectorErrorResponseException.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.api.exception;
+
+public class CreateChargeConnectorErrorResponseException extends RuntimeException {
+
+    private final int errorStatus;
+    private String errorBody;
+
+    public CreateChargeConnectorErrorResponseException(int errorStatus, String errorBody) {
+        this.errorStatus = errorStatus;
+        this.errorBody = errorBody;
+    }
+
+    int getErrorStatus() {
+        return errorStatus;
+    }
+
+    String getErrorBody() {
+        return errorBody;
+    }
+}

--- a/src/main/java/uk/gov/pay/api/exception/CreateChargeConnectorErrorResponseExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/CreateChargeConnectorErrorResponseExceptionMapper.java
@@ -2,11 +2,15 @@ package uk.gov.pay.api.exception;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.api.model.PaymentErrorResponse;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
-import static javax.ws.rs.core.Response.Status.*;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static uk.gov.pay.api.exception.CreateChargeConnectorErrorResponseExceptionMapper.CreateChargeErrorResponse.P0198;
+import static uk.gov.pay.api.exception.CreateChargeConnectorErrorResponseExceptionMapper.CreateChargeErrorResponse.P0199;
 
 public class CreateChargeConnectorErrorResponseExceptionMapper implements ExceptionMapper<CreateChargeConnectorErrorResponseException> {
 
@@ -18,14 +22,32 @@ public class CreateChargeConnectorErrorResponseExceptionMapper implements Except
         int errorStatus = exception.getErrorStatus();
 
         if (errorStatus == NOT_FOUND.getStatusCode()) {
-            LOGGER.warn("Authorization succeeded but Gateway account was not found in Connector", errorStatus);
-            return Response.serverError()
-                    .entity("There is an error with this account. Please contact support")
-                    .build();
+            LOGGER.error("Authorization succeeded but Gateway account was not found in Connector", errorStatus);
+            return P0199.response();
 
         }
 
         LOGGER.info("Error response from Connector unrecognised. status {}, body {}", errorStatus, exception.getErrorBody());
-        return Response.serverError().entity("Downstream system error").build();
+        return P0198.response();
+    }
+
+    enum CreateChargeErrorResponse {
+
+        P0199(INTERNAL_SERVER_ERROR, "There is an error with this account. Please contact support"),
+        P0198(INTERNAL_SERVER_ERROR, "Downstream system error");
+
+        private final Response.Status status;
+        private final String message;
+
+        CreateChargeErrorResponse(Response.Status status, String message) {
+            this.status = status;
+            this.message = message;
+        }
+
+        public Response response() {
+            return Response.status(status)
+                    .entity(new PaymentErrorResponse(name(), message))
+                    .build();
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/api/exception/CreateChargeConnectorErrorResponseExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/CreateChargeConnectorErrorResponseExceptionMapper.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.api.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.Response.Status.*;
+
+public class CreateChargeConnectorErrorResponseExceptionMapper implements ExceptionMapper<CreateChargeConnectorErrorResponseException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CreateChargeConnectorErrorResponseException.class);
+
+    @Override
+    public Response toResponse(CreateChargeConnectorErrorResponseException exception) {
+
+        int errorStatus = exception.getErrorStatus();
+
+        if (errorStatus == NOT_FOUND.getStatusCode()) {
+            LOGGER.warn("Authorization succeeded but Gateway account was not found in Connector", errorStatus);
+            return Response.serverError()
+                    .entity("There is an error with this account. Please contact support")
+                    .build();
+
+        }
+
+        LOGGER.info("Error response from Connector unrecognised. status {}, body {}", errorStatus, exception.getErrorBody());
+        return Response.serverError().entity("Downstream system error").build();
+    }
+}

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;

--- a/src/main/java/uk/gov/pay/api/model/PaymentErrorResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentErrorResponse.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.api.model;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(value="Payment Error response", description = "A Payment Error response")
+public class PaymentErrorResponse {
+    private String code;
+    private String message;
+
+    public PaymentErrorResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @ApiModelProperty(example = "P0198")
+    public String getCode() {
+        return code;
+    }
+
+    @ApiModelProperty(example = "Downstream system error")
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -218,8 +218,7 @@ public class PaymentsResource {
     @ApiResponses(value = {@ApiResponse(code = 201, message = "Created", response = PaymentWithLinks.class),
             @ApiResponse(code = 400, message = "Bad request"),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 500, message = "There is an error with this account. Please contact support"),
-            @ApiResponse(code = 500, message = "Downstream system error")})
+            @ApiResponse(code = 500, message = "Downstream system error", response = PaymentErrorResponse.class)})
     public Response createNewPayment(@ApiParam(value = "accountId", hidden = true) @Auth String accountId,
                                      @ApiParam(value = "requestPayload", required = true) @Valid CreatePaymentRequest requestPayload,
                                      @Context UriInfo uriInfo) {

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
@@ -146,13 +146,14 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
 
         postPaymentResponse(BEARER_TOKEN, SUCCESS_PAYLOAD)
                 .statusCode(500)
-                .body(is("Downstream system error"));
+                .body("code", is("P0198"))
+                .body("message", is("Downstream system error"));
 
         connectorMock.verifyCreateChargeConnectorRequest(AMOUNT, gatewayAccountId, RETURN_URL, DESCRIPTION, REFERENCE);
     }
 
     @Test
-    public void createPayment_responseWith403_whenTokenForGatewayAccountIsValidButConnectorResponseIsNotFound() {
+    public void createPayment_responseWith500_whenTokenForGatewayAccountIsValidButConnectorResponseIsNotFound() {
 
         String notFoundGatewayAccountId = "9876545";
         publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, notFoundGatewayAccountId);
@@ -160,7 +161,9 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
         connectorMock.respondNotFound_whenCreateCharge(AMOUNT, notFoundGatewayAccountId, RETURN_URL, DESCRIPTION, REFERENCE);
 
         postPaymentResponse(BEARER_TOKEN, SUCCESS_PAYLOAD)
-                .statusCode(500).body(is("Pay account error"));
+                .statusCode(500)
+                .body("code", is("P0199"))
+                .body("message", is("There is an error with this account. Please contact support"));
 
         connectorMock.verifyCreateChargeConnectorRequest(AMOUNT, notFoundGatewayAccountId, RETURN_URL, DESCRIPTION, REFERENCE);
     }

--- a/src/test/java/uk/gov/pay/api/utils/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/ConnectorMockClient.java
@@ -146,7 +146,12 @@ public class ConnectorMockClient {
 
     }
 
-    public void respondUnknownGateway_whenCreateCharge(long amount, String gatewayAccountId, String errorMsg, String returnUrl, String description, String reference) {
+    public void respondNotFound_whenCreateCharge(long amount, String gatewayAccountId, String returnUrl, String description, String reference) {
+        whenCreateCharge(amount, gatewayAccountId, returnUrl, description, reference)
+                .respond(response().withStatusCode(NOT_FOUND_404));
+    }
+
+    public void respondBadRequest_whenCreateCharge(long amount, String gatewayAccountId, String errorMsg, String returnUrl, String description, String reference) {
         whenCreateCharge(amount, gatewayAccountId, returnUrl, description, reference)
                 .respond(withStatusAndErrorMessage(BAD_REQUEST_400, errorMsg));
     }
@@ -281,7 +286,7 @@ public class ConnectorMockClient {
                 .withBody(jsonString("message", errorMsg));
     }
 
-    public void verifyCreateCharge(int amount, String gatewayAccountId, String returnUrl, String description, String reference) {
+    public void verifyCreateChargeConnectorRequest(int amount, String gatewayAccountId, String returnUrl, String description, String reference) {
         mockClient.verify(request()
                         .withMethod(POST)
                         .withPath(format(CONNECTOR_MOCK_CHARGES_PATH, gatewayAccountId))

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -87,7 +87,10 @@
             "description" : "Credentials are required to access this resource"
           },
           "500" : {
-            "description" : "Downstream system error"
+            "description" : "Downstream system error",
+            "schema" : {
+              "$ref" : "#/definitions/Payment Error response"
+            }
           }
         }
       }
@@ -210,6 +213,20 @@
         }
       },
       "description" : "The Payment Request Payload"
+    },
+    "Payment Error response" : {
+      "type" : "object",
+      "properties" : {
+        "code" : {
+          "type" : "string",
+          "example" : "P0198"
+        },
+        "message" : {
+          "type" : "string",
+          "example" : "Downstream system error"
+        }
+      },
+      "description" : "A Payment Error response"
     },
     "Payment Event information" : {
       "type" : "object",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -85,6 +85,9 @@
           },
           "401" : {
             "description" : "Credentials are required to access this resource"
+          },
+          "500" : {
+            "description" : "Downstream system error"
           }
         }
       }


### PR DESCRIPTION
- When Authorization succeed but Gateway account is Not Found in Connector, PublicAPI returns a 500 rather than a 400 Bad Request. This situation can't theoretically happen and a client can't recover from this without support.