### PR TITLE
PP-2636 Address Deserialization of Untrusted Data vulnerability (CVE-2017-7525)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.8.7</version>
+            <version>2.8.10</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

Bumped up version of `com.fasterxml.jackson.datatype:jackson-datatype-jsr310` from `2.8.7` to `2.8.10` to address the vulnerabilities below:

- Arbitrary Code Execution
  Vulnerable module: commons-collections:commons-collections
  Introduced through: commons-validator:commons-validator@1.6

- Deserialization of Untrusted Data
  Vulnerable module: com.fasterxml.jackson.core:jackson-databind
  Introduced through: black.door:hate@v1r4t0 and com.fasterxml.jackson.datatype:jackson-datatype-jsr310@2.8.7

See https://snyk.io/org/govuk-pay/project/b3895a37-37e2-40e5-ac85-5df4fb96cab7


