### PR TITLE
PP-3094: publicapi should deploy to ecs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,8 @@ pipeline {
         branch 'master'
       }
       steps {
-        deploy("publicapi", "test", null, true)
+        deploy("publicapi", "test", null, false, false)
+        deployEcs("publicapi", "test", null, true, true)
       }
     }
   }


### PR DESCRIPTION
- deploy should deploy to ecs
- regular deploy shouldn't tag or run tests
- ecs deploy should tag and run tests

solo @tlwr


