### PR TITLE
PP-1797 Add Java EditorConfig from the GDS Way

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root: true
+
+[*.java]
+indent_style: space
+indent_size: 4
+end_of_line: lf
+charset: utf-8
+insert_final_newline: true
+continuation_indent_size: 8


### PR DESCRIPTION
The GDS Way now specifies [EditorConfig](http://editorconfig.org/) properties to make compatible tooling (such as IntelliJ IDEA) automatically adhere to some of the guidelines in the Java style guide. This pull request adds a `.editorconfig` file containing those properties.