### PR TITLE
PP-1155 Removed email when logging payments

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/Payment.java
+++ b/src/main/java/uk/gov/pay/api/model/Payment.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
 @JsonInclude(value= JsonInclude.Include.NON_NULL)
-public abstract class Payment {
+public abstract class           Payment {
     public static final String LINKS_JSON_ATTRIBUTE = "_links";
 
     @JsonProperty("payment_id")
@@ -103,7 +103,6 @@ public abstract class Payment {
                 ", returnUrl='" + returnUrl + '\'' +
                 ", description='" + description + '\'' +
                 ", reference='" + reference + '\'' +
-                ", email='" + email + '\'' +
                 ", createdDate='" + createdDate + '\'' +
                 '}';
     }

--- a/src/test/java/uk/gov/pay/api/model/PaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/model/PaymentTest.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.api.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+public class PaymentTest {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void shouldNotPrintEmailWhenToString() throws IOException {
+
+        URI selfUri = URI.create("http://self.link.com");
+        URI eventsUri = URI.create("http://self.link.com/events");
+        URI cancelUri = URI.create("http://self.link.com/cancel");
+        URI refundsUri = URI.create("http://self.link.com/cancel");
+
+        ChargeFromResponse paymentFromConnector = objectMapper.readValue("{" +
+                "\"email\":\"user@example.com\"," +
+                "\"amount\":500," +
+                "\"state\":{" +
+                "\"status\":\"created\"," +
+                "\"finished\":false" +
+                "}}", ChargeFromResponse.class);
+
+        Payment payment = PaymentWithAllLinks.valueOf(paymentFromConnector, selfUri, eventsUri, cancelUri, refundsUri);
+
+        assertThat(payment.toString(), not(containsString("user@example.com")));
+    }
+}


### PR DESCRIPTION
## WHAT
- Personal information shouldn't be logged. Removed email from Payment.toString() to avoid logging unwanted data to be displayed.