### PR TITLE
PP-541 Begin swap of Confirmed/Captured to Success

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -180,7 +180,7 @@ public class PaymentsResource {
                                    @Auth String accountId,
                                    @ApiParam(value = "Your payment reference to search", hidden = false)
                                    @QueryParam(REFERENCE_KEY) String reference,
-                                   @ApiParam(value = "State of payments to be searched. Example=confirmed", hidden = false, allowableValues = "range[created,started,submitted,failed,cancelled,error,confirmed,captured")
+                                   @ApiParam(value = "State of payments to be searched. Example=success", hidden = false, allowableValues = "range[created,started,submitted,success,failed,cancelled,error")
                                    @QueryParam(STATE_KEY) String state,
                                    @ApiParam(value = "From date of payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z", hidden = false)
                                    @QueryParam(FROM_DATE_KEY) String fromDate,

--- a/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
@@ -15,8 +15,9 @@ import static uk.gov.pay.api.validation.PaymentRequestValidator.REFERENCE_MAX_LE
 
 public class PaymentSearchValidator {
     // we should really find a way to not have this anywhere but in the connector...
+    // confirmed and captured should be removed once PP-541 ammendments are complete
     public static final Set<String> VALID_STATES =
-        new HashSet<>(Arrays.asList("created", "started", "submitted", "failed", "cancelled", "error", "confirmed", "captured"));
+        new HashSet<>(Arrays.asList("created", "started", "submitted", "success", "failed", "cancelled", "error", "confirmed", "captured"));
 
     public static void validateSearchParameters(String state, String reference, String fromDate, String toDate) {
         List<String> validationErrors = new LinkedList<>();

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
@@ -68,7 +68,7 @@ public class PaymentSearchResultBuilder {
         states.add(new TestPaymentState("created", false));
         states.add(new TestPaymentState("started", false));
         states.add(new TestPaymentState("submitted", false));
-        states.add(new TestPaymentSuccessState("confirmed"));
+        states.add(new TestPaymentSuccessState("success"));
     };
 
     private int noOfResults = DEFAULT_NUMBER_OF_RESULTS;

--- a/src/test/java/uk/gov/pay/api/validation/PaymentSearchValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/PaymentSearchValidatorTest.java
@@ -14,7 +14,7 @@ public class PaymentSearchValidatorTest {
 
     @Test
     public void validateParams_shouldSuccessValidation() {
-        PaymentSearchValidator.validateSearchParameters("confirmed", "ref", "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z");
+        PaymentSearchValidator.validateSearchParameters("success", "ref", "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z");
     }
 
     @Test
@@ -22,7 +22,7 @@ public class PaymentSearchValidatorTest {
 
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: reference. See Public API documentation for the correct data formats"));
 
-        PaymentSearchValidator.validateSearchParameters("confirmed", randomAlphanumeric(500), "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z");
+        PaymentSearchValidator.validateSearchParameters("success", randomAlphanumeric(500), "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z");
     }
 
     @Test
@@ -38,7 +38,7 @@ public class PaymentSearchValidatorTest {
 
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: to_date. See Public API documentation for the correct data formats"));
 
-        PaymentSearchValidator.validateSearchParameters("confirmed", "ref", "2016-01-25T13:23:55Z", "2016-01-25T13-23:55Z");
+        PaymentSearchValidator.validateSearchParameters("success", "ref", "2016-01-25T13:23:55Z", "2016-01-25T13-23:55Z");
     }
 
     @Test
@@ -46,7 +46,7 @@ public class PaymentSearchValidatorTest {
 
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: from_date. See Public API documentation for the correct data formats"));
 
-        PaymentSearchValidator.validateSearchParameters("confirmed", "ref", "2016-01-25T13-23:55Z", "2016-01-25T13:23:55Z");
+        PaymentSearchValidator.validateSearchParameters("success", "ref", "2016-01-25T13-23:55Z", "2016-01-25T13:23:55Z");
     }
 
     @Test

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -23,10 +23,10 @@
         }, {
           "name" : "state",
           "in" : "query",
-          "description" : "State of payments to be searched. Example=confirmed",
+          "description" : "State of payments to be searched. Example=success",
           "required" : false,
           "type" : "string",
-          "enum" : [ "range[created", "started", "submitted", "failed", "cancelled", "error", "confirmed", "captured" ]
+          "enum" : [ "range[created", "started", "submitted", "success", "failed", "cancelled", "error" ]
         }, {
           "name" : "from_date",
           "in" : "query",


### PR DESCRIPTION
## WHAT
We allow the status 'success' to pass through publicapi without failing
validation. The Confirmed/Capture states will be removed after the changes
are applied to SelfService and Connector.

## HOW 
Add success to the list of allowed statuses. Switch some integration tests to 'success' so they will continue to be good tests after confirmed is removed.

## WHO
_Who should review this pull request:_

- [x] Developers
- [ ]  WebOps
