### PR TITLE
PP-677 stopped publicapi events end point from throwing null pointer for missing chargeID

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/PaymentEvent.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentEvent.java
@@ -20,17 +20,12 @@ public class PaymentEvent {
     @JsonProperty("_links")
     private PaymentEventLink paymentLink;
 
-    public static PaymentEvent createPaymentEvent(JsonNode payload, String paymentLink) {
-        return new PaymentEvent(
-            payload.get("charge_id").asText(),
-            payload.get("status").asText(),
-            payload.get("updated").asText(),
-            paymentLink
-        );
+    public static PaymentEvent createPaymentEvent(JsonNode payload, String paymentLink, String paymentId) {
+        return new PaymentEvent(paymentId, payload.get("status").asText(), payload.get("updated").asText(), paymentLink);
     }
 
-    private PaymentEvent(String chargeId, String status, String updated, String paymentLink) {
-        this.paymentId = chargeId;
+    private PaymentEvent(String paymentId, String status, String updated, String paymentLink) {
+        this.paymentId = paymentId;
         this.status = status;
         this.updated = updated;
         this.paymentLink = new PaymentEventLink(paymentLink);

--- a/src/main/java/uk/gov/pay/api/model/PaymentEvents.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentEvents.java
@@ -13,6 +13,7 @@ import static uk.gov.pay.api.model.PaymentEvent.createPaymentEvent;
 
 @ApiModel(value="PaymentEventsInformation", description = "A List of Payment Events information")
 public class PaymentEvents {
+    public static final String EVENTS = "events";
     @JsonProperty("payment_id")
     private final String paymentId;
 
@@ -23,9 +24,11 @@ public class PaymentEvents {
 
     public static PaymentEvents createPaymentEventsResponse(JsonNode payload, String paymentLink) {
         List<PaymentEvent> events = newArrayList();
-        if(payload.get("events").isArray()) {
-            for (JsonNode event : payload.get("events")) {
-                events.add(createPaymentEvent(event, paymentLink));
+        String paymentId = payload.get("charge_id").asText();
+
+        if(payload.get(EVENTS).isArray()) {
+            for (JsonNode event : payload.get(EVENTS)) {
+                events.add(createPaymentEvent(event, paymentLink, paymentId));
             }
         }
         return new PaymentEvents(

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
@@ -37,7 +37,7 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
     private static final String DESCRIPTION = "Some description <script> alert('This is a ?{simple} XSS attack.')</script>";
     private static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
     private static final String CREATED_DATE = DateTimeUtils.toUTCDateString(TIMESTAMP);
-    private static final Map<String, String> PAYMENT_CREATED = new ChargeEventBuilder(CHARGE_ID, STATUS, CREATED_DATE).build();
+    private static final Map<String, String> PAYMENT_CREATED = new ChargeEventBuilder(STATUS, CREATED_DATE).build();
     private static final List<Map<String, String>> EVENTS = Collections.singletonList(PAYMENT_CREATED);
 
     private static final String SUCCESS_PAYLOAD = paymentPayload(AMOUNT, RETURN_URL, DESCRIPTION, REFERENCE);

--- a/src/test/java/uk/gov/pay/api/utils/ChargeEventBuilder.java
+++ b/src/test/java/uk/gov/pay/api/utils/ChargeEventBuilder.java
@@ -11,19 +11,13 @@ public class ChargeEventBuilder {
 
     @JsonDeserialize
     @JsonSerialize
-    @JsonProperty("charge_id")
-    private String chargeId;
-
-    @JsonDeserialize
-    @JsonSerialize
     private String status;
 
     @JsonDeserialize
     @JsonSerialize
     private String updated;
 
-    public ChargeEventBuilder(String chargeId, String status, String updated) {
-        this.chargeId = chargeId;
+    public ChargeEventBuilder(String status, String updated) {
         this.status = status;
         this.updated = updated;
     }


### PR DESCRIPTION
Connector doesn’t return chargeID with every event structure anymore as its in the top level of the structure, which was causing null pointer exception as it was being probed from within the events, this fix stops the chargeId from being probed within every event and looks for it at the top level instead