### PR TITLE
PP-571 Relax rate limiter default values

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -16,7 +16,7 @@ jerseyClientConfig:
   disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS}
 
 rateLimiter:
-  rate: ${RATE_LIMITER_VALUE:-3}
+  rate: ${RATE_LIMITER_VALUE:-25}
   perMillis: ${RATE_LIMITER_PER_MILLIS:-1000}
 
 apiKeyHmacSecret: ${TOKEN_API_HMAC_SECRET}


### PR DESCRIPTION
# WHAT    
- Set default Rate limiter to 25/second for now since the current 3/second is very strict and there is no need.

# WHO
- Any dev/webops