### PR TITLE
PP-1282 expose payment card details in payment api's

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,20 @@ Content-Type: application/json
     "payment_provider": "Sandbox",
     "card_brand": "Visa",
     "created_date": "2016-01-15T16:30:56Z",
+    "card_details": {  
+    	"last_digits_card_number":"1234",
+    	"cardholder_name":"Mr. Payment",
+    	"expiry_date":"12/19",
+    	"card_brand":"Mastercard"
+    	"billing_address":{  
+    	   "line1":"line1",
+    	   "line2":"line2",
+    	   "postcode":"AB2 DEF",
+    	   "city":"city",
+    	   "county":"county",
+    	   "country":"UK"
+    	}
+    },
     "refund_summary": {
         "status": "available"
         "amount_available": 14500
@@ -860,6 +874,20 @@ GET /v1/payments
       "reference": "rahul-ref",
       "email": "mail@email.com",
       "created_date": "2016-05-23T15:22:50.972Z",
+      "card_details": {  
+      	"last_digits_card_number":"1234",
+      	"cardholder_name":"Mr. Payment",
+      	"expiry_date":"12/19",
+      	"card_brand":"Mastercard"
+      	"billing_address":{  
+      	   "line1":"line1",
+      	   "line2":"line2",
+      	   "postcode":"ABC2 DEF",
+      	   "city":"city",
+      	   "county":"county",
+      	   "country":"UK"
+      	}
+      },
       "refund_summary": {
          "status": "pending"
          "amount_available": 1
@@ -898,6 +926,20 @@ GET /v1/payments
       "reference": "rahul-ref",
       "email": "mail@email.com",
       "created_date": "2016-05-23T15:22:47.038Z",
+      "card_details": {  
+      	"last_digits_card_number":"1234",
+      	"cardholder_name":"Mrs. Payment",
+      	"expiry_date":"12/19",
+      	"card_brand":"Mastercard"
+      	"billing_address":{  
+      	   "line1":"line1",
+      	   "line2":"line2",
+      	   "postcode":"IJK3 LMN",
+      	   "city":"city",
+      	   "county":"county",
+      	   "country":"UK"
+      	}
+      },
       "refund_summary": {
          "status": "pending"
          "amount_available": 1
@@ -950,22 +992,32 @@ GET /v1/payments
 | `count`                           | Yes            | Number of payments displayed on this page                         |
 | `page`                            | Yes            | Page number of the current recordset                              |
 | `results`                         | Yes            | List of payments                                                  |
-| `results.payment_id`              | Yes            | The unique identifier for this payment                            |
-| `results.amount`                  | Yes            | The amount of this payment in pence                               |
-| `results.card_brand`              | Yes            | The card brand used for this payment                              |
-| `results.description`             | Yes            | The payment description                                           |
-| `results.reference`               | Yes            | There reference issued by the government service for this payment |
-| `results.email`                   | Yes            | The email address of the user of this payment                     |
-| `results.gateway_transaction_id`  | Yes            | The gateway transaction reference associated to this payment      |
-| `results.status`                  | Yes            | The current external status of the payment                        |
-| `results.created_date`            | Yes            | The created date in ISO_8601 format (```yyyy-MM-ddTHH:mm:ssZ```)  |
-| `results.refund_summary.status`   | Yes            | The refund status of this payment                                 |
-| `results.refund_summary.amount_available`| Yes     | The amount available for refunds for this payment                 |
-| `results.refund_summary.amount_submitted`| Yes     | The total refund amount submitted for this payment                |
-| `results._links.self`             | Yes            | Link to the payment                                               |
-| `results._links.events`           | Yes            | Link to payment events                                            |
-| `results._links.refunds`          | Yes            | Link to payment refunds                                           |
-| `results._links.cancel`           | No             | Link to cancel the payment (link only available when a payment can be cancelled (i.e. payment has one of the statuses - CREATED, IN PROGRESS |
+| `results[i].payment_id`              | Yes            | The unique identifier for this payment                            |
+| `results[i].amount`                  | Yes            | The amount of this payment in pence                               |
+| `results[i].card_brand`              | Yes            | The card brand used for this payment                              |
+| `results[i].description`             | Yes            | The payment description                                           |
+| `results[i].reference`               | Yes            | There reference issued by the government service for this payment |
+| `results[i].email`                   | Yes            | The email address of the user of this payment                     |
+| `results[i].gateway_transaction_id`  | Yes            | The gateway transaction reference associated to this payment      |
+| `results[i].status`                  | Yes            | The current external status of the payment                        |
+| `results[i].created_date`            | Yes            | The created date in ISO_8601 format (```yyyy-MM-ddTHH:mm:ssZ```)  |
+| `results[i].refund_summary.status`   | Yes            | The refund status of this payment                                 |
+| `results[i].refund_summary.amount_available`| Yes     | The amount available for refunds for this payment                 |
+| `results[i].refund_summary.amount_submitted`| Yes     | The total refund amount submitted for this payment                |
+| `results[i].card_details.card_brand` | No             | The card brand used for this payment                              |
+| `results[i].card_details.cardholder_name` | No        | The card card holder name of this payment                         |
+| `results[i].card_details.expiry_date` | No            | The expiry date of this card                                      |
+| `results[i].card_details.last_digits_card_number` | No| The last 4 digits of this card                                    |
+| `results[i].card_details.billing_address.line1` | No  | The line 1 of the billing address                                 |
+| `results[i].card_details.billing_address.line2` | No  | The line 2 of the billing address                                 |
+| `results[i].card_details.billing_address.postcode` | No| The postcode of the billing address                              |
+| `results[i].card_details.billing_address.city` | No   | The city of the billing address                                   |
+| `results[i].card_details.billing_address.county` | No | The county of the billing address                                 |
+| `results[i].card_details.billing_address.country` | No| The country of the billing address                                |
+| `results[i]._links.self`             | Yes            | Link to the payment                                               |
+| `results[i]._links.events`           | Yes            | Link to payment events                                            |
+| `results[i]._links.refunds`          | Yes            | Link to payment refunds                                           |
+| `results[i]._links.cancel`           | No             | Link to cancel the payment (link only available when a payment can be cancelled (i.e. payment has one of the statuses - CREATED, IN PROGRESS |
 | `_links.self.href`                | Yes            | Href link of the current page                                     |
 | `_links.next_page.href`           | No             | Href link of the next page (based on the display_size requested)  |
 | `_links.prev_page.href`           | No             | Href link of the previous page (based on the display_size requested) |

--- a/src/main/java/uk/gov/pay/api/model/Address.java
+++ b/src/main/java/uk/gov/pay/api/model/Address.java
@@ -1,0 +1,57 @@
+package uk.gov.pay.api.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
+@ApiModel(value = "Billing Address", description = "A structure representing the billing address of a card")
+public class Address {
+
+    private String line1;
+    private String line2;
+    private String postcode;
+    private String city;
+    private String county;
+    private String country;
+
+    public Address(@JsonProperty("line1") String line1,
+                   @JsonProperty("line2") String line2,
+                   @JsonProperty("postcode") String postcode,
+                   @JsonProperty("city") String city,
+                   @JsonProperty("county") String county,
+                   @JsonProperty("country") String country) {
+        this.line1 = line1;
+        this.line2 = line2;
+        this.postcode = postcode;
+        this.city = city;
+        this.county = county;
+        this.country = country;
+    }
+
+    public String getLine1() {
+        return line1;
+    }
+
+    public String getLine2() {
+        return line2;
+    }
+
+    public String getPostcode() {
+        return postcode;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public String getCounty() {
+        return county;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+}

--- a/src/main/java/uk/gov/pay/api/model/CardDetails.java
+++ b/src/main/java/uk/gov/pay/api/model/CardDetails.java
@@ -1,0 +1,59 @@
+package uk.gov.pay.api.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.ALWAYS;
+
+@JsonInclude(ALWAYS)
+@ApiModel(value = "Payment card details", description = "A structure representing the payment card")
+public class CardDetails {
+
+    @JsonProperty("last_digits_card_number")
+    private final String lastDigitsCardNumber;
+
+    @JsonProperty("cardholder_name")
+    private final String cardHolderName;
+
+    @JsonProperty("expiry_date")
+    private final String expiryDate;
+
+    @JsonProperty("billing_address")
+    private final Address billingAddress;
+
+    @JsonProperty("card_brand")
+    private final String cardBrand;
+
+    public CardDetails(@JsonProperty("last_digits_card_number") String lastDigitsCardNumber,
+                       @JsonProperty("cardholder_name") String cardHolderName,
+                       @JsonProperty("expiry_date") String expiryDate,
+                       @JsonProperty("billing_address") Address billingAddress,
+                       @JsonProperty("card_brand") String cardBrand) {
+        this.lastDigitsCardNumber = lastDigitsCardNumber;
+        this.cardHolderName = cardHolderName;
+        this.expiryDate = expiryDate;
+        this.billingAddress = billingAddress;
+        this.cardBrand = cardBrand;
+    }
+
+    public String getLastDigitsCardNumber() {
+        return lastDigitsCardNumber;
+    }
+
+    public String getCardHolderName() {
+        return cardHolderName;
+    }
+
+    public String getExpiryDate() {
+        return expiryDate;
+    }
+
+    public Address getBillingAddress() {
+        return billingAddress;
+    }
+
+    public String getCardBrand() {
+        return cardBrand;
+    }
+}

--- a/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
@@ -20,21 +20,23 @@ public class ChargeFromResponse {
     @JsonProperty("payment_provider")
     private String paymentProvider;
 
-    @JsonProperty("card_brand")
-    private String cardBrand;
-
     @JsonProperty("links")
     private List<PaymentConnectorResponseLink> links = new ArrayList<>();
 
     @JsonProperty(value = "refund_summary")
     private RefundSummary refundSummary;
 
+    @JsonProperty(value = "card_details")
+    private CardDetails cardDetails;
+
     private Long amount;
     private PaymentState state;
     private String description;
     private String reference;
     private String email;
-    private String created_date;
+
+    @JsonProperty(value = "created_date")
+    private String createdDate;
 
     public String getChargeId() {
         return chargeId;
@@ -68,10 +70,18 @@ public class ChargeFromResponse {
         return paymentProvider;
     }
 
-    public String getCardBrand() { return cardBrand; }
+    /**
+     * card brand is no longer a top level charge property. It is now at `card_details.card_brand` attribute
+     * We still need to support `v1` clients with a top level card brand attribute to keep support their integrations.
+     * @return
+     */
+    @JsonProperty("card_brand")
+    public String getCardBrand() {
+        return cardDetails != null ? cardDetails.getCardBrand() : "";
+    }
 
-    public String getCreated_date() {
-        return created_date;
+    public String getCreatedDate() {
+        return createdDate;
     }
 
     public List<PaymentConnectorResponseLink> getLinks() {
@@ -80,5 +90,9 @@ public class ChargeFromResponse {
 
     public RefundSummary getRefundSummary() {
         return refundSummary;
+    }
+
+    public CardDetails getCardDetails() {
+        return cardDetails;
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/Payment.java
+++ b/src/main/java/uk/gov/pay/api/model/Payment.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
-@JsonInclude(value= JsonInclude.Include.NON_NULL)
-public abstract class           Payment {
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
+public abstract class Payment {
     public static final String LINKS_JSON_ATTRIBUTE = "_links";
 
     @JsonProperty("payment_id")
@@ -13,9 +13,6 @@ public abstract class           Payment {
 
     @JsonProperty("payment_provider")
     private final String paymentProvider;
-
-    @JsonProperty("card_brand")
-    private final String cardBrand;
 
     private final long amount;
     private final PaymentState state;
@@ -32,9 +29,12 @@ public abstract class           Payment {
     @JsonProperty("refund_summary")
     private final RefundSummary refundSummary;
 
+    @JsonProperty("card_details")
+    private final CardDetails cardDetails;
+
     public Payment(String chargeId, long amount, PaymentState state, String returnUrl, String description,
-                   String reference, String email, String paymentProvider, String cardBrand,
-                   String createdDate, RefundSummary refundSummary) {
+                   String reference, String email, String paymentProvider, String createdDate,
+                   RefundSummary refundSummary, CardDetails cardDetails) {
         this.paymentId = chargeId;
         this.amount = amount;
         this.state = state;
@@ -43,9 +43,9 @@ public abstract class           Payment {
         this.reference = reference;
         this.email = email;
         this.paymentProvider = paymentProvider;
-        this.cardBrand = cardBrand;
         this.createdDate = createdDate;
         this.refundSummary = refundSummary;
+        this.cardDetails = cardDetails;
     }
 
     @ApiModelProperty(example = "2016-01-21T17:15:00Z")
@@ -93,9 +93,16 @@ public abstract class           Payment {
         return paymentProvider;
     }
 
-    @ApiModelProperty(value = "Card Brand", example = "Visa")
-    public String getCardBrand(){
-        return cardBrand;
+    /**
+     * card brand is no longer a top level charge property. It is now at `card_details.card_brand` attribute
+     * We still need to support `v1` clients with a top level card brand attribute to keep support their integrations.
+     * @return
+     */
+    @ApiModelProperty(value = "Card Brand", example = "Visa", notes = "Deprecated. Please use card_details.card_brand instead")
+    @JsonProperty("card_brand")
+    @Deprecated
+    public String getCardBrand() {
+        return cardDetails != null ? cardDetails.getCardBrand() : null;
     }
 
     @ApiModelProperty(dataType = "uk.gov.pay.api.model.RefundSummary")
@@ -103,12 +110,17 @@ public abstract class           Payment {
         return refundSummary;
     }
 
+    @ApiModelProperty(dataType = "uk.gov.pay.api.model.CardDetails")
+    public CardDetails getCardDetails() {
+        return cardDetails;
+    }
+
     @Override
     public String toString() {
         return "Payment{" +
                 "paymentId='" + paymentId + '\'' +
                 ", paymentProvider='" + paymentProvider + '\'' +
-                ", cardBrandLabel='" + cardBrand + '\'' +
+                ", cardBrandLabel='" + getCardBrand() + '\'' +
                 ", amount=" + amount +
                 ", state='" + state + '\'' +
                 ", returnUrl='" + returnUrl + '\'' +

--- a/src/main/java/uk/gov/pay/api/model/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentForSearchResult.java
@@ -12,9 +12,9 @@ public class PaymentForSearchResult extends Payment {
     private PaymentLinksForSearch links = new PaymentLinksForSearch();
 
     public PaymentForSearchResult(String chargeId, long amount, PaymentState state, String returnUrl, String description,
-                                  String reference, String email, String paymentProvider, String cardBrand, String createdDate,
-                                  RefundSummary refundSummary, URI selfLink, URI paymentEventsLink, URI paymentCancelLink, URI paymentRefundsLink) {
-        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, cardBrand, createdDate, refundSummary);
+                                  String reference, String email, String paymentProvider, String createdDate,
+                                  RefundSummary refundSummary, CardDetails cardDetails, URI selfLink, URI paymentEventsLink, URI paymentCancelLink, URI paymentRefundsLink) {
+        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate, refundSummary, cardDetails);
         this.links.addSelf(selfLink.toString());
         this.links.addEvents(paymentEventsLink.toString());
         this.links.addRefunds(paymentRefundsLink.toString());
@@ -40,9 +40,10 @@ public class PaymentForSearchResult extends Payment {
                 paymentResult.getReference(),
                 paymentResult.getEmail(),
                 paymentResult.getPaymentProvider(),
-                paymentResult.getCardBrand(),
-                paymentResult.getCreated_date(),
-                paymentResult.getRefundSummary(), selfLink,
+                paymentResult.getCreatedDate(),
+                paymentResult.getRefundSummary(),
+                paymentResult.getCardDetails(),
+                selfLink,
                 paymentEventsLink,
                 paymentCancelLink,
                 paymentRefundsLink);

--- a/src/main/java/uk/gov/pay/api/model/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentWithAllLinks.java
@@ -13,10 +13,10 @@ public class PaymentWithAllLinks extends Payment {
     private PaymentLinks links = new PaymentLinks();
 
     private PaymentWithAllLinks(String chargeId, long amount, PaymentState state, String returnUrl, String description,
-                                String reference, String email, String paymentProvider, String cardBrandLabel, String createdDate,
-                                RefundSummary refundSummary, List<PaymentConnectorResponseLink> paymentConnectorResponseLinks,
+                                String reference, String email, String paymentProvider, String createdDate,
+                                RefundSummary refundSummary, CardDetails cardDetails, List<PaymentConnectorResponseLink> paymentConnectorResponseLinks,
                                 URI selfLink, URI paymentEventsUri, URI paymentCancelUri, URI paymentRefundsUri) {
-        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, cardBrandLabel, createdDate, refundSummary);
+        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate, refundSummary, cardDetails);
         this.links.addSelf(selfLink.toString());
         this.links.addKnownLinksValueOf(paymentConnectorResponseLinks);
         this.links.addEvents(paymentEventsUri.toString());
@@ -41,9 +41,9 @@ public class PaymentWithAllLinks extends Payment {
                 paymentConnector.getReference(),
                 paymentConnector.getEmail(),
                 paymentConnector.getPaymentProvider(),
-                paymentConnector.getCardBrand(),
-                paymentConnector.getCreated_date(),
+                paymentConnector.getCreatedDate(),
                 paymentConnector.getRefundSummary(),
+                paymentConnector.getCardDetails(),
                 paymentConnector.getLinks(),
                 selfLink,
                 paymentEventsUri,

--- a/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
@@ -6,6 +6,8 @@ import com.jayway.restassured.response.Response;
 import com.jayway.restassured.response.ValidatableResponse;
 import org.junit.Test;
 import uk.gov.pay.api.it.fixtures.PaymentRefundJsonFixture;
+import uk.gov.pay.api.model.Address;
+import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.utils.DateTimeUtils;
 
@@ -30,6 +32,8 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
     private static final String REFUND_ID = "111999";
     private static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
     private static final String CREATED_DATE = DateTimeUtils.toUTCDateString(TIMESTAMP);
+    private static final Address BILLING_ADDRESS = new Address("line1","line2","NR2 5 6EG","city","county","UK");
+    private static final CardDetails CARD_DETAILS = new CardDetails("1234","Mr. Payment","12/19", BILLING_ADDRESS,"Visa");
 
     @Test
     public void getRefundById_shouldGetValidResponse() {
@@ -152,8 +156,8 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
     public void createRefundWithNoRefundAmountAvailable_shouldGetAcceptedResponse() {
         String payload = new GsonBuilder().create().toJson(
                 ImmutableMap.of("amount", AMOUNT));
-        connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, null, null, null, null, null, null, null, null, null,
-                new RefundSummary("available", 9000, 1000));
+        connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, null, null, null, null, null, null, null, null,
+                new RefundSummary("available", 9000, 1000), CARD_DETAILS);
 
         postRefundRequest(payload);
     }

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -11,6 +11,8 @@ import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.api.it.fixtures.PaymentNavigationLinksFixture;
+import uk.gov.pay.api.model.Address;
+import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.utils.DateTimeUtils;
 
 import java.io.InputStream;
@@ -44,7 +46,8 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
     private static final String TEST_FROM_DATE = "2016-01-28T00:00:00Z";
     private static final String TEST_TO_DATE = "2016-01-28T12:00:00Z";
     private static final String SEARCH_PATH = "/v1/payments";
-
+    private static final Address BILLING_ADDRESS = new Address("line1", "line2", "NR2 5 6EG", "city", "county", "UK");
+    private static final CardDetails CARD_DETAILS = new CardDetails("1234", "Mr. Payment", "12/19", BILLING_ADDRESS, TEST_CARD_BRAND_LABEL);
     @Before
     public void mapBearerTokenToAccountId() {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
@@ -59,6 +62,8 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                 .withPayments(aSuccessfulSearchPayment()
                         .withMatchingInProgressState(TEST_STATE)
                         .withMatchingReference(TEST_REFERENCE)
+                        .withMatchingCardBrand(TEST_CARD_BRAND_LABEL)
+                        .withMatchingCardDetails(CARD_DETAILS)
                         .withNumberOfResults(1)
                         .getResults())
                 .build();
@@ -88,6 +93,15 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                 .body("results[0].refund_summary.status", is("available"))
                 .body("results[0].refund_summary.amount_available", is(100))
                 .body("results[0].refund_summary.amount_submitted", is(300))
+                .body("results[0].card_details.card_brand", is(TEST_CARD_BRAND_LABEL))
+                .body("results[0].card_details.cardholder_name", is(CARD_DETAILS.getCardHolderName()))
+                .body("results[0].card_details.expiry_date", is(CARD_DETAILS.getExpiryDate()))
+                .body("results[0].card_details.last_digits_card_number", is(CARD_DETAILS.getLastDigitsCardNumber()))
+                .body("results[0].card_details.billing_address.line1", is(CARD_DETAILS.getBillingAddress().getLine1()))
+                .body("results[0].card_details.billing_address.line2", is(CARD_DETAILS.getBillingAddress().getLine2()))
+                .body("results[0].card_details.billing_address.postcode", is(CARD_DETAILS.getBillingAddress().getPostcode()))
+                .body("results[0].card_details.billing_address.county", is(CARD_DETAILS.getBillingAddress().getCounty()))
+                .body("results[0].card_details.billing_address.country", is(CARD_DETAILS.getBillingAddress().getCountry()))
                 .extract().asString();
 
         JsonAssert.with(responseBody)

--- a/src/test/java/uk/gov/pay/api/it/PaymentsRefundsResourceAmountValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsRefundsResourceAmountValidationITest.java
@@ -4,6 +4,8 @@ import com.jayway.jsonassert.JsonAssert;
 import com.jayway.restassured.response.ValidatableResponse;
 import org.junit.Before;
 import org.junit.Test;
+import uk.gov.pay.api.model.Address;
+import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.RefundSummary;
 
 import java.io.IOException;
@@ -18,6 +20,8 @@ import static org.hamcrest.core.Is.is;
 public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourceITestBase {
 
     private static final int REFUND_AMOUNT_AVAILABLE = 9000;
+    private static final Address BILLING_ADDRESS = new Address("line1","line2","NR2 5 6EG","city","county","UK");
+    private static final CardDetails CARD_DETAILS = new CardDetails("1234","Mr. Payment","12/19", BILLING_ADDRESS,"Visa");
 
     @Before
     public void setUpBearerToken() {
@@ -265,8 +269,8 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
         int amount = 1000;
         String externalChargeId = "charge_12345";
 
-        connectorMock.respondWithChargeFound(amount, GATEWAY_ACCOUNT_ID, externalChargeId, null, null, null, null, null, null, null, null, null,
-                new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000));
+        connectorMock.respondWithChargeFound(amount, GATEWAY_ACCOUNT_ID, externalChargeId, null, null, null, null, null, null, null, null,
+                new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000), CARD_DETAILS);
         connectorMock.respondBadRequest_whenCreateARefund("full", amount, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, externalChargeId);
 
         String refundRequest = "{\"amount\":" + amount + "}";
@@ -289,8 +293,8 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
         int amount = 1000;
         String externalChargeId = "charge_12345";
 
-        connectorMock.respondWithChargeFound(amount, GATEWAY_ACCOUNT_ID, externalChargeId, null, null, null, null, null, null, null, null, null,
-                new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000));
+        connectorMock.respondWithChargeFound(amount, GATEWAY_ACCOUNT_ID, externalChargeId, null, null, null, null, null, null, null, null,
+                new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000), CARD_DETAILS);
         connectorMock.respondBadRequest_whenCreateARefund("pending", amount, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, externalChargeId);
 
         String refundRequest = "{\"amount\":" + amount + "}";

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFiltersITest.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFiltersITest.java
@@ -9,6 +9,8 @@ import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.api.it.fixtures.PaymentNavigationLinksFixture;
+import uk.gov.pay.api.model.Address;
+import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.utils.ChargeEventBuilder;
@@ -52,6 +54,8 @@ public class ResourcesFiltersITest extends PaymentResourceITestBase {
     private static final String CREATED_DATE = DateTimeUtils.toUTCDateString(TIMESTAMP);
     private static final Map<String, String> PAYMENT_CREATED = new ChargeEventBuilder(STATE, CREATED_DATE).build();
     private static final List<Map<String, String>> EVENTS = Collections.singletonList(PAYMENT_CREATED);
+    private static final Address BILLING_ADDRESS = new Address("line1","line2","NR2 5 6EG","city","county","UK");
+    private static final CardDetails CARD_DETAILS = new CardDetails("1234","Mr. Payment","12/19", BILLING_ADDRESS,"Visa");
 
     private static final String PAYLOAD = paymentPayload(AMOUNT, RETURN_URL, DESCRIPTION, REFERENCE);
     private ExecutorService executor = Executors.newFixedThreadPool(2);
@@ -65,7 +69,7 @@ public class ResourcesFiltersITest extends PaymentResourceITestBase {
     public void createPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
 
         connectorMock.respondOk_whenCreateCharge(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID, STATE,
-                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CARD_BRAND, CREATED_DATE, REFUND_SUMMARY);
+                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, REFUND_SUMMARY, CARD_DETAILS);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> postPaymentResponse(API_KEY, PAYLOAD),
@@ -96,7 +100,7 @@ public class ResourcesFiltersITest extends PaymentResourceITestBase {
     public void getPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
 
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, STATE,
-                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CARD_BRAND, CREATED_DATE, CHARGE_TOKEN_ID, REFUND_SUMMARY);
+                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, CHARGE_TOKEN_ID, REFUND_SUMMARY, CARD_DETAILS);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> getPaymentResponse(API_KEY, CHARGE_ID),

--- a/src/test/java/uk/gov/pay/api/model/PaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/model/PaymentTest.java
@@ -15,7 +15,7 @@ public class PaymentTest {
     private ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    public void shouldNotPrintEmailWhenToString() throws IOException {
+    public void shouldNotPrintEmailAndCardDetailsWhenToString() throws IOException {
 
         URI selfUri = URI.create("http://self.link.com");
         URI eventsUri = URI.create("http://self.link.com/events");
@@ -24,6 +24,17 @@ public class PaymentTest {
 
         ChargeFromResponse paymentFromConnector = objectMapper.readValue("{" +
                 "\"email\":\"user@example.com\"," +
+                "\"card_details\":{" +
+                "\"card_brand\": \"Visa\"," +
+                "\"expiry_date\": \"12/19\"," +
+                "\"cardholder_name\": \"Mr. payment\"," +
+                "\"billing_address\": {" +
+                "\"line1\": \"line1\"," +
+                "\"postcode\": \"NR25 6EG\"," +
+                "\"country\": \"UK\"" +
+                "}," +
+                "\"last_digits_card_number\": \"4321\"" +
+                "}," +
                 "\"amount\":500," +
                 "\"state\":{" +
                 "\"status\":\"created\"," +
@@ -33,5 +44,11 @@ public class PaymentTest {
         Payment payment = PaymentWithAllLinks.valueOf(paymentFromConnector, selfUri, eventsUri, cancelUri, refundsUri);
 
         assertThat(payment.toString(), not(containsString("user@example.com")));
+        assertThat(payment.toString(), not(containsString("last_digits_card_number")));
+        assertThat(payment.toString(), not(containsString("4321")));
+        assertThat(payment.toString(), not(containsString("12/19")));
+        assertThat(payment.toString(), not(containsString("Mr. payment")));
+        assertThat(payment.toString(), not(containsString("NR25 6EG")));
+        assertThat(payment.toString(), not(containsString("UK")));
     }
 }

--- a/src/test/java/uk/gov/pay/api/utils/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/ConnectorMockClient.java
@@ -7,6 +7,7 @@ import org.mockserver.client.server.MockServerClient;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.model.Parameter;
 import uk.gov.pay.api.it.fixtures.PaymentRefundJsonFixture;
+import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.model.links.Link;
@@ -62,8 +63,8 @@ public class ConnectorMockClient {
     }
 
     private String buildChargeResponse(long amount, String chargeId, PaymentState state, String returnUrl, String description,
-                                       String reference, String email, String paymentProvider, String cardBrand,
-                                       String gatewayTransactionId, String createdDate, RefundSummary refundSummary, ImmutableMap<?, ?>... links) {
+                                       String reference, String email, String paymentProvider, String gatewayTransactionId,
+                                       String createdDate, RefundSummary refundSummary, CardDetails cardDetails, ImmutableMap<?, ?>... links) {
         JsonStringBuilder jsonStringBuilder = new JsonStringBuilder()
                 .add("charge_id", chargeId)
                 .add("amount", amount)
@@ -76,7 +77,8 @@ public class ConnectorMockClient {
                 .add("card_brand", CARD_BRAND_LABEL)
                 .add("created_date", createdDate)
                 .add("links", asList(links))
-                .add("refund_summary", refundSummary);
+                .add("refund_summary", refundSummary)
+                .add("card_details", cardDetails);
 
         if (gatewayTransactionId != null) {
             jsonStringBuilder.add("gateway_transaction_id", gatewayTransactionId);
@@ -142,7 +144,7 @@ public class ConnectorMockClient {
     }
 
     public void respondOk_whenCreateCharge(int amount, String gatewayAccountId, String chargeId, String chargeTokenId, PaymentState state, String returnUrl,
-                                           String description, String reference, String email, String paymentProvider, String cardBrand, String createdDate, RefundSummary refundSummary) {
+                                           String description, String reference, String email, String paymentProvider, String createdDate, RefundSummary refundSummary, CardDetails cardDetails) {
 
         whenCreateCharge(amount, gatewayAccountId, returnUrl, description, reference)
                 .respond(response()
@@ -158,10 +160,10 @@ public class ConnectorMockClient {
                                 reference,
                                 email,
                                 paymentProvider,
-                                cardBrand,
                                 null,
                                 createdDate,
                                 refundSummary,
+                                cardDetails,
                                 validGetLink(chargeLocation(gatewayAccountId, chargeId), "self"),
                                 validGetLink(nextUrl(chargeTokenId), "next_url"), validPostLink(nextUrlPost(), "next_url_post", "application/x-www-form-urlencoded",
                                         new HashMap<String, String>() {{
@@ -215,11 +217,11 @@ public class ConnectorMockClient {
     }
 
     public void respondWithChargeFound(long amount, String gatewayAccountId, String chargeId, PaymentState state, String returnUrl,
-                                       String description, String reference, String email, String paymentProvider, String cardBrand,
-                                       String createdDate, String chargeTokenId, RefundSummary refundSummary) {
+                                       String description, String reference, String email, String paymentProvider, String createdDate,
+                                       String chargeTokenId, RefundSummary refundSummary, CardDetails cardDetails) {
 
         String chargeResponseBody = buildChargeResponse(amount, chargeId, state, returnUrl,
-                description, reference, email, paymentProvider, cardBrand, gatewayAccountId, createdDate, refundSummary,
+                description, reference, email, paymentProvider, gatewayAccountId, createdDate, refundSummary, cardDetails,
                 validGetLink(chargeLocation(gatewayAccountId, chargeId), "self"),
                 validGetLink(chargeLocation(gatewayAccountId, chargeId) + "/refunds", "refunds"),
                 validGetLink(nextUrl(chargeId), "next_url"), validPostLink(nextUrlPost(), "next_url_post", "application/x-www-form-urlencoded",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -381,6 +381,36 @@
     }
   },
   "definitions" : {
+    "Billing Address" : {
+      "type" : "object",
+      "properties" : {
+        "line1" : {
+          "type" : "string",
+          "readOnly" : true
+        },
+        "line2" : {
+          "type" : "string",
+          "readOnly" : true
+        },
+        "postcode" : {
+          "type" : "string",
+          "readOnly" : true
+        },
+        "city" : {
+          "type" : "string",
+          "readOnly" : true
+        },
+        "county" : {
+          "type" : "string",
+          "readOnly" : true
+        },
+        "country" : {
+          "type" : "string",
+          "readOnly" : true
+        }
+      },
+      "description" : "A structure representing the billing address of a card"
+    },
     "CreatePaymentRefundRequest" : {
       "type" : "object",
       "required" : [ "amount" ],
@@ -480,6 +510,32 @@
       },
       "description" : "A List of Payment Events information"
     },
+    "Payment card details" : {
+      "type" : "object",
+      "properties" : {
+        "last_digits_card_number" : {
+          "type" : "string",
+          "readOnly" : true
+        },
+        "cardholder_name" : {
+          "type" : "string",
+          "readOnly" : true
+        },
+        "expiry_date" : {
+          "type" : "string",
+          "readOnly" : true
+        },
+        "billing_address" : {
+          "readOnly" : true,
+          "$ref" : "#/definitions/Billing Address"
+        },
+        "card_brand" : {
+          "type" : "string",
+          "readOnly" : true
+        }
+      },
+      "description" : "A structure representing the payment card"
+    },
     "Payment state" : {
       "type" : "object",
       "required" : [ "code", "finished", "message", "status" ],
@@ -564,12 +620,6 @@
           "example" : "worldpay",
           "readOnly" : true
         },
-        "card_brand" : {
-          "type" : "string",
-          "example" : "Visa",
-          "description" : "Card Brand",
-          "readOnly" : true
-        },
         "return_url" : {
           "type" : "string",
           "example" : "http://your.service.domain/your-reference",
@@ -584,9 +634,19 @@
           "readOnly" : true,
           "$ref" : "#/definitions/Refund Summary"
         },
+        "card_details" : {
+          "readOnly" : true,
+          "$ref" : "#/definitions/Payment card details"
+        },
         "_links" : {
           "readOnly" : true,
           "$ref" : "#/definitions/linksForSearchResults"
+        },
+        "card_brand" : {
+          "type" : "string",
+          "example" : "Visa",
+          "description" : "Card Brand",
+          "readOnly" : true
         }
       }
     },
@@ -635,12 +695,6 @@
           "example" : "worldpay",
           "readOnly" : true
         },
-        "card_brand" : {
-          "type" : "string",
-          "example" : "Visa",
-          "description" : "Card Brand",
-          "readOnly" : true
-        },
         "return_url" : {
           "type" : "string",
           "example" : "http://your.service.domain/your-reference",
@@ -655,9 +709,19 @@
           "readOnly" : true,
           "$ref" : "#/definitions/Refund Summary"
         },
+        "card_details" : {
+          "readOnly" : true,
+          "$ref" : "#/definitions/Payment card details"
+        },
         "_links" : {
           "readOnly" : true,
           "$ref" : "#/definitions/allLinksForAPayment"
+        },
+        "card_brand" : {
+          "type" : "string",
+          "example" : "Visa",
+          "description" : "Card Brand",
+          "readOnly" : true
         }
       }
     },


### PR DESCRIPTION
## WHAT
 - Enabled card details in get payments and search payments api's
 - removed top level `card_brand` attribute as it is now available in `card_details`. However keeping support for the root level `card_brand` attribute for existing clients. Marked it as Deprecated in documentation, to force teams to use the new API.
