### PR TITLE
PP-1172 Make publicapi ignore its Host: header

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -59,8 +59,8 @@ public class PublicApi extends Application<PublicApiConfig> {
 
         environment.healthChecks().register("ping", new Ping());
         environment.jersey().register(new HealthCheckResource(environment));
-        environment.jersey().register(new PaymentsResource(client, config.getConnectorUrl(), objectMapper));
-        environment.jersey().register(new PaymentRefundsResource(client, config.getConnectorUrl()));
+        environment.jersey().register(new PaymentsResource(config.getBaseUrl(), client, config.getConnectorUrl(), objectMapper));
+        environment.jersey().register(new PaymentRefundsResource(config.getBaseUrl(), client, config.getConnectorUrl()));
         environment.jersey().register(new RequestDeniedResource());
 
         RateLimiter rateLimiter = new RateLimiter(config.getRateLimiterConfig().getRate(), config.getRateLimiterConfig().getPerMillis());

--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
@@ -8,6 +8,8 @@ import javax.validation.constraints.NotNull;
 
 public class PublicApiConfig extends Configuration {
     @NotNull
+    private String baseUrl;
+    @NotNull
     private String connectorUrl;
     @NotNull
     private String publicAuthUrl;
@@ -26,6 +28,10 @@ public class PublicApiConfig extends Configuration {
 
     public RestClientConfig getRestClientConfig() {
         return restClientConfig;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
     }
 
     public String getConnectorUrl() {

--- a/src/main/java/uk/gov/pay/api/model/RefundResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundResponse.java
@@ -2,6 +2,7 @@ package uk.gov.pay.api.model;
 
 import uk.gov.pay.api.resources.RefundFromConnector;
 
+import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 
@@ -15,12 +16,12 @@ public class RefundResponse extends HalResourceResponse {
         super(refundHalRepresentation, location);
     }
 
-    public static RefundResponse valueOf(RefundFromConnector refundEntity, String paymentId, UriInfo uriInfo) {
-        URI selfLink = uriInfo.getBaseUriBuilder()
+    public static RefundResponse valueOf(RefundFromConnector refundEntity, String paymentId, String baseUrl) {
+        URI selfLink = UriBuilder.fromUri(baseUrl)
                 .path(PAYMENT_REFUND_BY_ID_PATH)
                 .build(paymentId, refundEntity.getRefundId());
 
-        URI paymentLink = uriInfo.getBaseUriBuilder()
+        URI paymentLink = UriBuilder.fromUri(baseUrl)
                 .path(PAYMENT_BY_ID_PATH)
                 .build(paymentId);
 

--- a/src/main/java/uk/gov/pay/api/model/RefundsResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundsResponse.java
@@ -3,6 +3,7 @@ package uk.gov.pay.api.model;
 import black.door.hate.HalResource;
 import uk.gov.pay.api.resources.RefundsFromConnector;
 
+import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.List;
@@ -19,18 +20,18 @@ public class RefundsResponse extends HalResourceResponse {
         super(refundHalRepresentation, location);
     }
 
-    public static RefundsResponse valueOf(RefundsFromConnector refundsEntity, UriInfo uriInfo) {
+    public static RefundsResponse valueOf(RefundsFromConnector refundsEntity, String baseUrl) {
 
-        URI selfLink = uriInfo.getBaseUriBuilder()
+        URI selfLink = UriBuilder.fromUri(baseUrl)
                 .path(PAYMENT_REFUNDS_PATH)
                 .build(refundsEntity.getPaymentId());
 
-        URI paymentLink = uriInfo.getBaseUriBuilder()
+        URI paymentLink = UriBuilder.fromUri(baseUrl)
                 .path(PAYMENT_BY_ID_PATH)
                 .build(refundsEntity.getPaymentId());
 
         List<HalResource> refundHalResources = refundsEntity.getEmbedded().getRefunds().stream()
-                .map(refund -> RefundResponse.valueOf(refund, refundsEntity.getPaymentId(), uriInfo))
+                .map(refund -> RefundResponse.valueOf(refund, refundsEntity.getPaymentId(), baseUrl))
                 .collect(Collectors.toList());
 
         HalRepresentationBuilder refundHalRepresentation = builder()

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -15,6 +15,7 @@ logging:
         target: stdout
         logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
 
+baseUrl: ${PUBLICAPI_BASE}
 connectorUrl: ${CONNECTOR_URL}
 publicAuthUrl: ${PUBLIC_AUTH_URL}
 

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
@@ -50,7 +50,7 @@ public abstract class PaymentResourceITestBase {
     }
 
     String paymentLocationFor(String chargeId) {
-        return "http://localhost:" + app.getLocalPort() + PAYMENTS_PATH + chargeId;
+        return "http://publicapi.url" + PAYMENTS_PATH + chargeId;
     }
 
     String paymentEventsLocationFor(String chargeId) {
@@ -62,7 +62,7 @@ public abstract class PaymentResourceITestBase {
     }
 
     String paymentRefundLocationFor(String chargeId, String refundId) {
-        return "http://localhost:" + app.getLocalPort() + PAYMENTS_PATH + chargeId + "/refunds/" +refundId;
+        return "http://publicapi.url" + PAYMENTS_PATH + chargeId + "/refunds/" +refundId;
     }
 
     String paymentCancelLocationFor(String chargeId) {

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -361,9 +361,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
     }
 
     private String expectedChargesLocationFor(String queryParams) {
-        return "http://localhost:" + app.getLocalPort()
-                + SEARCH_PATH
-                + queryParams;
+        return "http://publicapi.url" + SEARCH_PATH + queryParams;
     }
 
     @Test

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -15,6 +15,7 @@ logging:
         target: stdout
         logFormat: "[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
 
+baseUrl: http://publicapi.url/
 connectorUrl: http://connector.url/
 publicAuthUrl: http://publicauth.url/v1/auth
 


### PR DESCRIPTION
## WHAT
PP-1172 Make publicapi ignore its Host: header, instead always return canonical URLs with a base read from the environment provided by ansible.

See https://github.com/alphagov/pay-ansible/commit/dc031a1abe96d2f4a14dc0b2180bb962b8bdd79c




