### PR TITLE
PP-2636 adding exclusion to pom file for jackson-datatype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,14 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jsr310</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jdk8</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## WHAT

In addition to upgrading com.fasterxml.jackson.core:jackson-datatype we also need to exclude version 2.7.5 from a transient dependency (black.door:hate@v1r4t0). It is not strictly needed as per se but Snyk is reporting false alarms and we need to suppress those.

## HOW 
```
<dependency>
  <groupId>black.door</groupId>
  <artifactId>hate</artifactId>
  <version>v1r4t0</version>
  <exclusions>
    <exclusion>
      <groupId>com.fasterxml.jackson.core</groupId>
      <artifactId>jackson-databind</artifactId>
    </exclusion>
    <exclusion>
      <groupId>com.fasterxml.jackson.datatype</groupId>
      <artifactId>jackson-datatype-jsr310</artifactId>
    </exclusion>
    <exclusion>
      <groupId>com.fasterxml.jackson.datatype</groupId>
     <artifactId>jackson-datatype-jdk8</artifactId>
   </exclusion>
  </exclusions>
</dependency>
```
