### PR TITLE
PP-539 Fixing payment event dates and Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ Content-Type: application/json
         "next_url" : {
             "href": "http://frontend.co.uk/charge/1?chargeTokenId=82347",
             "method": "GET" 
+        },
+        "next_url_post" : {
+            "params" : {},
+            "type" : "",
+            "href": "http://frontend.co.uk/charge/1?chargeTokenId=82347",
+            "method": "POST" 
         }
     },
     "payment_id": "ab2341da231434",
@@ -138,7 +144,8 @@ Content-Type: application/json
 | `payment_provider`     | The payment provider for this payment                                                    |
 | `created_date`         | The payment creation date for this payment                                               |
 | `_links.self`          | Link to the payment                                                                      |
-| `_links.next_url`      | Where to navigate the user next                                                          |
+| `_links.next_url`      | Where to navigate the user next as a GET                                                 |
+| `_links.next_url_post` | Where to navigate the user next as a POST                                                |
 
 #### Payment creation failed
 
@@ -179,14 +186,20 @@ Content-Type: application/json
 
 {
     "_links": {
-            "self" :{
-                "href": "http://publicapi.co.uk/v1/payments/ab2341da231434",
-                "method": "GET" 
-            },
-            "next_url" : {
-                "href": "http://frontend.co.uk/charge/ab2341da231434?chargeTokenId=82347",
-                "method": "GET" 
-            }
+        "self" :{
+            "href": "http://publicapi.co.uk/v1/payments/ab2341da231434",
+            "method": "GET" 
+        },
+        "next_url" : {
+            "href": "http://frontend.co.uk/charge/ab2341da231434?chargeTokenId=82347",
+            "method": "GET" 
+        },
+        "next_url_post" : {
+            "params" : {},
+            "type" : "",
+            "href": "http://frontend.co.uk/charge/1?chargeTokenId=82347",
+            "method": "POST" 
+        }
     },
     "payment_id": "ab2341da231434",
     "amount": 50000,
@@ -245,8 +258,6 @@ Content-Type: application/json
             "updated": "2016-01-13 17:42:16",
             "_links": {
                 "payment_url" : {
-                    "params": {},
-                    "type": "multipart/form-data",
                     "method": "GET",
                     "href": "http://publicapi.co.uk/v1/payments/ab2341da231434"
                 }
@@ -258,8 +269,6 @@ Content-Type: application/json
             "updated": "2016-01-13 17:42:28",
             "_links": {
                 "payment_url" : {
-                    "params": {},
-                    "type": "multipart/form-data",
                     "method": "GET",
                     "href": "http://publicapi.co.uk/v1/payments/ab2341da231434"
                 }
@@ -271,8 +280,6 @@ Content-Type: application/json
             "updated": "2016-01-13 17:42:29",
             "_links": {
                 "payment_url" : {
-                    "params": {},
-                    "type": "multipart/form-data",
                     "method": "GET",
                     "href": "http://publicapi.co.uk/v1/payments/ab2341da231434"
                 }

--- a/src/main/java/uk/gov/pay/api/model/Link.java
+++ b/src/main/java/uk/gov/pay/api/model/Link.java
@@ -14,18 +14,10 @@ public class Link {
 
     private String href;
     private String method;
-    private String type;
-    private Map<String, Object> params;
 
     Link(String href, String method) {
         this.href = href;
         this.method = method;
-    }
-
-    Link(String href, String method, String type, Map<String, Object> params) {
-        this(href, method);
-        this.type = type;
-        this.params = params;
     }
 
     @ApiModelProperty(example = "https://an.example.link/from/payment/platform")
@@ -38,23 +30,11 @@ public class Link {
         return method;
     }
 
-    @ApiModelProperty(example = "multipart/form-data")
-    public String getType() {
-        return type;
-    }
-
-    @ApiModelProperty(example = "\"description\":\"This is a value for a parameter called description\"")
-    public Map<String, Object> getParams() {
-        return params;
-    }
-
     @Override
     public String toString() {
         return "Link{" +
                 "href='" + href + '\'' +
                 ", method='" + method + '\'' +
-                ", type='" + type + '\'' +
-                ", params=" + params +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/PaymentEvent.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentEvent.java
@@ -1,17 +1,9 @@
 package uk.gov.pay.api.model;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.joda.deser.LocalDateTimeDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 @ApiModel(value="Payment Event information", description = "A List of Payment Events information")
 public class PaymentEvent {
@@ -21,29 +13,22 @@ public class PaymentEvent {
     @JsonProperty("status")
     private final String status;
 
-    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-    @JsonSerialize(using = LocalDateTimeSerializer.class)
-    @JsonFormat(pattern="yyyy-MM-dd HH:mm:ss")
-    private final LocalDateTime updated;
+    @JsonProperty("updated")
+    private final String updated;
 
     @JsonProperty("_links")
     private PaymentEventLink paymentLink;
 
     public static PaymentEvent createPaymentEvent(JsonNode payload, String paymentLink) {
-        LocalDateTime updated = null;
-        if(payload.get("updated") != null) {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-            updated = LocalDateTime.parse(payload.get("updated").asText(), formatter);
-        }
         return new PaymentEvent(
             payload.get("charge_id").asText(),
             payload.get("status").asText(),
-            updated,
+            payload.get("updated").asText(),
             paymentLink
         );
     }
 
-    private PaymentEvent(String chargeId, String status, LocalDateTime updated, String paymentLink) {
+    private PaymentEvent(String chargeId, String status, String updated, String paymentLink) {
         this.paymentId = chargeId;
         this.status = status;
         this.updated = updated;
@@ -61,7 +46,7 @@ public class PaymentEvent {
     }
 
     @ApiModelProperty(value = "updated",example = "updated_date")
-    public LocalDateTime getUpdated() {
+    public String getUpdated() {
         return updated;
     }
 

--- a/src/main/java/uk/gov/pay/api/model/PostLink.java
+++ b/src/main/java/uk/gov/pay/api/model/PostLink.java
@@ -1,0 +1,48 @@
+package uk.gov.pay.api.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Map;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@ApiModel(value = "paymentPOSTLink", description = "A POST link related to a payment")
+@JsonInclude(Include.NON_NULL)
+public class PostLink extends Link {
+
+    private String type;
+    private Map<String, Object> params;
+
+    PostLink(String href, String method, String type, Map<String, Object> params) {
+        super(href, method);
+        this.type = type;
+        this.params = params;
+    }
+
+    @ApiModelProperty(example = "POST")
+    public String getMethod() {
+        return super.getMethod();
+    }
+
+    @ApiModelProperty(example = "multipart/form-data")
+    public String getType() {
+        return type;
+    }
+
+    @ApiModelProperty(example = "\"description\":\"This is a value for a parameter called description\"")
+    public Map<String, Object> getParams() {
+        return params;
+    }
+
+    @Override
+    public String toString() {
+        return "Link{" +
+                "href='" + getHref() + '\'' +
+                ", method='" + getMethod() + '\'' +
+                ", type='" + type + '\'' +
+                ", params=" + params +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/pay/api/model/SelfAndNextLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/SelfAndNextLinks.java
@@ -33,7 +33,7 @@ public class SelfAndNextLinks {
         return nextUrl;
     }
 
-    @ApiModelProperty(value = NEXT_URL_POST, dataType = "uk.gov.pay.api.model.Link")
+    @ApiModelProperty(value = NEXT_URL_POST, dataType = "uk.gov.pay.api.model.PostLink")
     public Link getNextUrlPost() {
         return nextUrlPost;
     }
@@ -60,7 +60,7 @@ public class SelfAndNextLinks {
         chargeLinks.stream()
                 .filter(chargeLink -> NEXT_URL_POST.equals(chargeLink.getRel()))
                 .findFirst()
-                .ifPresent(chargeLink -> this.nextUrlPost = new Link(chargeLink.getHref(), chargeLink.getMethod(), chargeLink.getType(), chargeLink.getParams()));
+                .ifPresent(chargeLink -> this.nextUrlPost = new PostLink(chargeLink.getHref(), chargeLink.getMethod(), chargeLink.getType(), chargeLink.getParams()));
     }
 
     private void addNextUrlIfPresent(List<PaymentConnectorResponseLink> chargeLinks) {

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -159,7 +159,7 @@ public class PaymentsResource {
                                    @QueryParam(STATUS_KEY) String status,
                                    @ApiParam(value = "From date of payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z", hidden = false)
                                    @QueryParam(FROM_DATE_KEY) String fromDate,
-                                   @ApiParam(value = "To date of payments to be searched (this date is exclusive). Example=2015-08-13T12:35:00Z", hidden = false)
+                                   @ApiParam(value = "To date of payments to be searched (this date is exclusive). Example=2015-08-14T12:35:00Z", hidden = false)
                                    @QueryParam(TO_DATE_KEY) String toDate,
                                    @Context UriInfo uriInfo) {
 

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -87,7 +87,9 @@ public class PaymentsResource {
     @Produces(APPLICATION_JSON)
     @ApiOperation(
             value = "Find payment by ID",
-            notes = "Return information about the payment",
+            notes = "Return information about the payment " +
+                    "The Authorisation token needs to be specified in the 'authorization' header " +
+                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             code = 200)
 
     @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = PaymentWithLinks.class),
@@ -113,7 +115,9 @@ public class PaymentsResource {
     @Produces(APPLICATION_JSON)
     @ApiOperation(
             value = "Return payment events by ID",
-            notes = "Return payment events information about a certain payment",
+            notes = "Return payment events information about a certain payment " +
+                    "The Authorisation token needs to be specified in the 'authorization' header " +
+                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             code = 200)
 
     @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = PaymentEvents.class),
@@ -143,7 +147,9 @@ public class PaymentsResource {
     @Produces(APPLICATION_JSON)
     @ApiOperation(
             value = "Search payments",
-            notes = "Search payments by reference, status, 'from' and 'to' date",
+            notes = "Search payments by reference, status, 'from' and 'to' date. " +
+                    "The Authorisation token needs to be specified in the 'authorization' header " +
+                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             responseContainer = "List",
             code = 200)
 
@@ -211,7 +217,9 @@ public class PaymentsResource {
     @Produces(APPLICATION_JSON)
     @ApiOperation(
             value = "Create new payment",
-            notes = "Create a new payment for the account associated to the Authorisation token",
+            notes = "Create a new payment for the account associated to the Authorisation token. " +
+                    "The Authorisation token needs to be specified in the 'authorization' header " +
+                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             code = 201,
             nickname = "newPayment")
 
@@ -252,7 +260,9 @@ public class PaymentsResource {
     @Produces(APPLICATION_JSON)
     @ApiOperation(
             value = "Cancel payment",
-            notes = "Cancel a payment based on the provided payment ID and the Authorisation token",
+            notes = "Cancel a payment based on the provided payment ID and the Authorisation token. " +
+                    "The Authorisation token needs to be specified in the 'authorization' header " +
+                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             code = 204)
 
     @ApiResponses(value = {@ApiResponse(code = 204, message = "No Content"),

--- a/src/test/java/uk/gov/pay/api/it/PaymentSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentSearchITest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.api.it;
 
 
 import com.google.common.collect.ImmutableMap;
+import com.jayway.jsonassert.JsonAssert;
 import com.jayway.restassured.response.ValidatableResponse;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -42,19 +43,27 @@ public class PaymentSearchITest extends PaymentResourceITestBase {
                         .build()
         );
 
-        searchPayments(BEARER_TOKEN, ImmutableMap.of("reference", TEST_REFERENCE))
+        String responseBody = searchPayments(BEARER_TOKEN, ImmutableMap.of("reference", TEST_REFERENCE))
                 .statusCode(200)
                 .contentType(JSON)
-                .body("results.get(0).created_date", is(DEFAULT_CREATED_DATE))
-                .body("results.get(0).reference", is(TEST_REFERENCE))
-                .body("results.get(0).return_url", is(DEFAULT_RETURN_URL))
-                .body("results.get(0).description", is("description-0"))
-                .body("results.get(0).status", is(TEST_STATUS))
-                .body("results.get(0).amount", is(DEFAULT_AMOUNT))
-                .body("results.get(0).payment_provider", is(DEFAULT_PAYMENT_PROVIDER))
-                .body("results.get(0).payment_id", is("0"))
-                .body("results.get(0)._links.self.method", is("GET"))
-                .body("results.get(0)._links.self.href", endsWith("/v1/payments/0"));
+                .body("results[0].created_date", is(DEFAULT_CREATED_DATE))
+                .body("results[0].reference", is(TEST_REFERENCE))
+                .body("results[0].return_url", is(DEFAULT_RETURN_URL))
+                .body("results[0].description", is("description-0"))
+                .body("results[0].status", is(TEST_STATUS))
+                .body("results[0].amount", is(DEFAULT_AMOUNT))
+                .body("results[0].payment_provider", is(DEFAULT_PAYMENT_PROVIDER))
+                .body("results[0].payment_id", is("0"))
+                .body("results[0]._links.self.method", is("GET"))
+                .body("results[0]._links.self.href", endsWith("/v1/payments/0"))
+                .extract().asString();
+
+        JsonAssert.with(responseBody)
+                .assertNotDefined("_links.self.type")
+                .assertNotDefined("_links.self.params")
+                .assertNotDefined("_links.next_url.type")
+                .assertNotDefined("_links.next_url.params");
+
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
@@ -4,12 +4,11 @@ import com.jayway.jsonassert.JsonAssert;
 import com.jayway.restassured.response.ValidatableResponse;
 import org.junit.Test;
 import uk.gov.pay.api.utils.ChargeEventBuilder;
+import uk.gov.pay.api.utils.DateTimeUtils;
 import uk.gov.pay.api.utils.JsonStringBuilder;
 
 import javax.ws.rs.core.HttpHeaders;
-import java.time.LocalDateTime;
-import java.time.Month;
-import java.time.format.DateTimeFormatter;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -30,9 +29,9 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
     private static final String RETURN_URL = "http://somewhere.gov.uk/rainbow/1";
     private static final String REFERENCE = "Some reference <script> alert('This is a ?{simple} XSS attack.')</script>";
     private static final String DESCRIPTION = "Some description <script> alert('This is a ?{simple} XSS attack.')</script>";
-    private static final LocalDateTime TIMESTAMP = LocalDateTime.of(2016, Month.JANUARY, 1, 12, 00, 00);
-    private static final String CREATED_DATE = TIMESTAMP.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:SS"));
-    private static final Map<String, String> PAYMENT_CREATED = new ChargeEventBuilder(CHARGE_ID, STATUS, TIMESTAMP).build();
+    private static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
+    private static final String CREATED_DATE = DateTimeUtils.toUTCDateString(TIMESTAMP);
+    private static final Map<String, String> PAYMENT_CREATED = new ChargeEventBuilder(CHARGE_ID, STATUS, CREATED_DATE).build();
     private static final List<Map<String, String>> EVENTS = newArrayList(PAYMENT_CREATED);
 
     private static final String SUCCESS_PAYLOAD = paymentPayload(AMOUNT, RETURN_URL, DESCRIPTION, REFERENCE);
@@ -245,7 +244,7 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
                 .body("events", hasSize(1))
                 .body("events[0].payment_id", is(CHARGE_ID))
                 .body("events[0].status", is(STATUS))
-                .body("events[0].updated", is("2016-01-01 12:00:00"))
+                .body("events[0].updated", is("2016-01-01T12:00:00Z"))
                 .body("events[0]._links.payment_url.href", is(paymentLocationFor(CHARGE_ID)));
     }
 

--- a/src/test/java/uk/gov/pay/api/utils/ChargeEventBuilder.java
+++ b/src/test/java/uk/gov/pay/api/utils/ChargeEventBuilder.java
@@ -1,14 +1,10 @@
 package uk.gov.pay.api.utils;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.joda.deser.LocalDateTimeDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
-import java.time.LocalDateTime;
 import java.util.Map;
 
 public class ChargeEventBuilder {
@@ -22,12 +18,11 @@ public class ChargeEventBuilder {
     @JsonSerialize
     private String status;
 
-    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-    @JsonSerialize(using = LocalDateTimeSerializer.class)
-    @JsonFormat(pattern="yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime updated;
+    @JsonDeserialize
+    @JsonSerialize
+    private String updated;
 
-    public ChargeEventBuilder(String chargeId, String status, LocalDateTime updated) {
+    public ChargeEventBuilder(String chargeId, String status, String updated) {
         this.chargeId = chargeId;
         this.status = status;
         this.updated = updated;
@@ -35,8 +30,7 @@ public class ChargeEventBuilder {
 
     public Map build() {
         ObjectMapper mapper = new ObjectMapper();
-        Map node = mapper.convertValue(this, Map.class);
-        return node;
+        return mapper.convertValue(this, Map.class);
     }
 
 }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -11,7 +11,7 @@
     "/v1/payments" : {
       "get" : {
         "summary" : "Search payments",
-        "description" : "Search payments by reference, status, 'from' and 'to' date",
+        "description" : "Search payments by reference, status, 'from' and 'to' date. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "searchPayments",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -60,7 +60,7 @@
       },
       "post" : {
         "summary" : "Create new payment",
-        "description" : "Create a new payment for the account associated to the Authorisation token",
+        "description" : "Create a new payment for the account associated to the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "newPayment",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
@@ -98,7 +98,7 @@
     "/v1/payments/{paymentId}" : {
       "get" : {
         "summary" : "Find payment by ID",
-        "description" : "Return information about the payment",
+        "description" : "Return information about the payment The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "getPayment",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -126,7 +126,7 @@
     "/v1/payments/{paymentId}/cancel" : {
       "post" : {
         "summary" : "Cancel payment",
-        "description" : "Cancel a payment based on the provided payment ID and the Authorisation token",
+        "description" : "Cancel a payment based on the provided payment ID and the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "cancelPayment",
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -151,7 +151,7 @@
     "/v1/payments/{paymentId}/events" : {
       "get" : {
         "summary" : "Return payment events by ID",
-        "description" : "Return payment events information about a certain payment",
+        "description" : "Return payment events information about a certain payment The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "getPaymentEvents",
         "produces" : [ "application/json" ],
         "parameters" : [ {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -36,7 +36,7 @@
         }, {
           "name" : "to_date",
           "in" : "query",
-          "description" : "To date of payments to be searched (this date is exclusive). Example=2015-08-13T12:35:00Z",
+          "description" : "To date of payments to be searched (this date is exclusive). Example=2015-08-14T12:35:00Z",
           "required" : false,
           "type" : "string"
         } ],
@@ -407,6 +407,20 @@
         "method" : {
           "type" : "string",
           "example" : "GET"
+        }
+      },
+      "description" : "A link related to a payment"
+    },
+    "paymentPOSTLink" : {
+      "type" : "object",
+      "properties" : {
+        "href" : {
+          "type" : "string",
+          "example" : "https://an.example.link/from/payment/platform"
+        },
+        "method" : {
+          "type" : "string",
+          "example" : "POST"
         },
         "type" : {
           "type" : "string",
@@ -420,7 +434,7 @@
           }
         }
       },
-      "description" : "A link related to a payment"
+      "description" : "A POST link related to a payment"
     },
     "selfAndNextLinks" : {
       "type" : "object",
@@ -437,7 +451,7 @@
         "next_url_post" : {
           "description" : "next_url_post",
           "readOnly" : true,
-          "$ref" : "#/definitions/paymentLink"
+          "$ref" : "#/definitions/paymentPOSTLink"
         }
       },
       "description" : "Resource self and next links of a Payment"

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -231,12 +231,6 @@
     "Payment Event information" : {
       "type" : "object",
       "properties" : {
-        "updated" : {
-          "type" : "string",
-          "format" : "date-time",
-          "example" : "updated_date",
-          "description" : "updated"
-        },
         "payment_id" : {
           "type" : "string",
           "example" : "hu20sqlact5260q2nanm0q8u93",
@@ -246,6 +240,12 @@
           "type" : "string",
           "example" : "SUCCEEDED",
           "description" : "status",
+          "readOnly" : true
+        },
+        "updated" : {
+          "type" : "string",
+          "example" : "updated_date",
+          "description" : "updated",
           "readOnly" : true
         },
         "_links" : {


### PR DESCRIPTION
- The payment event dates were using LocalDateTime. This has been changed now to use what the connector would return (as we do with dates returned by other end-points). Connector returns ZoneDateTime.
- The next_url_post has type and params as documentation. These don't apply to GET links. Therefore GET links and POST links are separated.
- Making it clear that authroization header requires Bearer <TOKEN> as swagger fails to document this nicely.