### PR TITLE
PP-3283 Use apache http client for public auth authentication [DO NOT MERGE]

### DIFF
--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
+java ${JAVA_OPTS} -jar *-allinone.jar buildTrustStore *.yaml
 java ${JAVA_OPTS} -jar *-allinone.jar server *.yaml

--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -86,7 +86,7 @@ public class PublicApi extends Application<PublicApiConfig> {
 
         environment.healthChecks().register("ping", new Ping());
         environment.jersey().register(new HealthCheckResource(environment));
-        environment.jersey().register(new PaymentsResource(config.getBaseUrl(), client, config.getConnectorUrl(), config.getConnectorDDUrl(), objectMapper));
+        environment.jersey().register(new PaymentsResource(config.getBaseUrl(), apacheHttpClient, config.getConnectorUrl(), config.getConnectorDDUrl(), objectMapper));
         environment.jersey().register(new PaymentRefundsResource(config.getBaseUrl(), client, config.getConnectorUrl()));
         environment.jersey().register(new RequestDeniedResource());
 

--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -39,6 +39,7 @@ import uk.gov.pay.api.json.CreatePaymentRefundRequestDeserializer;
 import uk.gov.pay.api.json.CreatePaymentRequestDeserializer;
 import uk.gov.pay.api.model.CreatePaymentRefundRequest;
 import uk.gov.pay.api.model.CreatePaymentRequest;
+import uk.gov.pay.api.resources.ConnectorClient;
 import uk.gov.pay.api.resources.HealthCheckResource;
 import uk.gov.pay.api.resources.PaymentRefundsResource;
 import uk.gov.pay.api.resources.PaymentsResource;
@@ -84,9 +85,11 @@ public class PublicApi extends Application<PublicApiConfig> {
         ObjectMapper objectMapper = environment.getObjectMapper();
         configureObjectMapper(config, objectMapper);
 
+        final ConnectorClient connectorClient = new ConnectorClient(apacheHttpClient, config.getConnectorUrl(), config.getConnectorDDUrl());
+
         environment.healthChecks().register("ping", new Ping());
         environment.jersey().register(new HealthCheckResource(environment));
-        environment.jersey().register(new PaymentsResource(config.getBaseUrl(), apacheHttpClient, config.getConnectorUrl(), config.getConnectorDDUrl(), objectMapper));
+        environment.jersey().register(new PaymentsResource(config.getBaseUrl(), connectorClient, objectMapper));
         environment.jersey().register(new PaymentRefundsResource(config.getBaseUrl(), client, config.getConnectorUrl()));
         environment.jersey().register(new RequestDeniedResource());
 

--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
@@ -2,6 +2,7 @@ package uk.gov.pay.api.app.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
+import io.dropwizard.client.HttpClientConfiguration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -34,6 +35,9 @@ public class PublicApiConfig extends Configuration {
     @NotNull
     @JsonProperty("jerseyClientConfig")
     private RestClientConfig restClientConfig;
+
+    @JsonProperty("httpClient")
+    private HttpClientConfiguration httpClientConfiguration;
 
     @Valid
     @NotNull
@@ -79,4 +83,7 @@ public class PublicApiConfig extends Configuration {
         return rateLimiterConfig;
     }
 
+    public HttpClientConfiguration getHttpClientConfiguration() {
+        return httpClientConfiguration;
+    }
 }

--- a/src/main/java/uk/gov/pay/api/auth/AccountAuthenticator.java
+++ b/src/main/java/uk/gov/pay/api/auth/AccountAuthenticator.java
@@ -1,55 +1,81 @@
 package uk.gov.pay.api.auth;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.dropwizard.auth.AuthenticationException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.auth.Authenticator;
+import io.dropwizard.jackson.Jackson;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.model.TokenPaymentType;
 
 import javax.ws.rs.ServiceUnavailableException;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import java.io.IOException;
 import java.util.Optional;
 
+import static javax.ws.rs.core.HttpHeaders.ACCEPT;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
-import static uk.gov.pay.api.model.TokenPaymentType.*;
+import static uk.gov.pay.api.model.TokenPaymentType.CARD;
 import static uk.gov.pay.api.model.TokenPaymentType.fromString;
 
 public class AccountAuthenticator implements Authenticator<String, Account> {
-    private static Logger logger = LoggerFactory.getLogger(AccountAuthenticator.class);
 
-    private final Client client;
+    private static Logger LOGGER = LoggerFactory.getLogger(AccountAuthenticator.class);
+
+    private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
+
+    private final HttpClient client;
     private final String publicAuthUrl;
 
-    public AccountAuthenticator(Client client, String publicAuthUrl) {
+
+    public AccountAuthenticator(HttpClient client, String publicAuthUrl) {
         this.client = client;
         this.publicAuthUrl = publicAuthUrl;
     }
 
+
     @Override
-    public Optional<Account> authenticate(String bearerToken) throws AuthenticationException {
-        Response response = client.target(publicAuthUrl).request()
-                .header(AUTHORIZATION, "Bearer " + bearerToken)
-                .accept(MediaType.APPLICATION_JSON)
-                .get();
-        if (response.getStatus() == OK.getStatusCode()) {
-            JsonNode responseEntity = response.readEntity(JsonNode.class);
-            String accountId = responseEntity.get("account_id").asText();
-            String tokenType = Optional.ofNullable(responseEntity.get("token_type"))
-                    .map(JsonNode::asText).orElse(CARD.toString());
-            TokenPaymentType tokenPaymentType = fromString(tokenType);
-            return Optional.of(new Account(accountId, tokenPaymentType));
-        } else if (response.getStatus() == UNAUTHORIZED.getStatusCode()) {
-            response.close();
-            return Optional.empty();
-        } else {
-            response.close();
-            logger.warn("Unexpected status code " + response.getStatus() + " from auth.");
-            throw new ServiceUnavailableException();
+    public Optional<Account> authenticate(String bearerToken) {
+
+        try {
+
+            HttpResponse response = client.execute(RequestBuilder
+                    .get()
+                    .setUri(publicAuthUrl)
+                    .setHeader(ACCEPT, APPLICATION_JSON)
+                    .setHeader(AUTHORIZATION, "Bearer " + bearerToken)
+                    .build());
+
+            if (response.getStatusLine().getStatusCode() == OK.getStatusCode()) {
+
+                return getAccountFromResponse(response);
+
+            } else if (response.getStatusLine().getStatusCode() == UNAUTHORIZED.getStatusCode()) {
+                return Optional.empty();
+            } else {
+                LOGGER.warn("Unexpected status code " + response.getStatusLine().getStatusCode() + " from auth.");
+                throw new ServiceUnavailableException();
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException("There was an error trying to call public auth for authentication.", e);
         }
+    }
+
+
+    private Optional<Account> getAccountFromResponse(HttpResponse response) throws IOException {
+        String json = EntityUtils.toString(response.getEntity());
+        JsonNode responseEntity = MAPPER.readTree(json);
+        String accountId = responseEntity.get("account_id").asText();
+        String tokenType = Optional.ofNullable(responseEntity.get("token_type"))
+                .map(JsonNode::asText).orElse(CARD.toString());
+        TokenPaymentType tokenPaymentType = fromString(tokenType);
+        return Optional.of(new Account(accountId, tokenPaymentType));
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
@@ -102,4 +102,23 @@ public class ChargeFromResponse {
     public CardDetails getCardDetails() {
         return cardDetails;
     }
+
+    @Override
+    public String toString() {
+        return "ChargeFromResponse{" +
+                "chargeId='" + chargeId + '\'' +
+                ", returnUrl='" + returnUrl + '\'' +
+                ", paymentProvider='" + paymentProvider + '\'' +
+                ", links=" + links +
+                ", refundSummary=" + refundSummary +
+                ", settlementSummary=" + settlementSummary +
+                ", cardDetails=" + cardDetails +
+                ", amount=" + amount +
+                ", state=" + state +
+                ", description='" + description + '\'' +
+                ", reference='" + reference + '\'' +
+                ", email='" + email + '\'' +
+                ", createdDate='" + createdDate + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/uk/gov/pay/api/resources/ApiClient.java
+++ b/src/main/java/uk/gov/pay/api/resources/ApiClient.java
@@ -13,12 +13,10 @@ abstract class ApiClient {
 
     private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper();
 
-    private final String apiName;
     private final HttpClient httpClient;
 
 
     ApiClient(HttpClient httpClient) {
-        this.apiName = this.getClass().getSimpleName();
         this.httpClient = httpClient;
     }
 

--- a/src/main/java/uk/gov/pay/api/resources/ApiClient.java
+++ b/src/main/java/uk/gov/pay/api/resources/ApiClient.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.api.resources;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.Jackson;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.util.EntityUtils;
+
+import java.io.IOException;
+
+abstract class ApiClient {
+
+    private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper();
+
+    private final String apiName;
+    private final HttpClient httpClient;
+
+
+    ApiClient(HttpClient httpClient) {
+        this.apiName = this.getClass().getSimpleName();
+        this.httpClient = httpClient;
+    }
+
+
+    <T> T deserialize(HttpResponse response, Class<T> valueType) {
+        try {
+            return OBJECT_MAPPER.readValue(EntityUtils.toString(response.getEntity()), valueType);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    HttpResponse request(HttpUriRequest request) {
+        try {
+            return httpClient.execute(request);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/api/resources/ConnectorClient.java
+++ b/src/main/java/uk/gov/pay/api/resources/ConnectorClient.java
@@ -1,0 +1,169 @@
+package uk.gov.pay.api.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.HttpEntityWrapper;
+import org.apache.http.entity.StringEntity;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.model.ChargeFromResponse;
+import uk.gov.pay.api.model.CreatePaymentRequest;
+import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.api.utils.JsonStringBuilder;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.io.UnsupportedEncodingException;
+import java.util.Collections;
+import java.util.List;
+
+import static java.lang.String.format;
+import static javax.ws.rs.client.Entity.json;
+import static javax.ws.rs.core.HttpHeaders.ACCEPT;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
+
+public class ConnectorClient extends ApiClient {
+
+    private static final String API_VERSION_PATH = "/v1";
+
+    private static final String CONNECTOR_ACCOUNT_RESOURCE = API_VERSION_PATH + "/api/accounts/%s";
+    private static final String CONNECTOR_CHARGES_RESOURCE = CONNECTOR_ACCOUNT_RESOURCE + "/charges";
+    private static final String CONNECTOR_CHARGE_RESOURCE = CONNECTOR_CHARGES_RESOURCE + "/%s";
+    private static final String CONNECTOR_CHARGE_EVENTS_RESOURCE = CONNECTOR_CHARGES_RESOURCE + "/%s" + "/events";
+    private static final String CONNECTOR_ACCOUNT_CHARGE_CANCEL_RESOURCE = CONNECTOR_CHARGE_RESOURCE + "/cancel";
+
+    private static final String REFERENCE_KEY = "reference";
+    private static final String DESCRIPTION_KEY = "description";
+    private static final String AMOUNT_KEY = "amount";
+    private static final String SERVICE_RETURN_URL = "return_url";
+
+    private final String connectorUrl;
+    private final String connectorDDUrl;
+
+
+    ConnectorClient(HttpClient httpClient, String connectorUrl, String connectorDDUrl) {
+        super(httpClient);
+        this.connectorUrl = connectorUrl;
+        this.connectorDDUrl = connectorDDUrl;
+    }
+
+
+    public Response getPayment(String paymentId, Account account) {
+
+        ChargeFromResponse chargeFromResponse = deserialize(request(RequestBuilder
+                .get()
+                .setUri(getConnectorUrl(
+                        account.getPaymentType(),
+                        format(CONNECTOR_CHARGE_RESOURCE, account.getName(), paymentId)))
+                .setHeader(ACCEPT, APPLICATION_JSON)
+                .build()), ChargeFromResponse.class);
+
+        return Response.ok(chargeFromResponse).build();
+    }
+
+    public Response getPaymentEvents(String paymentId, Account account) {
+
+        JsonNode paymentEvents = deserialize(request(RequestBuilder
+                .get()
+                .setUri(getConnectorUrl(
+                        account.getPaymentType(),
+                        format(CONNECTOR_CHARGE_EVENTS_RESOURCE, account.getName(), paymentId)))
+                .setHeader(ACCEPT, APPLICATION_JSON)
+                .build()), JsonNode.class);
+
+        return Response.ok(paymentEvents).build();
+    }
+
+    public Response getCharges(Account account, List<Pair<String, String>> queryParams) {
+
+        RequestBuilder requestBuilder = RequestBuilder.get();
+
+        queryParams.forEach(queryParam -> requestBuilder.addParameter(queryParam.getKey(), queryParam.getValue()));
+
+        JsonNode charges = deserialize(request(requestBuilder
+                .setUri(getConnectorUrl(
+                        account.getPaymentType(),
+                        format(CONNECTOR_CHARGES_RESOURCE, account.getName())))
+                .setHeader(ACCEPT, APPLICATION_JSON)
+                .build()), JsonNode.class);
+
+        return Response.ok(charges).build();
+    }
+
+    public Response createPayment(CreatePaymentRequest requestPayload, Account account) {
+
+        ChargeFromResponse chargeFromResponse;
+        try {
+            chargeFromResponse = deserialize(request(RequestBuilder
+                    .post()
+                    .setUri(getConnectorUrl(
+                            account.getPaymentType(),
+                            format(CONNECTOR_CHARGES_RESOURCE, account.getName())))
+                    .setHeader(ACCEPT, APPLICATION_JSON)
+                    .setHeader(CONTENT_TYPE, APPLICATION_JSON)
+                    .setEntity(new StringEntity(buildChargeRequestPayload(requestPayload)))
+                    .build()), ChargeFromResponse.class);
+        } catch (UnsupportedEncodingException e) {
+            return Response.serverError().entity(e.getMessage()).build();
+        }
+        return Response.ok(chargeFromResponse).build();
+    }
+
+    public Response cancelPayment(String paymentId, Account account) {
+
+        try {
+            HttpResponse response = request(RequestBuilder
+                    .post()
+                    .setUri(getConnectorUrl(
+                            account.getPaymentType(),
+                            format(CONNECTOR_ACCOUNT_CHARGE_CANCEL_RESOURCE, account.getName(), paymentId)))
+                    .setHeader(ACCEPT, APPLICATION_JSON)
+                    .setHeader(CONTENT_TYPE, APPLICATION_JSON)
+                    .setEntity(new StringEntity("{}"))
+                    .build());
+            JsonNode entity = deserialize(response, JsonNode.class);
+            return Response.status(response.getStatusLine().getStatusCode()).entity(entity).build();
+        } catch (UnsupportedEncodingException e) {
+            return Response.serverError().entity(e.getMessage()).build();
+        }
+    }
+
+
+    private String getConnectorUrl(TokenPaymentType paymentType, String urlPath) {
+        return getConnectorUrl(paymentType, urlPath, Collections.emptyList());
+    }
+
+    private String getConnectorUrl(TokenPaymentType paymentType, String urlPath, List<Pair<String, String>> queryParams) {
+        String url = paymentType.equals(DIRECT_DEBIT)? connectorDDUrl : connectorUrl;
+        UriBuilder builder = UriBuilder
+                .fromPath(url)
+                .path(urlPath);
+
+        queryParams.forEach(pair -> {
+            if (isNotBlank(pair.getRight())) {
+                builder.queryParam(pair.getKey(), pair.getValue());
+            }
+        });
+        return builder.toString();
+    }
+
+    private String buildChargeRequestPayload(CreatePaymentRequest requestPayload) {
+        int amount = requestPayload.getAmount();
+        String reference = requestPayload.getReference();
+        String description = requestPayload.getDescription();
+        String returnUrl = requestPayload.getReturnUrl();
+        return new JsonStringBuilder()
+                .add(AMOUNT_KEY, amount)
+                .add(REFERENCE_KEY, reference)
+                .add(DESCRIPTION_KEY, description)
+                .add(SERVICE_RETURN_URL, returnUrl)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/api/resources/ConnectorClient.java
+++ b/src/main/java/uk/gov/pay/api/resources/ConnectorClient.java
@@ -5,28 +5,30 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.entity.HttpEntityWrapper;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.ChargeFromResponse;
 import uk.gov.pay.api.model.CreatePaymentRequest;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.utils.JsonStringBuilder;
 
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
 
 import static java.lang.String.format;
-import static javax.ws.rs.client.Entity.json;
 import static javax.ws.rs.core.HttpHeaders.ACCEPT;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.http.HttpStatus.SC_CREATED;
+import static org.apache.http.HttpStatus.SC_OK;
 import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
 
 public class ConnectorClient extends ApiClient {
@@ -48,7 +50,7 @@ public class ConnectorClient extends ApiClient {
     private final String connectorDDUrl;
 
 
-    ConnectorClient(HttpClient httpClient, String connectorUrl, String connectorDDUrl) {
+    public ConnectorClient(HttpClient httpClient, String connectorUrl, String connectorDDUrl) {
         super(httpClient);
         this.connectorUrl = connectorUrl;
         this.connectorDDUrl = connectorDDUrl;
@@ -57,28 +59,36 @@ public class ConnectorClient extends ApiClient {
 
     public Response getPayment(String paymentId, Account account) {
 
-        ChargeFromResponse chargeFromResponse = deserialize(request(RequestBuilder
+        HttpResponse response = request(RequestBuilder
                 .get()
                 .setUri(getConnectorUrl(
                         account.getPaymentType(),
                         format(CONNECTOR_CHARGE_RESOURCE, account.getName(), paymentId)))
                 .setHeader(ACCEPT, APPLICATION_JSON)
-                .build()), ChargeFromResponse.class);
+                .build());
+        if (response.getStatusLine().getStatusCode() == SC_OK) {
 
-        return Response.ok(chargeFromResponse).build();
+            ChargeFromResponse chargeFromResponse = deserialize(response, ChargeFromResponse.class);
+            return Response.ok(chargeFromResponse).build();
+        }
+        return Response.status(response.getStatusLine().getStatusCode()).entity(response.getEntity()).build();
     }
 
     public Response getPaymentEvents(String paymentId, Account account) {
 
-        JsonNode paymentEvents = deserialize(request(RequestBuilder
+        HttpResponse response = request(RequestBuilder
                 .get()
                 .setUri(getConnectorUrl(
                         account.getPaymentType(),
                         format(CONNECTOR_CHARGE_EVENTS_RESOURCE, account.getName(), paymentId)))
                 .setHeader(ACCEPT, APPLICATION_JSON)
-                .build()), JsonNode.class);
+                .build());
+        if (response.getStatusLine().getStatusCode() == SC_OK) {
 
-        return Response.ok(paymentEvents).build();
+            JsonNode paymentEvents = deserialize(response, JsonNode.class);
+            return Response.ok(paymentEvents).build();
+        }
+        return Response.status(response.getStatusLine().getStatusCode()).entity(response.getEntity()).build();
     }
 
     public Response getCharges(Account account, List<Pair<String, String>> queryParams) {
@@ -87,21 +97,29 @@ public class ConnectorClient extends ApiClient {
 
         queryParams.forEach(queryParam -> requestBuilder.addParameter(queryParam.getKey(), queryParam.getValue()));
 
-        JsonNode charges = deserialize(request(requestBuilder
+        HttpResponse response = request(requestBuilder
                 .setUri(getConnectorUrl(
                         account.getPaymentType(),
                         format(CONNECTOR_CHARGES_RESOURCE, account.getName())))
                 .setHeader(ACCEPT, APPLICATION_JSON)
-                .build()), JsonNode.class);
+                .build());
+        if (response.getStatusLine().getStatusCode() == SC_OK) {
 
-        return Response.ok(charges).build();
+            try {
+                String json = EntityUtils.toString(response.getEntity());
+                return Response.ok(json).build();
+            } catch (IOException e) {
+                return Response.serverError().entity(e.getMessage()).build();
+            }
+        }
+        return Response.status(response.getStatusLine().getStatusCode()).entity(response.getEntity()).build();
     }
 
     public Response createPayment(CreatePaymentRequest requestPayload, Account account) {
 
-        ChargeFromResponse chargeFromResponse;
         try {
-            chargeFromResponse = deserialize(request(RequestBuilder
+
+            HttpResponse response = request(RequestBuilder
                     .post()
                     .setUri(getConnectorUrl(
                             account.getPaymentType(),
@@ -109,11 +127,17 @@ public class ConnectorClient extends ApiClient {
                     .setHeader(ACCEPT, APPLICATION_JSON)
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON)
                     .setEntity(new StringEntity(buildChargeRequestPayload(requestPayload)))
-                    .build()), ChargeFromResponse.class);
-        } catch (UnsupportedEncodingException e) {
+                    .build());
+
+            if (response.getStatusLine().getStatusCode() == SC_CREATED) {
+                ChargeFromResponse charge = deserialize(response, ChargeFromResponse.class);
+                return Response.created(new URI(response.getFirstHeader("Location").getValue())).entity(charge).build();
+            } else {
+                return Response.status(response.getStatusLine().getStatusCode()).entity(response.getEntity()).build();
+            }
+        } catch (UnsupportedEncodingException | URISyntaxException e) {
             return Response.serverError().entity(e.getMessage()).build();
         }
-        return Response.ok(chargeFromResponse).build();
     }
 
     public Response cancelPayment(String paymentId, Account account) {
@@ -128,8 +152,7 @@ public class ConnectorClient extends ApiClient {
                     .setHeader(CONTENT_TYPE, APPLICATION_JSON)
                     .setEntity(new StringEntity("{}"))
                     .build());
-            JsonNode entity = deserialize(response, JsonNode.class);
-            return Response.status(response.getStatusLine().getStatusCode()).entity(entity).build();
+            return Response.status(response.getStatusLine().getStatusCode()).build();
         } catch (UnsupportedEncodingException e) {
             return Response.serverError().entity(e.getMessage()).build();
         }
@@ -141,7 +164,7 @@ public class ConnectorClient extends ApiClient {
     }
 
     private String getConnectorUrl(TokenPaymentType paymentType, String urlPath, List<Pair<String, String>> queryParams) {
-        String url = paymentType.equals(DIRECT_DEBIT)? connectorDDUrl : connectorUrl;
+        String url = paymentType.equals(DIRECT_DEBIT) ? connectorDDUrl : connectorUrl;
         UriBuilder builder = UriBuilder
                 .fromPath(url)
                 .path(urlPath);

--- a/src/main/java/uk/gov/pay/api/utils/BuildTrustStoreCommand.java
+++ b/src/main/java/uk/gov/pay/api/utils/BuildTrustStoreCommand.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.api.utils;
+
+import io.dropwizard.cli.ConfiguredCommand;
+import io.dropwizard.setup.Bootstrap;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+import uk.gov.pay.api.app.config.PublicApiConfig;
+
+public class BuildTrustStoreCommand extends ConfiguredCommand<PublicApiConfig> {
+
+    public BuildTrustStoreCommand() {
+        super("buildTrustStore", "Build TLS trust store from certificates");
+    }
+
+    @Override
+    public void configure(Subparser subparser) {
+        super.configure(subparser);
+    }
+
+    @Override
+    protected void run(Bootstrap<PublicApiConfig> bs, Namespace ns, PublicApiConfig conf) {
+        TrustStoreLoader.initialiseTrustStore();
+    }
+}

--- a/src/main/java/uk/gov/pay/api/utils/TrustStoreLoader.java
+++ b/src/main/java/uk/gov/pay/api/utils/TrustStoreLoader.java
@@ -9,6 +9,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -18,38 +19,51 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 
 public class TrustStoreLoader {
+
     private static final Logger logger = LoggerFactory.getLogger(TrustStoreLoader.class);
 
-    private static final String CERTS_PATH;
+    private static final String CERTS_PATH_VARIABLE = "CERTS_PATH";
     private static final String TRUST_STORE_PASSWORD = "changeit";
     private static final String KEY_STORE_FILE_LOCATION = "/tmp/cacerts";
 
     private static final KeyStore TRUST_STORE;
 
+
+    /*
+     * To be removed if we switch all http clients to apache http client
+     */
     static {
-        CERTS_PATH = System.getenv("CERTS_PATH");
 
-        try {
-            TRUST_STORE = KeyStore.getInstance(KeyStore.getDefaultType());
-            TRUST_STORE.load(null, TRUST_STORE_PASSWORD.toCharArray());
-        } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {
-            throw new RuntimeException("Could not create a keystore", e);
-        }
+        String CERTS_PATH = System.getenv(TrustStoreLoader.CERTS_PATH_VARIABLE);
 
+        TRUST_STORE = initialiseEmptyKeyStore();
+
+        loadCertificatesIntoKeyStore(CERTS_PATH, TRUST_STORE);
+    }
+
+
+    public static void initialiseTrustStore() {
+
+        String CERTS_PATH = System.getenv(TrustStoreLoader.CERTS_PATH_VARIABLE);
+
+        KeyStore keyStore = initialiseEmptyKeyStore();
+        loadCertificatesIntoKeyStore(CERTS_PATH, keyStore);
+        storeKeyStoreInFile(keyStore);
+    }
+
+    private static void loadCertificatesIntoKeyStore(String CERTS_PATH, KeyStore keyStore) {
         if (CERTS_PATH != null) {
             try {
-                Files.walk(Paths.get(CERTS_PATH)).forEach(certPath -> {
-                    if (Files.isRegularFile(certPath)) {
+                Files.walk(Paths.get(CERTS_PATH)).forEach(certificatePath -> {
+                    if (Files.isRegularFile(certificatePath)) {
                         try {
-                            CertificateFactory cf = CertificateFactory.getInstance("X.509");
-                            Certificate cert = cf.generateCertificate(new ByteArrayInputStream(Files.readAllBytes(certPath)));
-                            TRUST_STORE.setCertificateEntry(certPath.getFileName().toString(), cert);
-                            logger.info("Loaded cert " + certPath);
+                            includeCertificateIntoKeyStore(certificatePath, keyStore);
                         } catch (SecurityException | KeyStoreException | CertificateException | IOException e) {
-                            logger.error("Could not load " + certPath, e);
+                            logger.error("Could not load " + certificatePath, e);
                         }
                     }
                 });
+                logger.info("Finished Trust Store initialisation.");
             } catch (NoSuchFileException nsfe) {
                 logger.warn("Did not find any certificates to load");
             } catch (IOException ioe) {
@@ -58,42 +72,14 @@ public class TrustStoreLoader {
         }
     }
 
-    public static void initialiseTrustStore() {
+    private static void includeCertificateIntoKeyStore(Path certPath, KeyStore keyStore) throws CertificateException, IOException, KeyStoreException {
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        Certificate cert = cf.generateCertificate(new ByteArrayInputStream(Files.readAllBytes(certPath)));
+        keyStore.setCertificateEntry(certPath.getFileName().toString(), cert);
+        logger.info("Loaded cert " + certPath);
+    }
 
-        logger.info("Initialising Trust Store.");
-
-        String CERTS_PATH = System.getenv(TrustStoreLoader.CERTS_PATH);
-
-        KeyStore keyStore;
-
-        try {
-            keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-            keyStore.load(null, TRUST_STORE_PASSWORD.toCharArray());
-        } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {
-            throw new RuntimeException("Could not create a keystore", e);
-        }
-
-        if (CERTS_PATH != null) {
-            try {
-                Files.walk(Paths.get(CERTS_PATH)).forEach(certPath -> {
-                    if (Files.isRegularFile(certPath)) {
-                        try {
-                            CertificateFactory cf = CertificateFactory.getInstance("X.509");
-                            Certificate cert = cf.generateCertificate(new ByteArrayInputStream(Files.readAllBytes(certPath)));
-                            keyStore.setCertificateEntry(certPath.getFileName().toString(), cert);
-                            logger.info("Loaded cert " + certPath);
-                        } catch (SecurityException | KeyStoreException | CertificateException | IOException e) {
-                            logger.error("Could not load " + certPath, e);
-                        }
-                    }
-                });
-            } catch (NoSuchFileException nsfe) {
-                logger.warn("Did not find any certificates to load");
-            } catch (IOException ioe) {
-                logger.error("Error walking certs directory", ioe);
-            }
-        }
-        logger.info("Finished Trust Store initialisation.");
+    private static void storeKeyStoreInFile(KeyStore keyStore) {
         File keyStoreFile = new File(KEY_STORE_FILE_LOCATION);
         try {
             keyStoreFile.createNewFile();
@@ -104,11 +90,26 @@ public class TrustStoreLoader {
         }
     }
 
+    private static KeyStore initialiseEmptyKeyStore() {
+
+        logger.info("Initialising Trust Store.");
+
+        KeyStore keyStore;
+
+        try {
+            keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            keyStore.load(null, TRUST_STORE_PASSWORD.toCharArray());
+        } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {
+            throw new RuntimeException("Could not create a keystore", e);
+        }
+        return keyStore;
+    }
+
     public static KeyStore getTrustStore() {
         return TRUST_STORE;
     }
 
     public static String getTrustStorePassword() {
-        return new String(TRUST_STORE_PASSWORD);
+        return TRUST_STORE_PASSWORD;
     }
 }

--- a/src/main/java/uk/gov/pay/api/utils/TrustStoreLoader.java
+++ b/src/main/java/uk/gov/pay/api/utils/TrustStoreLoader.java
@@ -4,6 +4,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -19,7 +21,8 @@ public class TrustStoreLoader {
     private static final Logger logger = LoggerFactory.getLogger(TrustStoreLoader.class);
 
     private static final String CERTS_PATH;
-    private static final String TRUST_STORE_PASSWORD = "";
+    private static final String TRUST_STORE_PASSWORD = "changeit";
+    private static final String KEY_STORE_FILE_LOCATION = "/tmp/cacerts";
 
     private static final KeyStore TRUST_STORE;
 
@@ -52,6 +55,52 @@ public class TrustStoreLoader {
             } catch (IOException ioe) {
                 logger.error("Error walking certs directory", ioe);
             }
+        }
+    }
+
+    public static void initialiseTrustStore() {
+
+        logger.info("Initialising Trust Store.");
+
+        String CERTS_PATH = System.getenv(TrustStoreLoader.CERTS_PATH);
+
+        KeyStore keyStore;
+
+        try {
+            keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            keyStore.load(null, TRUST_STORE_PASSWORD.toCharArray());
+        } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {
+            throw new RuntimeException("Could not create a keystore", e);
+        }
+
+        if (CERTS_PATH != null) {
+            try {
+                Files.walk(Paths.get(CERTS_PATH)).forEach(certPath -> {
+                    if (Files.isRegularFile(certPath)) {
+                        try {
+                            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+                            Certificate cert = cf.generateCertificate(new ByteArrayInputStream(Files.readAllBytes(certPath)));
+                            keyStore.setCertificateEntry(certPath.getFileName().toString(), cert);
+                            logger.info("Loaded cert " + certPath);
+                        } catch (SecurityException | KeyStoreException | CertificateException | IOException e) {
+                            logger.error("Could not load " + certPath, e);
+                        }
+                    }
+                });
+            } catch (NoSuchFileException nsfe) {
+                logger.warn("Did not find any certificates to load");
+            } catch (IOException ioe) {
+                logger.error("Error walking certs directory", ioe);
+            }
+        }
+        logger.info("Finished Trust Store initialisation.");
+        File keyStoreFile = new File(KEY_STORE_FILE_LOCATION);
+        try {
+            keyStoreFile.createNewFile();
+            FileOutputStream out = new FileOutputStream(keyStoreFile);
+            keyStore.store(out, TRUST_STORE_PASSWORD.toCharArray());
+        } catch (CertificateException | NoSuchAlgorithmException | KeyStoreException | IOException e) {
+            throw new RuntimeException("Could't save trust store to file.", e);
         }
     }
 

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -27,7 +27,7 @@ jerseyClientConfig:
   disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS}
 
 httpClient:
-  timeout: 500ms
+  timeout: 1s
   connectionTimeout: 500ms
   timeToLive: 1h
   cookiesEnabled: false

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -26,6 +26,22 @@ graphitePort: ${METRICS_PORT:-8092}
 jerseyClientConfig:
   disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS}
 
+httpClient:
+  timeout: 500ms
+  connectionTimeout: 500ms
+  timeToLive: 1h
+  cookiesEnabled: false
+  maxConnections: 1024
+  maxConnectionsPerRoute: 1024
+  keepAlive: 0ms
+  retries: 0
+  tls:
+      protocol: TLSv1.2
+      trustStorePath: /tmp/cacerts
+      trustStorePassword: changeit
+      trustStoreType: JKS
+      trustSelfSignedCertificates: true
+
 rateLimiter:
   rate: ${RATE_LIMITER_VALUE:-25}
   perMillis: ${RATE_LIMITER_PER_MILLIS:-1000}

--- a/src/test/java/uk/gov/pay/api/app/RestClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/api/app/RestClientFactoryTest.java
@@ -10,7 +10,13 @@ import uk.gov.pay.api.app.config.RestClientConfig;
 
 import javax.net.ssl.SSLContext;
 import javax.ws.rs.client.Client;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;

--- a/src/test/java/uk/gov/pay/api/auth/AccountAuthenticatorTest.java
+++ b/src/test/java/uk/gov/pay/api/auth/AccountAuthenticatorTest.java
@@ -1,25 +1,23 @@
 package uk.gov.pay.api.auth;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
-import io.dropwizard.auth.AuthenticationException;
-import org.junit.Assert;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.entity.EntityBuilder;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Matchers;
 
 import javax.ws.rs.ServiceUnavailableException;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.Map;
+import java.io.IOException;
 import java.util.Optional;
 
-import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
-import static javax.ws.rs.core.Response.Status.*;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
@@ -28,63 +26,82 @@ import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
 public class AccountAuthenticatorTest {
 
     private AccountAuthenticator accountAuthenticator;
-    private ObjectMapper objectMapper = new ObjectMapper();
-    private Response mockResponse;
+    private HttpResponse mockResponse;
 
     private final String bearerToken = "aaa";
     private final String accountName = "accountName";
 
+
     @Before
-    public void setup() {
-        Client publicAuthMock = mock(Client.class);
-        WebTarget mockTarget = mock(WebTarget.class);
-        Invocation.Builder mockRequest = mock(Invocation.Builder.class);
-        mockResponse = mock(Response.class);
+    public void setup() throws IOException {
+
+        HttpClient publicAuthMock = mock(HttpClient.class);
+
+        mockResponse = mock(HttpResponse.class);
+
         accountAuthenticator = new AccountAuthenticator(publicAuthMock, "");
-        when(publicAuthMock.target("")).thenReturn(mockTarget);
-        when(mockTarget.request()).thenReturn(mockRequest);
-        when(mockRequest.header(AUTHORIZATION, "Bearer " + bearerToken)).thenReturn(mockRequest);
-        when(mockRequest.accept(MediaType.APPLICATION_JSON)).thenReturn(mockRequest);
-        when(mockRequest.get()).thenReturn(mockResponse);
+
+        when(publicAuthMock.execute(Matchers.any())).thenReturn(mockResponse);
+    }
+
+
+    @Test
+    public void shouldReturnValidAccount() {
+
+        HttpEntity httpEntity = EntityBuilder.create()
+                .setText(String.format("{\"account_id\":\"%s\", \"token_type\": \"DIRECT_DEBIT\"}", accountName))
+                .build();
+
+        final StatusLine mockStatusLine = mock(StatusLine.class);
+
+        when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
+        when(mockStatusLine.getStatusCode()).thenReturn(OK.getStatusCode());
+        when(mockResponse.getEntity()).thenReturn(httpEntity);
+
+        Optional<Account> maybeAccount = accountAuthenticator.authenticate(bearerToken);
+
+        assertThat(maybeAccount.get().getName(), is(accountName));
+        assertThat(maybeAccount.get().getPaymentType(), is(DIRECT_DEBIT));
     }
 
     @Test
-    public void shouldReturnValidAccount() throws AuthenticationException {
-        Map<String, String> responseEntity = ImmutableMap.of(
-                "account_id", accountName,
-                "token_type", "DIRECT_DEBIT"
-        );
-        JsonNode response = objectMapper.valueToTree(responseEntity);
-        when(mockResponse.getStatus()).thenReturn(OK.getStatusCode());
-        when(mockResponse.readEntity(JsonNode.class)).thenReturn(response);
+    public void shouldReturnCCAccount_ifTokenTypeIsMissing() {
+
+        HttpEntity httpEntity = EntityBuilder.create()
+                .setText(String.format("{\"account_id\":\"%s\"}", accountName))
+                .build();
+
+        final StatusLine mockStatusLine = mock(StatusLine.class);
+
+        when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
+        when(mockStatusLine.getStatusCode()).thenReturn(OK.getStatusCode());
+        when(mockResponse.getEntity()).thenReturn(httpEntity);
+
         Optional<Account> maybeAccount = accountAuthenticator.authenticate(bearerToken);
-        Assert.assertThat(maybeAccount.get().getName(), is(accountName));
-        Assert.assertThat(maybeAccount.get().getPaymentType(), is(DIRECT_DEBIT));
+
+        assertThat(maybeAccount.get().getName(), is(accountName));
+        assertThat(maybeAccount.get().getPaymentType(), is(CARD));
     }
 
     @Test
-    public void shouldReturnCCAccount_ifTokenTypeIsMissing() throws AuthenticationException {
-        Map<String, String> responseEntity = ImmutableMap.of(
-                "account_id", accountName
-        );
-        JsonNode response = objectMapper.valueToTree(responseEntity);
-        when(mockResponse.getStatus()).thenReturn(OK.getStatusCode());
-        when(mockResponse.readEntity(JsonNode.class)).thenReturn(response);
-        Optional<Account> maybeAccount = accountAuthenticator.authenticate(bearerToken);
-        Assert.assertThat(maybeAccount.get().getName(), is(accountName));
-        Assert.assertThat(maybeAccount.get().getPaymentType(), is(CARD));
-    }
+    public void shouldNotReturnAccount_ifUnauthorised() {
 
-    @Test
-    public void shouldNotReturnAccount_ifUnauthorised() throws AuthenticationException {
-        when(mockResponse.getStatus()).thenReturn(UNAUTHORIZED.getStatusCode());
+        final StatusLine mockStatusLine = mock(StatusLine.class);
+        when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
+        when(mockStatusLine.getStatusCode()).thenReturn(UNAUTHORIZED.getStatusCode());
+
         Optional<Account> maybeAccount = accountAuthenticator.authenticate(bearerToken);
-        Assert.assertThat(maybeAccount.isPresent(), is(false));
+
+        assertThat(maybeAccount.isPresent(), is(false));
     }
 
     @Test(expected = ServiceUnavailableException.class)
-    public void shouldThrow_ifUnknownResponse() throws AuthenticationException {
-        when(mockResponse.getStatus()).thenReturn(NOT_FOUND.getStatusCode());
+    public void shouldThrow_ifUnknownResponse() {
+
+        final StatusLine mockStatusLine = mock(StatusLine.class);
+        when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
+        when(mockStatusLine.getStatusCode()).thenReturn(NOT_FOUND.getStatusCode());
+
         accountAuthenticator.authenticate(bearerToken);
     }
 }

--- a/src/test/java/uk/gov/pay/api/resources/ConnectorClientTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/ConnectorClientTest.java
@@ -1,0 +1,101 @@
+package uk.gov.pay.api.resources;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.StringEntity;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.model.TokenPaymentType;
+
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class ConnectorClientTest {
+
+    private static final String connectorUrl = "http://connector.local";
+    private static final String connectorDDUrl = "http://connector.dd.local";
+
+
+    private final HttpClient mockHttpClient = mock(HttpClient.class);
+
+    private final ConnectorClient connectorClient = new ConnectorClient(mockHttpClient, connectorUrl, connectorDDUrl);
+
+
+    @Test
+    public void getPayment_shouldReturnAnExistingCharge() throws IOException {
+
+        HttpResponse mockResponse = mock(HttpResponse.class);
+        StatusLine mockStatusLine = mock(StatusLine.class);
+
+        when(mockHttpClient.execute(argThat(aRequestWith(
+                "http://connector.local/v1/api/accounts/my-account/charges/a1234",
+                "GET"
+        )))).thenReturn(mockResponse);
+        when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
+        when(mockStatusLine.getStatusCode()).thenReturn(200);
+        when(mockResponse.getEntity()).thenReturn(new StringEntity("{\"charge_id\":\"999999\"}"));
+
+        Response response = connectorClient.getPayment("a1234", new Account("my-account", TokenPaymentType.CARD));
+
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getEntity(), is(notNullValue()));
+    }
+
+    @Test
+    public void getPayment_shouldReturn404IfPaymentIsNotFound() throws IOException {
+
+        HttpResponse mockResponse = mock(HttpResponse.class);
+        StatusLine mockStatusLine = mock(StatusLine.class);
+
+        when(mockHttpClient.execute(argThat(aRequestWith(
+                "http://connector.local/v1/api/accounts/my-account/charges/a000000",
+                "GET"
+        )))).thenReturn(mockResponse);
+        when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
+        when(mockStatusLine.getStatusCode()).thenReturn(404);
+
+        Response response = connectorClient.getPayment("a000000", new Account("my-account", TokenPaymentType.CARD));
+
+        assertThat(response.getStatus(), is(404));
+    }
+
+    @Ignore("WIP")
+    @Test
+    public void getPaymentEvents_shouldReturnAllEventsForAGivenPayment() throws IOException {
+
+        HttpResponse mockResponse = mock(HttpResponse.class);
+        StatusLine mockStatusLine = mock(StatusLine.class);
+
+        when(mockHttpClient.execute(argThat(aRequestWith(
+                "http://connector.local/v1/api/accounts/my-account/charges/a1234/events",
+                "GET"
+        )))).thenReturn(mockResponse);
+        when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
+        when(mockStatusLine.getStatusCode()).thenReturn(404);
+
+        Response response = connectorClient.getPayment("a1234", new Account("my-account", TokenPaymentType.CARD));
+
+        assertThat(response.getStatus(), is(404));
+    }
+
+
+
+
+    private ArgumentMatcher<HttpUriRequest> aRequestWith(String uri, String method) {
+        return httpUriRequest -> httpUriRequest.getMethod().equals(method) &&
+                httpUriRequest.getURI().toString().equals(uri);
+    }
+
+}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -27,6 +27,16 @@ graphitePort: ${METRICS_PORT:-8092}
 jerseyClientConfig:
   disabledSecureConnection: "true"
 
+httpClient:
+  timeout: 500ms
+  connectionTimeout: 500ms
+  timeToLive: 1h
+  cookiesEnabled: false
+  maxConnections: 1024
+  maxConnectionsPerRoute: 1024
+  keepAlive: 0ms
+  retries: 0
+
 rateLimiter:
   rate: 1
   perMillis: 1000


### PR DESCRIPTION
We've found that the issues we've been having running end2end tests in parallel were due to a bug in jersey client. It seems that sharing a jersey client and using a custom SSL context, when two threads try to call the client the first time at the first time it can return different SSL contexts. This implies that some requests can fail due to not having the right SSL configuration to communicate with public auth.
Although the solution has still to be discussed, we're trying one of the approaches to see if we can solve it by replacing jersey client only in AccountAuthenticator class, which calls public auth from our auth filter.