### PR TITLE
PP-864 We should not serialize email field if null

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
@@ -1,11 +1,13 @@
 package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ChargeFromResponse {
 

--- a/src/main/java/uk/gov/pay/api/model/Payment.java
+++ b/src/main/java/uk/gov/pay/api/model/Payment.java
@@ -1,8 +1,10 @@
 package uk.gov.pay.api.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
+@JsonInclude(value= JsonInclude.Include.NON_NULL)
 public abstract class Payment {
     public static final String LINKS_JSON_ATTRIBUTE = "_links";
 

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
@@ -51,7 +51,7 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
         connectorMock.respondOk_whenCreateCharge(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID,
-                STATE, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, REFUND_SUMMARY);
+                STATE, RETURN_URL, DESCRIPTION, REFERENCE, null, PAYMENT_PROVIDER, CREATED_DATE, REFUND_SUMMARY);
 
         String responseBody = postPaymentResponse(API_KEY, SUCCESS_PAYLOAD)
                 .statusCode(201)
@@ -60,7 +60,7 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
                 .body("payment_id", is(CHARGE_ID))
                 .body("amount", is(9999999))
                 .body("reference", is(REFERENCE))
-                .body("email", is(EMAIL))
+                .body("email", nullValue())
                 .body("description", is(DESCRIPTION))
                 .body("state.status", is(STATE.getStatus()))
                 .body("return_url", is(RETURN_URL))


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_
 * We should not serialize email field from the payment response if it is null

## HOW 
_Steps to test or reproduce:_

```
cd $WORKSPACE
msl reset && msl -a up && ./run-endtoend.sh
```


