### PR TITLE
PP-640 Add cancel link in payment objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ Content-Type: application/json
         "events" :{
             "href": "http://publicapi.co.uk/v1/payments/ab2341da231434/events",
             "method": "GET" 
+        },
+        "cancel" : {
+            "params" : {},
+            "type" : "",
+            "href": "http://publicapi.co.uk/v1/payments/ab2341da231434/cancel",
+            "method": "POST" 
         }
     },
     "payment_id": "ab2341da231434",
@@ -150,6 +156,8 @@ Content-Type: application/json
 | `_links.self`          | Link to the payment                                                                      |
 | `_links.next_url`      | Where to navigate the user next as a GET                                                 |
 | `_links.next_url_post` | Where to navigate the user next as a POST                                                |
+| `_links.events`        | Link to payment events                                                |
+| `_links.cancel`        | Link to cancel the payment (link only available when a payment can be cancelled (i.e. payment has one of the statuses - CREATED, IN PROGRESS |
 
 #### Payment creation failed
 
@@ -207,6 +215,12 @@ Content-Type: application/json
         "events" :{
             "href": "http://publicapi.co.uk/v1/payments/ab2341da231434/events",
             "method": "GET" 
+        },
+        "cancel" : {
+            "params" : {},
+            "type" : "",
+            "href": "http://publicapi.co.uk/v1/payments/ab2341da231434/cancel",
+            "method": "POST" 
         }
     },
     "payment_id": "ab2341da231434",
@@ -399,6 +413,12 @@ Content-Type: application/json
                 "events" :{
                     "href": "http://publicapi.co.uk/v1/payments/ab2341da231434/events",
                     "method": "GET" 
+                },
+                "cancel" : {
+                    "params" : {},
+                    "type" : "",
+                    "href": "http://publicapi.co.uk/v1/payments/ab2341da231434/cancel",
+                    "method": "POST" 
                 }
         },
         "payment_id": "hu20sqlact5260q2nanm0q8u93",
@@ -426,6 +446,8 @@ Content-Type: application/json
 | `status`                 | X | The current external status of the charge       |
 | `created_date`           | X | The created date in ISO_8601 format (```yyyy-MM-ddTHH:mm:ssZ```)|
 | `_links.self`            | X | Link to the payment                                                 |
+| `_links.events`          | X | Link to payment events                                                |
+| `_links.cancel`          | - | Link to cancel the payment (link only available when a payment can be cancelled (i.e. payment has one of the statuses - CREATED, IN PROGRESS |
 
 -----------------------------------------------------------------------------------------------------------
 

--- a/src/main/java/uk/gov/pay/api/model/Payment.java
+++ b/src/main/java/uk/gov/pay/api/model/Payment.java
@@ -3,7 +3,14 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
 public abstract class Payment {
+
+    public static final List<ExternalChargeStatus> CANCELLABLE_STATUS =
+            asList(ExternalChargeStatus.EXT_CREATED, ExternalChargeStatus.EXT_IN_PROGRESS);
 
     public static final String LINKS_JSON_ATTRIBUTE = "_links";
 

--- a/src/main/java/uk/gov/pay/api/model/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentForSearchResult.java
@@ -13,16 +13,22 @@ public class PaymentForSearchResult extends Payment {
 
     public PaymentForSearchResult(String chargeId, long amount, String status, String returnUrl, String description,
                                   String reference, String paymentProvider, String createdDate,
-                                  URI selfLink, URI paymentEventsLink) {
+                                  URI selfLink, URI paymentEventsLink, URI paymentCancelLink) {
         super(chargeId, amount, status, returnUrl, description, reference, paymentProvider, createdDate);
         this.links.addSelf(selfLink.toString());
         this.links.addEvents(paymentEventsLink.toString());
+        ExternalChargeStatus.mapFromStatus(status).ifPresent((paymentStatus) -> {
+            if(CANCELLABLE_STATUS.contains(paymentStatus)) {
+                this.links.addCancel(paymentCancelLink.toString());
+            }
+        });
     }
 
     public static PaymentForSearchResult valueOf(
             PaymentConnectorResponse paymentConnectorResponse,
             URI selfLink,
-            URI paymentEventsLink) {
+            URI paymentEventsLink,
+            URI paymentCancelLink) {
         return new PaymentForSearchResult(
                 paymentConnectorResponse.getChargeId(),
                 paymentConnectorResponse.getAmount(),
@@ -33,7 +39,8 @@ public class PaymentForSearchResult extends Payment {
                 paymentConnectorResponse.getPaymentProvider(),
                 paymentConnectorResponse.getCreated_date(),
                 selfLink,
-                paymentEventsLink
+                paymentEventsLink,
+                paymentCancelLink
         );
     }
 

--- a/src/main/java/uk/gov/pay/api/model/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentWithAllLinks.java
@@ -15,15 +15,24 @@ public class PaymentWithAllLinks extends Payment {
     private PaymentWithAllLinks(String chargeId, long amount, String status, String returnUrl, String description,
                                 String reference, String paymentProvider, String createdDate,
                                 List<PaymentConnectorResponseLink> paymentConnectorResponseLinks,
-                                URI selfLink, URI paymentEventsLink) {
+                                URI selfLink, URI paymentEventsLink, URI paymentCancelUri) {
         super(chargeId, amount, status, returnUrl, description, reference, paymentProvider, createdDate);
 
         this.links.addSelf(selfLink.toString());
         this.links.addKnownLinksValueOf(paymentConnectorResponseLinks);
         this.links.addEvents(paymentEventsLink.toString());
+        ExternalChargeStatus.mapFromStatus(status)
+                .ifPresent((paymentStatus) -> {
+                    if(CANCELLABLE_STATUS.contains(paymentStatus)) {
+                        this.links.addCancel(paymentCancelUri.toString());
+                    }
+                });
     }
 
-    public static PaymentWithAllLinks valueOf(PaymentConnectorResponse paymentConnector, URI selfLink, URI paymentEventsUri) {
+    public static PaymentWithAllLinks valueOf(PaymentConnectorResponse paymentConnector,
+                                              URI selfLink,
+                                              URI paymentEventsUri,
+                                              URI paymentCancelUri) {
         return new PaymentWithAllLinks(
                 paymentConnector.getChargeId(),
                 paymentConnector.getAmount(),
@@ -35,7 +44,8 @@ public class PaymentWithAllLinks extends Payment {
                 paymentConnector.getCreated_date(),
                 paymentConnector.getLinks(),
                 selfLink,
-                paymentEventsUri
+                paymentEventsUri,
+                paymentCancelUri
         );
     }
 

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentLinks.java
@@ -8,6 +8,7 @@ import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 import java.util.List;
 
 import static javax.ws.rs.HttpMethod.GET;
+import static javax.ws.rs.HttpMethod.POST;
 
 @ApiModel(value = "allLinksForAPayment", description = "self,events and next links of a Payment")
 public class PaymentLinks {
@@ -16,6 +17,7 @@ public class PaymentLinks {
     private static final String NEXT_URL = "next_url";
     private static final String NEXT_URL_POST = "next_url_post";
     public static final String EVENTS = "events";
+    private static final String CANCEL = "cancel";
 
     @JsonProperty(value = SELF)
     private Link self;
@@ -28,6 +30,10 @@ public class PaymentLinks {
 
     @JsonProperty(value = EVENTS)
     private Link events;
+
+    @JsonProperty(value = CANCEL)
+    private PostLink cancel;
+
 
     @ApiModelProperty(value = SELF, dataType = "uk.gov.pay.api.model.links.Link")
     public Link getSelf() {
@@ -49,6 +55,11 @@ public class PaymentLinks {
         return events;
     }
 
+    @ApiModelProperty(value = CANCEL, dataType = "uk.gov.pay.api.model.links.PostLink")
+    public PostLink getCancel() {
+        return cancel;
+    }
+
     public void addKnownLinksValueOf(List<PaymentConnectorResponseLink> chargeLinks) {
         addNextUrlIfPresent(chargeLinks);
         addNextUrlPostIfPresent(chargeLinks);
@@ -60,6 +71,10 @@ public class PaymentLinks {
 
     public void addEvents(String href) {
         this.events = new Link(href, GET);
+    }
+
+    public void addCancel(String href) {
+        this.cancel = new PostLink(href, POST);
     }
 
     private void addNextUrlPostIfPresent(List<PaymentConnectorResponseLink> chargeLinks) {

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentLinksForSearch.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentLinksForSearch.java
@@ -5,15 +5,20 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 import static javax.ws.rs.HttpMethod.GET;
+import static javax.ws.rs.HttpMethod.POST;
 
 @ApiModel(value = "linksForSearchResults", description = "links for search payment resource")
 public class PaymentLinksForSearch {
 
     public static final String SELF = "self";
     public static final String EVENTS = "events";
+    private static final String CANCEL = "cancel";
 
     @JsonProperty(value = SELF)
     private Link self;
+
+    @JsonProperty(value = CANCEL)
+    private PostLink cancel;
 
     @JsonProperty(value = EVENTS)
     private Link events;
@@ -23,10 +28,16 @@ public class PaymentLinksForSearch {
         return self;
     }
 
+    @ApiModelProperty(value = CANCEL, dataType = "uk.gov.pay.api.model.links.PostLink")
+    public PostLink getCancel() {
+        return cancel;
+    }
+
     @ApiModelProperty(value = EVENTS, dataType = "uk.gov.pay.api.model.links.Link")
     public Link getEvents() {
         return events;
     }
+
 
     public void addSelf(String href) {
         this.self = new Link(href, GET);
@@ -34,5 +45,9 @@ public class PaymentLinksForSearch {
 
     public void addEvents(String href) {
         this.events = new Link(href, GET);
+    }
+
+    public void addCancel(String href) {
+        this.cancel = new PostLink(href, POST);
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/links/PostLink.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PostLink.java
@@ -21,6 +21,10 @@ public class PostLink extends Link {
         this.params = params;
     }
 
+    PostLink(String href, String method) {
+        super(href, method);
+    }
+
     @ApiModelProperty(example = "POST")
     public String getMethod() {
         return super.getMethod();

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -19,16 +19,9 @@ import javax.ws.rs.*;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.*;
-import javax.ws.rs.core.Response.ResponseBuilder;
 import java.io.IOException;
 import java.net.URI;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Supplier;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -100,14 +93,27 @@ public class PaymentsResource {
                                @Context UriInfo uriInfo) {
 
         logger.info("received get payment request: [ {} ]", paymentId);
-
-        Response connectorResponse = client.target(connectorUrl + format(CONNECTOR_CHARGE_RESOURCE, accountId, paymentId))
+        Response connectorResponse = client
+                .target(getConnectorUlr(format(CONNECTOR_CHARGE_RESOURCE, accountId, paymentId)))
                 .request()
                 .get();
 
-        return responseForPaymentWithLinks(uriInfo, connectorResponse, SC_OK,
-                (locationUrl, data) -> Response.ok(data),
-                data -> notFoundResponse(logger, data));
+
+        if (connectorResponse.getStatus() == SC_OK) {
+            PaymentConnectorResponse response = connectorResponse.readEntity(PaymentConnectorResponse.class);
+            URI paymentURI = getPaymentURI(uriInfo, response.getChargeId());
+
+            PaymentWithAllLinks payment = PaymentWithAllLinks.valueOf(
+                    response,
+                    paymentURI,
+                    getPaymentEventsURI(uriInfo, response.getChargeId()),
+                    getPaymentCancelURI(uriInfo, response.getChargeId()));
+
+            logger.info("payment returned: [ {} ]", payment);
+            return Response.ok(payment).build();
+        } else {
+            return notFoundResponse(logger, connectorResponse.readEntity(JsonNode.class));
+        }
     }
 
     @GET
@@ -129,17 +135,31 @@ public class PaymentsResource {
 
         logger.info("received get payment request: [ {} ]", paymentId);
 
-        Response connectorResponse = client.target(connectorUrl + format(CONNECTOR_CHARGE_EVENTS_RESOURCE, accountId, paymentId))
+        Response connectorResponse = client
+                .target(getConnectorUlr(format(CONNECTOR_CHARGE_EVENTS_RESOURCE, accountId, paymentId)))
                 .request()
                 .get();
 
-        return eventsResponseFrom(
-                    uriInfo,
-                    connectorResponse,
-                    SC_OK,
-                    (locationUrl, data) -> Response.ok(data),
-                    data -> notFoundResponse(logger, data)
-        );
+        if (!connectorResponse.hasEntity()) {
+            return badRequestResponse(logger, "Connector response contains no payload!");
+        }
+
+        JsonNode payload = connectorResponse.readEntity(JsonNode.class);
+        if (connectorResponse.getStatus() == SC_OK) {
+            URI paymentEventsLink = getPaymentEventsURI(uriInfo, payload.get(CHARGE_KEY).asText());
+
+            URI paymentLink = getPaymentURI(uriInfo, payload.get(CHARGE_KEY).asText());
+
+            PaymentEvents response =
+                    PaymentEvents.createPaymentEventsResponse(payload, paymentLink.toString())
+                            .withSelfLink(paymentEventsLink.toString());
+
+            logger.info("payment returned: [ {} ]", response);
+
+            return Response.ok(response).build();
+        }
+
+        return notFoundResponse(logger, payload);
     }
 
     @GET
@@ -174,41 +194,53 @@ public class PaymentsResource {
 
         List<Pair<String, String>> validationErrors = new LinkedList<>();
 
-        if (!validateStatus(status)) {
-            validationErrors.add(Pair.of(STATUS_KEY, status));
-        }
+        validateSearchCriteria(status, fromDate, toDate, validationErrors);
 
-        if (!validateDate(fromDate)) {
-            validationErrors.add(Pair.of(FROM_DATE_KEY, fromDate));
-        }
-
-        if (!validateDate(toDate)) {
-            validationErrors.add(Pair.of(TO_DATE_KEY, toDate));
-        }
-
-        if (validationErrors.isEmpty()) {
-            List<Pair<String, String>> queryParams = asList(
-                    Pair.of(REFERENCE_KEY, reference),
-                    Pair.of(STATUS_KEY, upperCase(status)),
-                    Pair.of(FROM_DATE_KEY, fromDate),
-                    Pair.of(TO_DATE_KEY, toDate)
-            );
-
-            Response connectorResponse = client.target(getConnectorUlr(accountId, queryParams))
-                    .request()
-                    .header(HttpHeaders.ACCEPT, APPLICATION_JSON)
-                    .get();
-
-            return responseForPaymentSearchResults(
-                    uriInfo,
-                    connectorResponse, SC_OK,
-                    Response::ok,
-                    () -> serverErrorResponse(logger, "Search payments failed")
-            );
-
-        } else {
+        if (!validationErrors.isEmpty()) {
             return unprocessableEntityResponse(logger, errorMessageFrom(validationErrors));
         }
+
+        List<Pair<String, String>> queryParams = asList(
+                Pair.of(REFERENCE_KEY, reference),
+                Pair.of(STATUS_KEY, upperCase(status)),
+                Pair.of(FROM_DATE_KEY, fromDate),
+                Pair.of(TO_DATE_KEY, toDate)
+        );
+
+        Response connectorResponse = client
+                .target(getConnectorUlr(format(CONNECTOR_CHARGES_RESOURCE, accountId), queryParams))
+                .request()
+                .header(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .get();
+
+        if (connectorResponse.getStatus() == SC_OK) {
+            try {
+                JsonNode responseJson = connectorResponse.readEntity(JsonNode.class);
+
+                TypeReference<HashMap<String, List<PaymentConnectorResponse>>> typeRef
+                        = new TypeReference<HashMap<String, List<PaymentConnectorResponse>>>() {
+                };
+
+                Map<String, List<PaymentConnectorResponse>> chargesMap
+                        = objectMapper.readValue(responseJson.traverse(), typeRef);
+
+                List<PaymentForSearchResult> paymentsForSearchResults = chargesMap.get("results")
+                        .stream()
+                        .map(charge -> PaymentForSearchResult.valueOf(
+                                charge,
+                                getPaymentURI(uriInfo, charge.getChargeId()),
+                                getPaymentEventsURI(uriInfo, charge.getChargeId()),
+                                getPaymentCancelURI(uriInfo, charge.getChargeId())))
+                        .collect(Collectors.toList());
+
+                return Response.ok(new PaymentSearchResults(paymentsForSearchResults)).build();
+
+            } catch (IOException e) {
+                return serverErrorResponse(logger, "Search payments failed");
+            }
+        }
+
+        return serverErrorResponse(logger, "Search payments failed");
     }
 
     @POST
@@ -233,7 +265,8 @@ public class PaymentsResource {
 
         logger.info("received create payment request: [ {} ]", requestPayload);
 
-        Response connectorResponse = client.target(connectorUrl + format(CONNECTOR_CHARGES_RESOURCE, accountId))
+        Response connectorResponse = client
+                .target(getConnectorUlr(format(CONNECTOR_CHARGES_RESOURCE, accountId)))
                 .request()
                 .post(buildChargeRequestPayload(requestPayload));
 
@@ -241,19 +274,13 @@ public class PaymentsResource {
 
             PaymentConnectorResponse response = connectorResponse.readEntity(PaymentConnectorResponse.class);
 
-            URI paymentUri = uriInfo.getBaseUriBuilder()
-                    .path(PAYMENT_BY_ID)
-                    .build(response.getChargeId());
+            URI paymentUri = getPaymentURI(uriInfo, response.getChargeId());
 
-            URI paymentEventsUri = uriInfo.getBaseUriBuilder()
-                    .path(PAYMENT_EVENTS_BY_ID)
-                    .build(response.getChargeId());
-
-            URI paymentCancelUri = uriInfo.getBaseUriBuilder()
-                    .path(CANCEL_PAYMENT_PATH)
-                    .build(response.getChargeId());
-
-            PaymentWithAllLinks payment = PaymentWithAllLinks.valueOf(response, paymentUri, paymentEventsUri, paymentCancelUri);
+            PaymentWithAllLinks payment = PaymentWithAllLinks.valueOf(
+                    response,
+                    paymentUri,
+                    getPaymentEventsURI(uriInfo, response.getChargeId()),
+                    getPaymentCancelURI(uriInfo, response.getChargeId()));
 
             logger.info("payment returned: [ {} ]", payment);
             return Response.created(paymentUri).entity(payment).build();
@@ -270,7 +297,8 @@ public class PaymentsResource {
             value = "Cancel payment",
             notes = "Cancel a payment based on the provided payment ID and the Authorisation token. " +
                     "The Authorisation token needs to be specified in the 'authorization' header " +
-                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
+                    "as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be cancelled if its in " +
+                    "a CREATED or IN PROGRESS status",
             code = 204)
 
     @ApiResponses(value = {@ApiResponse(code = 204, message = "No Content"),
@@ -282,7 +310,8 @@ public class PaymentsResource {
 
         logger.info("received cancel payment request: [{}]", paymentId);
 
-        Response connectorResponse = client.target(connectorUrl + format(CONNECTOR_ACCOUNT_CHARGE_CANCEL_RESOURCE, accountId, paymentId))
+        Response connectorResponse = client
+                .target(getConnectorUlr(format(CONNECTOR_ACCOUNT_CHARGE_CANCEL_RESOURCE, accountId, paymentId)))
                 .request()
                 .post(Entity.json("{}"));
 
@@ -293,15 +322,46 @@ public class PaymentsResource {
         return badRequestResponse(logger, "Cancellation of charge failed.");
     }
 
-    private String errorMessageFrom(List<Pair<String, String>> invalidParams) {
-        List<String> keys = invalidParams.stream().map(Pair::getLeft).collect(Collectors.toList());
-        return String.format("fields [%s] are not in correct format. see public api documentation for the correct data formats", StringUtils.join(keys, ", "));
+    private void validateSearchCriteria(String status, String fromDate, String toDate, List<Pair<String, String>> validationErrors) {
+        if (!validateStatus(status)) {
+            validationErrors.add(Pair.of(STATUS_KEY, status));
+        }
+
+        if (!validateDate(fromDate)) {
+            validationErrors.add(Pair.of(FROM_DATE_KEY, fromDate));
+        }
+
+        if (!validateDate(toDate)) {
+            validationErrors.add(Pair.of(TO_DATE_KEY, toDate));
+        }
     }
 
-    private String getConnectorUlr(String accountId, List<Pair<String, String>> queryParams) {
+    private URI getPaymentURI(UriInfo uriInfo, String chargeId) {
+        return uriInfo.getBaseUriBuilder()
+                .path(PAYMENT_BY_ID)
+                .build(chargeId);
+    }
+
+    private URI getPaymentEventsURI(UriInfo uriInfo, String chargeId) {
+        return uriInfo.getBaseUriBuilder()
+                .path(PAYMENT_EVENTS_BY_ID)
+                .build(chargeId);
+    }
+
+    private URI getPaymentCancelURI(UriInfo uriInfo, String chargeId) {
+        return uriInfo.getBaseUriBuilder()
+                .path(CANCEL_PAYMENT_PATH)
+                .build(chargeId);
+    }
+
+    private String getConnectorUlr(String urlPath) {
+        return getConnectorUlr(urlPath, Collections.emptyList());
+    }
+
+    private String getConnectorUlr(String urlPath, List<Pair<String, String>> queryParams) {
         UriBuilder builder = UriBuilder
                 .fromPath(connectorUrl)
-                .path(format(CONNECTOR_CHARGES_RESOURCE, accountId));
+                .path(urlPath);
 
         queryParams.stream().forEach(pair -> {
             if (isNotBlank(pair.getRight())) {
@@ -311,103 +371,9 @@ public class PaymentsResource {
         return builder.toString();
     }
 
-    private Response responseForPaymentWithLinks(UriInfo uriInfo, Response connectorResponse, int okStatus,
-                                                 BiFunction<URI, Object, ResponseBuilder> okResponse,
-                                                 Function<JsonNode, Response> errorResponse) {
-        if (connectorResponse.getStatus() == okStatus) {
-            PaymentConnectorResponse response = connectorResponse.readEntity(PaymentConnectorResponse.class);
-            URI documentLocation = uriInfo.getBaseUriBuilder()
-                    .path(PAYMENT_BY_ID)
-                    .build(response.getChargeId());
-
-            URI paymentLink = uriInfo.getBaseUriBuilder()
-                    .path(PAYMENT_EVENTS_BY_ID)
-                    .build(response.getChargeId());
-
-            URI paymentCancelUri = uriInfo.getBaseUriBuilder()
-                    .path(CANCEL_PAYMENT_PATH)
-                    .build(response.getChargeId());
-
-            PaymentWithAllLinks payment = PaymentWithAllLinks.valueOf(response, documentLocation, paymentLink, paymentCancelUri);
-
-            logger.info("payment returned: [ {} ]", payment);
-            return okResponse.apply(documentLocation, payment).build();
-        } else {
-            return errorResponse.apply(connectorResponse.readEntity(JsonNode.class));
-        }
-    }
-
-    private Response responseForPaymentSearchResults(UriInfo uriInfo, Response connectorResponse, int okStatus,
-                                                     Function<Object, ResponseBuilder> okResponse,
-                                                     Supplier<Response> errorResponse) {
-
-        if (connectorResponse.getStatus() == okStatus) {
-            try {
-                JsonNode responseJson = connectorResponse.readEntity(JsonNode.class);
-
-                TypeReference<HashMap<String, List<PaymentConnectorResponse>>> typeRef
-                        = new TypeReference<HashMap<String, List<PaymentConnectorResponse>>>() {
-                };
-
-                Map<String, List<PaymentConnectorResponse>> chargesMap
-                        = objectMapper.readValue(responseJson.traverse(), typeRef);
-
-                List<PaymentForSearchResult> paymentsForSearchResults = chargesMap.get("results")
-                        .stream()
-                        .map(charge -> {
-                            URI paymentLink = uriInfo.getBaseUriBuilder()
-                                    .path(PAYMENT_BY_ID)
-                                    .build(charge.getChargeId());
-
-                            URI paymentEventsUri = uriInfo.getBaseUriBuilder()
-                                    .path(PAYMENT_EVENTS_BY_ID)
-                                    .build(charge.getChargeId());
-
-                            URI paymentCancelUri = uriInfo.getBaseUriBuilder()
-                                    .path(CANCEL_PAYMENT_PATH)
-                                    .build(charge.getChargeId());
-
-                            return PaymentForSearchResult.valueOf(charge, paymentLink, paymentEventsUri, paymentCancelUri);
-                        })
-                        .collect(Collectors.toList());
-
-                return okResponse.apply(new PaymentSearchResults(paymentsForSearchResults)).build();
-
-            } catch (IOException e) {
-                return errorResponse.get();
-            }
-        }
-
-        return errorResponse.get();
-    }
-
-    private Response eventsResponseFrom(UriInfo uriInfo, Response connectorResponse, int okStatus,
-                                        BiFunction<URI, Object, ResponseBuilder> okResponse,
-                                        Function<JsonNode, Response> errorResponse) {
-        if (!connectorResponse.hasEntity()) {
-            return badRequestResponse(logger, "Connector response contains no payload!");
-        }
-
-        JsonNode payload = connectorResponse.readEntity(JsonNode.class);
-        if (connectorResponse.getStatus() == okStatus) {
-            URI paymentEventsLink = uriInfo.getBaseUriBuilder()
-                    .path(PAYMENT_EVENTS_BY_ID)
-                    .build(payload.get(CHARGE_KEY).asText());
-
-            URI paymentLink = uriInfo.getBaseUriBuilder()
-                    .path(PAYMENT_BY_ID)
-                    .build(payload.get(CHARGE_KEY).asText());
-
-            PaymentEvents response =
-                    PaymentEvents.createPaymentEventsResponse(payload, paymentLink.toString())
-                            .withSelfLink(paymentEventsLink.toString());
-
-            logger.info("payment returned: [ {} ]", response);
-
-            return okResponse.apply(paymentEventsLink, response).build();
-        }
-
-        return errorResponse.apply(payload);
+    private String errorMessageFrom(List<Pair<String, String>> invalidParams) {
+        List<String> keys = invalidParams.stream().map(Pair::getLeft).collect(Collectors.toList());
+        return String.format("fields [%s] are not in correct format. see public api documentation for the correct data formats", StringUtils.join(keys, ", "));
     }
 
     private Entity buildChargeRequestPayload(CreatePaymentRequest requestPayload) {

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -199,7 +199,7 @@ public class PaymentsResource {
                     .header(HttpHeaders.ACCEPT, APPLICATION_JSON)
                     .get();
 
-            return responseForPaymentsForSearchResults(
+            return responseForPaymentSearchResults(
                     uriInfo,
                     connectorResponse, SC_OK,
                     Response::ok,
@@ -249,7 +249,11 @@ public class PaymentsResource {
                     .path(PAYMENT_EVENTS_BY_ID)
                     .build(response.getChargeId());
 
-            PaymentWithAllLinks payment = PaymentWithAllLinks.valueOf(response, paymentUri, paymentEventsUri);
+            URI paymentCancelUri = uriInfo.getBaseUriBuilder()
+                    .path(CANCEL_PAYMENT_PATH)
+                    .build(response.getChargeId());
+
+            PaymentWithAllLinks payment = PaymentWithAllLinks.valueOf(response, paymentUri, paymentEventsUri, paymentCancelUri);
 
             logger.info("payment returned: [ {} ]", payment);
             return Response.created(paymentUri).entity(payment).build();
@@ -320,7 +324,11 @@ public class PaymentsResource {
                     .path(PAYMENT_EVENTS_BY_ID)
                     .build(response.getChargeId());
 
-            PaymentWithAllLinks payment = PaymentWithAllLinks.valueOf(response, documentLocation, paymentLink);
+            URI paymentCancelUri = uriInfo.getBaseUriBuilder()
+                    .path(CANCEL_PAYMENT_PATH)
+                    .build(response.getChargeId());
+
+            PaymentWithAllLinks payment = PaymentWithAllLinks.valueOf(response, documentLocation, paymentLink, paymentCancelUri);
 
             logger.info("payment returned: [ {} ]", payment);
             return okResponse.apply(documentLocation, payment).build();
@@ -329,9 +337,9 @@ public class PaymentsResource {
         }
     }
 
-    private Response responseForPaymentsForSearchResults(UriInfo uriInfo, Response connectorResponse, int okStatus,
-                                                         Function<Object, ResponseBuilder> okResponse,
-                                                         Supplier<Response> errorResponse) {
+    private Response responseForPaymentSearchResults(UriInfo uriInfo, Response connectorResponse, int okStatus,
+                                                     Function<Object, ResponseBuilder> okResponse,
+                                                     Supplier<Response> errorResponse) {
 
         if (connectorResponse.getStatus() == okStatus) {
             try {
@@ -355,7 +363,11 @@ public class PaymentsResource {
                                     .path(PAYMENT_EVENTS_BY_ID)
                                     .build(charge.getChargeId());
 
-                            return PaymentForSearchResult.valueOf(charge, paymentLink, paymentEventsUri);
+                            URI paymentCancelUri = uriInfo.getBaseUriBuilder()
+                                    .path(CANCEL_PAYMENT_PATH)
+                                    .build(charge.getChargeId());
+
+                            return PaymentForSearchResult.valueOf(charge, paymentLink, paymentEventsUri, paymentCancelUri);
                         })
                         .collect(Collectors.toList());
 

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
@@ -56,4 +56,8 @@ public abstract class PaymentResourceITestBase {
         return paymentLocationFor(chargeId) + "/events";
     }
 
+    String paymentCancelLocationFor(String chargeId) {
+        return paymentLocationFor(chargeId) + "/cancel";
+    }
+
 }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -126,7 +126,7 @@
     "/v1/payments/{paymentId}/cancel" : {
       "post" : {
         "summary" : "Cancel payment",
-        "description" : "Cancel a payment based on the provided payment ID and the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
+        "description" : "Cancel a payment based on the provided payment ID and the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be cancelled if its in a CREATED or IN PROGRESS status",
         "operationId" : "cancelPayment",
         "produces" : [ "application/json" ],
         "parameters" : [ {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -408,6 +408,11 @@
           "description" : "events",
           "readOnly" : true,
           "$ref" : "#/definitions/paymentLink"
+        },
+        "cancel" : {
+          "description" : "cancel",
+          "readOnly" : true,
+          "$ref" : "#/definitions/paymentPOSTLink"
         }
       },
       "description" : "self,events and next links of a Payment"
@@ -430,6 +435,11 @@
           "description" : "self",
           "readOnly" : true,
           "$ref" : "#/definitions/paymentLink"
+        },
+        "cancel" : {
+          "description" : "cancel",
+          "readOnly" : true,
+          "$ref" : "#/definitions/paymentPOSTLink"
         },
         "events" : {
           "description" : "events",


### PR DESCRIPTION
**WHAT**
Introduces a cancel link in payment objects returned for creating a payment, issuing a GET on a payment and searching for a payment
Also includes some refactoring.

**HOW TO REVIEW**
Apart from the code changes, review the README as well please.
Also when reviewing this please note that https://payments-platform.atlassian.net/browse/PP-640 is also ready for review

**WHO**
any dev
