### PR TITLE
PP-1224 Including `refund amount available` parameter for every refund

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ Content-Type: application/json
 
 #### GET Payment Refunds response errors
 
-##### Refud ID not found
+##### Refund ID not found
 
 ```
 HTTP/1.1 404 Not Found
@@ -645,7 +645,8 @@ Creates a new refund associated with the payment.
 POST /v1/payments/ab2341da231434/refunds
 Authorization: Bearer BEARER_TOKEN
 {
-    "amount": 25000
+    "amount": 25000,
+    "refund_amount_available": 30000
 }
 ```
 
@@ -653,9 +654,10 @@ Authorization: Bearer BEARER_TOKEN
 
 BEARER_TOKEN: A valid bearer token for the account to associate the payment with.
 
-| Field                    | required | Description                               |
-| ------------------------ |:--------:| ----------------------------------------- |
-| `amount`                 | Yes      | Amount to refund in pence                 |
+| Field                    | required | Description                                             |
+| ------------------------ |:--------:| ------------------------------------------------------- |
+| `amount`                 | Yes      | Amount to refund in pence                               |
+| `refund_amount_available`| No       | Total amount still available before issuing the refund  |
 
 #### Refund created response
 
@@ -691,7 +693,19 @@ Content-Type: application/json
 | `status`               | Current status of the refund             |
 | `created_date`         | The creation date for this refund        |
 | `_links.self`          | Link to this refund                      |
-| `_links.payment`      | Link to the payment this refund relates to|
+| `_links.payment`       | Link to the payment this refund relates to|
+
+##### Refund amount available mismatch
+
+```
+HTTP/1.1 412 Precondition Failed
+Content-Type: application/json
+
+{
+    "code" : "P0604"
+    "description": "Refund amount available mismatch"
+}
+```
 
 #### POST Payment Refunds response errors
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,6 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.3.1</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.exparity</groupId>

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapper.java
@@ -8,12 +8,8 @@ import uk.gov.pay.api.model.PaymentError;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
-import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_REFUND_CONNECTOR_ERROR;
-import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_REFUND_NOT_AVAILABLE;
-import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_REFUND_NOT_FOUND_ERROR;
+import static javax.ws.rs.core.Response.Status.*;
+import static uk.gov.pay.api.model.PaymentError.Code.*;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 
 public class CreateRefundExceptionMapper implements ExceptionMapper<CreateRefundException> {
@@ -33,6 +29,9 @@ public class CreateRefundExceptionMapper implements ExceptionMapper<CreateRefund
         } else if (exception.getErrorStatus() == BAD_REQUEST.getStatusCode() && exception.hasReason()) {
             paymentError = aPaymentError(CREATE_PAYMENT_REFUND_NOT_AVAILABLE, exception.getReason());
             status = BAD_REQUEST;
+        } else if (exception.getErrorStatus() == PRECONDITION_FAILED.getStatusCode()) {
+            paymentError = aPaymentError(CREATE_PAYMENT_REFUND_AMOUNT_AVAILABLE_MISTMATCH);
+            status = PRECONDITION_FAILED;
         } else {
             paymentError = aPaymentError(CREATE_PAYMENT_REFUND_CONNECTOR_ERROR);
             status = INTERNAL_SERVER_ERROR;

--- a/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
+++ b/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
@@ -7,6 +7,7 @@ import uk.gov.pay.api.model.CreatePaymentRequest;
 import uk.gov.pay.api.model.PaymentError;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static uk.gov.pay.api.model.CreatePaymentRefundRequest.REFUND_AMOUNT_AVAILABLE;
 import static uk.gov.pay.api.model.CreatePaymentRequest.*;
 import static uk.gov.pay.api.model.PaymentError.Code.*;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
@@ -25,7 +26,8 @@ class RequestJsonParser {
 
     static CreatePaymentRefundRequest paymentRefundRequestValueOf(JsonNode rootNode) {
         Integer amount = parseInteger(rootNode, AMOUNT_FIELD_NAME, CREATE_PAYMENT_REFUND_VALIDATION_ERROR, CREATE_PAYMENT_REFUND_MISSING_FIELD_ERROR);
-        return new CreatePaymentRefundRequest(amount);
+        Integer refundAmountAvailable = rootNode.get(REFUND_AMOUNT_AVAILABLE) == null ? null : rootNode.get(REFUND_AMOUNT_AVAILABLE).asInt();
+        return new CreatePaymentRefundRequest(amount, refundAmountAvailable);
     }
 
     private static String parseString(JsonNode node, String fieldName) {

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRefundRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRefundRequest.java
@@ -3,6 +3,8 @@ package uk.gov.pay.api.model;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.Optional;
+
 @ApiModel(value = "CreatePaymentRefundRequest", description = "The Payment Refund Request Payload")
 public class CreatePaymentRefundRequest {
 
@@ -29,8 +31,8 @@ public class CreatePaymentRefundRequest {
      * @return
      */
     @ApiModelProperty(value = "Amount in pence. It should be the available amount for refund", required = false, allowableValues = "range[1, 10000000]", example = "200000")
-    public Integer getRefundAmountAvailable() {
-        return refundAmountAvailable;
+    public Optional<Integer> getRefundAmountAvailable() {
+        return Optional.ofNullable(refundAmountAvailable);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRefundRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRefundRequest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -11,6 +12,7 @@ public class CreatePaymentRefundRequest {
     public static final String REFUND_AMOUNT_AVAILABLE="refund_amount_available";
 
     private int amount;
+    @JsonProperty("refund_amount_available")
     private Integer refundAmountAvailable;
 
     public CreatePaymentRefundRequest() {
@@ -30,7 +32,7 @@ public class CreatePaymentRefundRequest {
      * This field should be made compulsory at a later stage
      * @return
      */
-    @ApiModelProperty(value = "Amount in pence. It should be the available amount for refund", required = false, allowableValues = "range[1, 10000000]", example = "200000")
+    @ApiModelProperty(value = "Amount in pence. Total amount still available before issuing the refund", required = false, allowableValues = "range[1, 10000000]", example = "200000")
     public Optional<Integer> getRefundAmountAvailable() {
         return Optional.ofNullable(refundAmountAvailable);
     }

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRefundRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRefundRequest.java
@@ -6,13 +6,17 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(value = "CreatePaymentRefundRequest", description = "The Payment Refund Request Payload")
 public class CreatePaymentRefundRequest {
 
+    public static final String REFUND_AMOUNT_AVAILABLE="refund_amount_available";
+
     private int amount;
+    private Integer refundAmountAvailable;
 
     public CreatePaymentRefundRequest() {
     }
 
-    public CreatePaymentRefundRequest(int amount) {
+    public CreatePaymentRefundRequest(int amount, Integer refundAmountAvailable) {
         this.amount = amount;
+        this.refundAmountAvailable = refundAmountAvailable;
     }
 
     @ApiModelProperty(value = "Amount in pence. Can't be more than the available amount for refunds", required = true, allowableValues = "range[1, 10000000]", example = "150000")
@@ -20,11 +24,20 @@ public class CreatePaymentRefundRequest {
         return amount;
     }
 
+    /**
+     * This field should be made compulsory at a later stage
+     * @return
+     */
+    @ApiModelProperty(value = "Amount in pence. It should be the available amount for refund", required = false, allowableValues = "range[1, 10000000]", example = "200000")
+    public Integer getRefundAmountAvailable() {
+        return refundAmountAvailable;
+    }
 
     @Override
     public String toString() {
         return "CreatePaymentRefundRequest{" +
                 "amount=" + amount +
+                ", refundAmountAvailable=" + refundAmountAvailable +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/PaymentError.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentError.java
@@ -41,6 +41,7 @@ public class PaymentError {
         CREATE_PAYMENT_REFUND_MISSING_FIELD_ERROR("P0601", "Missing mandatory attribute: %s"),
         CREATE_PAYMENT_REFUND_VALIDATION_ERROR("P0602", "Invalid attribute value: %s. %s"),
         CREATE_PAYMENT_REFUND_NOT_AVAILABLE("P0603", "The payment is not available for refund. Payment refund status: %s"),
+        CREATE_PAYMENT_REFUND_AMOUNT_AVAILABLE_MISTMATCH("P0604", "Refund amount available mismatch."),
 
         GET_PAYMENT_REFUND_NOT_FOUND_ERROR("P0700", "Not found"),
         GET_PAYMENT_REFUND_CONNECTOR_ERROR("P0798", "Downstream system error"),

--- a/src/main/java/uk/gov/pay/api/model/RefundFromConnector.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundFromConnector.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.api.resources;
+package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/uk/gov/pay/api/model/RefundResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundResponse.java
@@ -1,13 +1,11 @@
 package uk.gov.pay.api.model;
 
-import uk.gov.pay.api.resources.RefundFromConnector;
-
 import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 
-import static black.door.hate.HalRepresentation.*;
-import static uk.gov.pay.api.resources.PaymentRefundsResource.*;
+import static black.door.hate.HalRepresentation.HalRepresentationBuilder;
+import static black.door.hate.HalRepresentation.builder;
+import static uk.gov.pay.api.resources.PaymentRefundsResource.PAYMENT_BY_ID_PATH;
 import static uk.gov.pay.api.resources.PaymentRefundsResource.PAYMENT_REFUND_BY_ID_PATH;
 
 public class RefundResponse extends HalResourceResponse {

--- a/src/main/java/uk/gov/pay/api/model/RefundsFromConnector.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundsFromConnector.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.api.resources;
+package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/uk/gov/pay/api/model/RefundsResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundsResponse.java
@@ -1,10 +1,8 @@
 package uk.gov.pay.api.model;
 
 import black.door.hate.HalResource;
-import uk.gov.pay.api.resources.RefundsFromConnector;
 
 import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -137,6 +137,7 @@ public class PaymentRefundsResource {
             @ApiResponse(code = 201, message = "ACCEPTED"),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
+            @ApiResponse(code = 412, message = "Refund amount available mismatch"),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response submitRefund(@ApiParam(value = "accountId", hidden = true) @Auth String accountId,
                                  @ApiParam(value = "paymentId", required = true) @PathParam(PATH_PAYMENT_KEY) String paymentId,

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -144,16 +144,16 @@ public class PaymentRefundsResource {
 
         logger.info("Create a refund for payment request - paymentId={}", paymentId);
 
-        Integer refundAmountAvailable = requestPayload.getRefundAmountAvailable();
-        if (refundAmountAvailable == null) {
-            Response getChargeResponse = client
-                    .target(getConnectorUrl(format(CONNECTOR_CHARGE_RESOURCE, accountId, paymentId)))
-                    .request()
-                    .get();
+        Integer refundAmountAvailable = requestPayload.getRefundAmountAvailable()
+                .orElseGet(() -> {
+                    Response getChargeResponse = client
+                            .target(getConnectorUrl(format(CONNECTOR_CHARGE_RESOURCE, accountId, paymentId)))
+                            .request()
+                            .get();
 
-            ChargeFromResponse chargeFromResponse = getChargeResponse.readEntity(ChargeFromResponse.class);
-            refundAmountAvailable = Long.valueOf(chargeFromResponse.getRefundSummary().getAmountAvailable()).intValue();
-        }
+                    ChargeFromResponse chargeFromResponse = getChargeResponse.readEntity(ChargeFromResponse.class);
+                    return Long.valueOf(chargeFromResponse.getRefundSummary().getAmountAvailable()).intValue();
+        });
 
         ImmutableMap<String, Object> payloadMap = ImmutableMap.of("amount", requestPayload.getAmount(), "refund_amount_available", refundAmountAvailable);
         String connectorPayload = new GsonBuilder().create().toJson(

--- a/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
@@ -1,8 +1,11 @@
 package uk.gov.pay.api.it;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.GsonBuilder;
 import com.jayway.restassured.response.ValidatableResponse;
 import org.junit.Test;
 import uk.gov.pay.api.it.fixtures.PaymentRefundJsonFixture;
+import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.utils.DateTimeUtils;
 
 import java.time.ZonedDateTime;
@@ -20,6 +23,7 @@ import static org.hamcrest.core.Is.is;
 public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
     private static final int AMOUNT = 1000;
+    private static final int REFUND_AMOUNT_AVAILABLE = 9000;
     private static final String CHARGE_ID = "ch_ab2341da231434l";
     private static final String REFUND_ID = "111999";
     private static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
@@ -29,7 +33,7 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
     public void getRefundById_shouldGetValidResponse() {
 
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respondWithGetRefundById(GATEWAY_ACCOUNT_ID, CHARGE_ID, REFUND_ID, AMOUNT, "available", CREATED_DATE);
+        connectorMock.respondWithGetRefundById(GATEWAY_ACCOUNT_ID, CHARGE_ID, REFUND_ID, AMOUNT, REFUND_AMOUNT_AVAILABLE, "available", CREATED_DATE);
 
         getPaymentRefundByIdResponse(API_KEY, CHARGE_ID, REFUND_ID)
                 .statusCode(200)
@@ -136,27 +140,20 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void createRefund_shouldGetAcceptedResponse() {
+        String payload = new GsonBuilder().create().toJson(
+                ImmutableMap.of("amount", AMOUNT, "refund_amount_available", REFUND_AMOUNT_AVAILABLE));
 
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        String refundStatus = "available";
-        connectorMock.respondAccepted_whenCreateARefund(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, REFUND_ID, refundStatus, CREATED_DATE);
+        postRefundRequest(payload);
+    }
 
-        String body = "{\"amount\":" + AMOUNT + "}";
+    @Test
+    public void createRefundWithNoRefundAmountAvailable_shouldGetAcceptedResponse() {
+        String payload = new GsonBuilder().create().toJson(
+                ImmutableMap.of("amount", AMOUNT));
+        connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, null, null, null, null, null, null, null, null, null,
+                new RefundSummary("available", 9000, 1000));
 
-        given().port(app.getLocalPort())
-                .header(AUTHORIZATION, "Bearer " + API_KEY)
-                .header(CONTENT_TYPE, APPLICATION_JSON)
-                .body(body)
-                .post(format("/v1/payments/%s/refunds", CHARGE_ID))
-                .then()
-                .statusCode(ACCEPTED.getStatusCode())
-                .contentType(JSON)
-                .body("refund_id", is(REFUND_ID))
-                .body("amount", is(AMOUNT))
-                .body("status", is(refundStatus))
-                .body("created_date", is(CREATED_DATE))
-                .body("_links.self.href", is(paymentRefundLocationFor(CHARGE_ID, REFUND_ID)))
-                .body("_links.payment.href", is(paymentLocationFor(CHARGE_ID)));
+        postRefundRequest(payload);
     }
 
     @Test
@@ -171,6 +168,27 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
                 .post(format("/v1/payments/%s/refunds", CHARGE_ID))
                 .then()
                 .statusCode(401);
+    }
+
+    private void postRefundRequest(String payload) {
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        String refundStatus = "available";
+        connectorMock.respondAccepted_whenCreateARefund(AMOUNT, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, CHARGE_ID, REFUND_ID, refundStatus, CREATED_DATE);
+
+        given().port(app.getLocalPort())
+                .header(AUTHORIZATION, "Bearer " + API_KEY)
+                .header(CONTENT_TYPE, APPLICATION_JSON)
+                .body(payload)
+                .post(format("/v1/payments/%s/refunds", CHARGE_ID))
+                .then()
+                .statusCode(ACCEPTED.getStatusCode())
+                .contentType(JSON)
+                .body("refund_id", is(REFUND_ID))
+                .body("amount", is(AMOUNT))
+                .body("status", is(refundStatus))
+                .body("created_date", is(CREATED_DATE))
+                .body("_links.self.href", is(paymentRefundLocationFor(CHARGE_ID, REFUND_ID)))
+                .body("_links.payment.href", is(paymentLocationFor(CHARGE_ID)));
     }
 
     private ValidatableResponse getPaymentRefundByIdResponse(String bearerToken, String paymentId, String refundId) {

--- a/src/test/java/uk/gov/pay/api/it/PaymentsRefundsResourceAmountValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsRefundsResourceAmountValidationITest.java
@@ -16,6 +16,8 @@ import static org.hamcrest.core.Is.is;
 
 public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourceITestBase {
 
+    private static final int REFUND_AMOUNT_AVAILABLE = 9000;
+
     @Before
     public void setUpBearerToken() {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
@@ -262,7 +264,7 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
         int amount = 1000;
         String externalChargeId = "charge_12345";
 
-        connectorMock.respondBadRequest_whenCreateARefund("full", amount, GATEWAY_ACCOUNT_ID, externalChargeId);
+        connectorMock.respondBadRequest_whenCreateARefund("full", amount, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, externalChargeId);
 
         String refundRequest = "{\"amount\":" + amount + "}";
 
@@ -284,7 +286,7 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
         int amount = 1000;
         String externalChargeId = "charge_12345";
 
-        connectorMock.respondBadRequest_whenCreateARefund("pending", amount, GATEWAY_ACCOUNT_ID, externalChargeId);
+        connectorMock.respondBadRequest_whenCreateARefund("pending", amount, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, externalChargeId);
 
         String refundRequest = "{\"amount\":" + amount + "}";
 

--- a/src/test/java/uk/gov/pay/api/it/PaymentsRefundsResourceAmountValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsRefundsResourceAmountValidationITest.java
@@ -4,6 +4,7 @@ import com.jayway.jsonassert.JsonAssert;
 import com.jayway.restassured.response.ValidatableResponse;
 import org.junit.Before;
 import org.junit.Test;
+import uk.gov.pay.api.model.RefundSummary;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -264,6 +265,8 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
         int amount = 1000;
         String externalChargeId = "charge_12345";
 
+        connectorMock.respondWithChargeFound(amount, GATEWAY_ACCOUNT_ID, externalChargeId, null, null, null, null, null, null, null, null, null,
+                new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000));
         connectorMock.respondBadRequest_whenCreateARefund("full", amount, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, externalChargeId);
 
         String refundRequest = "{\"amount\":" + amount + "}";
@@ -286,6 +289,8 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
         int amount = 1000;
         String externalChargeId = "charge_12345";
 
+        connectorMock.respondWithChargeFound(amount, GATEWAY_ACCOUNT_ID, externalChargeId, null, null, null, null, null, null, null, null, null,
+                new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000));
         connectorMock.respondBadRequest_whenCreateARefund("pending", amount, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, externalChargeId);
 
         String refundRequest = "{\"amount\":" + amount + "}";

--- a/src/test/java/uk/gov/pay/api/utils/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/ConnectorMockClient.java
@@ -209,6 +209,11 @@ public class ConnectorMockClient {
                 .respond(withStatusAndErrorMessage(BAD_REQUEST_400, errorMsg));
     }
 
+    public void respondPreconditionFailed_whenCreateRefund(int amount, int refundAmountAvailable, String gatewayAccountId, String errorMsg, String chargeId) {
+        whenCreateRefund(amount, refundAmountAvailable, gatewayAccountId, chargeId)
+                .respond(withStatusAndErrorMessage(PRECONDITION_FAILED_412, errorMsg));
+    }
+
     public void respondWithChargeFound(long amount, String gatewayAccountId, String chargeId, PaymentState state, String returnUrl,
                                        String description, String reference, String email, String paymentProvider, String cardBrand,
                                        String createdDate, String chargeTokenId, RefundSummary refundSummary) {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -327,6 +327,9 @@
               "$ref" : "#/definitions/Payment Error"
             }
           },
+          "412" : {
+            "description" : "Refund amount available mismatch"
+          },
           "500" : {
             "description" : "Downstream system error",
             "schema" : {
@@ -387,6 +390,15 @@
           "format" : "int32",
           "example" : "150000",
           "description" : "Amount in pence. Can't be more than the available amount for refunds",
+          "minimum" : 1.0,
+          "maximum" : 1.0E7
+        },
+        "refund_amount_available" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : "200000",
+          "description" : "Amount in pence. Total amount still available before issuing the refund",
+          "readOnly" : true,
           "minimum" : 1.0,
           "maximum" : 1.0E7
         }


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

_As a client that needs to execute a refund
Then it will always need to pass the "Total Refund Amount Available" with every Refund request.
And the refund should only go ahead if the "Total Refund Amount Available" in the DB matches the "Total Refund Amount Available" in the body request._

The idea is from preventing a user from submitting a refund request by pressing the form submit button twice in quick succession and from two members of staff submitting the same refund amount for the same payment.

This would result in the refund attempted twice. If the request was for a partial refund then it's possible that double the intended amount would be refunded.

Furthermore, it is also possible to request a refund twice in quick succession via the public API and this would result in a similar possible unexpected/unintended behaviour.


## HOW 
_Steps to test or reproduce:_

```
cd $WORKSPACE/pay-scripts
msl reset && msl -a up && ./run-endtoend.sh
```

