### PR TITLE
PP-3312 Upgraded remaining dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,10 @@
     <properties>
         <dropwizard.version>1.2.2</dropwizard.version>
         <mockserver.version>3.10.4</mockserver.version>
-        <swagger.jersey2.version>1.5.12</swagger.jersey2.version>
+        <swagger.jersey2.version>1.5.18</swagger.jersey2.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jackson.version>2.9.4</jackson.version>
-        <logback.version>1.2.2</logback.version>
+        <logback.version>1.2.3</logback.version>
     </properties>
 
     <dependencies>
@@ -45,12 +45,12 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
+            <version>1.11</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-graphite</artifactId>
-            <version>3.1.2</version>
+            <version>4.0.2</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.3</version>
+            <version>4.5.5</version>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
-            <version>2.2.0</version>
+            <version>2.4.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -194,7 +194,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.0</version>
+            <version>2.8.2</version>
         </dependency>
         <dependency>
             <groupId>org.exparity</groupId>


### PR DESCRIPTION
# WHAT
* Upgraded the following dependencies:
	* `swagger-jersey2-jaxrs` v1.5.12 -> v1.5.18
	* `mockserver-netty` v3.10.4 -> v5.3.0
	* `mockserver-client-java` v3.10.4 -> v5.3.0
	* `logback-classic` v1.2.2 -> v1.2.3
	* `logback-access` v1.2.2 -> v1.2.3
	* `commons-codec` v1.10 -> v1.11
	* `metrics-graphite` v3.1.2 -> v4.0.2
	* `httpclient` v4.5.3 -> v4.5.5
	* `json-path-assert` v2.2.0 -> 2.4.0
	* `gson` v2.8.0 -> v2.8.2

# NOTE
metrics-graphite 3.1.2 had been pinned down for a while due to an an issue which changed the way metrics paths were sanitised: https://github.com/dropwizard/metrics/pull/1098
Since then the problem has been addressed in more recent versions and it is now safe to rollout version 4.0.2. 

Tested locally using Telegraf, metrics are still been sent.


