### PR TITLE
PP-3219 Try a better approach to fix issue with jersey client.

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -45,8 +45,8 @@ import uk.gov.pay.api.validation.PaymentRefundRequestValidator;
 import uk.gov.pay.api.validation.PaymentRequestValidator;
 import uk.gov.pay.api.validation.URLValidator;
 
+import javax.net.ssl.HttpsURLConnection;
 import javax.ws.rs.client.Client;
-import javax.ws.rs.core.MediaType;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.EnumSet.of;
@@ -74,7 +74,7 @@ public class PublicApi extends Application<PublicApiConfig> {
 
         final Client client = RestClientFactory.buildClient(config.getRestClientConfig());
 
-        initialRequestToLoadSSLContextProperly(client);
+        initialiseSSLSocketFactory();
 
         ObjectMapper objectMapper = environment.getObjectMapper();
         configureObjectMapper(config, objectMapper);
@@ -109,18 +109,11 @@ public class PublicApi extends Application<PublicApiConfig> {
     }
 
     /*
-    Adding an extra request at startup until we find a resolution for the following jersey client bug (JERSEY-3124).
+    Adding a call to initialise SSL socket factory at startup until we find a resolution for the following jersey client bug (JERSEY-3124).
     @see <a href="https://jersey.github.io/release-notes/2.24.html">https://jersey.github.io/release-notes/2.24.html</a>
      */
-    private void initialRequestToLoadSSLContextProperly(Client client) {
-
-        try {
-            client.target("https://connector.pymnt.localdomain/accounts").request()
-                    .accept(MediaType.APPLICATION_JSON)
-                    .get();
-        } catch (Exception e) {
-            //swallow
-        }
+    private void initialiseSSLSocketFactory() {
+        HttpsURLConnection.getDefaultSSLSocketFactory();
     }
 
     private void attachExceptionMappersTo(JerseyEnvironment jersey) {


### PR DESCRIPTION
The root cause of the issue is a bug in jdk as this method is not thread-safe:

http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/8u40-b25/javax/net/ssl/HttpsURLConnection.java#HttpsURLConnection.getDefaultSSLSocketFactory%28%29

This method is not thread-safe, as multiple threads can get different instances, a double-checked locking should be added in order to make it thread safe.

```
public static SSLSocketFactory getDefaultSSLSocketFactory() {
        if (defaultSSLSocketFactory == null) {
            defaultSSLSocketFactory = (SSLSocketFactory)SSLSocketFactory.getDefault();
        }

        return defaultSSLSocketFactory;
    }
```

The code that invokes this method in jersey client is in `HttpUrlConnector`:

```
if (HttpsURLConnection.getDefaultSSLSocketFactory() == suc.getSSLSocketFactory()) {
                // indicates that the custom socket factory was not set
                suc.setSSLSocketFactory(sslSocketFactory.get());
            }
```

So for some threads the ssl socket factory is not set, as the instances do not match when they're checked, and that's why we get the SSL handshake errors initially.

So another way to fix this issue temporarily, instead of making a rest call, is to call `HttpsURLConnection.getDefaultSSLSocketFactory()` on service startup. 
That will initialise `defaultSSLSocketFactory` and all the threads will then get the same result afterwards.


