### PR TITLE
[REVIEW ONLY] PP-1753 Upgraded project dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,21 @@
             <artifactId>logback-classic</artifactId>
             <version>1.2.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <version>2.25.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-jaxb</artifactId>
+            <version>2.25.1</version>
+        </dependency>
         <!-- testing -->
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -110,16 +125,7 @@
                     <groupId>org.glassfish.jersey.containers</groupId>
                     <artifactId>jersey-container-servlet-core</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.glassfish.jersey.media</groupId>
-                    <artifactId>jersey-media-multipart</artifactId>
-                </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-multipart</artifactId>
-            <version>${jersey2.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,12 +62,12 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
-            <version>2.25.1</version>
+            <version>${jersey2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-jaxb</artifactId>
-            <version>2.25.1</version>
+            <version>${jersey2.version}</version>
         </dependency>
         <!-- testing -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
     <artifactId>pay-publicapi</artifactId>
 
     <properties>
-        <dropwizard.version>0.8.1</dropwizard.version>
-        <mockserver.version>3.9.17</mockserver.version>
+        <dropwizard.version>1.0.6</dropwizard.version>
+        <mockserver.version>3.10.4</mockserver.version>
         <swagger.jersey2.version>1.5.12</swagger.jersey2.version>
-        <jersey2.version>2.17</jersey2.version>
+        <jersey2.version>2.25.1</jersey2.version>
         <hamcrest.version>1.3</hamcrest.version>
     </properties>
 
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.5.1</version>
+            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
@@ -42,12 +42,17 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>3.1.2</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-graphite</artifactId>
-            <version>3.1.2</version>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.1</version>
         </dependency>
         <!-- testing -->
         <dependency>
@@ -59,7 +64,7 @@
         <dependency>
             <groupId>com.jayway.restassured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>2.4.0</version>
+            <version>2.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -119,12 +124,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.8.6</version>
+            <version>2.8.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.8.6</version>
+            <version>2.8.7</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -140,7 +145,7 @@
         <dependency>
             <groupId>black.door</groupId>
             <artifactId>hate</artifactId>
-            <version>v1r3t1</version>
+            <version>v1r4t0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/uk/gov/pay/api/auth/Account.java
+++ b/src/main/java/uk/gov/pay/api/auth/Account.java
@@ -1,0 +1,17 @@
+package uk.gov.pay.api.auth;
+
+import java.security.Principal;
+
+public class Account implements Principal {
+
+    private final String name;
+
+    public Account(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.*;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CreateRefundException;
 import uk.gov.pay.api.exception.GetRefundException;
 import uk.gov.pay.api.exception.GetRefundsException;
@@ -71,12 +72,12 @@ public class PaymentRefundsResource {
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
-    public Response getRefunds(@ApiParam(value = "accountId", hidden = true) @Auth String accountId,
+    public Response getRefunds(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                @PathParam(PATH_PAYMENT_KEY) String paymentId) {
 
         logger.info("Get refunds for payment request - paymentId={}", paymentId);
         Response connectorResponse = client
-                .target(getConnectorUrl(format(CONNECTOR_CHARGE_REFUNDS_RESOURCE, accountId, paymentId)))
+                .target(getConnectorUrl(format(CONNECTOR_CHARGE_REFUNDS_RESOURCE, account.getName(), paymentId)))
                 .request()
                 .get();
 
@@ -105,13 +106,13 @@ public class PaymentRefundsResource {
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
-    public Response getRefundById(@ApiParam(value = "accountId", hidden = true) @Auth String accountId,
+    public Response getRefundById(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                   @PathParam(PATH_PAYMENT_KEY) String paymentId,
                                   @PathParam(PATH_REFUND_KEY) String refundId) {
 
         logger.info("Payment refund request - paymentId={}, refundId={}", paymentId, refundId);
         Response connectorResponse = client
-                .target(getConnectorUrl(format(CONNECTOR_CHARGE_REFUND_BY_ID_RESOURCE, accountId, paymentId, refundId)))
+                .target(getConnectorUrl(format(CONNECTOR_CHARGE_REFUND_BY_ID_RESOURCE, account.getName(), paymentId, refundId)))
                 .request()
                 .get();
 
@@ -139,7 +140,7 @@ public class PaymentRefundsResource {
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
             @ApiResponse(code = 412, message = "Refund amount available mismatch"),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
-    public Response submitRefund(@ApiParam(value = "accountId", hidden = true) @Auth String accountId,
+    public Response submitRefund(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                  @ApiParam(value = "paymentId", required = true) @PathParam(PATH_PAYMENT_KEY) String paymentId,
                                  @ApiParam(value = "requestPayload", required = true) CreatePaymentRefundRequest requestPayload) {
 
@@ -148,7 +149,7 @@ public class PaymentRefundsResource {
         Integer refundAmountAvailable = requestPayload.getRefundAmountAvailable()
                 .orElseGet(() -> {
                     Response getChargeResponse = client
-                            .target(getConnectorUrl(format(CONNECTOR_CHARGE_RESOURCE, accountId, paymentId)))
+                            .target(getConnectorUrl(format(CONNECTOR_CHARGE_RESOURCE, account.getName(), paymentId)))
                             .request()
                             .get();
 
@@ -161,7 +162,7 @@ public class PaymentRefundsResource {
                 payloadMap);
 
         Response connectorResponse = client
-                .target(getConnectorUrl(format(CONNECTOR_CHARGE_REFUNDS_RESOURCE, accountId, paymentId)))
+                .target(getConnectorUrl(format(CONNECTOR_CHARGE_REFUNDS_RESOURCE, account.getName(), paymentId)))
                 .request()
                 .post(json(connectorPayload));
 

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.*;
 import uk.gov.pay.api.model.*;
 import uk.gov.pay.api.utils.JsonStringBuilder;
@@ -98,12 +99,12 @@ public class PaymentsResource {
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
-    public Response getPayment(@ApiParam(value = "accountId", hidden = true) @Auth String accountId,
+    public Response getPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                @PathParam(PAYMENT_KEY) String paymentId) {
 
         logger.info("Payment request - paymentId={}", paymentId);
         Response connectorResponse = client
-                .target(getConnectorUrl(format(CONNECTOR_CHARGE_RESOURCE, accountId, paymentId)))
+                .target(getConnectorUrl(format(CONNECTOR_CHARGE_RESOURCE, account.getName(), paymentId)))
                 .request()
                 .get();
 
@@ -138,13 +139,13 @@ public class PaymentsResource {
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
-    public Response getPaymentEvents(@ApiParam(value = "accountId", hidden = true) @Auth String accountId,
+    public Response getPaymentEvents(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                      @PathParam(PAYMENT_KEY) String paymentId) {
 
         logger.info("Payment events request - payment_id={}", paymentId);
 
         Response connectorResponse = client
-                .target(getConnectorUrl(format(CONNECTOR_CHARGE_EVENTS_RESOURCE, accountId, paymentId)))
+                .target(getConnectorUrl(format(CONNECTOR_CHARGE_EVENTS_RESOURCE, account.getName(), paymentId)))
                 .request()
                 .get();
 
@@ -184,7 +185,7 @@ public class PaymentsResource {
             @ApiResponse(code = 422, message = "Invalid parameters: from_date, to_date, status. See Public API documentation for the correct data formats", response = PaymentError.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response searchPayments(@ApiParam(value = "accountId", hidden = true)
-                                   @Auth String accountId,
+                                   @Auth Account account,
                                    @ApiParam(value = "Your payment reference to search", hidden = false)
                                    @QueryParam(REFERENCE_KEY) String reference,
                                    @ApiParam(value = "The user email used in the payment to be searched", hidden = false)
@@ -224,7 +225,7 @@ public class PaymentsResource {
                 Pair.of(DISPLAY_SIZE, displaySize)
         );
         Response connectorResponse = client
-                .target(getConnectorUrl(format(CONNECTOR_CHARGES_RESOURCE, accountId), queryParams))
+                .target(getConnectorUrl(format(CONNECTOR_CHARGES_RESOURCE, account.getName()), queryParams))
                 .request()
                 .header(HttpHeaders.ACCEPT, APPLICATION_JSON)
                 .get();
@@ -301,13 +302,13 @@ public class PaymentsResource {
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 422, message = "Invalid attribute value: description. Must be less than or equal to 255 characters length", response = PaymentError.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
-    public Response createNewPayment(@ApiParam(value = "accountId", hidden = true) @Auth String accountId,
+    public Response createNewPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                      @ApiParam(value = "requestPayload", required = true) CreatePaymentRequest requestPayload) {
 
         logger.info("Payment create request - [ {} ]", requestPayload);
 
         Response connectorResponse = client
-                .target(getConnectorUrl(format(CONNECTOR_CHARGES_RESOURCE, accountId)))
+                .target(getConnectorUrl(format(CONNECTOR_CHARGES_RESOURCE, account.getName())))
                 .request()
                 .post(buildChargeRequestPayload(requestPayload));
 
@@ -347,13 +348,13 @@ public class PaymentsResource {
             @ApiResponse(code = 409, message = "Conflict", response = PaymentError.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)
     })
-    public Response cancelPayment(@ApiParam(value = "accountId", hidden = true) @Auth String accountId,
+    public Response cancelPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                   @PathParam(PAYMENT_KEY) String paymentId) {
 
         logger.info("Payment cancel request - payment_id=[{}]", paymentId);
 
         Response connectorResponse = client
-                .target(getConnectorUrl(format(CONNECTOR_ACCOUNT_CHARGE_CANCEL_RESOURCE, accountId, paymentId)))
+                .target(getConnectorUrl(format(CONNECTOR_ACCOUNT_CHARGE_CANCEL_RESOURCE, account.getName(), paymentId)))
                 .request()
                 .post(Entity.json("{}"));
 

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
@@ -37,16 +37,16 @@ public abstract class PaymentResourceITestBase {
 
     @Before
     public void setup() {
-        connectorMock = new ConnectorMockClient(connectorMockRule.getHttpPort(), connectorBaseUrl());
-        publicAuthMock = new PublicAuthMockClient(publicAuthMockRule.getHttpPort());
+        connectorMock = new ConnectorMockClient(connectorMockRule.getPort(), connectorBaseUrl());
+        publicAuthMock = new PublicAuthMockClient(publicAuthMockRule.getPort());
     }
 
     private String connectorBaseUrl() {
-        return "http://localhost:" + connectorMockRule.getHttpPort();
+        return "http://localhost:" + connectorMockRule.getPort();
     }
 
     private String publicAuthBaseUrl() {
-        return "http://localhost:" + publicAuthMockRule.getHttpPort() + "/v1/auth";
+        return "http://localhost:" + publicAuthMockRule.getPort() + "/v1/auth";
     }
 
     String paymentLocationFor(String chargeId) {

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -325,11 +325,11 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
     public void searchPayments_getsPaginatedResultsFromConnector() throws Exception {
 
         PaymentNavigationLinksFixture links = new PaymentNavigationLinksFixture()
-                .withPrevLink("http://server:port/path?query=prev")
-                .withNextLink("http://server:port/path?query=next")
-                .withSelfLink("http://server:port/path?query=self")
-                .withFirstLink("http://server:port/path?query=first")
-                .withLastLink("http://server:port/path?query=last");
+                .withPrevLink("http://server:port/path?query=prev&from_date=2016-01-01T23:59:59Z")
+                .withNextLink("http://server:port/path?query=next&from_date=2016-01-01T23:59:59Z")
+                .withSelfLink("http://server:port/path?query=self&from_date=2016-01-01T23:59:59Z")
+                .withFirstLink("http://server:port/path?query=first&from_date=2016-01-01T23:59:59Z")
+                .withLastLink("http://server:port/path?query=last&from_date=2016-01-01T23:59:59Z");
 
         String payments = aPaginatedPaymentSearchResult()
                 .withCount(10)
@@ -361,11 +361,11 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                 .body("total", is(40))
                 .body("count", is(10))
                 .body("page", is(2))
-                .body("_links.next_page.href", Matchers.is(expectedChargesLocationFor("?query=next")))
-                .body("_links.prev_page.href", Matchers.is(expectedChargesLocationFor("?query=prev")))
-                .body("_links.first_page.href", Matchers.is(expectedChargesLocationFor("?query=first")))
-                .body("_links.last_page.href", Matchers.is(Matchers.is(expectedChargesLocationFor("?query=last"))))
-                .body("_links.self.href", Matchers.is(Matchers.is(expectedChargesLocationFor("?query=self"))));
+                .body("_links.next_page.href", Matchers.is(expectedChargesLocationFor("?query=next&from_date=2016-01-01T23%3A59%3A59Z")))
+                .body("_links.prev_page.href", Matchers.is(expectedChargesLocationFor("?query=prev&from_date=2016-01-01T23%3A59%3A59Z")))
+                .body("_links.first_page.href", Matchers.is(expectedChargesLocationFor("?query=first&from_date=2016-01-01T23%3A59%3A59Z")))
+                .body("_links.last_page.href", Matchers.is(Matchers.is(expectedChargesLocationFor("?query=last&from_date=2016-01-01T23%3A59%3A59Z"))))
+                .body("_links.self.href", Matchers.is(Matchers.is(expectedChargesLocationFor("?query=self&from_date=2016-01-01T23%3A59%3A59Z"))));
 
         List<Map<String, Object>> results = response.extract().body().jsonPath().getList("results");
         assertThat(results, matchesField("reference", TEST_REFERENCE));


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

- Upgraded the following libraries:
  - `Dropwizard` from version `0.8.1` to `1.0.6`.
  - `commons-validator` from version `1.5.1` to `1.6`.
  - `io.dropwizard.metrics` from version `3.1.2` to `3.2.0`.
  - `com.fasterxml.jackson.datatype` from version `2.8.6` to `2.8.7`.
  - `com.fasterxml.jackson.core` from version `2.8.6` to `2.8.7`.
  - `black.door` from version `v1r3t1` to `v1r4t0`
  - `httpclient` from version `4.5.2` to `4.5.3`
  - `jersey-common` from version `2.23.2` to `2.25.1`
  - `jersey-media-jaxb` from version `2.23.2` to `2.25.1`

- The implementation of `Dropwizard Authentication` has undergone a major overhaul since version 0.9.x of `Dropwizard` introducing a new interface for `Authenticators` and the use of a `Principal`. The code was refactored to conform to the new Auth implementation.

- Added test checking that colon characters `:` that can be found in the query string portion of all navigation links are being encoded as expected since the upgrade of Jersey library. 

- The `Dropwizard` upgrade caused a dependency conflicts with `ch.qos.logback` which was resolved by pulling the latest version explicitly.

NOTE: The SourceClear report still shows a medium risk vulnerabilites in `jersey-common` and `jersey-media-jaxb` libraries even in the latest version.

https://app.sourceclear.com/teams/100t11M/scans/1050886

