### PR TITLE
PP-864 Allow the ability to search charges by email 

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
@@ -28,6 +28,7 @@ public class ChargeFromResponse {
     private PaymentState state;
     private String description;
     private String reference;
+    private String email;
     private String created_date;
 
     public String getChargeId() {
@@ -52,6 +53,10 @@ public class ChargeFromResponse {
 
     public String getReference() {
         return reference;
+    }
+
+    public String getEmail() {
+        return email;
     }
 
     public String getPaymentProvider() {

--- a/src/main/java/uk/gov/pay/api/model/Payment.java
+++ b/src/main/java/uk/gov/pay/api/model/Payment.java
@@ -19,6 +19,7 @@ public abstract class Payment {
     @JsonProperty("return_url")
     private final String returnUrl;
     private final String reference;
+    private final String email;
 
     @JsonProperty("created_date")
     private final String createdDate;
@@ -27,13 +28,14 @@ public abstract class Payment {
     private final RefundSummary refundSummary;
 
     public Payment(String chargeId, long amount, PaymentState state, String returnUrl, String description,
-                   String reference, String paymentProvider, String createdDate, RefundSummary refundSummary) {
+                   String reference, String email, String paymentProvider, String createdDate, RefundSummary refundSummary) {
         this.paymentId = chargeId;
         this.amount = amount;
         this.state = state;
         this.returnUrl = returnUrl;
         this.description = description;
         this.reference = reference;
+        this.email = email;
         this.paymentProvider = paymentProvider;
         this.createdDate = createdDate;
         this.refundSummary = refundSummary;
@@ -74,6 +76,11 @@ public abstract class Payment {
         return reference;
     }
 
+    @ApiModelProperty(example = "your email")
+    public String getEmail() {
+        return email;
+    }
+
     @ApiModelProperty(example = "worldpay")
     public String getPaymentProvider() {
         return paymentProvider;
@@ -94,6 +101,7 @@ public abstract class Payment {
                 ", returnUrl='" + returnUrl + '\'' +
                 ", description='" + description + '\'' +
                 ", reference='" + reference + '\'' +
+                ", email='" + email + '\'' +
                 ", createdDate='" + createdDate + '\'' +
                 '}';
     }

--- a/src/main/java/uk/gov/pay/api/model/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentForSearchResult.java
@@ -14,7 +14,7 @@ public class PaymentForSearchResult extends Payment {
     public PaymentForSearchResult(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                                   String reference, String email, String paymentProvider, String createdDate,
                                   RefundSummary refundSummary, URI selfLink, URI paymentEventsLink, URI paymentCancelLink, URI paymentRefundsLink) {
-        super(chargeId, amount, state, returnUrl, description, reference, paymentProvider, createdDate, refundSummary);
+        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate, refundSummary);
         this.links.addSelf(selfLink.toString());
         this.links.addEvents(paymentEventsLink.toString());
         this.links.addRefunds(paymentRefundsLink.toString());

--- a/src/main/java/uk/gov/pay/api/model/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentForSearchResult.java
@@ -12,7 +12,7 @@ public class PaymentForSearchResult extends Payment {
     private PaymentLinksForSearch links = new PaymentLinksForSearch();
 
     public PaymentForSearchResult(String chargeId, long amount, PaymentState state, String returnUrl, String description,
-                                  String reference, String paymentProvider, String createdDate,
+                                  String reference, String email, String paymentProvider, String createdDate,
                                   RefundSummary refundSummary, URI selfLink, URI paymentEventsLink, URI paymentCancelLink, URI paymentRefundsLink) {
         super(chargeId, amount, state, returnUrl, description, reference, paymentProvider, createdDate, refundSummary);
         this.links.addSelf(selfLink.toString());
@@ -38,6 +38,7 @@ public class PaymentForSearchResult extends Payment {
                 paymentResult.getReturnUrl(),
                 paymentResult.getDescription(),
                 paymentResult.getReference(),
+                paymentResult.getEmail(),
                 paymentResult.getPaymentProvider(),
                 paymentResult.getCreated_date(),
                 paymentResult.getRefundSummary(), selfLink,

--- a/src/main/java/uk/gov/pay/api/model/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentWithAllLinks.java
@@ -13,10 +13,10 @@ public class PaymentWithAllLinks extends Payment {
     private PaymentLinks links = new PaymentLinks();
 
     private PaymentWithAllLinks(String chargeId, long amount, PaymentState state, String returnUrl, String description,
-                                String reference, String paymentProvider, String createdDate, RefundSummary refundSummary,
-                                List<PaymentConnectorResponseLink> paymentConnectorResponseLinks,
+                                String reference, String email, String paymentProvider, String createdDate,
+                                RefundSummary refundSummary, List<PaymentConnectorResponseLink> paymentConnectorResponseLinks,
                                 URI selfLink, URI paymentEventsUri, URI paymentCancelUri, URI paymentRefundsUri) {
-        super(chargeId, amount, state, returnUrl, description, reference, paymentProvider, createdDate, refundSummary);
+        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate, refundSummary);
         this.links.addSelf(selfLink.toString());
         this.links.addKnownLinksValueOf(paymentConnectorResponseLinks);
         this.links.addEvents(paymentEventsUri.toString());
@@ -39,6 +39,7 @@ public class PaymentWithAllLinks extends Payment {
                 paymentConnector.getReturnUrl(),
                 paymentConnector.getDescription(),
                 paymentConnector.getReference(),
+                paymentConnector.getEmail(),
                 paymentConnector.getPaymentProvider(),
                 paymentConnector.getCreated_date(),
                 paymentConnector.getRefundSummary(),

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -42,6 +42,7 @@ public class PaymentsResource {
     public static final String API_VERSION_PATH = "/v1";
 
     public static final String REFERENCE_KEY = "reference";
+    public static final String EMAIL_KEY = "email";
     public static final String STATE_KEY = "state";
     public static final String FROM_DATE_KEY = "from_date";
     public static final String TO_DATE_KEY = "to_date";
@@ -184,6 +185,8 @@ public class PaymentsResource {
                                    @Auth String accountId,
                                    @ApiParam(value = "Your payment reference to search", hidden = false)
                                    @QueryParam(REFERENCE_KEY) String reference,
+                                   @ApiParam(value = "The user email used in the payment to be searched", hidden = false)
+                                   @QueryParam(EMAIL_KEY) String email,
                                    @ApiParam(value = "State of payments to be searched. Example=success", hidden = false, allowableValues = "range[created,started,submitted,success,failed,cancelled,error")
                                    @QueryParam(STATE_KEY) String state,
                                    @ApiParam(value = "From date of payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z", hidden = false)
@@ -197,12 +200,14 @@ public class PaymentsResource {
                                    @Context UriInfo uriInfo) {
 
         logger.info("Payments search request - [ {} ]",
-                format("reference:%s, status: %s, fromDate: %s, toDate: %s, page: %s, display_size: %s", reference, state, fromDate, toDate, pageNumber, displaySize));
+                format("reference:%s, email: %s, status: %s, fromDate: %s, toDate: %s, page: %s, display_size: %s",
+                        reference, email, state, fromDate, toDate, pageNumber, displaySize));
 
-        validateSearchParameters(state, reference, fromDate, toDate, pageNumber, displaySize);
+        validateSearchParameters(state, reference, email, fromDate, toDate, pageNumber, displaySize);
 
         List<Pair<String, String>> queryParams = asList(
                 Pair.of(REFERENCE_KEY, reference),
+                Pair.of(EMAIL_KEY, email),
                 Pair.of(STATE_KEY, state),
                 Pair.of(FROM_DATE_KEY, fromDate),
                 Pair.of(TO_DATE_KEY, toDate),

--- a/src/main/java/uk/gov/pay/api/validation/PaymentRequestValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/PaymentRequestValidator.java
@@ -23,6 +23,7 @@ public class PaymentRequestValidator {
     private static final int DESCRIPTION_MAX_LENGTH = 255;
     private static final int URL_MAX_LENGTH = 2000;
     static final int REFERENCE_MAX_LENGTH = 255;
+    static final int EMAIL_MAX_LENGTH = 254;
 
     private URLValidator urlValidator;
 

--- a/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
@@ -13,6 +13,7 @@ import static uk.gov.pay.api.model.PaymentError.Code.SEARCH_PAYMENTS_VALIDATION_
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 import static uk.gov.pay.api.resources.PaymentsResource.*;
 import static uk.gov.pay.api.validation.MaxLengthValidator.isValid;
+import static uk.gov.pay.api.validation.PaymentRequestValidator.EMAIL_MAX_LENGTH;
 import static uk.gov.pay.api.validation.PaymentRequestValidator.REFERENCE_MAX_LENGTH;
 
 public class PaymentSearchValidator {
@@ -20,11 +21,12 @@ public class PaymentSearchValidator {
     public static final Set<String> VALID_STATES =
             new HashSet<>(Arrays.asList("created", "started", "submitted", "success", "failed", "cancelled", "error"));
 
-    public static void validateSearchParameters(String state, String reference, String fromDate, String toDate, String pageNumber, String displaySize) {
+    public static void validateSearchParameters(String state, String reference, String email, String fromDate, String toDate, String pageNumber, String displaySize) {
         List<String> validationErrors = new LinkedList<>();
         try {
             validateState(state, validationErrors);
             validateReference(reference, validationErrors);
+            validateEmail(email, validationErrors);
             validateFromDate(fromDate, validationErrors);
             validateToDate(toDate, validationErrors);
             validatePageIfNotNull(pageNumber, validationErrors);
@@ -64,6 +66,12 @@ public class PaymentSearchValidator {
     private static void validateReference(String reference, List<String> validationErrors) {
         if (!isValid(reference, REFERENCE_MAX_LENGTH)) {
             validationErrors.add(REFERENCE_KEY);
+        }
+    }
+
+    private static void validateEmail(String email, List<String> validationErrors) {
+        if (!isValid(email, EMAIL_MAX_LENGTH)) {
+            validationErrors.add(EMAIL_KEY);
         }
     }
 

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchValidationITest.java
@@ -21,8 +21,10 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
 
     private static final String VALID_REFERENCE = "test_reference";
     private static final String VALID_STATE = "success";
+    private static final String VALID_EMAIL = "alice.111@mail.fake";
     private static final String VALID_FROM_DATE = "2016-01-28T00:00:00Z";
     private static final String VALID_TO_DATE = "2016-01-28T12:00:00Z";
+    private static final String INVALID_EMAIL = RandomStringUtils.randomAlphanumeric(254) + "@mail.fake";
 
     private static final String SEARCH_PATH = "/v1/payments";
 
@@ -34,7 +36,12 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
     @Test
     public void searchPayments_errorWhenToDateIsNotInZoneDateTimeFormat() throws Exception {
         InputStream body = searchPayments(API_KEY,
-                ImmutableMap.of("reference", VALID_REFERENCE, "state", VALID_STATE, "from_date", VALID_FROM_DATE, "to_date", "2016-01-01 00:00"))
+                ImmutableMap.of(
+                        "reference", VALID_REFERENCE,
+                        "email", VALID_EMAIL,
+                        "state", VALID_STATE,
+                        "from_date", VALID_FROM_DATE,
+                        "to_date", "2016-01-01 00:00"))
                 .statusCode(422)
                 .contentType(JSON).extract()
                 .body().asInputStream();
@@ -48,7 +55,12 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
     @Test
     public void searchPayments_errorWhenFromDateIsNotInZoneDateTimeFormat() throws Exception {
         InputStream body = searchPayments(API_KEY,
-                ImmutableMap.of("reference", VALID_REFERENCE, "state", VALID_STATE, "from_date", "2016-01-01 00:00", "to_date", VALID_TO_DATE))
+                ImmutableMap.of(
+                        "reference", VALID_REFERENCE,
+                        "email", VALID_EMAIL,
+                        "state", VALID_STATE,
+                        "from_date", "2016-01-01 00:00",
+                        "to_date", VALID_TO_DATE))
                 .statusCode(422)
                 .contentType(JSON).extract()
                 .body().asInputStream();
@@ -62,7 +74,12 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
     @Test
     public void searchPayments_errorWhenStatusNotMatchingWithExpectedExternalStatuses() throws Exception {
         InputStream body = searchPayments(API_KEY,
-                ImmutableMap.of("reference", VALID_REFERENCE, "state", "invalid state", "from_date", VALID_FROM_DATE, "to_date", VALID_TO_DATE))
+                ImmutableMap.of(
+                        "reference", VALID_REFERENCE,
+                        "email", VALID_EMAIL,
+                        "state", "invalid state",
+                        "from_date", VALID_FROM_DATE,
+                        "to_date", VALID_TO_DATE))
                 .statusCode(422)
                 .contentType(JSON).extract()
                 .body().asInputStream();
@@ -76,7 +93,12 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
     @Test
     public void searchPayments_errorWhenReferenceSizeIsLongerThan255() throws Exception {
         InputStream body = searchPayments(API_KEY,
-                ImmutableMap.of("reference", RandomStringUtils.randomAlphanumeric(256), "state", VALID_STATE, "from_date", VALID_FROM_DATE, "to_date", VALID_TO_DATE))
+                ImmutableMap.of(
+                        "reference", RandomStringUtils.randomAlphanumeric(256),
+                        "email", VALID_EMAIL,
+                        "state", VALID_STATE,
+                        "from_date", VALID_FROM_DATE,
+                        "to_date", VALID_TO_DATE))
                 .statusCode(422)
                 .contentType(JSON).extract()
                 .body().asInputStream();
@@ -88,9 +110,33 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
     }
 
     @Test
+    public void searchPayments_errorWhenEmailSizeIsLongerThan254() throws Exception {
+        InputStream body = searchPayments(API_KEY,
+                ImmutableMap.of(
+                        "reference", "ref",
+                        "email", RandomStringUtils.randomAlphanumeric(254) + "@mail.fake",
+                        "state", VALID_STATE,
+                        "from_date", VALID_FROM_DATE,
+                        "to_date", VALID_TO_DATE))
+                .statusCode(422)
+                .contentType(JSON).extract()
+                .body().asInputStream();
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(2))
+                .assertThat("$.code", is("P0401"))
+                .assertThat("$.description", is("Invalid parameters: email. See Public API documentation for the correct data formats"));
+    }
+
+    @Test
     public void searchPayments_errorWhenToDateNotInZoneDateTimeFormat_andInvalidStatus() throws Exception {
         InputStream body = searchPayments(API_KEY,
-                ImmutableMap.of("reference", VALID_REFERENCE, "state", "invalid state", "from_date", VALID_FROM_DATE, "to_date", "2016-01-01 00:00"))
+                ImmutableMap.of(
+                        "reference", VALID_REFERENCE,
+                        "email", VALID_EMAIL,
+                        "state", "invalid state",
+                        "from_date", VALID_FROM_DATE,
+                        "to_date", "2016-01-01 00:00"))
                 .statusCode(422)
                 .contentType(JSON).extract()
                 .body().asInputStream();
@@ -104,7 +150,12 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
     @Test
     public void searchPayments_errorWhenFromAndToDatesAreNotInZoneDateTimeFormat() throws Exception {
         InputStream body = searchPayments(API_KEY,
-                ImmutableMap.of("reference", VALID_REFERENCE, "state", VALID_STATE, "from_date", "12345", "to_date", "2016-01-01 00:00"))
+                ImmutableMap.of(
+                        "reference", VALID_REFERENCE,
+                        "email", VALID_EMAIL,
+                        "state", VALID_STATE,
+                        "from_date", "12345",
+                        "to_date", "2016-01-01 00:00"))
                 .statusCode(422)
                 .contentType(JSON).extract()
                 .body().asInputStream();
@@ -118,7 +169,12 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
     @Test
     public void searchPayments_errorWhenAllFieldsAreInvalid() throws Exception {
         InputStream body = searchPayments(API_KEY,
-                ImmutableMap.of("reference", RandomStringUtils.randomAlphanumeric(256), "state", "invalid state", "from_date", "12345", "to_date", "98765"))
+                ImmutableMap.of(
+                        "reference", RandomStringUtils.randomAlphanumeric(256),
+                        "email", INVALID_EMAIL,
+                        "state", "invalid state",
+                        "from_date", "12345",
+                        "to_date", "98765"))
                 .statusCode(422)
                 .contentType(JSON).extract()
                 .body().asInputStream();
@@ -128,7 +184,7 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
         JsonAssert.with(json)
                 .assertThat("$.*", hasSize(2))
                 .assertThat("$.code", is("P0401"))
-                .assertThat("$.description", is("Invalid parameters: state, reference, from_date, to_date. See Public API documentation for the correct data formats"));
+                .assertThat("$.description", is("Invalid parameters: state, reference, email, from_date, to_date. See Public API documentation for the correct data formats"));
     }
 
     private ValidatableResponse searchPayments(String bearerToken, ImmutableMap<String, String> queryParams) {

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFiltersITest.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFiltersITest.java
@@ -44,6 +44,7 @@ public class ResourcesFiltersITest extends PaymentResourceITestBase {
     private static final String PAYMENT_PROVIDER = "Sandbox";
     private static final String RETURN_URL = "http://somewhere.gov.uk/rainbow/1";
     private static final String REFERENCE = "Some reference";
+    private static final String EMAIL = "alice.111@mail.fake";
     private static final String DESCRIPTION = "Some description";
     private static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
     private static final String CREATED_DATE = DateTimeUtils.toUTCDateString(TIMESTAMP);
@@ -62,7 +63,7 @@ public class ResourcesFiltersITest extends PaymentResourceITestBase {
     public void createPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
 
         connectorMock.respondOk_whenCreateCharge(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID, STATE,
-                RETURN_URL, DESCRIPTION, REFERENCE, PAYMENT_PROVIDER, CREATED_DATE, REFUND_SUMMARY);
+                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, REFUND_SUMMARY);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> postPaymentResponse(API_KEY, PAYLOAD),
@@ -93,7 +94,7 @@ public class ResourcesFiltersITest extends PaymentResourceITestBase {
     public void getPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
 
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, STATE,
-                RETURN_URL, DESCRIPTION, REFERENCE, PAYMENT_PROVIDER, CREATED_DATE, CHARGE_TOKEN_ID, REFUND_SUMMARY);
+                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, CHARGE_TOKEN_ID, REFUND_SUMMARY);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> getPaymentResponse(API_KEY, CHARGE_ID),
@@ -163,9 +164,7 @@ public class ResourcesFiltersITest extends PaymentResourceITestBase {
                         .withNumberOfResults(1).getResults())
                 .build();
 
-        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, REFERENCE, null, null, null,
-                payments
-        );
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, REFERENCE, null, null, null, null, payments);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> searchPayments(API_KEY, ImmutableMap.of("reference", REFERENCE)),

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
@@ -23,6 +23,7 @@ public class PaymentSearchResultBuilder {
     public static final String DEFAULT_CREATED_DATE = DateTimeUtils.toUTCDateString(ZonedDateTime.now());
     public static final String DEFAULT_RETURN_URL = "http://example.com/service";
     public static final int DEFAULT_AMOUNT = 10000;
+    public static final String DEFAULT_EMAIL = "alice.111@mail.fake";
     public static final String DEFAULT_PAYMENT_PROVIDER = "worldpay";
 
     private static class RefundSummary {
@@ -33,7 +34,7 @@ public class PaymentSearchResultBuilder {
 
     private static class TestPayment {
         public TestPaymentState state;
-        public String charge_id, description, reference, created_date;
+        public String charge_id, description, reference, email, created_date;
         public int amount;
         public String gateway_transaction_id, return_url, payment_provider;
         public RefundSummary refund_summary = new RefundSummary();
@@ -82,6 +83,7 @@ public class PaymentSearchResultBuilder {
     private int noOfResults = DEFAULT_NUMBER_OF_RESULTS;
 
     private String reference = null;
+    private String email = null;
     private TestPaymentState state = null;
     private String fromDate = null;
     private String toDate = null;
@@ -93,6 +95,11 @@ public class PaymentSearchResultBuilder {
 
     public PaymentSearchResultBuilder withMatchingReference(String reference) {
         this.reference = reference;
+        return this;
+    }
+
+    public PaymentSearchResultBuilder withMatchingEmail(String email) {
+        this.email = email;
         return this;
     }
 
@@ -168,6 +175,7 @@ public class PaymentSearchResultBuilder {
         payment.charge_id = "" + i;
         payment.description = "description-" + i;
         payment.reference = randomUUID().toString();
+        payment.email = DEFAULT_EMAIL;
         payment.state = state;
         payment.amount = DEFAULT_AMOUNT;
         payment.gateway_transaction_id = randomUUID().toString();

--- a/src/test/java/uk/gov/pay/api/validation/PaymentSearchValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/PaymentSearchValidatorTest.java
@@ -11,64 +11,72 @@ public class PaymentSearchValidatorTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+    private static final String SUCCESSFUL_TEST_EMAIL = "alice.111@mail.fake";
+    private static final String UNSUCCESSFUL_TEST_EMAIL = randomAlphanumeric(255) + "@mail.fake";
 
     @Test
     public void validateParams_shouldSuccessValidation() {
-        PaymentSearchValidator.validateSearchParameters("success", "ref", "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "1", "1");
+        PaymentSearchValidator.validateSearchParameters("success", "ref", SUCCESSFUL_TEST_EMAIL, "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "1", "1");
     }
 
     @Test
     public void validateParams_reference_shouldGiveAnErrorValidation() throws Exception {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: reference. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("success", randomAlphanumeric(500), "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "1", "1");
+        PaymentSearchValidator.validateSearchParameters("success", randomAlphanumeric(500), SUCCESSFUL_TEST_EMAIL, "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "1", "1");
+    }
+
+    @Test
+    public void validateParams_email_shouldGiveAnErrorValidation() throws Exception {
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: email. See Public API documentation for the correct data formats"));
+        PaymentSearchValidator.validateSearchParameters("success", "ref", UNSUCCESSFUL_TEST_EMAIL, "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "1", "1");
     }
 
     @Test
     public void validateParams_state_shouldGiveAnErrorValidation() throws Exception {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("invalid", "ref", "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "1", "1");
+        PaymentSearchValidator.validateSearchParameters("invalid", "ref", SUCCESSFUL_TEST_EMAIL, "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "1", "1");
     }
 
     @Test
     public void validateParams_toDate_shouldGiveAnErrorValidation() throws Exception {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: to_date. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("success", "ref", "2016-01-25T13:23:55Z", "2016-01-25T13-23:55Z", "1", "1");
+        PaymentSearchValidator.validateSearchParameters("success", "ref", SUCCESSFUL_TEST_EMAIL, "2016-01-25T13:23:55Z", "2016-01-25T13-23:55Z", "1", "1");
     }
 
     @Test
     public void validateParams_fromDate_shouldGiveAnErrorValidation() throws Exception {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: from_date. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("success", "ref", "2016-01-25T13-23:55Z", "2016-01-25T13:23:55Z", "1", "1");
+        PaymentSearchValidator.validateSearchParameters("success", "ref", SUCCESSFUL_TEST_EMAIL, "2016-01-25T13-23:55Z", "2016-01-25T13:23:55Z", "1", "1");
     }
 
     @Test
     public void validateParams_shouldGiveAnErrorValidation_forAllParams() throws Exception {
-        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", "-1", "-1");
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
+        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", "-1", "-1");
     }
 
     @Test
     public void validateParams_shouldGiveAnErrorValidation_forZeroPageDisplay() throws Exception {
-        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", "0", "0");
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
+        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", "0", "0");
     }
 
     @Test
     public void validateParams_shouldGiveAnErrorValidation_forMaxedOutValuesPageDisplaySize() throws Exception {
-        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", String.valueOf(Integer.MAX_VALUE+1), String.valueOf(Integer.MAX_VALUE+1));
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
+        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", String.valueOf(Integer.MAX_VALUE+1), String.valueOf(Integer.MAX_VALUE+1));
     }
 
     @Test
     public void validateParams_shouldNotGiveAnErrorValidation_ForMissingPageDisplaySize() throws Exception {
-        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, from_date, to_date. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", null, null);
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date. See Public API documentation for the correct data formats"));
+        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", null, null);
     }
 
     @Test
     public void validateParams_shouldNotGiveAnErrorValidation_ForNonNumberPageAndSize() throws Exception {
-        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", "non-numeric-page", "non-numeric-size");
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
+        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", "non-numeric-page", "non-numeric-size");
     }
 
 


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

* pay-connector is already returning the `email` field, so we just capture that field and pass it accross to the client.    
* The email will do a partial and full match.
* Amending the unit tests for search charges by email

## HOW 
_Steps to test or reproduce:_
```
cd $WORKSPACE
msl reset && msl -a up && ./run-endtoend.sh

