### PR TITLE
PP-541 Remove confirmed / captured backwards compat

### DIFF
--- a/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
@@ -16,9 +16,8 @@ import static uk.gov.pay.api.validation.PaymentRequestValidator.REFERENCE_MAX_LE
 
 public class PaymentSearchValidator {
     // we should really find a way to not have this anywhere but in the connector...
-    // confirmed and captured should be removed once PP-541 ammendments are complete
     public static final Set<String> VALID_STATES =
-            new HashSet<>(Arrays.asList("created", "started", "submitted", "success", "failed", "cancelled", "error", "confirmed", "captured"));
+            new HashSet<>(Arrays.asList("created", "started", "submitted", "success", "failed", "cancelled", "error"));
 
     public static void validateSearchParameters(String state, String reference, String fromDate, String toDate, String pageNumber, String displaySize) {
         List<String> validationErrors = new LinkedList<>();

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -95,7 +95,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
     @Test
     public void searchPayments_ShouldNotIncludeCancelLinkIfThePaymentCannotBeCancelled() {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        String SUCCEEDED_STATE = "confirmed";
+        String SUCCEEDED_STATE = "success";
 
         String payments = aPaginatedPaymentSearchResult()
                 .withCount(10)

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchValidationITest.java
@@ -20,7 +20,7 @@ import static org.hamcrest.core.Is.is;
 public class PaymentResourceSearchValidationITest extends PaymentResourceITestBase {
 
     private static final String VALID_REFERENCE = "test_reference";
-    private static final String VALID_STATE = "confirmed";
+    private static final String VALID_STATE = "success";
     private static final String VALID_FROM_DATE = "2016-01-28T00:00:00Z";
     private static final String VALID_TO_DATE = "2016-01-28T12:00:00Z";
 

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
@@ -219,7 +219,7 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
     public void getPayment_ShouldNotIncludeCancelLinkIfPaymentCannotBeCancelled() {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID,
-                new PaymentState("confirmed", true, null, null),
+                new PaymentState("success", true, null, null),
                 RETURN_URL, DESCRIPTION, REFERENCE, PAYMENT_PROVIDER, CREATED_DATE, CHARGE_TOKEN_ID);
 
         getPaymentResponse(API_KEY, CHARGE_ID)


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_
Remove backwards compatibility with old 'confirmed' and 'captured' states.

## HOW 
_Steps to test or reproduce:_
Fail validation of 'confirmed' and 'captured' states now we moved to 'success'.
A few tests were still using 'confirmed' but this did not affect their function. Correct these too.

## WHO
_Who should review this pull request:_

- [x] Developers
- [ ] WebOps


