### PR TITLE
PP-571 Authorization check - Rate Limiter - depends on publicauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ Then the script creates a keystore (KEYSTORE_FILE) in a separate directory (KEYS
 | KEYSTORE_DIR                | Yes      |  The directory where the java keystore will be created |
 | KEYSTORE_FILE               | Yes      |  The name of the java keystore file |
 
+## Rate limiter and Authorization filters setup
+
+These ara the variables related to Public API filters.
+
+| Variable                    | required         |  Description                               |
+| --------------------------- | -----------------| ------------------------------------------ |
+| RATE_LIMITER_VALUE          | No (Default 3)   | Number of requests allowed per time defined by RATE_LIMITER_PER_MILLIS |
+| RATE_LIMITER_PER_MILLIS     | No (Default 1000)| Rate limiter time window |
+| TOKEN_API_HMAC_SECRET       | Yes              | Hmac secret to be used to validate that the given token is genuine (Api Key = Token + Hmac (Token, Secret) |
 
 For example:
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>commons-validator</artifactId>
             <version>1.5.0</version>
         </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.10</version>
+        </dependency>
 
         <!-- testing -->
         <dependency>

--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
@@ -17,8 +17,12 @@ public class PublicApiConfig extends Configuration {
     @JsonProperty("jerseyClientConfig")
     private RestClientConfig restClientConfig;
 
+    @Valid
+    @NotNull
     @JsonProperty("rateLimiter")
     private RateLimiterConfig rateLimiterConfig;
+
+    private String apiKeyHmacSecret;
 
     public RestClientConfig getRestClientConfig() {
         return restClientConfig;
@@ -34,5 +38,9 @@ public class PublicApiConfig extends Configuration {
 
     public RateLimiterConfig getRateLimiterConfig() {
         return rateLimiterConfig;
+    }
+
+    public String getApiKeyHmacSecret(){
+        return apiKeyHmacSecret;
     }
 }

--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
@@ -17,6 +17,9 @@ public class PublicApiConfig extends Configuration {
     @JsonProperty("jerseyClientConfig")
     private RestClientConfig restClientConfig;
 
+    @JsonProperty("rateLimiter")
+    private RateLimiterConfig rateLimiterConfig;
+
     public RestClientConfig getRestClientConfig() {
         return restClientConfig;
     }
@@ -27,5 +30,9 @@ public class PublicApiConfig extends Configuration {
 
     public String getPublicAuthUrl() {
         return publicAuthUrl;
+    }
+
+    public RateLimiterConfig getRateLimiterConfig() {
+        return rateLimiterConfig;
     }
 }

--- a/src/main/java/uk/gov/pay/api/app/config/RateLimiterConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/RateLimiterConfig.java
@@ -1,0 +1,17 @@
+package uk.gov.pay.api.app.config;
+
+import io.dropwizard.Configuration;
+
+public class RateLimiterConfig extends Configuration {
+
+    private int rate;
+    private int perMillis;
+
+    public int getRate() {
+        return rate;
+    }
+
+    public int getPerMillis() {
+        return perMillis;
+    }
+}

--- a/src/main/java/uk/gov/pay/api/app/config/RateLimiterConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/RateLimiterConfig.java
@@ -2,9 +2,14 @@ package uk.gov.pay.api.app.config;
 
 import io.dropwizard.Configuration;
 
+import javax.validation.constraints.Min;
+
 public class RateLimiterConfig extends Configuration {
 
+    @Min(1)
     private int rate;
+
+    @Min(500)
     private int perMillis;
 
     public int getRate() {

--- a/src/main/java/uk/gov/pay/api/exception/mapper/BadRequestExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/BadRequestExceptionMapper.java
@@ -11,7 +11,7 @@ import javax.ws.rs.ext.ExceptionMapper;
 
 public class BadRequestExceptionMapper implements ExceptionMapper<BadRequestException> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(BadRequestException.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BadRequestExceptionMapper.class);
 
     @Override
     public Response toResponse(BadRequestException exception) {

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -16,7 +16,7 @@ import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 
 public class CreateChargeExceptionMapper implements ExceptionMapper<CreateChargeException> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CreateChargeException.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CreateChargeExceptionMapper.class);
 
     @Override
     public Response toResponse(CreateChargeException exception) {

--- a/src/main/java/uk/gov/pay/api/exception/mapper/SearchChargesExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/SearchChargesExceptionMapper.java
@@ -14,7 +14,7 @@ import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 
 public class SearchChargesExceptionMapper implements ExceptionMapper<SearchChargesException> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SearchChargesException.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SearchChargesExceptionMapper.class);
 
     @Override
     public Response toResponse(SearchChargesException exception) {

--- a/src/main/java/uk/gov/pay/api/exception/mapper/ValidationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/ValidationExceptionMapper.java
@@ -10,7 +10,7 @@ import javax.ws.rs.ext.ExceptionMapper;
 
 public class ValidationExceptionMapper implements ExceptionMapper<ValidationException> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ValidationException.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ValidationExceptionMapper.class);
 
     @Override
     public Response toResponse(ValidationException exception) {

--- a/src/main/java/uk/gov/pay/api/filter/AuthorizationValidationFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/AuthorizationValidationFilter.java
@@ -1,0 +1,66 @@
+package uk.gov.pay.api.filter;
+
+import com.google.common.io.BaseEncoding;
+import org.apache.commons.codec.digest.HmacUtils;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
+
+public class AuthorizationValidationFilter implements Filter {
+
+    private static final int HMAC_SHA1_LENGTH = 32;
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private String apiKeyHmacSecret;
+
+    public AuthorizationValidationFilter(String apiKeyHmacSecret) {
+        this.apiKeyHmacSecret = apiKeyHmacSecret;
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {}
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        final String authorization = ((HttpServletRequest) request).getHeader("Authorization");
+
+        if (isValidAuthorizationHeader(authorization)) {
+            chain.doFilter(request, response);
+
+        } else {
+            ((HttpServletResponse) response).sendError(UNAUTHORIZED.getStatusCode(), UNAUTHORIZED.getReasonPhrase());
+        }
+    }
+
+    @Override
+    public void destroy() {}
+
+    private boolean isValidAuthorizationHeader(String authorization) {
+        return authorization!= null
+                && authorization.startsWith(BEARER_PREFIX)
+                && isValidTokenIntegrity(authorization.substring(BEARER_PREFIX.length()));
+    }
+
+    private boolean isValidTokenIntegrity(String apiKey) {
+        boolean isValid = false;
+        if (apiKey.length() >= HMAC_SHA1_LENGTH + 1) {
+            int initHmacIndex = apiKey.length() - HMAC_SHA1_LENGTH;
+            String hmacFromApiKey = apiKey.substring(initHmacIndex);
+            String tokenFromApiKey = apiKey.substring(0, initHmacIndex);
+            isValid = tokenMatchesHmac(tokenFromApiKey, hmacFromApiKey);
+        }
+        return isValid;
+    }
+
+    private boolean tokenMatchesHmac(String token, String currentHmac) {
+        final String hmacCalculatedFromToken = BaseEncoding.base32Hex()
+                .lowerCase().omitPadding()
+                .encode(HmacUtils.hmacSha1(apiKeyHmacSecret, token));
+        return hmacCalculatedFromToken.equals(currentHmac);
+    }
+}

--- a/src/main/java/uk/gov/pay/api/filter/RateLimit.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimit.java
@@ -1,0 +1,40 @@
+package uk.gov.pay.api.filter;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static java.time.temporal.ChronoUnit.MILLIS;
+
+final class RateLimit {
+
+    private final int rate;
+    private final int perMillis;
+
+    private Instant created;
+    private int requestCount;
+
+    RateLimit(int rate, int perMillis) {
+        this.rate = rate;
+        this.perMillis = perMillis;
+        this.requestCount = 0;
+        this.created = Instant.now().truncatedTo(MILLIS);
+    }
+
+    /**
+     * This block needs to be synchronous. Each RateLimit object will be shared between requests
+     * from the same source (Service), so is not shared across all the requests.
+     * 
+     * @throws RateLimitException
+     */
+    synchronized void updateAllowance() throws RateLimitException {
+        requestCount += 1;
+        Instant now = Instant.now().truncatedTo(MILLIS);
+        if (Duration.between(created, now).toMillis() >= perMillis) {
+            requestCount = 1;
+            created = now;
+        }
+        if (requestCount > rate) {
+            throw new RateLimitException();
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/api/filter/RateLimitException.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimitException.java
@@ -1,0 +1,3 @@
+package uk.gov.pay.api.filter;
+
+public class RateLimitException extends Exception {}

--- a/src/main/java/uk/gov/pay/api/filter/RateLimitException.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimitException.java
@@ -1,3 +1,3 @@
 package uk.gov.pay.api.filter;
 
-public class RateLimitException extends Exception {}
+class RateLimitException extends Exception {}

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiter.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.api.filter;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+public class RateLimiter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RateLimiter.class);
+
+    private final int rate;
+    private final int perMillis;
+    private final Cache<String, RateLimit> cache;
+
+    public RateLimiter(int rate, int perMillis) {
+        this.rate = rate;
+        this.perMillis = perMillis;
+        this.cache = CacheBuilder.newBuilder()
+                .expireAfterAccess(perMillis, TimeUnit.MILLISECONDS)
+                .build();
+    }
+
+    void checkRateOf(String key) throws RateLimitException {
+        try {
+            cache.get(key, () -> new RateLimit(rate, perMillis)).updateAllowance();
+        } catch (ExecutionException e) {
+            //ExecutionException is thrown when the valueLoader throws a checked exception.
+            //We just create a new instance so no exceptions will be thrown, this should never happen.
+            LOGGER.error("Unexpected error creating a Rate Limiter object in cache", e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
@@ -1,0 +1,64 @@
+package uk.gov.pay.api.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.pay.api.model.PaymentError.Code;
+import static uk.gov.pay.api.model.PaymentError.aPaymentError;
+
+/**
+ * Allow only a certain number of requests from the same source (given by the Authorization Header)
+ * within the given time configured in the RateLimiter. See {@link RateLimiter}
+ * <p>
+ * 429 Too Many Requests will be returned when rate limit is reached.
+ */
+public class RateLimiterFilter implements Filter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RateLimiterFilter.class);
+    private static final int TOO_MANY_REQUESTS_STATUS_CODE = 429;
+    private static final String UTF8_CHARACTER_ENCODING = "utf-8";
+
+    private final RateLimiter rateLimiter;
+    private ObjectMapper objectMapper;
+
+    /**
+     * @param rateLimiter Limiter in number of requests per given time coming from the same source (Authorization)
+     */
+    public RateLimiterFilter(RateLimiter rateLimiter, ObjectMapper objectMapper) {
+        this.rateLimiter = rateLimiter;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {}
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        final String authorization = ((HttpServletRequest) request).getHeader("Authorization");
+        try {
+            rateLimiter.checkRateOf(authorization);
+            chain.doFilter(request, response);
+        } catch (RateLimitException e) {
+            LOGGER.info("Rate limit reached for current service. Sending response '429 Too Many Requests'");
+            setTooManyRequestsError((HttpServletResponse) response);
+        }
+    }
+
+    private void setTooManyRequestsError(HttpServletResponse response) throws IOException {
+        response.setStatus(TOO_MANY_REQUESTS_STATUS_CODE);
+        response.setContentType(APPLICATION_JSON);
+        response.setCharacterEncoding(UTF8_CHARACTER_ENCODING);
+        response.getWriter().print(objectMapper.writeValueAsString(aPaymentError(Code.TOO_MANY_REQUESTS_ERROR)));
+    }
+
+    @Override
+    public void destroy() {}
+}

--- a/src/main/java/uk/gov/pay/api/model/PaymentError.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentError.java
@@ -31,7 +31,9 @@ public class PaymentError {
 
         CANCEL_PAYMENT_NOT_FOUND_ERROR("P0500", "Not found"),
         CANCEL_PAYMENT_CONNECTOR_BAD_REQUEST_ERROR("P0501", "Cancellation of payment failed"),
-        CANCEL_PAYMENT_CONNECTOR_ERROR("P0598", "Downstream system error");
+        CANCEL_PAYMENT_CONNECTOR_ERROR("P0598", "Downstream system error"),
+
+        TOO_MANY_REQUESTS_ERROR("P0900", "Too many requests");
 
         private String value;
         private String format;

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -14,3 +14,7 @@ publicAuthUrl: ${PUBLIC_AUTH_URL}
 
 jerseyClientConfig:
   disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS}
+
+rateLimiter:
+  rate: ${RATE_LIMITER_VALUE:-3}
+  perMillis: ${RATE_LIMITER_PER_MILLIS:-1000}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -18,3 +18,5 @@ jerseyClientConfig:
 rateLimiter:
   rate: ${RATE_LIMITER_VALUE:-3}
   perMillis: ${RATE_LIMITER_PER_MILLIS:-1000}
+
+apiKeyHmacSecret: ${TOKEN_API_HMAC_SECRET}

--- a/src/test/java/uk/gov/pay/api/filter/AuthorizationValidationFilterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/AuthorizationValidationFilterTest.java
@@ -1,0 +1,100 @@
+package uk.gov.pay.api.filter;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Mockito.*;
+import static uk.gov.pay.api.utils.ApiKeyGenerator.apiKeyValueOf;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuthorizationValidationFilterTest {
+
+    private static final String SECRET_KEY = "mysupersecret";
+    private AuthorizationValidationFilter authorizationValidationFilter;
+
+    @Mock
+    private HttpServletRequest mockRequest;
+    @Mock
+    private HttpServletResponse mockResponse;
+    @Mock
+    private FilterChain mockFilterChain;
+
+    @Before
+    public void setup() {
+        authorizationValidationFilter = new AuthorizationValidationFilter(SECRET_KEY);
+    }
+
+    @Test
+    public void shouldProcessFilterChain_whenAuthorizationHeaderIsValid() throws Exception {
+
+        String validToken = "asdfghdasd";
+        String authorization = "Bearer " + apiKeyValueOf(validToken, SECRET_KEY);
+
+        when(mockRequest.getHeader("Authorization")).thenReturn(authorization);
+
+        authorizationValidationFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        verify(mockFilterChain).doFilter(mockRequest, mockResponse);
+    }
+
+    @Test
+    public void shouldRejectRequest_with401ResponseError_whenAuthorizationHeaderIsInvalid() throws Exception {
+
+        String invalidApiKey = "asdfghdasdakjshdkjwhdjweghrhjgwerguweurweruhiweuiweriuui";
+        String authorization = "Bearer " + invalidApiKey;
+
+        when(mockRequest.getHeader("Authorization")).thenReturn(authorization);
+
+        authorizationValidationFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        verifyZeroInteractions(mockFilterChain);
+        verify(mockResponse).sendError(401, "Unauthorized");
+    }
+
+    @Test
+    public void shouldRejectRequest_with401ResponseError_whenAuthorizationHeaderIsNotPresent() throws Exception {
+
+        when(mockRequest.getHeader("Authorization")).thenReturn(null);
+
+        authorizationValidationFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        verifyZeroInteractions(mockFilterChain);
+        verify(mockResponse).sendError(401, "Unauthorized");
+    }
+
+    @Test
+    public void shouldRejectRequest_with401ResponseError_whenAuthorizationHeaderHasInvalidFormat() throws Exception {
+
+        String validToken = "asdfghdasd";
+        String authorization = "Bearer" + apiKeyValueOf(validToken, SECRET_KEY);
+
+        when(mockRequest.getHeader("Authorization")).thenReturn(authorization);
+
+        authorizationValidationFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        verifyZeroInteractions(mockFilterChain);
+        verify(mockResponse).sendError(401, "Unauthorized");
+    }
+
+    @Test
+    public void shouldRejectRequest_with401ResponseError_whenAuthorizationHeaderHasNotMinimumLengthExpected() throws Exception {
+
+        String apiKey = RandomStringUtils.randomAlphanumeric(32);
+        String authorization = "Bearer " + apiKey;
+
+        when(mockRequest.getHeader("Authorization")).thenReturn(authorization);
+
+        authorizationValidationFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        verifyZeroInteractions(mockFilterChain);
+        verify(mockResponse).sendError(401, "Unauthorized");
+    }
+}

--- a/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
@@ -1,0 +1,73 @@
+package uk.gov.pay.api.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RateLimiterFilterTest {
+
+    private RateLimiterFilter rateLimiterFilter;
+
+    @Mock
+    private RateLimiter rateLimiter;
+
+    @Mock
+    private HttpServletRequest mockRequest;
+    @Mock
+    private HttpServletResponse mockResponse;
+    @Mock
+    private FilterChain mockFilterChain;
+
+    @Before
+    public void setup() {
+        rateLimiterFilter = new RateLimiterFilter(rateLimiter, new ObjectMapper());
+    }
+
+    @Test
+    public void shouldProcessFilterChain_whenRateLimiterDoesNotThrowARateLimiterException() throws Exception {
+
+        String authorization = "Bearer whateverAuthorizationToken";
+        when(mockRequest.getHeader("Authorization")).thenReturn(authorization);
+
+        rateLimiterFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        verify(rateLimiter).checkRateOf(authorization);
+        verify(mockFilterChain, times(1)).doFilter(mockRequest, mockResponse);
+    }
+
+    @Test
+    public void shouldRespondWith429TooManyRequests_whenRateLimiterThrowsRateLimiterException() throws Exception {
+
+        // given
+        String authorization = "Bearer whateverAuthorizationToken";
+        when(mockRequest.getHeader("Authorization")).thenReturn(authorization);
+
+        doThrow(RateLimitException.class).when(rateLimiter).checkRateOf(authorization);
+
+        PrintWriter mockPrinter = mock(PrintWriter.class);
+        when(mockResponse.getWriter()).thenReturn(mockPrinter);
+
+        // when
+        rateLimiterFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        // then
+        verifyZeroInteractions(mockFilterChain);
+        verify(mockResponse).setStatus(429);
+        verify(mockResponse).setContentType("application/json");
+        verify(mockResponse).setCharacterEncoding("utf-8");
+        verify(mockResponse).getWriter();
+        verify(mockPrinter).print("{\"code\":\"P0900\",\"description\":\"Too many requests\"}");
+        verifyNoMoreInteractions(mockResponse);
+    }
+}

--- a/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
@@ -47,7 +47,7 @@ public class RateLimiterFilterTest {
     }
 
     @Test
-    public void shouldRespondWith429TooManyRequests_whenRateLimiterThrowsRateLimiterException() throws Exception {
+    public void shouldRejectRequest_with429ResponseError__whenRateLimiterThrowsRateLimiterException() throws Exception {
 
         // given
         String authorization = "Bearer whateverAuthorizationToken";

--- a/src/test/java/uk/gov/pay/api/filter/RateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/RateLimiterTest.java
@@ -1,0 +1,144 @@
+package uk.gov.pay.api.filter;
+
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.fail;
+
+public class RateLimiterTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void rateLimiterSetTo_1CallPerSecond_shouldAllowSingleCall() throws Exception {
+        RateLimiter rateLimiter = new RateLimiter(1, 1000);
+        rateLimiter.checkRateOf("1");
+    }
+
+    @Test
+    public void rateLimiterSetTo_2CallsPerSecond_shouldAllow2ConsecutiveCallsWithSameKeys() throws Exception {
+
+        RateLimiter rateLimiter = new RateLimiter(2, 1000);
+
+        rateLimiter.checkRateOf("2");
+        rateLimiter.checkRateOf("2");
+    }
+
+    @Test
+    public void rateLimiterSetTo_2CallsPerSecond_shouldAFailWhen3ConsecutiveCallsWithSameKeysAreMade() throws Exception {
+        RateLimiter rateLimiter = new RateLimiter(2, 1000);
+
+        rateLimiter.checkRateOf("3");
+        rateLimiter.checkRateOf("3");
+
+        expectedException.expect(RateLimitException.class);
+        rateLimiter.checkRateOf("3");
+    }
+
+    @Test
+    public void rateLimiterSetTo_2CallsPer300Millis_shouldAllowMaking3CallsWithinTheAllowedTimeWithSameKey() throws Exception {
+
+        RateLimiter rateLimiter = new RateLimiter(2, 300);
+
+        rateLimiter.checkRateOf("4");
+        rateLimiter.checkRateOf("4");
+
+        Thread.sleep(300);
+        rateLimiter.checkRateOf("4");
+    }
+
+    @Test
+    public void rateLimiterSetTo_2CallsPer500Millis_shouldAllowMakingACallPerSecondWithSameKey() throws Exception {
+        RateLimiter rateLimiter = new RateLimiter(2, 500);
+
+        rateLimiter.checkRateOf("5");
+        Thread.sleep(250);
+        rateLimiter.checkRateOf("5");
+        Thread.sleep(250);
+        rateLimiter.checkRateOf("5");
+        Thread.sleep(250);
+        rateLimiter.checkRateOf("5");
+        Thread.sleep(250);
+        rateLimiter.checkRateOf("5");
+        Thread.sleep(250);
+        rateLimiter.checkRateOf("5");
+    }
+
+    @Test
+    public void rateLimiterSetTo_2CallsPer300Millis_shouldAllowMakingOnly2CallsWithSameKey() throws Exception {
+
+        final RateLimiter rateLimiter = new RateLimiter(2, 300);
+
+        ExecutorService executor = Executors.newFixedThreadPool(3);
+
+        List<Callable<String>> tasks = Arrays.asList(
+                () -> {
+                    rateLimiter.checkRateOf("1");
+                    return "task1";
+                },
+                () -> {
+                    rateLimiter.checkRateOf("1");
+                    return "task2";
+                },
+                () -> {
+                    rateLimiter.checkRateOf("1");
+                    return "task3";
+                },
+                () -> {
+                    rateLimiter.checkRateOf("1");
+                    return "task4";
+                }
+        );
+
+        List<String> successfulTasks = executor.invokeAll(tasks)
+                .stream()
+                .map(future -> {
+                    try {
+                        return future.get();
+                    } catch (Exception e) {
+                        assertThat(e, is(instanceOf(ExecutionException.class)));
+                        ExecutionException ex = (ExecutionException) e;
+                        assertThat(ex.getCause(), is(instanceOf(RateLimitException.class)));
+                        return null;
+                    }
+                })
+                .filter(task -> task != null)
+                .collect(Collectors.toList());
+
+        assertThat(successfulTasks.size(), is(2));
+    }
+
+    @Test
+    public void rateLimiterSetTo_2CallsPerSecond_shouldNotAllowMakingAThirdCallsWithSameKey() throws Exception {
+
+        RateLimiter rateLimiter = new RateLimiter(2, 1000);
+
+        rateLimiter.checkRateOf("6");
+        Thread.sleep(910);
+        rateLimiter.checkRateOf("6");
+
+        try {
+            rateLimiter.checkRateOf("6");
+            fail("Expected RateLimitException to be thrown");
+        } catch (RateLimitException e) {
+
+        }
+
+        Thread.sleep(900);
+        rateLimiter.checkRateOf("6");
+    }
+}

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
@@ -6,6 +6,7 @@ import org.junit.Rule;
 import org.mockserver.junit.MockServerRule;
 import uk.gov.pay.api.app.PublicApi;
 import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.utils.ApiKeyGenerator;
 import uk.gov.pay.api.utils.ConnectorMockClient;
 import uk.gov.pay.api.utils.PublicAuthMockClient;
 
@@ -13,8 +14,8 @@ import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 
 public abstract class PaymentResourceITestBase {
-
-    protected static final String BEARER_TOKEN = "TEST_BEARER_TOKEN";
+    //Must use same secret set int configured test-config.xml
+    protected static final String API_KEY = ApiKeyGenerator.apiKeyValueOf("TEST_BEARER_TOKEN", "qwer9yuhgf");
     protected static final String GATEWAY_ACCOUNT_ID = "GATEWAY_ACCOUNT_ID";
     protected static final String PAYMENTS_PATH = "/v1/payments/";
 

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -40,7 +40,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
 
     @Before
     public void mapBearerTokenToAccountId() {
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
     }
 
     @Test
@@ -54,7 +54,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .build()
         );
 
-        String responseBody = searchPayments(BEARER_TOKEN, ImmutableMap.of("reference", TEST_REFERENCE))
+        String responseBody = searchPayments(API_KEY, ImmutableMap.of("reference", TEST_REFERENCE))
                 .statusCode(200)
                 .contentType(JSON)
                 .body("results[0].created_date", is(DEFAULT_CREATED_DATE))
@@ -85,7 +85,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
 
     @Test
     public void searchPayments_ShouldNotIncludeCancelLinkIfThePaymentCannotBeCancelled() {
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         String SUCCEEDED_STATUS = "succeeded";
         connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, TEST_REFERENCE, null, null, null,
                 aSuccessfulSearchResponse()
@@ -95,7 +95,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .build()
         );
 
-        searchPayments(BEARER_TOKEN, ImmutableMap.of("reference", TEST_REFERENCE))
+        searchPayments(API_KEY, ImmutableMap.of("reference", TEST_REFERENCE))
                 .statusCode(200)
                 .contentType(JSON)
                 .body("results[0]._links.cancel", is(nullValue()));
@@ -111,7 +111,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .build()
         );
 
-        ValidatableResponse response = searchPayments(BEARER_TOKEN, ImmutableMap.of("reference", TEST_REFERENCE))
+        ValidatableResponse response = searchPayments(API_KEY, ImmutableMap.of("reference", TEST_REFERENCE))
                 .statusCode(200)
                 .contentType(JSON)
                 .body("results.size()", equalTo(3));
@@ -130,7 +130,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .build()
         );
 
-        ValidatableResponse response = searchPayments(BEARER_TOKEN, ImmutableMap.of("status", TEST_STATUS))
+        ValidatableResponse response = searchPayments(API_KEY, ImmutableMap.of("status", TEST_STATUS))
                 .statusCode(200)
                 .contentType(JSON)
                 .body("results.size()", equalTo(3));
@@ -148,7 +148,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .build()
         );
 
-        ValidatableResponse response = searchPayments(BEARER_TOKEN, ImmutableMap.of("status", TEST_STATUS.toLowerCase()))
+        ValidatableResponse response = searchPayments(API_KEY, ImmutableMap.of("status", TEST_STATUS.toLowerCase()))
                 .statusCode(200)
                 .contentType(JSON)
                 .body("results.size()", equalTo(3));
@@ -166,7 +166,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .build()
         );
 
-        ValidatableResponse response = searchPayments(BEARER_TOKEN, ImmutableMap.of("from_date", TEST_FROM_DATE, "to_date", TEST_TO_DATE))
+        ValidatableResponse response = searchPayments(API_KEY, ImmutableMap.of("from_date", TEST_FROM_DATE, "to_date", TEST_TO_DATE))
                 .statusCode(200)
                 .contentType(JSON)
                 .body("results.size()", equalTo(3));
@@ -188,7 +188,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .build()
         );
 
-        ValidatableResponse response = searchPayments(BEARER_TOKEN,
+        ValidatableResponse response = searchPayments(API_KEY,
                 ImmutableMap.of("reference", TEST_REFERENCE, "status", TEST_STATUS, "from_date", TEST_FROM_DATE, "to_date", TEST_TO_DATE))
                 .statusCode(200)
                 .contentType(JSON)
@@ -204,7 +204,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
     @Test
     public void searchPayments_errorIfConnectorResponseFails() throws Exception {
 
-        InputStream body = searchPayments(BEARER_TOKEN,
+        InputStream body = searchPayments(API_KEY,
                 ImmutableMap.of("reference", TEST_REFERENCE, "status", TEST_STATUS, "from_date", TEST_FROM_DATE, "to_date", TEST_TO_DATE))
                 .statusCode(500)
                 .contentType(JSON).extract()
@@ -225,7 +225,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .withHeader(CONTENT_TYPE, APPLICATION_JSON)
                         .withBody("wtf"));
 
-        InputStream body = searchPayments(BEARER_TOKEN,
+        InputStream body = searchPayments(API_KEY,
                 ImmutableMap.of("reference", TEST_REFERENCE, "status", TEST_STATUS, "from_date", TEST_FROM_DATE, "to_date", TEST_TO_DATE))
                 .statusCode(500)
                 .contentType(JSON).extract()

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchValidationITest.java
@@ -27,13 +27,13 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
 
     @Before
     public void mapBearerTokenToAccountId() {
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
     }
 
     @Test
     public void searchPayments_errorWhenToDateIsNotInZoneDateTimeFormat() throws Exception {
 
-        InputStream body = searchPayments(BEARER_TOKEN,
+        InputStream body = searchPayments(API_KEY,
                 ImmutableMap.of("reference", VALID_REFERENCE, "status", VALID_STATUS, "from_date", VALID_FROM_DATE, "to_date", "2016-01-01 00:00"))
                 .statusCode(422)
                 .contentType(JSON).extract()
@@ -48,7 +48,7 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
     @Test
     public void searchPayments_errorWhenFromDateIsNotInZoneDateTimeFormat() throws Exception {
 
-        InputStream body = searchPayments(BEARER_TOKEN,
+        InputStream body = searchPayments(API_KEY,
                 ImmutableMap.of("reference", VALID_REFERENCE, "status", VALID_STATUS, "from_date", "2016-01-01 00:00", "to_date", VALID_TO_DATE))
                 .statusCode(422)
                 .contentType(JSON).extract()
@@ -63,7 +63,7 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
     @Test
     public void searchPayments_errorWhenStatusNotMatchingWithExpectedExternalStatuses() throws Exception {
 
-        InputStream body = searchPayments(BEARER_TOKEN,
+        InputStream body = searchPayments(API_KEY,
                 ImmutableMap.of("reference", VALID_REFERENCE, "status", "invalid status", "from_date", VALID_FROM_DATE, "to_date", VALID_TO_DATE))
                 .statusCode(422)
                 .contentType(JSON).extract()
@@ -78,7 +78,7 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
     @Test
     public void searchPayments_errorWhenReferenceSizeIsLongerThan255() throws Exception {
 
-        InputStream body = searchPayments(BEARER_TOKEN,
+        InputStream body = searchPayments(API_KEY,
                 ImmutableMap.of("reference", RandomStringUtils.randomAlphanumeric(256), "status", VALID_STATUS, "from_date", VALID_FROM_DATE, "to_date", VALID_TO_DATE))
                 .statusCode(422)
                 .contentType(JSON).extract()
@@ -93,7 +93,7 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
     @Test
     public void searchPayments_errorWhenToDateNotInZoneDateTimeFormat_andInvalidStatus() throws Exception {
 
-        InputStream body = searchPayments(BEARER_TOKEN,
+        InputStream body = searchPayments(API_KEY,
                 ImmutableMap.of("reference", VALID_REFERENCE, "status", "invalid status", "from_date", VALID_FROM_DATE, "to_date", "2016-01-01 00:00"))
                 .statusCode(422)
                 .contentType(JSON).extract()
@@ -108,7 +108,7 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
     @Test
     public void searchPayments_errorWhenFromAndToDatesAreNotInZoneDateTimeFormat() throws Exception {
 
-        InputStream body = searchPayments(BEARER_TOKEN,
+        InputStream body = searchPayments(API_KEY,
                 ImmutableMap.of("reference", VALID_REFERENCE, "status", VALID_STATUS, "from_date", "12345", "to_date", "2016-01-01 00:00"))
                 .statusCode(422)
                 .contentType(JSON).extract()
@@ -123,7 +123,7 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
     @Test
     public void searchPayments_errorWhenAllFieldsAreInvalid() throws Exception {
 
-        InputStream body = searchPayments(BEARER_TOKEN,
+        InputStream body = searchPayments(API_KEY,
                 ImmutableMap.of("reference", RandomStringUtils.randomAlphanumeric(256), "status", "invalid status", "from_date", "12345", "to_date", "98765"))
                 .statusCode(422)
                 .contentType(JSON).extract()

--- a/src/test/java/uk/gov/pay/api/it/PaymentsCancelResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsCancelResourceITest.java
@@ -29,7 +29,7 @@ public class PaymentsCancelResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void successful_whenConnector_AllowsCancellation() {
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondOk_whenCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID);
 
         postCancelPaymentResponse(TEST_CHARGE_ID)
@@ -40,7 +40,7 @@ public class PaymentsCancelResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void cancelPayment_returns400_whenConnectorRespondsWithA400() throws IOException {
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondBadRequest_WhenCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "Invalid account Id");
 
         InputStream body = postCancelPaymentResponse(TEST_CHARGE_ID)
@@ -56,7 +56,7 @@ public class PaymentsCancelResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void cancelPayment_returns404_whenPaymentNotFound() throws IOException {
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondChargeNotFound_WhenCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "some backend error message");
 
         InputStream body = postCancelPaymentResponse(TEST_CHARGE_ID)
@@ -72,7 +72,7 @@ public class PaymentsCancelResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void cancelPayment_returns500_whenConnectorResponseIsUnexpected() throws IOException {
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respond_WhenCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "some backend error message", CONFLICT_409);
 
         InputStream body = postCancelPaymentResponse(TEST_CHARGE_ID)
@@ -88,7 +88,7 @@ public class PaymentsCancelResourceITest extends PaymentResourceITestBase {
 
     private ValidatableResponse postCancelPaymentResponse(String paymentId) {
         return given().port(app.getLocalPort())
-                .header(AUTHORIZATION, "Bearer " + BEARER_TOKEN)
+                .header(AUTHORIZATION, "Bearer " + API_KEY)
                 .post(String.format(CANCEL_PAYMENTS_PATH, paymentId))
                 .then();
     }

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceAmountValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceAmountValidationITest.java
@@ -18,7 +18,7 @@ public class PaymentsResourceAmountValidationITest extends PaymentResourceITestB
 
     @Before
     public void setUpBearerToken() {
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
     }
 
     @Test
@@ -31,7 +31,7 @@ public class PaymentsResourceAmountValidationITest extends PaymentResourceITestB
                 "  \"return_url\" : \"http://somewhere.gov.uk/rainbow/1\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(422)
                 .contentType(JSON)
                 .extract()
@@ -54,7 +54,7 @@ public class PaymentsResourceAmountValidationITest extends PaymentResourceITestB
                 "  \"return_url\" : \"http://somewhere.gov.uk/rainbow/1\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(422)
                 .contentType(JSON)
                 .extract()
@@ -77,7 +77,7 @@ public class PaymentsResourceAmountValidationITest extends PaymentResourceITestB
                 "  \"return_url\" : \"http://somewhere.gov.uk/rainbow/1\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .contentType(JSON)
@@ -101,7 +101,7 @@ public class PaymentsResourceAmountValidationITest extends PaymentResourceITestB
                 "  \"return_url\" : \"http://somewhere.gov.uk/rainbow/1\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -124,7 +124,7 @@ public class PaymentsResourceAmountValidationITest extends PaymentResourceITestB
                 "  \"return_url\" : \"http://somewhere.gov.uk/rainbow/1\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -147,7 +147,7 @@ public class PaymentsResourceAmountValidationITest extends PaymentResourceITestB
                 "  \"return_url\" : \"http://somewhere.gov.uk/rainbow/1\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -169,7 +169,7 @@ public class PaymentsResourceAmountValidationITest extends PaymentResourceITestB
                 "  \"return_url\" : \"http://somewhere.gov.uk/rainbow/1\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -192,7 +192,7 @@ public class PaymentsResourceAmountValidationITest extends PaymentResourceITestB
                 "  \"return_url\" : \"http://somewhere.gov.uk/rainbow/1\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -214,7 +214,7 @@ public class PaymentsResourceAmountValidationITest extends PaymentResourceITestB
                 "  \"return_url\" : \"http://somewhere.gov.uk/rainbow/1\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -236,7 +236,7 @@ public class PaymentsResourceAmountValidationITest extends PaymentResourceITestB
                 "  \"return_url\" : \"http://somewhere.gov.uk/rainbow/1\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -258,7 +258,7 @@ public class PaymentsResourceAmountValidationITest extends PaymentResourceITestB
                 "  \"return_url\" : \"http://somewhere.gov.uk/rainbow/1\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -280,7 +280,7 @@ public class PaymentsResourceAmountValidationITest extends PaymentResourceITestB
                 "  \"return_url\" : \"http://somewhere.gov.uk/rainbow/1\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -301,7 +301,7 @@ public class PaymentsResourceAmountValidationITest extends PaymentResourceITestB
                 "  \"return_url\" : \"whatever\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceDescriptionValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceDescriptionValidationITest.java
@@ -19,7 +19,7 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
 
     @Before
     public void setUpBearerToken() {
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
     }
 
     @Test
@@ -32,7 +32,7 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
                 "  \"return_url\" : \"http://my-payments.com\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -55,7 +55,7 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
                 "  \"return_url\" : \"http://my-payments.com\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -78,7 +78,7 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
                 "  \"return_url\" : \"http://my-payments.com\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -100,7 +100,7 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
                 "  \"return_url\" : \"http://my-payments.com\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -124,7 +124,7 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
                 "  \"return_url\" : \"http://my-payments.com\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -149,7 +149,7 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
                 "  \"return_url\" : \"http://my-payments.com\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(422)
                 .contentType(JSON)
                 .extract()
@@ -172,7 +172,7 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
                 "  \"return_url\" : \"http://my-payments.com\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -194,7 +194,7 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
                 "  \"return_url\" : \"http://my-payments.com\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
@@ -45,12 +45,12 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
     @Test
     public void createPayment() {
 
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
         connectorMock.respondOk_whenCreateCharge(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID, STATUS, RETURN_URL,
                 DESCRIPTION, REFERENCE, PAYMENT_PROVIDER, CREATED_DATE);
 
-        String responseBody = postPaymentResponse(BEARER_TOKEN, SUCCESS_PAYLOAD)
+        String responseBody = postPaymentResponse(API_KEY, SUCCESS_PAYLOAD)
                 .statusCode(201)
                 .contentType(JSON)
                 .header(HttpHeaders.LOCATION, is(paymentLocationFor(CHARGE_ID)))
@@ -92,11 +92,11 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
 
         int minimumAmount = 1;
 
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondOk_whenCreateCharge(minimumAmount, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID, STATUS, RETURN_URL,
                 DESCRIPTION, REFERENCE, PAYMENT_PROVIDER, CREATED_DATE);
 
-        postPaymentResponse(BEARER_TOKEN, paymentPayload(minimumAmount, RETURN_URL, DESCRIPTION, REFERENCE))
+        postPaymentResponse(API_KEY, paymentPayload(minimumAmount, RETURN_URL, DESCRIPTION, REFERENCE))
                 .statusCode(201)
                 .contentType(JSON)
                 .body("payment_id", is(CHARGE_ID))
@@ -119,7 +119,7 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
         String description = randomAlphanumeric(255);
         String return_url = "http://govdemopay.gov.uk?data=" + randomAlphanumeric(1970);
 
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondOk_whenCreateCharge(amount, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID, STATUS, return_url,
                 description, reference, PAYMENT_PROVIDER, CREATED_DATE);
 
@@ -130,7 +130,7 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
                 .add("return_url", return_url)
                 .build();
 
-        postPaymentResponse(BEARER_TOKEN, body)
+        postPaymentResponse(API_KEY, body)
                 .statusCode(201)
                 .contentType(JSON)
                 .body("payment_id", is(CHARGE_ID))
@@ -149,11 +149,11 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
         String gatewayAccountId = "1234567";
         String errorMessage = "something went wrong";
 
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, gatewayAccountId);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, gatewayAccountId);
 
         connectorMock.respondBadRequest_whenCreateCharge(AMOUNT, gatewayAccountId, errorMessage, RETURN_URL, DESCRIPTION, REFERENCE);
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, SUCCESS_PAYLOAD)
+        InputStream body = postPaymentResponse(API_KEY, SUCCESS_PAYLOAD)
                 .statusCode(500)
                 .contentType(JSON).extract()
                 .body().asInputStream();
@@ -170,11 +170,11 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
     public void createPayment_responseWith500_whenTokenForGatewayAccountIsValidButConnectorResponseIsNotFound() {
 
         String notFoundGatewayAccountId = "9876545";
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, notFoundGatewayAccountId);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, notFoundGatewayAccountId);
 
         connectorMock.respondNotFound_whenCreateCharge(AMOUNT, notFoundGatewayAccountId, RETURN_URL, DESCRIPTION, REFERENCE);
 
-        postPaymentResponse(BEARER_TOKEN, SUCCESS_PAYLOAD)
+        postPaymentResponse(API_KEY, SUCCESS_PAYLOAD)
                 .statusCode(500)
                 .contentType(JSON)
                 .body("code", is("P0199"))
@@ -185,11 +185,11 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void getPayment_ReturnsPayment() {
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, STATUS, RETURN_URL,
                 DESCRIPTION, REFERENCE, PAYMENT_PROVIDER, CREATED_DATE, CHARGE_TOKEN_ID);
 
-        getPaymentResponse(BEARER_TOKEN, CHARGE_ID)
+        getPaymentResponse(API_KEY, CHARGE_ID)
                 .statusCode(200)
                 .contentType(JSON)
                 .body("payment_id", is(CHARGE_ID))
@@ -219,11 +219,11 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void getPayment_ShouldNotIncludeCancelLinkIfPaymentCannotBeCancelled() {
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, ExternalChargeStatus.EXT_SUCCEEDED.name(), RETURN_URL,
                 DESCRIPTION, REFERENCE, PAYMENT_PROVIDER, CREATED_DATE, CHARGE_TOKEN_ID);
 
-        getPaymentResponse(BEARER_TOKEN, CHARGE_ID)
+        getPaymentResponse(API_KEY, CHARGE_ID)
                 .statusCode(200)
                 .contentType(JSON)
                 .body("_links.cancel", is(nullValue()));
@@ -233,7 +233,7 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
     public void getPayment_Returns401_WhenUnauthorised() {
         publicAuthMock.respondUnauthorised();
 
-        getPaymentResponse(BEARER_TOKEN, CHARGE_ID)
+        getPaymentResponse(API_KEY, CHARGE_ID)
                 .statusCode(401);
     }
 
@@ -242,10 +242,10 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
 
         String paymentId = "ds2af2afd3df112";
         String errorMessage = "backend-error-message";
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondChargeNotFound(GATEWAY_ACCOUNT_ID, paymentId, errorMessage);
 
-        InputStream body = getPaymentResponse(BEARER_TOKEN, paymentId)
+        InputStream body = getPaymentResponse(API_KEY, paymentId)
                 .statusCode(404)
                 .contentType(JSON).extract()
                 .body().asInputStream();
@@ -261,10 +261,10 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
 
         String paymentId = "ds2af2afd3df112";
         String errorMessage = "backend-error-message";
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWhenGetCharge(GATEWAY_ACCOUNT_ID, paymentId, errorMessage, SC_NOT_ACCEPTABLE);
 
-        InputStream body = getPaymentResponse(BEARER_TOKEN, paymentId)
+        InputStream body = getPaymentResponse(API_KEY, paymentId)
                 .statusCode(500)
                 .contentType(JSON).extract()
                 .body().asInputStream();
@@ -277,10 +277,10 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void getPaymentEvents_ReturnsPaymentEvents() {
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWithChargeEventsFound(GATEWAY_ACCOUNT_ID, CHARGE_ID, EVENTS);
 
-        getPaymentEventsResponse(BEARER_TOKEN, CHARGE_ID)
+        getPaymentEventsResponse(API_KEY, CHARGE_ID)
                 .statusCode(200)
                 .contentType(JSON)
                 .body("payment_id", is(CHARGE_ID))
@@ -296,7 +296,7 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
     public void getPaymentEvents_Returns401_WhenUnauthorised() {
         publicAuthMock.respondUnauthorised();
 
-        getPaymentEventsResponse(BEARER_TOKEN, CHARGE_ID)
+        getPaymentEventsResponse(API_KEY, CHARGE_ID)
                 .statusCode(401);
     }
 
@@ -305,10 +305,10 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
 
         String paymentId = "ds2af2afd3df112";
         String errorMessage = "backend-error-message";
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondChargeEventsNotFound(GATEWAY_ACCOUNT_ID, paymentId, errorMessage);
 
-        InputStream body = getPaymentEventsResponse(BEARER_TOKEN, paymentId)
+        InputStream body = getPaymentEventsResponse(API_KEY, paymentId)
                 .statusCode(404)
                 .contentType(JSON).extract()
                 .body().asInputStream();
@@ -324,10 +324,10 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
 
         String paymentId = "ds2af2afd3df112";
         String errorMessage = "backend-error-message";
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWhenGetChargeEvents(GATEWAY_ACCOUNT_ID, paymentId, errorMessage, SC_NOT_ACCEPTABLE);
 
-        InputStream body = getPaymentEventsResponse(BEARER_TOKEN, paymentId)
+        InputStream body = getPaymentEventsResponse(API_KEY, paymentId)
                 .statusCode(500)
                 .contentType(JSON).extract()
                 .body().asInputStream();
@@ -342,7 +342,7 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
     public void createPayment_Returns401_WhenUnauthorised() {
         publicAuthMock.respondUnauthorised();
 
-        postPaymentResponse(BEARER_TOKEN, SUCCESS_PAYLOAD)
+        postPaymentResponse(API_KEY, SUCCESS_PAYLOAD)
                 .statusCode(401);
     }
 
@@ -350,7 +350,7 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
     public void createPayment_Returns_WhenPublicAuthInaccessible() {
         publicAuthMock.respondWithError();
 
-        postPaymentResponse(BEARER_TOKEN, SUCCESS_PAYLOAD)
+        postPaymentResponse(API_KEY, SUCCESS_PAYLOAD)
                 .statusCode(503);
     }
 

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceReferenceValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceReferenceValidationITest.java
@@ -19,7 +19,7 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
 
     @Before
     public void setUpBearerToken() {
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
     }
 
     @Test
@@ -32,7 +32,7 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
                 "  \"return_url\" : \"http://my-payments.com\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -55,7 +55,7 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
                 "  \"return_url\" : \"http://my-payments.com\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -78,7 +78,7 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
                 "  \"return_url\" : \"http://my-payments.com\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -100,7 +100,7 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
                 "  \"return_url\" : \"http://my-payments.com\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -124,7 +124,7 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
                 "  \"return_url\" : \"http://my-payments.com\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -149,7 +149,7 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
                 "  \"return_url\" : \"http://my-payments.com\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(422)
                 .contentType(JSON)
                 .extract()
@@ -172,7 +172,7 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
                 "  \"return_url\" : \"http://my-payments.com\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -194,7 +194,7 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
                 "  \"return_url\" : \"http://my-payments.com\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceReturnUrlValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceReturnUrlValidationITest.java
@@ -19,7 +19,7 @@ public class PaymentsResourceReturnUrlValidationITest extends PaymentResourceITe
 
     @Before
     public void setUpBearerToken() {
-        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
     }
 
     @Test
@@ -32,7 +32,7 @@ public class PaymentsResourceReturnUrlValidationITest extends PaymentResourceITe
                 "  \"return_url\" : 123" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -55,7 +55,7 @@ public class PaymentsResourceReturnUrlValidationITest extends PaymentResourceITe
                 "  \"return_url\" : \"\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -78,7 +78,7 @@ public class PaymentsResourceReturnUrlValidationITest extends PaymentResourceITe
                 "  \"return_url\" : \"  \"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -100,7 +100,7 @@ public class PaymentsResourceReturnUrlValidationITest extends PaymentResourceITe
                 "  \"description\" : \"Some description\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -123,7 +123,7 @@ public class PaymentsResourceReturnUrlValidationITest extends PaymentResourceITe
                 "  \"return_url\" : null" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -148,7 +148,7 @@ public class PaymentsResourceReturnUrlValidationITest extends PaymentResourceITe
                 "  \"return_url\" : \"" + aVeryBigInvalidReturnUrl + "\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(422)
                 .contentType(JSON)
                 .extract()
@@ -173,7 +173,7 @@ public class PaymentsResourceReturnUrlValidationITest extends PaymentResourceITe
                 "  \"return_url\" : \"" + aVeryBigValidReturnUrl + "\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(422)
                 .contentType(JSON)
                 .extract()
@@ -198,7 +198,7 @@ public class PaymentsResourceReturnUrlValidationITest extends PaymentResourceITe
                 "  \"return_url\" : \"" + anInvalidUrl + "\"" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(422)
                 .contentType(JSON)
                 .extract()
@@ -221,7 +221,7 @@ public class PaymentsResourceReturnUrlValidationITest extends PaymentResourceITe
                 "  \"return_url\" : " +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()
@@ -243,7 +243,7 @@ public class PaymentsResourceReturnUrlValidationITest extends PaymentResourceITe
                 "  \"return_url\" : []" +
                 "}";
 
-        InputStream body = postPaymentResponse(BEARER_TOKEN, payload)
+        InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(400)
                 .contentType(JSON)
                 .extract()

--- a/src/test/java/uk/gov/pay/api/it/RateLimitResourcesITest.java
+++ b/src/test/java/uk/gov/pay/api/it/RateLimitResourcesITest.java
@@ -1,0 +1,245 @@
+package uk.gov.pay.api.it;
+
+import com.google.common.collect.ImmutableMap;
+import com.jayway.restassured.response.ExtractableResponse;
+import com.jayway.restassured.response.Response;
+import com.jayway.restassured.response.ValidatableResponse;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.api.utils.ChargeEventBuilder;
+import uk.gov.pay.api.utils.DateTimeUtils;
+import uk.gov.pay.api.utils.JsonStringBuilder;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+import static com.jayway.restassured.RestAssured.given;
+import static com.jayway.restassured.http.ContentType.JSON;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static uk.gov.pay.api.it.fixtures.PaymentSearchResultBuilder.aSuccessfulSearchResponse;
+
+public class RateLimitResourcesITest extends PaymentResourceITestBase {
+
+    private static final int AMOUNT = 9999999;
+    private static final String CHARGE_ID = "ch_ab2341da231434l";
+    private static final String CHARGE_TOKEN_ID = "token_1234567asdf";
+    private static final String STATUS = "created";
+    private static final String PAYMENT_PROVIDER = "Sandbox";
+    private static final String RETURN_URL = "http://somewhere.gov.uk/rainbow/1";
+    private static final String REFERENCE = "Some reference";
+    private static final String DESCRIPTION = "Some description";
+    private static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
+    private static final String CREATED_DATE = DateTimeUtils.toUTCDateString(TIMESTAMP);
+    private static final Map<String, String> PAYMENT_CREATED = new ChargeEventBuilder(STATUS, CREATED_DATE).build();
+    private static final List<Map<String, String>> EVENTS = Collections.singletonList(PAYMENT_CREATED);
+
+    private static final String SUCCESS_PAYLOAD = paymentPayload(AMOUNT, RETURN_URL, DESCRIPTION, REFERENCE);
+    private ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    @Before
+    public void setupApiKey() {
+        publicAuthMock.mapBearerTokenToAccountId(BEARER_TOKEN, GATEWAY_ACCOUNT_ID);
+    }
+
+    @Test
+    public void createPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
+
+        connectorMock.respondOk_whenCreateCharge(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID, STATUS, RETURN_URL,
+                DESCRIPTION, REFERENCE, PAYMENT_PROVIDER, CREATED_DATE);
+
+        List<Callable<ValidatableResponse>> tasks = Arrays.asList(
+                () -> postPaymentResponse(BEARER_TOKEN, SUCCESS_PAYLOAD),
+                () -> postPaymentResponse(BEARER_TOKEN, SUCCESS_PAYLOAD)
+        );
+
+        List<ValidatableResponse> finishedTasks = invokeAll(tasks);
+
+        assertThat(finishedTasks, hasItem(aResponse(201)));
+        assertThat(finishedTasks, hasItem(anErrorResponse(429, "P0900", "Too many requests")));
+    }
+
+    @Test
+    public void getPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
+
+        connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, STATUS, RETURN_URL,
+                DESCRIPTION, REFERENCE, PAYMENT_PROVIDER, CREATED_DATE, CHARGE_TOKEN_ID);
+
+        List<Callable<ValidatableResponse>> tasks = Arrays.asList(
+                () -> getPaymentResponse(BEARER_TOKEN, CHARGE_ID),
+                () -> getPaymentResponse(BEARER_TOKEN, CHARGE_ID)
+        );
+
+        List<ValidatableResponse> finishedTasks = invokeAll(tasks);
+
+        assertThat(finishedTasks, hasItem(aResponse(200)));
+        assertThat(finishedTasks, hasItem(anErrorResponse(429, "P0900", "Too many requests")));
+    }
+
+    @Test
+    public void getPaymentEvents_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
+
+        connectorMock.respondWithChargeEventsFound(GATEWAY_ACCOUNT_ID, CHARGE_ID, EVENTS);
+
+        List<Callable<ValidatableResponse>> tasks = Arrays.asList(
+                () -> getPaymentEventsResponse(BEARER_TOKEN, CHARGE_ID),
+                () -> getPaymentEventsResponse(BEARER_TOKEN, CHARGE_ID)
+        );
+
+        List<ValidatableResponse> finishedTasks = invokeAll(tasks);
+
+        assertThat(finishedTasks, hasItem(aResponse(200)));
+        assertThat(finishedTasks, hasItem(anErrorResponse(429, "P0900", "Too many requests")));
+    }
+
+    @Test
+    public void searchPayments_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
+
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, REFERENCE, null, null, null,
+                aSuccessfulSearchResponse()
+                        .withMatchingStatus(STATUS)
+                        .withMatchingReference(REFERENCE)
+                        .numberOfResults(1)
+                        .build());
+
+        List<Callable<ValidatableResponse>> tasks = Arrays.asList(
+                () -> searchPayments(BEARER_TOKEN, ImmutableMap.of("reference", REFERENCE)),
+                () -> searchPayments(BEARER_TOKEN, ImmutableMap.of("reference", REFERENCE))
+        );
+
+        List<ValidatableResponse> finishedTasks = invokeAll(tasks);
+
+        assertThat(finishedTasks, hasItem(aResponse(200)));
+        assertThat(finishedTasks, hasItem(anErrorResponse(429, "P0900", "Too many requests")));
+    }
+
+    @Test
+    public void cancelPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
+
+        connectorMock.respondOk_whenCancelCharge(CHARGE_ID, GATEWAY_ACCOUNT_ID);
+
+        List<Callable<ValidatableResponse>> tasks = Arrays.asList(
+                () -> postCancelPaymentResponse(CHARGE_ID),
+                () -> postCancelPaymentResponse(CHARGE_ID)
+        );
+
+        List<ValidatableResponse> finishedTasks = invokeAll(tasks);
+
+        assertThat(finishedTasks, hasItem(aResponse(204)));
+        assertThat(finishedTasks, hasItem(anErrorResponse(429, "P0900", "Too many requests")));
+    }
+
+    private List<ValidatableResponse> invokeAll(List<Callable<ValidatableResponse>> tasks) throws InterruptedException {
+        return executor.invokeAll(tasks)
+                .stream()
+                .map(future -> {
+                    try {
+                        return future.get();
+                    } catch (Exception e) {
+                        fail("Test fail with exception calling resource");
+                        return null;
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    private TypeSafeMatcher<ValidatableResponse> aResponse(final int statusCode) {
+        return new TypeSafeMatcher<ValidatableResponse>() {
+            @Override
+            protected boolean matchesSafely(ValidatableResponse validatableResponse) {
+                return validatableResponse.extract().statusCode() == statusCode;
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(" Status code: ")
+                        .appendValue(statusCode);
+            }
+        };
+    }
+
+    private TypeSafeMatcher<ValidatableResponse> anErrorResponse(int statusCode, String publicApiErrorCode, String expectedDescription) {
+        return new TypeSafeMatcher<ValidatableResponse>() {
+            @Override
+            protected boolean matchesSafely(ValidatableResponse validatableResponse) {
+                ExtractableResponse<Response> extract = validatableResponse.extract();
+                System.out.println("extract.body().asString() = " + extract.body().asString());
+                return extract.statusCode() == statusCode
+                        && publicApiErrorCode.equals(extract.body().<String>path("code"))
+                        && expectedDescription.equals(extract.body().<String>path("description"));
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(" Status code: ")
+                        .appendValue(statusCode)
+                        .appendText(", error code: ")
+                        .appendValue(publicApiErrorCode)
+                        .appendText(", message: ")
+                        .appendValue(expectedDescription)
+                ;
+            }
+        };
+    }
+
+    private static String paymentPayload(long amount, String returnUrl, String description, String reference) {
+        return new JsonStringBuilder()
+                .add("amount", amount)
+                .add("reference", reference)
+                .add("description", description)
+                .add("return_url", returnUrl)
+                .build();
+    }
+
+    private ValidatableResponse getPaymentResponse(String bearerToken, String paymentId) {
+        return given().port(app.getLocalPort())
+                .header(AUTHORIZATION, "Bearer " + bearerToken)
+                .get(PAYMENTS_PATH + paymentId)
+                .then();
+    }
+
+    private ValidatableResponse getPaymentEventsResponse(String bearerToken, String paymentId) {
+        return given().port(app.getLocalPort())
+                .header(AUTHORIZATION, "Bearer " + bearerToken)
+                .get(String.format("/v1/payments/%s/events", paymentId))
+                .then();
+    }
+
+    private ValidatableResponse postPaymentResponse(String bearerToken, String payload) {
+        return given().port(app.getLocalPort())
+                .body(payload)
+                .accept(JSON)
+                .contentType(JSON)
+                .header(AUTHORIZATION, "Bearer " + bearerToken)
+                .post(PAYMENTS_PATH)
+                .then();
+    }
+
+    private ValidatableResponse searchPayments(String bearerToken, ImmutableMap<String, String> queryParams) {
+        return given().port(app.getLocalPort())
+                .accept(JSON)
+                .contentType(JSON)
+                .header(AUTHORIZATION, "Bearer " + bearerToken)
+                .queryParameters(queryParams)
+                .get("/v1/payments")
+                .then();
+    }
+
+    private ValidatableResponse postCancelPaymentResponse(String paymentId) {
+        return given().port(app.getLocalPort())
+                .header(AUTHORIZATION, "Bearer " + BEARER_TOKEN)
+                .post(String.format("/v1/payments/%s/cancel", paymentId))
+                .then();
+    }
+}

--- a/src/test/java/uk/gov/pay/api/utils/ApiKeyGenerator.java
+++ b/src/test/java/uk/gov/pay/api/utils/ApiKeyGenerator.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.api.utils;
+
+import com.google.common.io.BaseEncoding;
+import org.apache.commons.codec.digest.HmacUtils;
+
+public class ApiKeyGenerator {
+
+    public static String apiKeyValueOf(String token, String secret) {
+        byte[] hmacBytes = HmacUtils.hmacSha1(secret, token);
+        String encodedHmac = BaseEncoding.base32Hex().lowerCase().omitPadding().encode(hmacBytes);
+        return token + encodedHmac;
+    }
+}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -20,3 +20,7 @@ publicAuthUrl: http://publicauth.url/v1/auth
 
 jerseyClientConfig:
   disabledSecureConnection: "true"
+
+rateLimiter:
+  rate: 1
+  perMillis: 1000

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -24,3 +24,5 @@ jerseyClientConfig:
 rateLimiter:
   rate: 1
   perMillis: 1000
+
+apiKeyHmacSecret: qwer9yuhgf


### PR DESCRIPTION
# WHAT 
So far, Authorization headers were non validated values, provoking for every single request, no matter the Authorization header value (as long it had one), a query into the database.
-  Added an Authorization filter that checks the Authorization header format and also validates that the token is valid by re-creating its Hash value and check the provided Hash being _API Key = Token + Hash_
- Added a Rate Limiter filter after the Authorization validation by limiting the number of requests per a period of time (configurable), current default is 3 requests per second per Authorization (hence a client service).
# WHO
Any dev 