### PR TITLE
PP-3129 Add request id to log format

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -13,7 +13,7 @@ logging:
         threshold: ALL
         timeZone: UTC
         target: stdout
-        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] [%-5level] [%logger{15}] [requestID=%X{X-Request-Id}] - %msg %n"
 
 baseUrl: ${PUBLICAPI_BASE}
 connectorUrl: ${CONNECTOR_URL}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -13,7 +13,7 @@ logging:
         threshold: ALL
         timeZone: UTC
         target: stdout
-        logFormat: "[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+        logFormat: "[%thread] [%-5level] [%logger{15}] [requestID=%X{X-Request-Id}] - %msg %n"
 
 baseUrl: http://publicapi.url/
 connectorUrl: http://connector_card.url/


### PR DESCRIPTION
At the moment we're not logging the request id for this component, so we're not able to correlate logs to each request.


