### PR TITLE
PP-3312/upgrade dropwizard v1.2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,11 @@
     <artifactId>pay-publicapi</artifactId>
 
     <properties>
-        <dropwizard.version>1.0.6</dropwizard.version>
+        <dropwizard.version>1.2.2</dropwizard.version>
         <mockserver.version>3.10.4</mockserver.version>
         <swagger.jersey2.version>1.5.12</swagger.jersey2.version>
-        <jersey2.version>2.25.1</jersey2.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <jackson.version>2.8.11</jackson.version>
+        <jackson.version>2.9.4</jackson.version>
         <logback.version>1.2.2</logback.version>
     </properties>
 
@@ -69,25 +68,26 @@
             <version>4.5.3</version>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-common</artifactId>
-            <version>${jersey2.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-jaxb</artifactId>
-            <version>${jersey2.version}</version>
-        </dependency>
-        <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
             <version>3.2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>24.0-jre</version>
         </dependency>
         <!-- testing -->
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
             <version>${dropwizard.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.15.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## WHAT

* Upgraded Dropwizard 1.0.6 to version 1.2.2:
	* Since version 1.1.0, Dropwizard dropped dependency to `org.mockito`intentional. The Mockito dependency was only accidentally Maven's "compile" scope and has since moved into the correct "test" scope. See https://github.com/dropwizard/dropwizard/pull/1851 for details. Since Dropwizard itself has no dependency on Mockito except for its internal tests, a dependency to the latest stable version 2.15.0 had to be added to the project explicitly.  Same goes for Guava which was explicitly added at version 24.0-jre.

* Removed explicit dependency of jersey version 2.25.1 which is not anymore needed since Dropwizard 1.2.2 already ships with that version. Note: jersey 2.25.1 is reported to have a medium vulnerability “XML Entity Expansion (XEE)” which has not yet been addressed in any subsequent version.

* Pinned Jackson to version 2.9.4 which has a fix to address a vulnerability detected in version 2.9.1 which would otherwise be pulled by Dropwizard 1.2.2.

* Hibernate Validator version 5.4.1.Final pulled down with Dropwizard 1.2.2 is reported to have a “Privilege Escalation” vulnerability issue. Upgrading to 6.0.7.Final as recommended breaks the build due to api incompatibilities. The security issue has to do with Java Security manager which is not been used therefore we are safe to leave it as it is.

