### PR TITLE
PP-2117 Pinned down version of commons-collections dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
             <artifactId>jersey-media-jaxb</artifactId>
             <version>${jersey2.version}</version>
         </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.2</version>
+        </dependency>
         <!-- testing -->
         <dependency>
             <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

Pinned down version 3.2.2 of `commons-collections` transient dependency to prevent Maven to pull any of the previous versions which may contain vulnerabilities as reported previously by `Snyk`:

- https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-7501

