### PR TITLE
PP-3602 Remove products smoke test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,17 +69,6 @@ pipeline {
                 runCardPaymentsE2E("publicapi")
             }
         }
-        stage('Products End-to-End Tests') {
-            when {
-                anyOf {
-                  branch 'master'
-                  environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
-                }
-            }
-            steps {
-                runProductsE2E("publicapi")
-            }
-        }
         stage('Direct-Debit End-to-End Tests') {
             when {
                 anyOf {


### PR DESCRIPTION
When doing the selenium tests for staging we decided publicapi should
not run product smoke tests. Updating the Jenkinsfile so that there is
consistency across all the environments

solo @belindac


