### PR TITLE
PP-1517 Pass settlement_summary through PublicApi

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ Content-Type: application/json
         "amount_available": 14500
         "amount_submitted": 0
     }
+    "settlement_summary": {
+        "captured_date": "2016-01-15",
+        "capture_submit_time": "2016-01-15T16:30:56Z" 
+    }
 }
 ```
 
@@ -169,6 +173,8 @@ Content-Type: application/json
 | `refund_summary.status`| Refund availability status of the payment                                                |
 | `refund_summary.amount_available`| Amount available for refunds                                                   |
 | `refund_summary.amount_submitted`| Total amount of refunds submitted for this payment                             |
+| `settlement_summary.captured_date`| Date of the capture according to the payment gateway                          |
+| `settlement_summary.capture_submit_time`| Date and time of submission of the capture request, if present          |
 | `created_date`         | The payment creation date for this payment                                               |
 | `_links.self`          | Link to the payment                                                                      |
 | `_links.next_url`      | Where to navigate the user next as a GET                                                 |
@@ -333,6 +339,10 @@ Content-Type: application/json
         "status": "available"
         "amount_available": 14500
         "amount_submitted": 0
+    },
+    "settlement_summary": {
+        "captured_date": "2016-01-15",
+        "capture_submit_time": "2016-01-15T16:30:56Z" 
     }
 }
 ```
@@ -890,7 +900,11 @@ GET /v1/payments
          "status": "pending"
          "amount_available": 1
          "amount_submitted": 0
-      }
+      },
+      "settlement_summary": {
+          "captured_date": "2016-01-15",
+          "capture_submit_time": "2016-01-15T16:30:56Z" 
+      },
       "_links": {
         "self": {
           "href": "https://publicapi.pymnt.localdomain/v1/payments/4hn0c8bbtfbnp5tmite2274h5c",
@@ -941,7 +955,11 @@ GET /v1/payments
          "status": "pending"
          "amount_available": 1
          "amount_submitted": 0
-      }
+      },
+      "settlement_summary": {
+         "captured_date": "2016-01-15",
+         "capture_submit_time": "2016-01-15T16:30:56Z" 
+        },
       "_links": {
         "self": {
           "href": "https://publicapi.pymnt.localdomain/v1/payments/am6f5d1583563deb7ss5obju2",
@@ -1002,6 +1020,8 @@ GET /v1/payments
 | `results[i].refund_summary.status`   | Yes            | The refund status of this payment                                 |
 | `results[i].refund_summary.amount_available`| Yes     | The amount available for refunds for this payment                 |
 | `results[i].refund_summary.amount_submitted`| Yes     | The total refund amount submitted for this payment                |
+| `results[i].settlement_summary.captured_date`| No | Date of the capture according to the payment gateway                  |
+| `results[i].settlement_summary.capture_submit_time`| No | Date and time of submission of the capture request              |
 | `results[i].card_details.card_brand` | No             | The card brand used for this payment                              |
 | `results[i].card_details.cardholder_name` | No        | The card card holder name of this payment                         |
 | `results[i].card_details.expiry_date` | No            | The expiry date of this card                                      |

--- a/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
@@ -26,6 +26,9 @@ public class ChargeFromResponse {
     @JsonProperty(value = "refund_summary")
     private RefundSummary refundSummary;
 
+    @JsonProperty(value = "settlement_summary")
+    private SettlementSummary settlementSummary;
+
     @JsonProperty(value = "card_details")
     private CardDetails cardDetails;
 
@@ -90,6 +93,10 @@ public class ChargeFromResponse {
 
     public RefundSummary getRefundSummary() {
         return refundSummary;
+    }
+
+    public SettlementSummary getSettlementSummary() {
+        return settlementSummary;
     }
 
     public CardDetails getCardDetails() {

--- a/src/main/java/uk/gov/pay/api/model/Payment.java
+++ b/src/main/java/uk/gov/pay/api/model/Payment.java
@@ -29,12 +29,15 @@ public abstract class Payment {
     @JsonProperty("refund_summary")
     private final RefundSummary refundSummary;
 
+    @JsonProperty("settlement_summary")
+    private final SettlementSummary settlementSummary;
+
     @JsonProperty("card_details")
     private final CardDetails cardDetails;
 
     public Payment(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                    String reference, String email, String paymentProvider, String createdDate,
-                   RefundSummary refundSummary, CardDetails cardDetails) {
+                   RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails) {
         this.paymentId = chargeId;
         this.amount = amount;
         this.state = state;
@@ -45,6 +48,7 @@ public abstract class Payment {
         this.paymentProvider = paymentProvider;
         this.createdDate = createdDate;
         this.refundSummary = refundSummary;
+        this.settlementSummary = settlementSummary;
         this.cardDetails = cardDetails;
     }
 
@@ -108,6 +112,11 @@ public abstract class Payment {
     @ApiModelProperty(dataType = "uk.gov.pay.api.model.RefundSummary")
     public RefundSummary getRefundSummary() {
         return refundSummary;
+    }
+
+    @ApiModelProperty(dataType = "uk.gov.pay.api.model.SettlementSummary")
+    public SettlementSummary getSettlementSummary() {
+        return settlementSummary;
     }
 
     @ApiModelProperty(dataType = "uk.gov.pay.api.model.CardDetails")

--- a/src/main/java/uk/gov/pay/api/model/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentForSearchResult.java
@@ -13,8 +13,9 @@ public class PaymentForSearchResult extends Payment {
 
     public PaymentForSearchResult(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                                   String reference, String email, String paymentProvider, String createdDate,
-                                  RefundSummary refundSummary, CardDetails cardDetails, URI selfLink, URI paymentEventsLink, URI paymentCancelLink, URI paymentRefundsLink) {
-        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate, refundSummary, cardDetails);
+                                  RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
+                                  URI selfLink, URI paymentEventsLink, URI paymentCancelLink, URI paymentRefundsLink) {
+        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate, refundSummary, settlementSummary, cardDetails);
         this.links.addSelf(selfLink.toString());
         this.links.addEvents(paymentEventsLink.toString());
         this.links.addRefunds(paymentRefundsLink.toString());
@@ -42,6 +43,7 @@ public class PaymentForSearchResult extends Payment {
                 paymentResult.getPaymentProvider(),
                 paymentResult.getCreatedDate(),
                 paymentResult.getRefundSummary(),
+                paymentResult.getSettlementSummary(),
                 paymentResult.getCardDetails(),
                 selfLink,
                 paymentEventsLink,

--- a/src/main/java/uk/gov/pay/api/model/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentWithAllLinks.java
@@ -14,9 +14,9 @@ public class PaymentWithAllLinks extends Payment {
 
     private PaymentWithAllLinks(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                                 String reference, String email, String paymentProvider, String createdDate,
-                                RefundSummary refundSummary, CardDetails cardDetails, List<PaymentConnectorResponseLink> paymentConnectorResponseLinks,
+                                RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails, List<PaymentConnectorResponseLink> paymentConnectorResponseLinks,
                                 URI selfLink, URI paymentEventsUri, URI paymentCancelUri, URI paymentRefundsUri) {
-        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate, refundSummary, cardDetails);
+        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate, refundSummary, settlementSummary, cardDetails);
         this.links.addSelf(selfLink.toString());
         this.links.addKnownLinksValueOf(paymentConnectorResponseLinks);
         this.links.addEvents(paymentEventsUri.toString());
@@ -43,6 +43,7 @@ public class PaymentWithAllLinks extends Payment {
                 paymentConnector.getPaymentProvider(),
                 paymentConnector.getCreatedDate(),
                 paymentConnector.getRefundSummary(),
+                paymentConnector.getSettlementSummary(),
                 paymentConnector.getCardDetails(),
                 paymentConnector.getLinks(),
                 selfLink,

--- a/src/main/java/uk/gov/pay/api/model/SettlementSummary.java
+++ b/src/main/java/uk/gov/pay/api/model/SettlementSummary.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.api.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.time.ZonedDateTime;
+
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
+@ApiModel(value="Settlement Summary", description = "A structure representing information about a settlement")
+public class SettlementSummary {
+
+    @JsonProperty("capture_submit_time")
+    private String captureSubmitTime;
+
+    @JsonProperty("captured_date")
+    private String capturedDate;
+
+    public SettlementSummary() {}
+
+    public SettlementSummary(String captureSubmitTime, String capturedDate) {
+        this.captureSubmitTime = captureSubmitTime;
+        this.capturedDate = capturedDate;
+    }
+
+    @ApiModelProperty(value = "Date and time capture request has been submitted", example = "2016-01-21T17:15:00Z")
+    public String getCaptureSubmitTime() {
+        return captureSubmitTime;
+    }
+
+    @ApiModelProperty(value = "Date of the capture event", example = "2016-01-21")
+    public String getCapturedDate() {
+        return capturedDate;
+    }
+}

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -103,7 +103,7 @@ public class PaymentsResource {
 
         logger.info("Payment request - paymentId={}", paymentId);
         Response connectorResponse = client
-                .target(getConnectorUlr(format(CONNECTOR_CHARGE_RESOURCE, accountId, paymentId)))
+                .target(getConnectorUrl(format(CONNECTOR_CHARGE_RESOURCE, accountId, paymentId)))
                 .request()
                 .get();
 
@@ -144,7 +144,7 @@ public class PaymentsResource {
         logger.info("Payment events request - payment_id={}", paymentId);
 
         Response connectorResponse = client
-                .target(getConnectorUlr(format(CONNECTOR_CHARGE_EVENTS_RESOURCE, accountId, paymentId)))
+                .target(getConnectorUrl(format(CONNECTOR_CHARGE_EVENTS_RESOURCE, accountId, paymentId)))
                 .request()
                 .get();
 
@@ -224,7 +224,7 @@ public class PaymentsResource {
                 Pair.of(DISPLAY_SIZE, displaySize)
         );
         Response connectorResponse = client
-                .target(getConnectorUlr(format(CONNECTOR_CHARGES_RESOURCE, accountId), queryParams))
+                .target(getConnectorUrl(format(CONNECTOR_CHARGES_RESOURCE, accountId), queryParams))
                 .request()
                 .header(HttpHeaders.ACCEPT, APPLICATION_JSON)
                 .get();
@@ -307,7 +307,7 @@ public class PaymentsResource {
         logger.info("Payment create request - [ {} ]", requestPayload);
 
         Response connectorResponse = client
-                .target(getConnectorUlr(format(CONNECTOR_CHARGES_RESOURCE, accountId)))
+                .target(getConnectorUrl(format(CONNECTOR_CHARGES_RESOURCE, accountId)))
                 .request()
                 .post(buildChargeRequestPayload(requestPayload));
 
@@ -353,7 +353,7 @@ public class PaymentsResource {
         logger.info("Payment cancel request - payment_id=[{}]", paymentId);
 
         Response connectorResponse = client
-                .target(getConnectorUlr(format(CONNECTOR_ACCOUNT_CHARGE_CANCEL_RESOURCE, accountId, paymentId)))
+                .target(getConnectorUrl(format(CONNECTOR_ACCOUNT_CHARGE_CANCEL_RESOURCE, accountId, paymentId)))
                 .request()
                 .post(Entity.json("{}"));
 
@@ -389,11 +389,11 @@ public class PaymentsResource {
                 .build(chargeId);
     }
 
-    private String getConnectorUlr(String urlPath) {
-        return getConnectorUlr(urlPath, Collections.emptyList());
+    private String getConnectorUrl(String urlPath) {
+        return getConnectorUrl(urlPath, Collections.emptyList());
     }
 
-    private String getConnectorUlr(String urlPath, List<Pair<String, String>> queryParams) {
+    private String getConnectorUrl(String urlPath, List<Pair<String, String>> queryParams) {
         UriBuilder builder = UriBuilder
                 .fromPath(connectorUrl)
                 .path(urlPath);

--- a/src/main/java/uk/gov/pay/api/utils/DateTimeUtils.java
+++ b/src/main/java/uk/gov/pay/api/utils/DateTimeUtils.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.api.utils;
 
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -10,6 +11,7 @@ public class DateTimeUtils {
     private static final ZoneId UTC = ZoneId.of("Z");
     private static DateTimeFormatter dateTimeFormatterUTC = DateTimeFormatter.ISO_INSTANT.withZone(UTC);
     private static DateTimeFormatter dateTimeFormatterAny = DateTimeFormatter.ISO_ZONED_DATE_TIME;
+    private static DateTimeFormatter localDateFormatter = DateTimeFormatter.ISO_LOCAL_DATE;
 
     /**
      * Converts any valid ZonedDateTime String (ISO_8601) representation to a UTC ZonedDateTime
@@ -47,5 +49,20 @@ public class DateTimeUtils {
      */
     public static String toUTCDateString(ZonedDateTime dateTime) {
         return dateTime.format(dateTimeFormatterUTC);
+    }
+
+    /**
+     * Converts a LocalDateTime to a UTC ISO_8601 string representation
+     * <p>
+     * e.g. <br/>
+     * 1. LocalDateTime("2010-01-01") ==> "2010-12-01" <br/>
+     * 2. LocalDateTime("2010-12-31") ==> "2010-12-31" <br/>
+     * </p>
+     *
+     * @param zonedDateTime
+     * @return UTC ISO_8601 date string
+     */
+    public static String toLocalDateString(ZonedDateTime zonedDateTime) {
+        return zonedDateTime.withZoneSameInstant(ZoneOffset.UTC).toLocalDate().format(localDateFormatter);
     }
 }

--- a/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
@@ -157,7 +157,7 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
         String payload = new GsonBuilder().create().toJson(
                 ImmutableMap.of("amount", AMOUNT));
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, null, null, null, null, null, null, null, null,
-                new RefundSummary("available", 9000, 1000), CARD_DETAILS);
+                new RefundSummary("available", 9000, 1000), null, CARD_DETAILS);
 
         postRefundRequest(payload);
     }

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -93,6 +93,8 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                 .body("results[0].refund_summary.status", is("available"))
                 .body("results[0].refund_summary.amount_available", is(100))
                 .body("results[0].refund_summary.amount_submitted", is(300))
+                .body("results[0].settlement_summary.capture_submit_time", is(DEFAULT_CAPTURE_SUBMIT_TIME))
+                .body("results[0].settlement_summary.captured_date", is(DEFAULT_CAPTURED_DATE))
                 .body("results[0].card_details.card_brand", is(TEST_CARD_BRAND_LABEL))
                 .body("results[0].card_details.cardholder_name", is(CARD_DETAILS.getCardHolderName()))
                 .body("results[0].card_details.expiry_date", is(CARD_DETAILS.getExpiryDate()))

--- a/src/test/java/uk/gov/pay/api/it/PaymentsRefundsResourceAmountValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsRefundsResourceAmountValidationITest.java
@@ -270,7 +270,7 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
         String externalChargeId = "charge_12345";
 
         connectorMock.respondWithChargeFound(amount, GATEWAY_ACCOUNT_ID, externalChargeId, null, null, null, null, null, null, null, null,
-                new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000), CARD_DETAILS);
+                new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000), null, CARD_DETAILS);
         connectorMock.respondBadRequest_whenCreateARefund("full", amount, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, externalChargeId);
 
         String refundRequest = "{\"amount\":" + amount + "}";
@@ -294,7 +294,7 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
         String externalChargeId = "charge_12345";
 
         connectorMock.respondWithChargeFound(amount, GATEWAY_ACCOUNT_ID, externalChargeId, null, null, null, null, null, null, null, null,
-                new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000), CARD_DETAILS);
+                new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000), null, CARD_DETAILS);
         connectorMock.respondBadRequest_whenCreateARefund("pending", amount, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, externalChargeId);
 
         String refundRequest = "{\"amount\":" + amount + "}";

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFiltersITest.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFiltersITest.java
@@ -41,7 +41,7 @@ public class ResourcesFiltersITest extends PaymentResourceITestBase {
     private static final int AMOUNT = 9999999;
     private static final String CHARGE_ID = "ch_ab2341da231434l";
     private static final String CHARGE_TOKEN_ID = "token_1234567asdf";
-    private static final PaymentState STATE = new PaymentState("created", false, null, null);
+    private static final PaymentState CREATED = new PaymentState("created", false, null, null);
     private static final RefundSummary REFUND_SUMMARY = new RefundSummary("pending", 100L, 50L);
     private static final String PAYMENT_PROVIDER = "Sandbox";
     private static final String CARD_BRAND = "master-card";
@@ -52,7 +52,7 @@ public class ResourcesFiltersITest extends PaymentResourceITestBase {
     private static final String DESCRIPTION = "Some description";
     private static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
     private static final String CREATED_DATE = DateTimeUtils.toUTCDateString(TIMESTAMP);
-    private static final Map<String, String> PAYMENT_CREATED = new ChargeEventBuilder(STATE, CREATED_DATE).build();
+    private static final Map<String, String> PAYMENT_CREATED = new ChargeEventBuilder(CREATED, CREATED_DATE).build();
     private static final List<Map<String, String>> EVENTS = Collections.singletonList(PAYMENT_CREATED);
     private static final Address BILLING_ADDRESS = new Address("line1", "line2", "NR2 5 6EG", "city", "UK");
     private static final CardDetails CARD_DETAILS = new CardDetails("1234", "Mr. Payment", "12/19", BILLING_ADDRESS, "Visa");
@@ -68,8 +68,8 @@ public class ResourcesFiltersITest extends PaymentResourceITestBase {
     @Test
     public void createPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
 
-        connectorMock.respondOk_whenCreateCharge(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID, STATE,
-                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, REFUND_SUMMARY, CARD_DETAILS);
+        connectorMock.respondOk_whenCreateCharge(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID, CREATED,
+                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, REFUND_SUMMARY, null, CARD_DETAILS);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> postPaymentResponse(API_KEY, PAYLOAD),
@@ -99,8 +99,8 @@ public class ResourcesFiltersITest extends PaymentResourceITestBase {
     @Test
     public void getPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
 
-        connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, STATE,
-                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, CHARGE_TOKEN_ID, REFUND_SUMMARY, CARD_DETAILS);
+        connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CREATED,
+                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, CHARGE_TOKEN_ID, REFUND_SUMMARY, null, CARD_DETAILS);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> getPaymentResponse(API_KEY, CHARGE_ID),

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
@@ -21,6 +21,8 @@ public class PaymentSearchResultBuilder {
     private static final int DEFAULT_NUMBER_OF_RESULTS = 3;
 
     public static final String DEFAULT_CREATED_DATE = DateTimeUtils.toUTCDateString(ZonedDateTime.now());
+    public static final String DEFAULT_CAPTURE_SUBMIT_TIME = DateTimeUtils.toUTCDateString(ZonedDateTime.now());
+    public static final String DEFAULT_CAPTURED_DATE = DateTimeUtils.toLocalDateString(ZonedDateTime.now());
     public static final String DEFAULT_RETURN_URL = "http://example.com/service";
     public static final int DEFAULT_AMOUNT = 10000;
     public static final String DEFAULT_EMAIL = "alice.111@mail.fake";
@@ -70,13 +72,17 @@ public class PaymentSearchResultBuilder {
         public long amount_available;
         public long amount_submitted;
     }
-
+    private static class SettlementSummary {
+        public String capture_submit_time;
+        public String captured_date;
+    }
     private static class TestPayment {
         public TestPaymentState state;
         public String charge_id, description, reference, email, created_date;
         public int amount;
         public String gateway_transaction_id, return_url, payment_provider, card_brand;
         public RefundSummary refund_summary = new RefundSummary();
+        public SettlementSummary settlement_summary = new SettlementSummary();
         public CardDetails card_details = new CardDetails();
     }
 
@@ -243,6 +249,8 @@ public class PaymentSearchResultBuilder {
         payment.refund_summary.status = "available";
         payment.refund_summary.amount_available = 100;
         payment.refund_summary.amount_submitted = 300;
+        payment.settlement_summary.capture_submit_time = DEFAULT_CAPTURE_SUBMIT_TIME;
+        payment.settlement_summary.captured_date = DEFAULT_CAPTURED_DATE;
 
         return payment;
     }

--- a/src/test/java/uk/gov/pay/api/utils/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/ConnectorMockClient.java
@@ -10,6 +10,7 @@ import uk.gov.pay.api.it.fixtures.PaymentRefundJsonFixture;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
+import uk.gov.pay.api.model.SettlementSummary;
 import uk.gov.pay.api.model.links.Link;
 
 import java.util.*;
@@ -64,7 +65,7 @@ public class ConnectorMockClient {
 
     private String buildChargeResponse(long amount, String chargeId, PaymentState state, String returnUrl, String description,
                                        String reference, String email, String paymentProvider, String gatewayTransactionId,
-                                       String createdDate, RefundSummary refundSummary, CardDetails cardDetails, ImmutableMap<?, ?>... links) {
+                                       String createdDate, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails, ImmutableMap<?, ?>... links) {
         JsonStringBuilder jsonStringBuilder = new JsonStringBuilder()
                 .add("charge_id", chargeId)
                 .add("amount", amount)
@@ -78,6 +79,7 @@ public class ConnectorMockClient {
                 .add("created_date", createdDate)
                 .add("links", asList(links))
                 .add("refund_summary", refundSummary)
+                .add("settlement_summary", settlementSummary)
                 .add("card_details", cardDetails);
 
         if (gatewayTransactionId != null) {
@@ -144,7 +146,7 @@ public class ConnectorMockClient {
     }
 
     public void respondOk_whenCreateCharge(int amount, String gatewayAccountId, String chargeId, String chargeTokenId, PaymentState state, String returnUrl,
-                                           String description, String reference, String email, String paymentProvider, String createdDate, RefundSummary refundSummary, CardDetails cardDetails) {
+                                           String description, String reference, String email, String paymentProvider, String createdDate, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails) {
 
         whenCreateCharge(amount, gatewayAccountId, returnUrl, description, reference)
                 .respond(response()
@@ -163,6 +165,7 @@ public class ConnectorMockClient {
                                 null,
                                 createdDate,
                                 refundSummary,
+                                settlementSummary,
                                 cardDetails,
                                 validGetLink(chargeLocation(gatewayAccountId, chargeId), "self"),
                                 validGetLink(nextUrl(chargeTokenId), "next_url"), validPostLink(nextUrlPost(), "next_url_post", "application/x-www-form-urlencoded",
@@ -218,10 +221,9 @@ public class ConnectorMockClient {
 
     public void respondWithChargeFound(long amount, String gatewayAccountId, String chargeId, PaymentState state, String returnUrl,
                                        String description, String reference, String email, String paymentProvider, String createdDate,
-                                       String chargeTokenId, RefundSummary refundSummary, CardDetails cardDetails) {
-
+                                       String chargeTokenId, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails) {
         String chargeResponseBody = buildChargeResponse(amount, chargeId, state, returnUrl,
-                description, reference, email, paymentProvider, gatewayAccountId, createdDate, refundSummary, cardDetails,
+                description, reference, email, paymentProvider, gatewayAccountId, createdDate, refundSummary, settlementSummary, cardDetails,
                 validGetLink(chargeLocation(gatewayAccountId, chargeId), "self"),
                 validGetLink(chargeLocation(gatewayAccountId, chargeId) + "/refunds", "refunds"),
                 validGetLink(nextUrl(chargeId), "next_url"), validPostLink(nextUrlPost(), "next_url_post", "application/x-www-form-urlencoded",

--- a/src/test/java/uk/gov/pay/api/utils/DateTimeUtilsTest.java
+++ b/src/test/java/uk/gov/pay/api/utils/DateTimeUtilsTest.java
@@ -22,6 +22,14 @@ public class DateTimeUtilsTest {
     }
 
     @Test
+    public void shouldConvertUTCZonedDateTimeToLocalDateString() throws Exception {
+        ZonedDateTime localDateTime = ZonedDateTime.of(2010, 11, 13, 12, 0, 0, 0, ZoneId.of("Z"));
+
+        String dateString = DateTimeUtils.toLocalDateString(localDateTime);
+        assertThat(dateString, is("2010-11-13"));
+    }
+
+    @Test
     public void shouldConvertNonUTCZonedDateTimeToAISO_8601_UTCString() throws Exception {
         ZonedDateTime localDateTime = ZonedDateTime.of(2010, 11, 13, 12, 0, 0, 0, ZoneId.of("Europe/Paris"));
 

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -419,19 +419,19 @@
         "amount" : {
           "type" : "integer",
           "format" : "int32",
-          "example" : 150000,
+          "example" : "150000",
           "description" : "Amount in pence. Can't be more than the available amount for refunds",
-          "minimum" : 1,
-          "maximum" : 10000000
+          "minimum" : 1.0,
+          "maximum" : 1.0E7
         },
         "refund_amount_available" : {
           "type" : "integer",
           "format" : "int32",
-          "example" : 200000,
+          "example" : "200000",
           "description" : "Amount in pence. Total amount still available before issuing the refund",
           "readOnly" : true,
-          "minimum" : 1,
-          "maximum" : 10000000
+          "minimum" : 1.0,
+          "maximum" : 1.0E7
         }
       },
       "description" : "The Payment Refund Request Payload"
@@ -443,10 +443,10 @@
         "amount" : {
           "type" : "integer",
           "format" : "int32",
-          "example" : 12000,
+          "example" : "12000",
           "description" : "amount in pence",
-          "minimum" : 1,
-          "maximum" : 10000000
+          "minimum" : 1.0,
+          "maximum" : 1.0E7
         },
         "reference" : {
           "type" : "string",
@@ -598,7 +598,7 @@
         "amount" : {
           "type" : "integer",
           "format" : "int64",
-          "example" : 1200
+          "example" : "1200"
         },
         "state" : {
           "$ref" : "#/definitions/Payment state"
@@ -638,6 +638,10 @@
         "refund_summary" : {
           "readOnly" : true,
           "$ref" : "#/definitions/Refund Summary"
+        },
+        "settlement_summary" : {
+          "readOnly" : true,
+          "$ref" : "#/definitions/Settlement Summary"
         },
         "card_details" : {
           "readOnly" : true,
@@ -673,7 +677,7 @@
         "amount" : {
           "type" : "integer",
           "format" : "int64",
-          "example" : 1200
+          "example" : "1200"
         },
         "state" : {
           "$ref" : "#/definitions/Payment state"
@@ -713,6 +717,10 @@
         "refund_summary" : {
           "readOnly" : true,
           "$ref" : "#/definitions/Refund Summary"
+        },
+        "settlement_summary" : {
+          "readOnly" : true,
+          "$ref" : "#/definitions/Settlement Summary"
         },
         "card_details" : {
           "readOnly" : true,
@@ -752,6 +760,24 @@
         }
       },
       "description" : "A structure representing the refunds availability"
+    },
+    "Settlement Summary" : {
+      "type" : "object",
+      "properties" : {
+        "capture_submit_time" : {
+          "type" : "string",
+          "example" : "2016-01-21T17:15:00Z",
+          "description" : "Date and time capture request has been submitted",
+          "readOnly" : true
+        },
+        "captured_date" : {
+          "type" : "string",
+          "example" : "2016-01-21",
+          "description" : "Date of the capture event",
+          "readOnly" : true
+        }
+      },
+      "description" : "A structure representing information about a settlement"
     },
     "allLinksForAPayment" : {
       "type" : "object",


### PR DESCRIPTION
## WHAT
- `settlement_summary` is a structure coming from connector, containing
  two fields: `capture_submit_time`, which is the timestamp of us
  receiving the payment gateway's notification of a capture, and
  `captured_date`, which is the date contained in the notification
  payload.
- if a charge has not been captured, both those dates  could potentially
  be empty; connector would be returning null.
  In this case, public api would not show at all the keys in the json structure
- `settlement_summary` is serialised in calls to `/payments` and
  `/payments/{id}` endpoints

## HOW 
_Steps to test or reproduce:_


