### PR TITLE
Limit search to 500 transactions

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -194,7 +194,7 @@ public class PaymentsResource {
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK", response = PaymentSearchResults.class),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 422, message = "Invalid parameters: from_date, to_date, status. See Public API documentation for the correct data formats", response = PaymentError.class),
+            @ApiResponse(code = 422, message = "Invalid parameters: from_date, to_date, status, display_size. See Public API documentation for the correct data formats", response = PaymentError.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response searchPayments(@ApiParam(value = "accountId", hidden = true)
                                    @Auth Account account,
@@ -212,7 +212,7 @@ public class PaymentsResource {
                                    @QueryParam(TO_DATE_KEY) String toDate,
                                    @ApiParam(value = "Page number requested for the search, should be a positive integer (optional, defaults to 1)", hidden = false)
                                    @QueryParam(PAGE) String pageNumber,
-                                   @ApiParam(value = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500)", hidden = false)
+                                   @ApiParam(value = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)", hidden = false)
                                    @QueryParam(DISPLAY_SIZE) String displaySize,
                                    @Context UriInfo uriInfo) {
 

--- a/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
@@ -49,7 +49,7 @@ public class PaymentSearchValidator {
     }
 
     private static void validateDisplaySizeIfNotNull(String displaySize, List<String> validationErrors) {
-        if (isNotBlank(displaySize) && (!StringUtils.isNumeric(displaySize) || Integer.valueOf(displaySize) < 1)) {
+        if (isNotBlank(displaySize) && (!StringUtils.isNumeric(displaySize) || Integer.valueOf(displaySize) < 1 || Integer.valueOf(displaySize) > 500)) {
             validationErrors.add(DISPLAY_SIZE);
         }
     }

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchValidationITest.java
@@ -187,6 +187,27 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
                 .assertThat("$.description", is("Invalid parameters: state, reference, email, from_date, to_date. See Public API documentation for the correct data formats"));
     }
 
+    @Test
+    public void searchPayments_errorWhenDisplaySizeInvalid() throws Exception {
+        InputStream body = searchPayments(API_KEY,
+                ImmutableMap.<String, String>builder()
+                        .put("reference", VALID_REFERENCE)
+                        .put("email", VALID_EMAIL)
+                        .put("state", VALID_STATE)
+                        .put("from_date", VALID_FROM_DATE)
+                        .put("to_date", VALID_TO_DATE)
+                        .put("display_size", "501")
+                        .build())
+                .statusCode(422)
+                .contentType(JSON).extract()
+                .body().asInputStream();
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(2))
+                .assertThat("$.code", is("P0401"))
+                .assertThat("$.description", is("Invalid parameters: display_size. See Public API documentation for the correct data formats"));
+    }
+
     private ValidatableResponse searchPayments(String bearerToken, ImmutableMap<String, String> queryParams) {
         return given().port(app.getLocalPort())
                 .accept(JSON)

--- a/src/test/java/uk/gov/pay/api/matcher/ValidationExceptionMatcher.java
+++ b/src/test/java/uk/gov/pay/api/matcher/ValidationExceptionMatcher.java
@@ -33,7 +33,7 @@ public class ValidationExceptionMatcher extends TypeSafeMatcher<ValidationExcept
                 .appendText(" PaymentError. { code = ")
                 .appendValue(code)
                 .appendText(", description = ")
-                .appendValue(description)
+                .appendValue(this.description)
                 .appendText(" }");
     }
 }

--- a/src/test/java/uk/gov/pay/api/validation/PaymentSearchValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/PaymentSearchValidatorTest.java
@@ -75,6 +75,12 @@ public class PaymentSearchValidatorTest {
     }
 
     @Test
+    public void validateParams_shouldGiveAnErrorValidation_forToLargePageDisplay() throws Exception {
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
+        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", "0", "501");
+    }
+
+    @Test
     public void validateParams_shouldNotGiveAnErrorValidation_ForNonNumberPageAndSize() throws Exception {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", "non-numeric-page", "non-numeric-size");

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -64,7 +64,7 @@
         }, {
           "name" : "display_size",
           "in" : "query",
-          "description" : "Number of results to be shown per page, should be a positive integer (optional, defaults to 500)",
+          "description" : "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)",
           "required" : false,
           "type" : "string"
         } ],
@@ -79,7 +79,7 @@
             "description" : "Credentials are required to access this resource"
           },
           "422" : {
-            "description" : "Invalid parameters: from_date, to_date, status. See Public API documentation for the correct data formats",
+            "description" : "Invalid parameters: from_date, to_date, status, display_size. See Public API documentation for the correct data formats",
             "schema" : {
               "$ref" : "#/definitions/Payment Error"
             }


### PR DESCRIPTION
When you do a search there is a parameter to specify the number of
results returned called display_size. Currently this defaults to 500
but does not have a max value. As we have seen the speed of searches is
very dependent on the number of results returned we want limit how big
this can be. Have limited display_size to be 500 or less.