### PR TITLE
PP-3841: Publish pacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,8 +28,15 @@ pipeline {
       steps {
         script {
           def long stepBuildTime = System.currentTimeMillis()
+          def commit = gitCommit()
 
-          sh 'mvn clean package'
+          withCredentials([
+                  string(credentialsId: 'pact_broker_username', variable: 'PACT_BROKER_USERNAME'),
+                  string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
+          ) {
+              sh "mvn clean package pact:publish -DPACT_BROKER_URL=https://pact-broker-test.cloudapps.digital -DPACT_CONSUMER_VERSION=${commit}" +
+                      " -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD}"
+          }
           postSuccessfulMetrics("publicapi.maven-build", stepBuildTime)
         }
       }

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,10 @@
         <jackson.version>2.9.4</jackson.version>
         <logback.version>1.2.3</logback.version>
         <pact.version>3.5.16</pact.version>
+        <PACT_BROKER_URL></PACT_BROKER_URL>
+        <PACT_BROKER_USERNAME></PACT_BROKER_USERNAME>
+        <PACT_BROKER_PASSWORD></PACT_BROKER_PASSWORD>
+        <PACT_CONSUMER_VERSION></PACT_CONSUMER_VERSION>
     </properties>
 
     <dependencies>
@@ -232,6 +236,19 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>au.com.dius</groupId>
+                <artifactId>pact-jvm-provider-maven_2.12</artifactId>
+                <version>${pact.version}</version>
+                <configuration>
+                    <pactDirectory>target/pacts</pactDirectory>
+                    <pactBrokerUrl>${PACT_BROKER_URL}</pactBrokerUrl>
+                    <pactBrokerUsername>${PACT_BROKER_USERNAME}</pactBrokerUsername>
+                    <pactBrokerPassword>${PACT_BROKER_PASSWORD}</pactBrokerPassword>
+                    <projectVersion>${PACT_CONSUMER_VERSION}</projectVersion>
+                    <trimSnapshot>true</trimSnapshot>
+                </configuration>
+            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>


### PR DESCRIPTION
## WHAT
Add the pact maven plugin to enable publishing of pacts.
Set trimSnapshot to true in the pom.xml as the pact broker has issues parsing
SNAPSHOT versions (even though we aren't using SNAPSHOT versions but rather the
git commit sha, but just in case). See
https://github.com/DiUS/pact-jvm/tree/master/pact-jvm-provider-maven#publishing-pact-files-to-a-pact-broker.

For some reason the pact broker homepage (https://pact-broker-test.cloudapps.digital/) doesn't show the latest publicapi pact that was published. But the latest version that was published from the https://build.ci.pymnt.uk/job/pay-publicapi/job/PR-178/3 is definitely there at https://pact-broker-test.cloudapps.digital/hal-browser/browser.html#/pacts/provider/direct-debit-connector/consumer/publicapi/version/1fb63718d85705ab17d2e032e84ad49c1d5c5fbf.

@oswaldquek
