### PR TITLE
PP-3337 Allowing .internal TLD in return_url

### DIFF
--- a/src/main/java/uk/gov/pay/api/validation/URLValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/URLValidator.java
@@ -1,8 +1,11 @@
 package uk.gov.pay.api.validation;
 
-import org.apache.commons.validator.routines.UrlValidator;
 
 import static org.apache.commons.validator.routines.UrlValidator.ALLOW_LOCAL_URLS;
+
+import org.apache.commons.validator.routines.DomainValidator;
+import org.apache.commons.validator.routines.DomainValidator.ArrayType;
+import org.apache.commons.validator.routines.UrlValidator;
 
 public enum URLValidator  {
     SECURITY_ENABLED {
@@ -21,6 +24,11 @@ public enum URLValidator  {
             return URL_VALIDATOR.isValid(value);
         }
     };
+
+    static {
+        String[] otherValidTlds = new String[]{"internal"};
+        DomainValidator.updateTLDOverride(ArrayType.GENERIC_PLUS, otherValidTlds);
+    }
 
     public static URLValidator urlValidatorValueOf(boolean isDisabledSecureConnection) {
         return isDisabledSecureConnection ? SECURITY_DISABLED : SECURITY_ENABLED;

--- a/src/test/java/uk/gov/pay/api/validation/URLValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/URLValidatorTest.java
@@ -67,6 +67,16 @@ public class URLValidatorTest {
     }
 
     @Test
+    public void whenIsEnabledSecureConnection_allowingInternalDomains() {
+        assertThat(SECURITY_ENABLED.isValid("https://staging.service.core.internal/claim/pay/id/receiver"), is(true));
+    }
+
+    @Test
+    public void whenIsEnabledSecureConnection_disallowingEvilDomains() {
+        assertThat(SECURITY_ENABLED.isValid("https://an.evil/claim/pay/id/receiver"), is(false));
+    }
+
+    @Test
     public void whenUrlIsBlank_shouldFailValidation_whenDisabledSecureConnection() {
         assertThat(SECURITY_DISABLED.isValid("   "), is(false));
     }


### PR DESCRIPTION
One of our partners needed to use an ".internal" TLD for the `return_url` during their testing. This PR allows that.

Actually, this changes the `URLValidator` altogether, which may be used potentially for something else than just return_url. However, for now, it seems that is not the case. And, even if that changes in the future, it should not be an issue.

This implementation uses a static initialiser in an enum, which may not be that common. However, we needed that because the `DomainValidator.updateTLDOverride()` method needs to be called before any call to `getInstance()`. Source: https://commons.apache.org/proper/commons-validator/apidocs/org/apache/commons/validator/routines/DomainValidator.html#updateTLDOverride%28org.apache.commons.validator.routines.DomainValidator.ArrayType,%20java.lang.String%5B%5D%29

I would have liked to place the static initialiser at the top of the Enum declaration, because I feel that is the standard way. However, I could not - it needs to go after the enum instances declaration.
