### PR TITLE
PP-582 Add logging filter

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -14,6 +14,7 @@ import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.AccountAuthenticator;
 import uk.gov.pay.api.exception.mapper.*;
 import uk.gov.pay.api.filter.AuthorizationValidationFilter;
+import uk.gov.pay.api.filter.LoggingFilter;
 import uk.gov.pay.api.filter.RateLimiter;
 import uk.gov.pay.api.filter.RateLimiterFilter;
 import uk.gov.pay.api.healthcheck.Ping;
@@ -28,6 +29,7 @@ import javax.ws.rs.client.Client;
 
 import static java.util.EnumSet.of;
 import static javax.servlet.DispatcherType.REQUEST;
+import static uk.gov.pay.api.resources.PaymentsResource.API_VERSION_PATH;
 import static uk.gov.pay.api.validation.URLValidator.urlValidatorValueOf;
 
 public class PublicApi extends Application<PublicApiConfig> {
@@ -57,10 +59,13 @@ public class PublicApi extends Application<PublicApiConfig> {
         RateLimiter rateLimiter = new RateLimiter(config.getRateLimiterConfig().getRate(), config.getRateLimiterConfig().getPerMillis());
 
         environment.servlets().addFilter("AuthorizationValidationFilter", new AuthorizationValidationFilter(config.getApiKeyHmacSecret()))
-                .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
+                .addMappingForUrlPatterns(of(REQUEST), true, API_VERSION_PATH + "/*");
 
         environment.servlets().addFilter("RateLimiterFilter", new RateLimiterFilter(rateLimiter, objectMapper))
-                .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
+                .addMappingForUrlPatterns(of(REQUEST), true, API_VERSION_PATH + "/*");
+
+        environment.servlets().addFilter("LoggingFilter", new LoggingFilter())
+                .addMappingForUrlPatterns(of(REQUEST), true, API_VERSION_PATH + "/*");
 
         environment.jersey().register(AuthFactory.binder(new OAuthFactory<>(new AccountAuthenticator(client, config.getPublicAuthUrl()), "", String.class)));
 

--- a/src/main/java/uk/gov/pay/api/filter/LoggingFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/LoggingFilter.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.api.filter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+public class LoggingFilter implements Filter {
+
+    private static final Logger logger = LoggerFactory.getLogger(LoggingFilter.class);
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {}
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        String requestURL = ((HttpServletRequest) servletRequest).getRequestURI();
+
+        logger.info("Start - publicapi request - " + requestURL);
+        try {
+            filterChain.doFilter(servletRequest, servletResponse);
+        } catch (Throwable throwable){
+            logger.error("Exception - publicapi request - "+ requestURL + " - exception - "+ throwable.getMessage(), throwable);
+        }
+        finally {
+            logger.info("End - publicapi request - " + requestURL);
+        }
+    }
+
+    @Override
+    public void destroy() {}
+}

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.auth.Auth;
 import io.swagger.annotations.*;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
@@ -13,7 +12,6 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.exception.*;
 import uk.gov.pay.api.model.*;
 import uk.gov.pay.api.utils.JsonStringBuilder;
-import uk.gov.pay.api.validation.PaymentSearchValidator;
 
 import javax.ws.rs.*;
 import javax.ws.rs.client.Client;
@@ -32,7 +30,6 @@ import static java.util.Arrays.asList;
 import static javax.ws.rs.client.Entity.json;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.apache.commons.lang3.StringUtils.upperCase;
 import static org.apache.http.HttpStatus.SC_OK;
 import static uk.gov.pay.api.validation.PaymentSearchValidator.validateSearchParameters;
 
@@ -42,25 +39,27 @@ import static uk.gov.pay.api.validation.PaymentSearchValidator.validateSearchPar
 public class PaymentsResource {
     private static final Logger logger = LoggerFactory.getLogger(PaymentsResource.class);
 
-    public static final String PAYMENT_KEY = "paymentId";
+    public static final String API_VERSION_PATH = "/v1";
+
     public static final String REFERENCE_KEY = "reference";
     public static final String STATE_KEY = "state";
-    public static final String STATUS_KEY = "status";
     public static final String FROM_DATE_KEY = "from_date";
     public static final String TO_DATE_KEY = "to_date";
-    public static final String DESCRIPTION_KEY = "description";
-    public static final String AMOUNT_KEY = "amount";
-    public static final String SERVICE_RETURN_URL = "return_url";
-    public static final String CHARGE_KEY = "charge_id";
 
-    private static final String PAYMENTS_PATH = "/v1/payments";
+    private static final String PAYMENT_KEY = "paymentId";
+    private static final String DESCRIPTION_KEY = "description";
+    private static final String AMOUNT_KEY = "amount";
+    private static final String SERVICE_RETURN_URL = "return_url";
+    private static final String CHARGE_KEY = "charge_id";
+
+    private static final String PAYMENTS_PATH = API_VERSION_PATH + "/payments";
     private static final String PAYMENTS_ID_PLACEHOLDER = "{" + PAYMENT_KEY + "}";
-    private static final String PAYMENT_BY_ID = "/v1/payments/" + PAYMENTS_ID_PLACEHOLDER;
-    private static final String PAYMENT_EVENTS_BY_ID = "/v1/payments/" + PAYMENTS_ID_PLACEHOLDER + "/events";
+    private static final String PAYMENT_BY_ID = API_VERSION_PATH + "/payments/" + PAYMENTS_ID_PLACEHOLDER;
+    private static final String PAYMENT_EVENTS_BY_ID = API_VERSION_PATH + "/payments/" + PAYMENTS_ID_PLACEHOLDER + "/events";
 
     private static final String CANCEL_PATH_SUFFIX = "/cancel";
-    private static final String CANCEL_PAYMENT_PATH = "/v1/payments/" + PAYMENTS_ID_PLACEHOLDER + CANCEL_PATH_SUFFIX;
-    private static final String CONNECTOR_ACCOUNT_RESOURCE = "/v1/api/accounts/%s";
+    private static final String CANCEL_PAYMENT_PATH = API_VERSION_PATH + "/payments/" + PAYMENTS_ID_PLACEHOLDER + CANCEL_PATH_SUFFIX;
+    private static final String CONNECTOR_ACCOUNT_RESOURCE = API_VERSION_PATH + "/api/accounts/%s";
     private static final String CONNECTOR_CHARGES_RESOURCE = CONNECTOR_ACCOUNT_RESOURCE + "/charges";
     private static final String CONNECTOR_CHARGE_RESOURCE = CONNECTOR_CHARGES_RESOURCE + "/%s";
     private static final String CONNECTOR_CHARGE_EVENTS_RESOURCE = CONNECTOR_CHARGES_RESOURCE + "/%s" + "/events";

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -7,7 +7,13 @@ server:
       port: ${ADMIN_PORT}
 
 logging:
-  level: INFO
+    level: INFO
+    appenders:
+      - type: console
+        threshold: ALL
+        timeZone: UTC
+        target: stdout
+        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
 
 connectorUrl: ${CONNECTOR_URL}
 publicAuthUrl: ${PUBLIC_AUTH_URL}

--- a/src/test/java/uk/gov/pay/api/filter/LoggingFilterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/LoggingFilterTest.java
@@ -1,0 +1,94 @@
+package uk.gov.pay.api.filter;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LoggingFilterTest {
+
+    private LoggingFilter loggingFilter;
+
+    @Mock
+    HttpServletRequest mockRequest;
+
+    @Mock
+    HttpServletResponse mockResponse;
+
+    @Mock
+    FilterChain mockFilterChain;
+
+    private Appender<ILoggingEvent> mockAppender;
+
+    @Captor
+    ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+
+    @Before
+    public void setup() {
+        loggingFilter = new LoggingFilter();
+        Logger root = (Logger) LoggerFactory.getLogger(LoggingFilter.class);
+        mockAppender = mockAppender();
+        root.addAppender(mockAppender);
+    }
+
+    @Test
+    public void shouldLogEntryAndExitPointsOfEndPoints() throws Exception {
+
+        String requestUrl = "/publicapi-request";
+        when(mockRequest.getRequestURI()).thenReturn(requestUrl);
+        loggingFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+
+        assertThat(loggingEvents.get(0).getFormattedMessage(), is("Start - publicapi request - " + requestUrl));
+        assertThat(loggingEvents.get(1).getFormattedMessage(), is("End - publicapi request - " + requestUrl));
+        verify(mockFilterChain).doFilter(mockRequest, mockResponse);
+    }
+
+    @Test
+    public void shouldLogEntryAndExitPointsEvenWhenFilterChainingThrowsException() throws Exception {
+        String requestUrl = "/publicapi-url-with-exception";
+        when(mockRequest.getRequestURI()).thenReturn(requestUrl);
+
+        IOException exception = new IOException("Failed request");
+        doThrow(exception).when(mockFilterChain).doFilter(mockRequest, mockResponse);
+
+        loggingFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+
+        verify(mockAppender, times(3)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+
+        assertThat(loggingEvents.get(0).getFormattedMessage(), is("Start - publicapi request - "+ requestUrl));
+        assertThat(loggingEvents.get(1).getFormattedMessage(), is("Exception - publicapi request - "+ requestUrl + " - exception - "+ exception.getMessage()));
+        assertThat(loggingEvents.get(1).getLevel(), is(Level.ERROR));
+        assertThat(loggingEvents.get(1).getThrowableProxy().getMessage(), is("Failed request"));
+        assertThat(loggingEvents.get(2).getFormattedMessage(), is("End - publicapi request - "+ requestUrl));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Appender<T> mockAppender() {
+        return mock(Appender.class);
+    }
+
+}


### PR DESCRIPTION
## WHAT
Introducing a Logging filter that would log all incoming requests with a prefix. 
This gives us a nice trace of the request in the form of; start->error(if any)->end

## HOW TO REVIEW
Run through a payment journey and you should be able to see start->end logging for each resource hit on the connector.

## WHO
Any Dev