### PR TITLE
PP-2057 document that capture_submit_time can be null

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/SettlementSummary.java
+++ b/src/main/java/uk/gov/pay/api/model/SettlementSummary.java
@@ -24,7 +24,7 @@ public class SettlementSummary {
         this.capturedDate = capturedDate;
     }
 
-    @ApiModelProperty(value = "Date and time capture request has been submitted", example = "2016-01-21T17:15:00Z")
+    @ApiModelProperty(value = "Date and time capture request has been submitted (may be null if capture request was not immediately acknowledged by payment gateway)", example = "2016-01-21T17:15:00Z")
     public String getCaptureSubmitTime() {
         return captureSubmitTime;
     }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -767,7 +767,7 @@
         "capture_submit_time" : {
           "type" : "string",
           "example" : "2016-01-21T17:15:00Z",
-          "description" : "Date and time capture request has been submitted",
+          "description" : "Date and time capture request has been submitted (may be null if capture request was not immediately acknowledged by payment gateway)",
           "readOnly" : true
         },
         "captured_date" : {


### PR DESCRIPTION
If we don't get an acknowledgement from a payment gateway of a capture order,
but that gateway does successfully process the order, then a payment can be
`CAPTURED` but `capture_submit_time` will be null.