### PR TITLE
PP-800 Support for all supported HTTP verbs in request-denied resource

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/RequestDeniedResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/RequestDeniedResource.java
@@ -3,10 +3,7 @@ package uk.gov.pay.api.resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -19,10 +16,35 @@ public class RequestDeniedResource {
 
     private static final Logger logger = LoggerFactory.getLogger(RequestDeniedResource.class);
 
+    @GET
+    @Path("request-denied")
+    @Produces(APPLICATION_JSON)
+    public Response requestDeniedGet(@HeaderParam("x-naxsi_sig") String naxsiViolatedRules) {
+        return requestDenied(naxsiViolatedRules);
+    }
+
     @POST
     @Path("request-denied")
     @Produces(APPLICATION_JSON)
-    public Response requestDenied(@HeaderParam("x-naxsi_sig") String naxsiViolatedRules) {
+    public Response requestDeniedPost(@HeaderParam("x-naxsi_sig") String naxsiViolatedRules) {
+        return requestDenied(naxsiViolatedRules);
+    }
+
+    @PUT
+    @Path("request-denied")
+    @Produces(APPLICATION_JSON)
+    public Response requestDeniedPut(@HeaderParam("x-naxsi_sig") String naxsiViolatedRules) {
+        return requestDenied(naxsiViolatedRules);
+    }
+
+    @DELETE
+    @Path("request-denied")
+    @Produces(APPLICATION_JSON)
+    public Response requestDeniedDelete(@HeaderParam("x-naxsi_sig") String naxsiViolatedRules) {
+        return requestDenied(naxsiViolatedRules);
+    }
+
+    private Response requestDenied(@HeaderParam("x-naxsi_sig") String naxsiViolatedRules) {
         logger.info("Naxsi rules violated - [ {} ]", naxsiViolatedRules);
         return Response.status(BAD_REQUEST).entity(aPaymentError(REQUEST_DENIED_ERROR)).build();
     }

--- a/src/test/java/uk/gov/pay/api/it/RequestDeniedResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/RequestDeniedResourceITest.java
@@ -14,11 +14,65 @@ import static org.hamcrest.core.Is.is;
 public class RequestDeniedResourceITest extends PaymentResourceITestBase {
 
     @Test
-    public void requestDenied() throws IOException {
+    public void requestDeniedPost() throws IOException {
 
         InputStream body = given().port(app.getLocalPort())
-                .header("x-naxsi_sig","rules violated")
+                .header("x-naxsi_sig", "rules violated")
                 .post("request-denied")
+                .then()
+                .statusCode(400)
+                .contentType(JSON).extract()
+                .body().asInputStream();
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(2))
+                .assertThat("$.code", is("P0920"))
+                .assertThat("$.description", is("Request blocked by security rules. Please consult API documentation for more information."));
+
+    }
+
+    @Test
+    public void requestDeniedGet() throws IOException {
+
+        InputStream body = given().port(app.getLocalPort())
+                .header("x-naxsi_sig", "rules violated")
+                .get("request-denied")
+                .then()
+                .statusCode(400)
+                .contentType(JSON).extract()
+                .body().asInputStream();
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(2))
+                .assertThat("$.code", is("P0920"))
+                .assertThat("$.description", is("Request blocked by security rules. Please consult API documentation for more information."));
+
+    }
+
+    @Test
+    public void requestDeniedPut() throws IOException {
+
+        InputStream body = given().port(app.getLocalPort())
+                .header("x-naxsi_sig", "rules violated")
+                .put("request-denied")
+                .then()
+                .statusCode(400)
+                .contentType(JSON).extract()
+                .body().asInputStream();
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(2))
+                .assertThat("$.code", is("P0920"))
+                .assertThat("$.description", is("Request blocked by security rules. Please consult API documentation for more information."));
+
+    }
+
+    @Test
+    public void requestDeniedDelete() throws IOException {
+
+        InputStream body = given().port(app.getLocalPort())
+                .header("x-naxsi_sig", "rules violated")
+                .delete("request-denied")
                 .then()
                 .statusCode(400)
                 .contentType(JSON).extract()


### PR DESCRIPTION
## WHAT
- When _Naxsi_ triggers a redirect (rule violated), the request to _/request-denied_ will use the same verb as the origin request so added the other verbs for this resource.

## WHO
- [X] Developers
- [X] WebOps


