### PR TITLE
PP-1940 Don’t log payment descriptions because they may contain PII

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
@@ -47,11 +47,11 @@ public class CreatePaymentRequest {
 
     @Override
     public String toString() {
+        // Some services put PII in the description, so don’t include it in the stringification
         return "CreatePaymentRequest{" +
                 "amount=" + amount +
                 ", returnUrl='" + returnUrl + '\'' +
                 ", reference='" + reference + '\'' +
-                ", description='" + description + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/Payment.java
+++ b/src/main/java/uk/gov/pay/api/model/Payment.java
@@ -126,6 +126,7 @@ public abstract class Payment {
 
     @Override
     public String toString() {
+        // Some services put PII in the description, so don’t include it in the stringification
         return "Payment{" +
                 "paymentId='" + paymentId + '\'' +
                 ", paymentProvider='" + paymentProvider + '\'' +
@@ -133,7 +134,6 @@ public abstract class Payment {
                 ", amount=" + amount +
                 ", state='" + state + '\'' +
                 ", returnUrl='" + returnUrl + '\'' +
-                ", description='" + description + '\'' +
                 ", reference='" + reference + '\'' +
                 ", createdDate='" + createdDate + '\'' +
                 '}';


### PR DESCRIPTION
Some services put personally-identifiable information into payment descriptions. In order to avoid this ending up in the logs, exclude the description when logging payment details.