### PR TITLE
PP-656 Improve healthchecks so they are consistent and more useful

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ hs_err_pid*
 # Maven
 target
 
+# Floobits
+.floo
+.flooignore
+
 bin
 
 .DS_Store

--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -16,6 +16,7 @@ import uk.gov.pay.api.exception.mapper.*;
 import uk.gov.pay.api.healthcheck.Ping;
 import uk.gov.pay.api.json.CreatePaymentRequestDeserializer;
 import uk.gov.pay.api.model.CreatePaymentRequest;
+import uk.gov.pay.api.resources.HealthCheckResource;
 import uk.gov.pay.api.resources.PaymentsResource;
 import uk.gov.pay.api.validation.PaymentRequestValidator;
 import uk.gov.pay.api.validation.URLValidator;
@@ -45,6 +46,7 @@ public class PublicApi extends Application<PublicApiConfig> {
         environment.healthChecks().register("ping", new Ping());
 
         environment.jersey().register(new PaymentsResource(client, config.getConnectorUrl()));
+        environment.jersey().register(new HealthCheckResource(environment));
         environment.jersey().register(AuthFactory.binder(new OAuthFactory<>(new AccountAuthenticator(client, config.getPublicAuthUrl()), "", String.class)));
         environment.jersey().register(CreateChargeExceptionMapper.class);
         environment.jersey().register(GetChargeExceptionMapper.class);

--- a/src/main/java/uk/gov/pay/api/resources/HealthCheckResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/HealthCheckResource.java
@@ -1,0 +1,56 @@
+package uk.gov.pay.api.resources;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.setup.Environment;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.Response.status;
+
+@Path("/")
+public class HealthCheckResource {
+    public static final String HEALTHCHECK = "healthcheck";
+    public static final String HEALTHY = "healthy";
+
+    Environment environment;
+
+    public HealthCheckResource(Environment environment) {
+        this.environment = environment;
+    }
+
+    @GET
+    @Path(HEALTHCHECK)
+    @Produces(APPLICATION_JSON)
+    public Response healthCheck() throws JsonProcessingException {
+        SortedMap<String, HealthCheck.Result> results = environment.healthChecks().runHealthChecks();
+
+        Map<String, Map<String, Boolean>> response = getResponse(results);
+
+        boolean healthy = results.size() == results.values()
+                .stream()
+                .filter(HealthCheck.Result::isHealthy)
+                .count();
+
+        if(healthy) {
+            return Response.ok().entity(response).build();
+        }
+        return status(503).entity(response).build();
+    }
+
+    private Map<String, Map<String, Boolean>> getResponse(SortedMap<String, HealthCheck.Result> results) {
+        Map<String, Map<String, Boolean>> response = new HashMap<>();
+        for (SortedMap.Entry<String, HealthCheck.Result> entry : results.entrySet() ) {
+            response.put(entry.getKey(), ImmutableMap.of(HEALTHY, entry.getValue().isHealthy()));
+        }
+        return response;
+    }
+}

--- a/src/test/java/uk/gov/pay/api/it/HealthCheckResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/HealthCheckResourceITest.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.api.it;
+
+import com.jayway.restassured.RestAssured;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.api.resources.HealthCheckResource.HEALTHCHECK;
+
+public class HealthCheckResourceITest extends PaymentResourceITestBase {
+
+    @Test
+    public void getAccountShouldReturn404IfAccountIdIsUnknown() throws Exception {
+        RestAssured.given().port(app.getLocalPort())
+                .get(HEALTHCHECK)
+                .then()
+                .statusCode(200)
+                .body("ping.healthy", is(true))
+                .body("deadlocks.healthy", is(true));
+    }
+}

--- a/src/test/java/uk/gov/pay/api/resources/HealthCheckResourceTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/HealthCheckResourceTest.java
@@ -1,0 +1,93 @@
+package uk.gov.pay.api.resources;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.jayway.jsonassert.JsonAssert;
+import io.dropwizard.setup.Environment;
+import org.hamcrest.core.Is;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.ws.rs.core.Response;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HealthCheckResourceTest {
+    @Mock
+    private Environment environment;
+
+    @Mock
+    private HealthCheckRegistry healthCheckRegistry;
+
+    private HealthCheckResource resource;
+
+    @Before
+    public void setup() {
+        when(environment.healthChecks()).thenReturn(healthCheckRegistry);
+        resource = new HealthCheckResource(environment);
+    }
+
+    @Test
+    public void checkHealthCheck_isUnHealthy() throws JsonProcessingException {
+        SortedMap<String,HealthCheck.Result> map = new TreeMap<>();
+        map.put("ping", HealthCheck.Result.unhealthy("application is unavailable"));
+        map.put("deadlocks", HealthCheck.Result.unhealthy("no new threads available"));
+        when(healthCheckRegistry.runHealthChecks()).thenReturn(map);
+        Response response = resource.healthCheck();
+        assertThat(response.getStatus(), is(503));
+        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        String body = ow.writeValueAsString(response.getEntity());
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(2))
+                .assertThat("$.ping.healthy", Is.is(false))
+                .assertThat("$.deadlocks.healthy", Is.is(false));
+    }
+
+    @Test
+    public void checkHealthCheck_isHealthy() throws JsonProcessingException {
+        SortedMap<String,HealthCheck.Result> map = new TreeMap<>();
+        map.put("ping", HealthCheck.Result.healthy());
+        map.put("deadlocks", HealthCheck.Result.healthy());
+        when(healthCheckRegistry.runHealthChecks()).thenReturn(map);
+        Response response = resource.healthCheck();
+        assertThat(response.getStatus(), is(200));
+        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        String body = ow.writeValueAsString(response.getEntity());
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(2))
+                .assertThat("$.ping.healthy", Is.is(true))
+                .assertThat("$.deadlocks.healthy", Is.is(true));
+    }
+
+    @Test
+    public void checkHealthCheck_pingIsHealthy_deadlocksIsUnhealthy() throws JsonProcessingException {
+        SortedMap<String,HealthCheck.Result> map = new TreeMap<>();
+        map.put("ping", HealthCheck.Result.healthy());
+        map.put("deadlocks", HealthCheck.Result.unhealthy("no new threads available"));
+        when(healthCheckRegistry.runHealthChecks()).thenReturn(map);
+        Response response = resource.healthCheck();
+        assertThat(response.getStatus(), is(503));
+        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        String body = ow.writeValueAsString(response.getEntity());
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(2))
+                .assertThat("$.ping.healthy", Is.is(true))
+                .assertThat("$.deadlocks.healthy", Is.is(false));
+    }
+
+}


### PR DESCRIPTION
## WHAT
 * The DropWizard healthcheck endpoint is on the admin port and this
   creates much more complexity when routing ports through nginxes, proxies
   and security groups.

## HOW 
 * The Healthcheck should be available on the application port, making use
   of the existing healthchecks that follow Dropwizard's standards.

## WHO
 * Developers and DevOps