### PR TITLE
PP-720 Pass through conflict state from connector

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CancelChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CancelChargeExceptionMapper.java
@@ -29,6 +29,9 @@ public class CancelChargeExceptionMapper implements ExceptionMapper<CancelCharge
         } else if (errorStatus == BAD_REQUEST.getStatusCode()) {
             paymentError = aPaymentError(CANCEL_PAYMENT_CONNECTOR_BAD_REQUEST_ERROR);
             status = BAD_REQUEST;
+        } else if (errorStatus == CONFLICT.getStatusCode()) {
+            paymentError = aPaymentError(CANCEL_PAYMENT_CONNECTOR_CONFLICT_ERROR);
+            status = CONFLICT;
         } else {
             paymentError = aPaymentError(CANCEL_PAYMENT_CONNECTOR_ERROR);
             status = INTERNAL_SERVER_ERROR;

--- a/src/main/java/uk/gov/pay/api/model/PaymentError.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentError.java
@@ -32,6 +32,7 @@ public class PaymentError {
 
         CANCEL_PAYMENT_NOT_FOUND_ERROR("P0500", "Not found"),
         CANCEL_PAYMENT_CONNECTOR_BAD_REQUEST_ERROR("P0501", "Cancellation of payment failed"),
+        CANCEL_PAYMENT_CONNECTOR_CONFLICT_ERROR("P0502", "Cancellation of payment failed"),
         CANCEL_PAYMENT_CONNECTOR_ERROR("P0598", "Downstream system error"),
 
         CREATE_PAYMENT_REFUND_CONNECTOR_ERROR("P0698", "Downstream system error"),

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -336,6 +336,7 @@ public class PaymentsResource {
             @ApiResponse(code = 400, message = "Cancellation of payment failed", response = PaymentError.class),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
+            @ApiResponse(code = 409, message = "Conflict", response = PaymentError.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)
     })
     public Response cancelPayment(@ApiParam(value = "accountId", hidden = true) @Auth String accountId,


### PR DESCRIPTION
Connector has been updated to return 409 CONFLICT when charge cancellation attempted on charge  in lock state. This commit ensures the correct code is passed on to the world.