### PR TITLE
Guice publicapi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
 
     <properties>
         <dropwizard.version>1.2.2</dropwizard.version>
+        <guice.version>4.2.0</guice.version>
         <mockserver.version>3.10.4</mockserver.version>
         <swagger.jersey2.version>1.5.18</swagger.jersey2.version>
         <hamcrest.version>1.3</hamcrest.version>
@@ -36,6 +37,11 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-client</artifactId>
             <version>${dropwizard.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>${guice.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>

--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -38,7 +38,6 @@ import uk.gov.pay.api.resources.PaymentsResource;
 import uk.gov.pay.api.resources.RequestDeniedResource;
 
 import javax.net.ssl.HttpsURLConnection;
-import javax.ws.rs.client.Client;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.EnumSet.of;
@@ -62,9 +61,7 @@ public class PublicApi extends Application<PublicApiConfig> {
 
     @Override
     public void run(PublicApiConfig configuration, Environment environment) {
-
-        final Client client = RestClientFactory.buildClient(configuration.getRestClientConfig());
-
+        
         initialiseSSLSocketFactory();
         
         final Injector injector = Guice.createInjector(new PublicApiModule(configuration, environment));
@@ -87,7 +84,7 @@ public class PublicApi extends Application<PublicApiConfig> {
 
         environment.jersey().register(new AuthDynamicFeature(
                 new OAuthCredentialAuthFilter.Builder<Account>()
-                        .setAuthenticator(new AccountAuthenticator(client, configuration.getPublicAuthUrl()))
+                        .setAuthenticator(injector.getInstance(AccountAuthenticator.class))
                         .setPrefix("Bearer")
                         .buildAuthFilter()));
         environment.jersey().register(new AuthValueFactoryProvider.Binder<>(Account.class));

--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.api.app.config;
+
+import com.google.inject.AbstractModule;
+import io.dropwizard.setup.Environment;
+
+public class PublicApiModule extends AbstractModule {
+
+    private final PublicApiConfig configuration;
+    private final Environment environment;
+
+    public PublicApiModule(final PublicApiConfig configuration, final Environment environment) {
+        this.configuration = configuration;
+        this.environment = environment;
+    }
+
+    @Override
+    protected void configure() {
+        bind(PublicApiConfig.class).toInstance(configuration);
+        bind(Environment.class).toInstance(environment);
+    }
+    
+}

--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
@@ -1,7 +1,25 @@
 package uk.gov.pay.api.app.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import io.dropwizard.setup.Environment;
+import uk.gov.pay.api.app.RestClientFactory;
+import uk.gov.pay.api.filter.RateLimiter;
+import uk.gov.pay.api.json.CreatePaymentRefundRequestDeserializer;
+import uk.gov.pay.api.json.CreatePaymentRequestDeserializer;
+import uk.gov.pay.api.model.CreatePaymentRefundRequest;
+import uk.gov.pay.api.model.CreatePaymentRequest;
+import uk.gov.pay.api.validation.PaymentRefundRequestValidator;
+import uk.gov.pay.api.validation.PaymentRequestValidator;
+import uk.gov.pay.api.validation.URLValidator;
+
+import javax.ws.rs.client.Client;
+
+import static uk.gov.pay.api.validation.URLValidator.urlValidatorValueOf;
 
 public class PublicApiModule extends AbstractModule {
 
@@ -19,4 +37,33 @@ public class PublicApiModule extends AbstractModule {
         bind(Environment.class).toInstance(environment);
     }
     
+    @Provides
+    @Singleton
+    public Client provideClient() {
+        return RestClientFactory.buildClient(configuration.getRestClientConfig());
+    }
+
+    @Provides
+    @Singleton
+    public ObjectMapper provideObjectMapper() {
+        ObjectMapper objectMapper = environment.getObjectMapper();
+        
+        URLValidator urlValidator = urlValidatorValueOf(configuration.getAllowHttpForReturnUrl());
+        CreatePaymentRequestDeserializer paymentRequestDeserializer = new CreatePaymentRequestDeserializer(new PaymentRequestValidator(urlValidator));
+        CreatePaymentRefundRequestDeserializer paymentRefundRequestDeserializer = new CreatePaymentRefundRequestDeserializer(new PaymentRefundRequestValidator());
+
+        SimpleModule publicApiDeserializationModule = new SimpleModule("publicApiDeserializationModule");
+        publicApiDeserializationModule.addDeserializer(CreatePaymentRequest.class, paymentRequestDeserializer);
+        publicApiDeserializationModule.addDeserializer(CreatePaymentRefundRequest.class, paymentRefundRequestDeserializer);
+
+        objectMapper.configure(DeserializationFeature.ACCEPT_FLOAT_AS_INT, false);
+        objectMapper.registerModule(publicApiDeserializationModule);
+        
+        return objectMapper;
+    }
+
+    @Provides
+    public RateLimiter provideRateLimiter() {
+        return new RateLimiter(configuration.getRateLimiterConfig().getRate(), configuration.getRateLimiterConfig().getPerMillis());
+    }
 }

--- a/src/main/java/uk/gov/pay/api/auth/AccountAuthenticator.java
+++ b/src/main/java/uk/gov/pay/api/auth/AccountAuthenticator.java
@@ -1,12 +1,13 @@
 package uk.gov.pay.api.auth;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.model.TokenPaymentType;
 
+import javax.inject.Inject;
 import javax.ws.rs.ServiceUnavailableException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.MediaType;
@@ -16,7 +17,7 @@ import java.util.Optional;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
-import static uk.gov.pay.api.model.TokenPaymentType.*;
+import static uk.gov.pay.api.model.TokenPaymentType.CARD;
 import static uk.gov.pay.api.model.TokenPaymentType.fromString;
 
 public class AccountAuthenticator implements Authenticator<String, Account> {
@@ -24,10 +25,11 @@ public class AccountAuthenticator implements Authenticator<String, Account> {
 
     private final Client client;
     private final String publicAuthUrl;
-
-    public AccountAuthenticator(Client client, String publicAuthUrl) {
+    
+    @Inject
+    public AccountAuthenticator(Client client, PublicApiConfig configuration) {
         this.client = client;
-        this.publicAuthUrl = publicAuthUrl;
+        this.publicAuthUrl = configuration.getPublicAuthUrl();
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/api/filter/AuthorizationValidationFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/AuthorizationValidationFilter.java
@@ -2,8 +2,15 @@ package uk.gov.pay.api.filter;
 
 import com.google.common.io.BaseEncoding;
 import org.apache.commons.codec.digest.HmacUtils;
+import uk.gov.pay.api.app.config.PublicApiConfig;
 
-import javax.servlet.*;
+import javax.inject.Inject;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -17,12 +24,13 @@ public class AuthorizationValidationFilter implements Filter {
 
     private String apiKeyHmacSecret;
 
-    public AuthorizationValidationFilter(String apiKeyHmacSecret) {
-        this.apiKeyHmacSecret = apiKeyHmacSecret;
+    @Inject
+    public AuthorizationValidationFilter(PublicApiConfig configuration) {
+        this.apiKeyHmacSecret = configuration.getApiKeyHmacSecret();
     }
 
     @Override
-    public void init(FilterConfig filterConfig) throws ServletException {}
+    public void init(FilterConfig filterConfig) {}
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
@@ -4,7 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.*;
+import javax.inject.Inject;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -31,6 +37,7 @@ public class RateLimiterFilter implements Filter {
     /**
      * @param rateLimiter Limiter in number of requests per given time coming from the same source (Authorization)
      */
+    @Inject
     public RateLimiterFilter(RateLimiter rateLimiter, ObjectMapper objectMapper) {
         this.rateLimiter = rateLimiter;
         this.objectMapper = objectMapper;

--- a/src/main/java/uk/gov/pay/api/resources/HealthCheckResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/HealthCheckResource.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
 import io.dropwizard.setup.Environment;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -24,6 +25,7 @@ public class HealthCheckResource {
 
     Environment environment;
 
+    @Inject
     public HealthCheckResource(Environment environment) {
         this.environment = environment;
     }

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -4,17 +4,34 @@ import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
 import io.dropwizard.auth.Auth;
-import io.swagger.annotations.*;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CreateRefundException;
 import uk.gov.pay.api.exception.GetRefundException;
 import uk.gov.pay.api.exception.GetRefundsException;
-import uk.gov.pay.api.model.*;
+import uk.gov.pay.api.model.ChargeFromResponse;
+import uk.gov.pay.api.model.CreatePaymentRefundRequest;
+import uk.gov.pay.api.model.PaymentError;
+import uk.gov.pay.api.model.RefundFromConnector;
+import uk.gov.pay.api.model.RefundResponse;
+import uk.gov.pay.api.model.RefundsFromConnector;
+import uk.gov.pay.api.model.RefundsResponse;
 
-import javax.ws.rs.*;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
@@ -55,10 +72,11 @@ public class PaymentRefundsResource {
     private final Client client;
     private final String connectorUrl;
 
-    public PaymentRefundsResource(String baseUrl, Client client, String connectorUrl) {
-        this.baseUrl = baseUrl;
+    @Inject
+    public PaymentRefundsResource(Client client, PublicApiConfig configuration) {
         this.client = client;
-        this.connectorUrl = connectorUrl;
+        this.baseUrl = configuration.getBaseUrl();
+        this.connectorUrl = configuration.getConnectorUrl();
     }
 
     @GET

--- a/src/test/java/uk/gov/pay/api/auth/AccountAuthenticatorTest.java
+++ b/src/test/java/uk/gov/pay/api/auth/AccountAuthenticatorTest.java
@@ -3,10 +3,10 @@ package uk.gov.pay.api.auth;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
-import io.dropwizard.auth.AuthenticationException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import uk.gov.pay.api.app.config.PublicApiConfig;
 
 import javax.ws.rs.ServiceUnavailableException;
 import javax.ws.rs.client.Client;
@@ -18,7 +18,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
-import static javax.ws.rs.core.Response.Status.*;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -40,7 +42,9 @@ public class AccountAuthenticatorTest {
         WebTarget mockTarget = mock(WebTarget.class);
         Invocation.Builder mockRequest = mock(Invocation.Builder.class);
         mockResponse = mock(Response.class);
-        accountAuthenticator = new AccountAuthenticator(publicAuthMock, "");
+        PublicApiConfig mockConfiguration = mock(PublicApiConfig.class);
+        when(mockConfiguration.getPublicAuthUrl()).thenReturn("");
+        accountAuthenticator = new AccountAuthenticator(publicAuthMock, mockConfiguration);
         when(publicAuthMock.target("")).thenReturn(mockTarget);
         when(mockTarget.request()).thenReturn(mockRequest);
         when(mockRequest.header(AUTHORIZATION, "Bearer " + bearerToken)).thenReturn(mockRequest);
@@ -49,7 +53,7 @@ public class AccountAuthenticatorTest {
     }
 
     @Test
-    public void shouldReturnValidAccount() throws AuthenticationException {
+    public void shouldReturnValidAccount() {
         Map<String, String> responseEntity = ImmutableMap.of(
                 "account_id", accountName,
                 "token_type", "DIRECT_DEBIT"
@@ -63,7 +67,7 @@ public class AccountAuthenticatorTest {
     }
 
     @Test
-    public void shouldReturnCCAccount_ifTokenTypeIsMissing() throws AuthenticationException {
+    public void shouldReturnCCAccount_ifTokenTypeIsMissing() {
         Map<String, String> responseEntity = ImmutableMap.of(
                 "account_id", accountName
         );
@@ -76,14 +80,14 @@ public class AccountAuthenticatorTest {
     }
 
     @Test
-    public void shouldNotReturnAccount_ifUnauthorised() throws AuthenticationException {
+    public void shouldNotReturnAccount_ifUnauthorised() {
         when(mockResponse.getStatus()).thenReturn(UNAUTHORIZED.getStatusCode());
         Optional<Account> maybeAccount = accountAuthenticator.authenticate(bearerToken);
         Assert.assertThat(maybeAccount.isPresent(), is(false));
     }
 
     @Test(expected = ServiceUnavailableException.class)
-    public void shouldThrow_ifUnknownResponse() throws AuthenticationException {
+    public void shouldThrow_ifUnknownResponse() {
         when(mockResponse.getStatus()).thenReturn(NOT_FOUND.getStatusCode());
         accountAuthenticator.authenticate(bearerToken);
     }

--- a/src/test/java/uk/gov/pay/api/filter/AuthorizationValidationFilterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/AuthorizationValidationFilterTest.java
@@ -5,13 +5,16 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.api.app.config.PublicApiConfig;
 
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 import static uk.gov.pay.api.utils.ApiKeyGenerator.apiKeyValueOf;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -21,6 +24,8 @@ public class AuthorizationValidationFilterTest {
     private AuthorizationValidationFilter authorizationValidationFilter;
 
     @Mock
+    private PublicApiConfig mockConfiguration;
+    @Mock
     private HttpServletRequest mockRequest;
     @Mock
     private HttpServletResponse mockResponse;
@@ -29,7 +34,9 @@ public class AuthorizationValidationFilterTest {
 
     @Before
     public void setup() {
-        authorizationValidationFilter = new AuthorizationValidationFilter(SECRET_KEY);
+        when(mockConfiguration.getApiKeyHmacSecret()).thenReturn(SECRET_KEY);
+        
+        authorizationValidationFilter = new AuthorizationValidationFilter(mockConfiguration);
     }
 
     @Test


### PR DESCRIPTION
Start using Guice to instantiate objects added to the environment in the `PublicApi` class.

This will make it easier to extract some of the logic in the `*Resource` classes to separate service classes (because we will be able to use Guice to inject their dependencies).

with @heathd