### PR TITLE
Allocate free port in integration tests

### DIFF
--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -1,10 +1,10 @@
 server:
   applicationConnectors:
     - type: http
-      port: 9010
+      port: 0
   adminConnectors:
     - type: http
-      port: 9011
+      port: 0
 
 logging:
     level: INFO


### PR DESCRIPTION
in order to avoid port clashes if multiple test runs are happening in parallel

a setting of `0` causes a random free port to be allocated