### PR TITLE
PP-2514 Enable https validation for return url

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -27,7 +27,7 @@ BEARER_TOKEN: A valid bearer token for the account to associate the payment with
 | ------------------------ |:--------:| ----------------------------------------- |
 | `amount`                 | Yes      | Amount to pay in pence                           |
 | `description`            | Yes      | Payment description                              |
-| `return_url`             | Yes      | The URL where the user should be redirected to when the payment workflow is finished.         |
+| `return_url`             | Yes      | The URL where the user should be redirected to when the payment workflow is finished (**must be HTTPS only**).         |
 | `reference`              | Yes      | There reference issued by the government service for this payment         |
 
 ### Payment created response

--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -115,7 +115,7 @@ public class PublicApi extends Application<PublicApiConfig> {
     }
     private void configureObjectMapper(PublicApiConfig config, ObjectMapper objectMapper) {
 
-        URLValidator urlValidator = urlValidatorValueOf(config.getRestClientConfig().isDisabledSecureConnection());
+        URLValidator urlValidator = urlValidatorValueOf(config.getAllowHttpForReturnUrl());
         CreatePaymentRequestDeserializer paymentRequestDeserializer = new CreatePaymentRequestDeserializer(new PaymentRequestValidator(urlValidator));
         CreatePaymentRefundRequestDeserializer paymentRefundRequestDeserializer = new CreatePaymentRefundRequestDeserializer(new PaymentRefundRequestValidator());
 

--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
@@ -7,16 +7,26 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 public class PublicApiConfig extends Configuration {
+
     @NotNull
     private String baseUrl;
+
     @NotNull
     private String connectorUrl;
+
     @NotNull
     private String publicAuthUrl;
+
     @NotNull
     private String graphiteHost;
     @NotNull
     private String graphitePort;
+
+    @NotNull
+    private Boolean allowHttpForReturnUrl;
+
+    private String apiKeyHmacSecret;
+
     @Valid
     @NotNull
     @JsonProperty("jerseyClientConfig")
@@ -26,12 +36,6 @@ public class PublicApiConfig extends Configuration {
     @NotNull
     @JsonProperty("rateLimiter")
     private RateLimiterConfig rateLimiterConfig;
-
-    private String apiKeyHmacSecret;
-
-    public RestClientConfig getRestClientConfig() {
-        return restClientConfig;
-    }
 
     public String getBaseUrl() {
         return baseUrl;
@@ -45,13 +49,6 @@ public class PublicApiConfig extends Configuration {
         return publicAuthUrl;
     }
 
-    public RateLimiterConfig getRateLimiterConfig() {
-        return rateLimiterConfig;
-    }
-
-    public String getApiKeyHmacSecret(){
-        return apiKeyHmacSecret;
-    }
     public String getGraphiteHost() {
         return graphiteHost;
     }
@@ -59,4 +56,21 @@ public class PublicApiConfig extends Configuration {
     public String getGraphitePort() {
         return graphitePort;
     }
+
+    public Boolean getAllowHttpForReturnUrl() {
+        return allowHttpForReturnUrl;
+    }
+
+    public String getApiKeyHmacSecret() {
+        return apiKeyHmacSecret;
+    }
+
+    public RestClientConfig getRestClientConfig() {
+        return restClientConfig;
+    }
+
+    public RateLimiterConfig getRateLimiterConfig() {
+        return rateLimiterConfig;
+    }
+
 }

--- a/src/main/java/uk/gov/pay/api/validation/PaymentRequestValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/PaymentRequestValidator.java
@@ -20,8 +20,8 @@ public class PaymentRequestValidator {
     static final int AMOUNT_MAX_VALUE = 10000000;
     static final int AMOUNT_MIN_VALUE = 1;
 
-    private static final int DESCRIPTION_MAX_LENGTH = 255;
-    private static final int URL_MAX_LENGTH = 2000;
+    static final int DESCRIPTION_MAX_LENGTH = 255;
+    static final int URL_MAX_LENGTH = 2000;
     static final int REFERENCE_MAX_LENGTH = 255;
     static final int EMAIL_MAX_LENGTH = 254;
     static final int CARD_BRAND_MAX_LENGTH = 20;

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -29,4 +29,6 @@ rateLimiter:
   rate: ${RATE_LIMITER_VALUE:-25}
   perMillis: ${RATE_LIMITER_PER_MILLIS:-1000}
 
+allowHttpForReturnUrl: ${ALLOW_HTTP_FOR_RETURN_URL:-false}
+
 apiKeyHmacSecret: ${TOKEN_API_HMAC_SECRET}

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceDescriptionValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceDescriptionValidationITest.java
@@ -146,7 +146,7 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
                 "  \"amount\" : 9900," +
                 "  \"description\" : \"" + aVeryLongReference + "\"," +
                 "  \"reference\" : \"Some reference\"," +
-                "  \"return_url\" : \"http://my-payments.com\"" +
+                "  \"return_url\" : \"https://www.example.com/return_url\"" +
                 "}";
 
         InputStream body = postPaymentResponse(API_KEY, payload)

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceITest.java
@@ -39,7 +39,7 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
     private static final RefundSummary REFUND_SUMMARY = new RefundSummary("pending", 100L, 50L);
     private static final String PAYMENT_PROVIDER = "Sandbox";
     private static final String CARD_BRAND_LABEL = "Mastercard";
-    private static final String RETURN_URL = "http://somewhere.gov.uk/rainbow/1";
+    private static final String RETURN_URL = "https://somewhere.gov.uk/rainbow/1";
     private static final String REFERENCE = "Some reference <script> alert('This is a ?{simple} XSS attack.')</script>";
     private static final String EMAIL = "alice.111@mail.fake";
     private static final String DESCRIPTION = "Some description <script> alert('This is a ?{simple} XSS attack.')</script>";
@@ -133,7 +133,7 @@ public class PaymentsResourceITest extends PaymentResourceITestBase {
         String reference = randomAlphanumeric(255);
         String description = randomAlphanumeric(255);
         String email = randomAlphanumeric(254) + "@mail.fake";
-        String return_url = "http://govdemopay.gov.uk?data=" + randomAlphanumeric(1970);
+        String return_url = "https://govdemopay.gov.uk?data=" + randomAlphanumeric(1969);
 
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondOk_whenCreateCharge(amount, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID,

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceReferenceValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceReferenceValidationITest.java
@@ -146,7 +146,7 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
                 "  \"amount\" : 9900," +
                 "  \"reference\" : \"" + aVeryLongReference + "\"," +
                 "  \"description\" : \"Some description\"," +
-                "  \"return_url\" : \"http://my-payments.com\"" +
+                "  \"return_url\" : \"https://www.example.com/return_url\"" +
                 "}";
 
         InputStream body = postPaymentResponse(API_KEY, payload)

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFiltersITest.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFiltersITest.java
@@ -46,7 +46,7 @@ public class ResourcesFiltersITest extends PaymentResourceITestBase {
     private static final String PAYMENT_PROVIDER = "Sandbox";
     private static final String CARD_BRAND = "master-card";
     private static final String CARD_BRAND_LABEL = "Mastercard";
-    private static final String RETURN_URL = "http://somewhere.gov.uk/rainbow/1";
+    private static final String RETURN_URL = "https://somewhere.gov.uk/rainbow/1";
     private static final String REFERENCE = "Some reference";
     private static final String EMAIL = "alice.111@mail.fake";
     private static final String DESCRIPTION = "Some description";

--- a/src/test/java/uk/gov/pay/api/validation/PaymentRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/PaymentRequestValidatorTest.java
@@ -13,34 +13,80 @@ public class PaymentRequestValidatorTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
-    private static final String SUCCESSFUL_TEST_EMAIL = "alice.111@mail.fake";
-    private static final String UNSUCCESSFUL_TEST_EMAIL = randomAlphanumeric(255) + "@mail.fake";
+
+    private static final int VALID_AMOUNT = 100;
+    private static final String VALID_RETURN_URL = "https://www.example.com/return_url";
+    private static final String VALID_REFERENCE = "reference";
+    private static final String VALID_DESCRIPTION = "description";
+
+    private final PaymentRequestValidator paymentRequestValidator = new PaymentRequestValidator(URLValidator.SECURITY_ENABLED);
 
     @Test
-    public void validateMinimumAmount_shouldSuccessValue(){
-        PaymentRequestValidator paymentRequestValidator = new PaymentRequestValidator(URLValidator.SECURITY_ENABLED);
-        CreatePaymentRequest paymentRequest = new CreatePaymentRequest(1, "https://return.to/return_url", "reference", "description");
+    public void validParameters_shouldSuccessValue() {
+        CreatePaymentRequest createPaymentRequest = createPaymentRequest(VALID_AMOUNT, VALID_RETURN_URL, VALID_REFERENCE, VALID_DESCRIPTION);
+        paymentRequestValidator.validate(createPaymentRequest);
     }
 
     @Test
-    public void validateMinimumAmount_shouldFailValue() throws Exception{
-        PaymentRequestValidator paymentRequestValidator = new PaymentRequestValidator(URLValidator.SECURITY_ENABLED);
-        CreatePaymentRequest paymentRequest = new CreatePaymentRequest(PaymentRequestValidator.AMOUNT_MAX_VALUE + 1, "https://return.to/return_url", "reference", "description");
+    public void validateMinimumAmount_shouldSuccessValue() {
+        CreatePaymentRequest createPaymentRequest = createPaymentRequest(PaymentRequestValidator.AMOUNT_MIN_VALUE, VALID_RETURN_URL, VALID_REFERENCE, VALID_DESCRIPTION);
+        paymentRequestValidator.validate(createPaymentRequest);
+    }
+
+    @Test
+    public void validateMinimumAmount_shouldFailValue() throws Exception {
+        CreatePaymentRequest createPaymentRequest = createPaymentRequest(PaymentRequestValidator.AMOUNT_MIN_VALUE - 1, VALID_RETURN_URL, VALID_REFERENCE, VALID_DESCRIPTION);
+        expectedException.expect(ValidationException.class);
+        paymentRequestValidator.validate(createPaymentRequest);
+    }
+
+    @Test
+    public void validateMaximumAmount_shouldSuccessValue() {
+        CreatePaymentRequest createPaymentRequest = createPaymentRequest(PaymentRequestValidator.AMOUNT_MAX_VALUE, VALID_RETURN_URL, VALID_REFERENCE, VALID_DESCRIPTION);
+        paymentRequestValidator.validate(createPaymentRequest);
+    }
+
+    @Test
+    public void validateMaximumAmount_shouldFailValue() throws Exception {
+        CreatePaymentRequest paymentRequest = createPaymentRequest(PaymentRequestValidator.AMOUNT_MAX_VALUE + 1, VALID_RETURN_URL, VALID_REFERENCE, VALID_DESCRIPTION);
         expectedException.expect(ValidationException.class);
         paymentRequestValidator.validate(paymentRequest);
     }
 
     @Test
-    public void validateMaximumAmount_shouldSuccessValue(){
-        PaymentRequestValidator paymentRequestValidator = new PaymentRequestValidator(URLValidator.SECURITY_ENABLED);
-        CreatePaymentRequest paymentRequest = new CreatePaymentRequest(100, "https://return.to/return_url", "reference", "description");
-    }
-
-    @Test
-    public void validateMaximumAmount_shouldFailValue() throws Exception{
-        PaymentRequestValidator paymentRequestValidator = new PaymentRequestValidator(URLValidator.SECURITY_ENABLED);
-        CreatePaymentRequest paymentRequest = new CreatePaymentRequest(PaymentRequestValidator.AMOUNT_MAX_VALUE + 1, "https://return.to/return_url", "reference", "description");
+    public void validateReturnUrlMaxLength_shouldFailValue() throws Exception {
+        String invalidMaxLengthReturnUrl = "https://" + randomAlphanumeric(PaymentRequestValidator.URL_MAX_LENGTH) + ".com/";
+        CreatePaymentRequest paymentRequest = createPaymentRequest(VALID_AMOUNT, invalidMaxLengthReturnUrl, VALID_REFERENCE, VALID_DESCRIPTION);
         expectedException.expect(ValidationException.class);
         paymentRequestValidator.validate(paymentRequest);
     }
+
+    @Test
+    public void validateReturnUrlNotHttps_shouldFailValue() throws Exception {
+        String validHttpOnlyUrl = "http://www.example.com/";
+        CreatePaymentRequest paymentRequest = createPaymentRequest(VALID_AMOUNT, validHttpOnlyUrl, VALID_REFERENCE, VALID_DESCRIPTION);
+        expectedException.expect(ValidationException.class);
+        paymentRequestValidator.validate(paymentRequest);
+    }
+
+    @Test
+    public void validateReferenceMaxLength_shouldFailValue() throws Exception {
+        String invalidMaxLengthReference = randomAlphanumeric(PaymentRequestValidator.REFERENCE_MAX_LENGTH + 1);
+        CreatePaymentRequest paymentRequest = createPaymentRequest(VALID_AMOUNT, VALID_RETURN_URL, invalidMaxLengthReference, VALID_DESCRIPTION);
+        expectedException.expect(ValidationException.class);
+        paymentRequestValidator.validate(paymentRequest);
+    }
+
+    @Test
+    public void validateDescriptionMaxLength_shouldFailValue() throws Exception {
+        String invalidMaxLengthDescription = randomAlphanumeric(PaymentRequestValidator.DESCRIPTION_MAX_LENGTH + 1);
+        CreatePaymentRequest paymentRequest = createPaymentRequest(VALID_AMOUNT, VALID_RETURN_URL, VALID_REFERENCE, invalidMaxLengthDescription);
+        expectedException.expect(ValidationException.class);
+        paymentRequestValidator.validate(paymentRequest);
+    }
+
+    private CreatePaymentRequest createPaymentRequest(int amount, String returnUrl, String reference, String description) {
+        return new CreatePaymentRequest(amount, returnUrl, reference, description);
+    }
+
 }

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -30,4 +30,6 @@ rateLimiter:
   rate: 1
   perMillis: 1000
 
+allowHttpForReturnUrl: false
+
 apiKeyHmacSecret: qwer9yuhgf


### PR DESCRIPTION
## WHAT

We need to return client error HTTP status code in case we submit `return_url` which is non-HTTPS (currently `NAXSI` is returning `404` in case we submit non-HTTPS url).
We use `422 Unprocessable Entity` for client errors.

## HOW 

- Added `allowHttpForReturnUrl` setting (default is `false`) which enables or disables "https only" check for `return_url` request parameter
- Added related tests in `PaymentRequestValidatorTest` and modified existing ones
- Updated documentation
