### PR TITLE
BAU: Add timing annotation to all endpoints

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/HealthCheckResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/HealthCheckResource.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import com.codahale.metrics.health.HealthCheck;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
@@ -28,6 +29,7 @@ public class HealthCheckResource {
     }
 
     @GET
+    @Timed
     @Path(HEALTHCHECK)
     @Produces(APPLICATION_JSON)
     public Response healthCheck() throws JsonProcessingException {

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
 import io.dropwizard.auth.Auth;
@@ -61,6 +62,7 @@ public class PaymentRefundsResource {
     }
 
     @GET
+    @Timed
     @Produces(APPLICATION_JSON)
     @ApiOperation(
             value = "Get all refunds for a payment.",
@@ -93,6 +95,7 @@ public class PaymentRefundsResource {
     }
 
     @GET
+    @Timed
     @Path("/{refundId}")
     @Produces(APPLICATION_JSON)
     @ApiOperation(
@@ -127,6 +130,7 @@ public class PaymentRefundsResource {
     }
 
     @POST
+    @Timed
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
     @ApiOperation(

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.api.resources;
 
 import black.door.hate.HalRepresentation;
+import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -93,6 +94,7 @@ public class PaymentsResource {
     }
 
     @GET
+    @Timed
     @Path(PAYMENT_BY_ID)
     @Produces(APPLICATION_JSON)
     @ApiOperation(
@@ -136,6 +138,7 @@ public class PaymentsResource {
     }
 
     @GET
+    @Timed
     @Path(PAYMENT_EVENTS_BY_ID)
     @Produces(APPLICATION_JSON)
     @ApiOperation(
@@ -181,6 +184,7 @@ public class PaymentsResource {
     }
 
     @GET
+    @Timed
     @Path(PAYMENTS_PATH)
     @Produces(APPLICATION_JSON)
     @ApiOperation(
@@ -302,6 +306,7 @@ public class PaymentsResource {
     }
 
     @POST
+    @Timed
     @Path(PAYMENTS_PATH)
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
@@ -350,6 +355,7 @@ public class PaymentsResource {
     }
 
     @POST
+    @Timed
     @Path(CANCEL_PAYMENT_PATH)
     @Produces(APPLICATION_JSON)
     @ApiOperation(

--- a/src/main/java/uk/gov/pay/api/resources/RequestDeniedResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/RequestDeniedResource.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,6 +18,7 @@ public class RequestDeniedResource {
     private static final Logger logger = LoggerFactory.getLogger(RequestDeniedResource.class);
 
     @GET
+    @Timed
     @Path("request-denied")
     @Produces(APPLICATION_JSON)
     public Response requestDeniedGet(@HeaderParam("x-naxsi_sig") String naxsiViolatedRules) {
@@ -24,6 +26,7 @@ public class RequestDeniedResource {
     }
 
     @POST
+    @Timed
     @Path("request-denied")
     @Produces(APPLICATION_JSON)
     public Response requestDeniedPost(@HeaderParam("x-naxsi_sig") String naxsiViolatedRules) {
@@ -31,6 +34,7 @@ public class RequestDeniedResource {
     }
 
     @PUT
+    @Timed
     @Path("request-denied")
     @Produces(APPLICATION_JSON)
     public Response requestDeniedPut(@HeaderParam("x-naxsi_sig") String naxsiViolatedRules) {
@@ -38,6 +42,7 @@ public class RequestDeniedResource {
     }
 
     @DELETE
+    @Timed
     @Path("request-denied")
     @Produces(APPLICATION_JSON)
     public Response requestDeniedDelete(@HeaderParam("x-naxsi_sig") String naxsiViolatedRules) {


### PR DESCRIPTION
the [`@Timed` annotation](https://www.dropwizard.io/1.3.2/docs/manual/core.html#man-core-resources-metrics)
allows an endpoint to emit timing metrics of its use. Having timings on public api for each endpoint will help
us in diagnosing any performance issues

with @oswaldquek 