### PR TITLE
PP-2888 Override toString() method of PaymentWithAllLinks

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -108,4 +108,9 @@ public class PaymentWithAllLinks {
                 return PaymentWithAllLinks.valueOf(paymentConnector, selfLink, paymentEventsUri, paymentCancelUri, paymentRefundsUri);
         }
     }
+
+    @Override
+    public String toString() {
+        return getPayment().toString();
+    }
 }


### PR DESCRIPTION
## WHAT
 - `PaymentWithAllLinks` has been changed to _have_ payment, instead of _being_ a payment - the `toString()` method has to change accordingly, as we use that to log information about a payment.
 - Without the `toString()` method we end up logging things like
```
Payment returned - [ uk.gov.pay.api.model.links.PaymentWithAllLinks@11c97822 ]
```

