### PR TITLE
Extract create payments service

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -42,7 +42,6 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.EnumSet.of;
 import static javax.servlet.DispatcherType.REQUEST;
-import static uk.gov.pay.api.resources.PaymentsResource.API_VERSION_PATH;
 
 public class PublicApi extends Application<PublicApiConfig> {
 
@@ -74,13 +73,13 @@ public class PublicApi extends Application<PublicApiConfig> {
         environment.jersey().register(injector.getInstance(RequestDeniedResource.class));
         
         environment.servlets().addFilter("AuthorizationValidationFilter", injector.getInstance(AuthorizationValidationFilter.class))
-                .addMappingForUrlPatterns(of(REQUEST), true, API_VERSION_PATH + "/*");
+                .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
 
         environment.servlets().addFilter("RateLimiterFilter", injector.getInstance(RateLimiterFilter.class))
-                .addMappingForUrlPatterns(of(REQUEST), true, API_VERSION_PATH + "/*");
+                .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
 
         environment.servlets().addFilter("LoggingFilter", injector.getInstance(LoggingFilter.class))
-                .addMappingForUrlPatterns(of(REQUEST), true, API_VERSION_PATH + "/*");
+                .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
 
         environment.jersey().register(new AuthDynamicFeature(
                 new OAuthCredentialAuthFilter.Builder<Account>()

--- a/src/main/java/uk/gov/pay/api/app/config/RestClientConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/RestClientConfig.java
@@ -3,7 +3,15 @@ package uk.gov.pay.api.app.config;
 import io.dropwizard.Configuration;
 
 public class RestClientConfig extends Configuration {
-    private String disabledSecureConnection;
+    
+    private String disabledSecureConnection = "false";
+
+    public RestClientConfig() {
+    }
+
+    public RestClientConfig(boolean disabledSecureConnection) {
+        this.disabledSecureConnection = Boolean.valueOf(disabledSecureConnection).toString();
+    }
 
     public Boolean isDisabledSecureConnection() {
         return "true".equals(disabledSecureConnection);

--- a/src/main/java/uk/gov/pay/api/auth/Account.java
+++ b/src/main/java/uk/gov/pay/api/auth/Account.java
@@ -6,17 +6,21 @@ import java.security.Principal;
 
 public class Account implements Principal {
 
-    private final String name;
+    private final String accountId;
     private final TokenPaymentType paymentType;
 
-    public Account(String name, TokenPaymentType paymentType) {
-        this.name = name;
+    public Account(String accountId, TokenPaymentType paymentType) {
+        this.accountId = accountId;
         this.paymentType = paymentType;
     }
 
     @Override
     public String getName() {
-        return name;
+        return getAccountId();
+    }
+    
+    public String getAccountId() {
+        return accountId;
     }
 
     public TokenPaymentType getPaymentType() {

--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
-import static uk.gov.pay.api.model.TokenPaymentType.*;
+import static uk.gov.pay.api.model.TokenPaymentType.CARD;
 
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)

--- a/src/main/java/uk/gov/pay/api/model/DirectDebitPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/DirectDebitPayment.java
@@ -1,11 +1,9 @@
 package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 
-import static uk.gov.pay.api.model.TokenPaymentType.*;
+import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
 
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)

--- a/src/main/java/uk/gov/pay/api/model/PaymentState.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentState.java
@@ -91,7 +91,6 @@ public class PaymentState {
 
     @Override
     public int hashCode() {
-
         return Objects.hash(status, finished, message, code);
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/PaymentState.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentState.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.Objects;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @ApiModel(value="PaymentState", description = "A structure representing the current state of the payment in its lifecycle.")
@@ -33,6 +35,10 @@ public class PaymentState {
     }
 
     public PaymentState() {
+    }
+
+    public PaymentState(String status, boolean finished) {
+        this(status, finished, null, null);
     }
 
     public PaymentState(String status, boolean finished, String message, String code) {
@@ -70,5 +76,22 @@ public class PaymentState {
                 ", message=" + message +
                 ", code=" + code +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PaymentState that = (PaymentState) o;
+        return finished == that.finished &&
+                Objects.equals(status, that.status) &&
+                Objects.equals(message, that.message) &&
+                Objects.equals(code, that.code);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(status, finished, message, code);
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/links/Link.java
+++ b/src/main/java/uk/gov/pay/api/model/links/Link.java
@@ -58,7 +58,6 @@ public class Link {
 
     @Override
     public int hashCode() {
-
         return Objects.hash(href, method);
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/links/Link.java
+++ b/src/main/java/uk/gov/pay/api/model/links/Link.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.Objects;
+
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 @ApiModel(value = "Link", description = "A link related to a payment")
@@ -16,7 +18,7 @@ public class Link {
     @JsonProperty(value = "method")
     private String method;
 
-    Link(String href, String method) {
+    public Link(String href, String method) {
         this.href = href;
         this.method = method;
     }
@@ -43,5 +45,20 @@ public class Link {
                 "href='" + href + '\'' +
                 ", method='" + method + '\'' +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Link link = (Link) o;
+        return Objects.equals(href, link.href) &&
+                Objects.equals(method, link.method);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(href, method);
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -37,10 +37,6 @@ public class PaymentWithAllLinks {
         return payment;
     }
 
-    public String getPaymentId() {
-        return payment.getPaymentId();
-    }
-
     private PaymentWithAllLinks(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                                 String reference, String email, String paymentProvider, String createdDate,
                                 RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails, List<PaymentConnectorResponseLink> paymentConnectorResponseLinks,

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -37,6 +37,10 @@ public class PaymentWithAllLinks {
         return payment;
     }
 
+    public String getPaymentId() {
+        return payment.getPaymentId();
+    }
+
     private PaymentWithAllLinks(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                                 String reference, String email, String paymentProvider, String createdDate,
                                 RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails, List<PaymentConnectorResponseLink> paymentConnectorResponseLinks,

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -3,7 +3,16 @@ package uk.gov.pay.api.model.links;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.swagger.annotations.ApiModelProperty;
-import uk.gov.pay.api.model.*;
+import uk.gov.pay.api.model.CardDetails;
+import uk.gov.pay.api.model.CardPayment;
+import uk.gov.pay.api.model.ChargeFromResponse;
+import uk.gov.pay.api.model.DirectDebitPayment;
+import uk.gov.pay.api.model.Payment;
+import uk.gov.pay.api.model.PaymentConnectorResponseLink;
+import uk.gov.pay.api.model.PaymentState;
+import uk.gov.pay.api.model.RefundSummary;
+import uk.gov.pay.api.model.SettlementSummary;
+import uk.gov.pay.api.model.TokenPaymentType;
 
 import java.net.URI;
 import java.util.List;

--- a/src/main/java/uk/gov/pay/api/model/links/PostLink.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PostLink.java
@@ -63,7 +63,6 @@ public class PostLink extends Link {
 
     @Override
     public int hashCode() {
-
         return Objects.hash(super.hashCode(), type, params);
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/links/PostLink.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PostLink.java
@@ -5,6 +5,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 import java.util.Map;
+import java.util.Objects;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
@@ -15,13 +16,13 @@ public class PostLink extends Link {
     private String type;
     private Map<String, Object> params;
 
-    PostLink(String href, String method, String type, Map<String, Object> params) {
+    public PostLink(String href, String method, String type, Map<String, Object> params) {
         super(href, method);
         this.type = type;
         this.params = params;
     }
 
-    PostLink(String href, String method) {
+    public PostLink(String href, String method) {
         super(href, method);
     }
 
@@ -48,5 +49,21 @@ public class PostLink extends Link {
                 ", type='" + type + '\'' +
                 ", params=" + params +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        PostLink postLink = (PostLink) o;
+        return Objects.equals(type, postLink.type) &&
+                Objects.equals(params, postLink.params);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(super.hashCode(), type, params);
     }
 }

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -97,7 +97,7 @@ public class PaymentRefundsResource {
 
         logger.info("Get refunds for payment request - paymentId={}", paymentId);
         Response connectorResponse = client
-                .target(getConnectorUrl(format(CONNECTOR_CHARGE_REFUNDS_RESOURCE, account.getName(), paymentId)))
+                .target(getConnectorUrl(format(CONNECTOR_CHARGE_REFUNDS_RESOURCE, account.getAccountId(), paymentId)))
                 .request()
                 .get();
 
@@ -133,7 +133,7 @@ public class PaymentRefundsResource {
 
         logger.info("Payment refund request - paymentId={}, refundId={}", paymentId, refundId);
         Response connectorResponse = client
-                .target(getConnectorUrl(format(CONNECTOR_CHARGE_REFUND_BY_ID_RESOURCE, account.getName(), paymentId, refundId)))
+                .target(getConnectorUrl(format(CONNECTOR_CHARGE_REFUND_BY_ID_RESOURCE, account.getAccountId(), paymentId, refundId)))
                 .request()
                 .get();
 
@@ -171,7 +171,7 @@ public class PaymentRefundsResource {
         Integer refundAmountAvailable = requestPayload.getRefundAmountAvailable()
                 .orElseGet(() -> {
                     Response getChargeResponse = client
-                            .target(getConnectorUrl(format(CONNECTOR_CHARGE_RESOURCE, account.getName(), paymentId)))
+                            .target(getConnectorUrl(format(CONNECTOR_CHARGE_RESOURCE, account.getAccountId(), paymentId)))
                             .request()
                             .get();
 
@@ -184,7 +184,7 @@ public class PaymentRefundsResource {
                 payloadMap);
 
         Response connectorResponse = client
-                .target(getConnectorUrl(format(CONNECTOR_CHARGE_REFUNDS_RESOURCE, account.getName(), paymentId)))
+                .target(getConnectorUrl(format(CONNECTOR_CHARGE_REFUNDS_RESOURCE, account.getAccountId(), paymentId)))
                 .request()
                 .post(json(connectorPayload));
 

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -145,7 +145,7 @@ public class PaymentsResource {
         Response connectorResponse = client
                 .target(getConnectorUrl(
                         account.getPaymentType(),
-                        format(CONNECTOR_CHARGE_RESOURCE, account.getName(), paymentId)))
+                        format(CONNECTOR_CHARGE_RESOURCE, account.getAccountId(), paymentId)))
                 .request()
                 .get();
 
@@ -190,7 +190,7 @@ public class PaymentsResource {
         Response connectorResponse = client
                 .target(getConnectorUrl(
                         account.getPaymentType(),
-                        format(CONNECTOR_CHARGE_EVENTS_RESOURCE, account.getName(), paymentId)))
+                        format(CONNECTOR_CHARGE_EVENTS_RESOURCE, account.getAccountId(), paymentId)))
                 .request()
                 .get();
 
@@ -274,7 +274,7 @@ public class PaymentsResource {
         Response connectorResponse = client
                 .target(getConnectorUrl(
                         account.getPaymentType(),
-                        format(CONNECTOR_CHARGES_RESOURCE, account.getName()),
+                        format(CONNECTOR_CHARGES_RESOURCE, account.getAccountId()),
                         queryParams))
                 .request()
                 .header(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -361,7 +361,7 @@ public class PaymentsResource {
         Response connectorResponse = client
                 .target(getConnectorUrl(
                         account.getPaymentType(),
-                        format(CONNECTOR_CHARGES_RESOURCE, account.getName())))
+                        format(CONNECTOR_CHARGES_RESOURCE, account.getAccountId())))
                 .request()
                 .accept(MediaType.APPLICATION_JSON)
                 .post(buildChargeRequestPayload(requestPayload));
@@ -411,7 +411,7 @@ public class PaymentsResource {
         Response connectorResponse = client
                 .target(getConnectorUrl(
                         account.getPaymentType(),
-                        format(CONNECTOR_ACCOUNT_CHARGE_CANCEL_RESOURCE, account.getName(), paymentId)))
+                        format(CONNECTOR_ACCOUNT_CHARGE_CANCEL_RESOURCE, account.getAccountId(), paymentId)))
                 .request()
                 .post(Entity.json("{}"));
 

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -327,7 +327,7 @@ public class PaymentsResource {
         PaymentWithAllLinks createdPayment = createPaymentService.create(account, requestPayload);
 
         Response response = Response
-                .created(publicApiUriGenerator.getPaymentURI(baseUrl, createdPayment.getPaymentId()))
+                .created(publicApiUriGenerator.getPaymentURI(baseUrl, createdPayment.getPayment().getPaymentId()))
                 .entity(createdPayment)
                 .build();
 

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -66,6 +66,7 @@ import static uk.gov.pay.api.validation.PaymentSearchValidator.validateSearchPar
 @Api(value = "/", description = "Public Api Endpoints")
 @Produces({"application/json"})
 public class PaymentsResource {
+
     private static final Logger logger = LoggerFactory.getLogger(PaymentsResource.class);
 
     private final String baseUrl;
@@ -323,7 +324,7 @@ public class PaymentsResource {
                                      @ApiParam(value = "requestPayload", required = true) CreatePaymentRequest requestPayload) {
         logger.info("Payment create request - [ {} ]", requestPayload);
 
-        PaymentWithAllLinks createdPayment = createPaymentService.invoke(account, requestPayload);
+        PaymentWithAllLinks createdPayment = createPaymentService.create(account, requestPayload);
 
         Response response = Response
                 .created(publicApiUriGenerator.getPaymentURI(baseUrl, createdPayment.getPaymentId()))

--- a/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.api.service;
+
+import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.auth.Account;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.UriBuilder;
+
+import java.net.URI;
+
+import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
+
+public class ConnectorUriGenerator {
+    private final PublicApiConfig configuration;
+
+    @Inject
+    public ConnectorUriGenerator(PublicApiConfig configuration) {
+        this.configuration = configuration;
+    }
+
+    public String chargesURI(Account account) {
+        return UriBuilder
+                .fromPath(connectorBaseUrlForAccount(account))
+                .path(String.format("/v1/api/accounts/%s/charges", account.getAccountId()))
+                .toString();
+    }
+
+    private String connectorBaseUrlForAccount(Account account) {
+        return isDirectDebitAccount(account) ? configuration.getConnectorDDUrl() : configuration.getConnectorUrl();
+    }
+
+    private boolean isDirectDebitAccount(Account account) {
+        return account.getPaymentType().equals(DIRECT_DEBIT);
+    }
+
+    public URI getPaymentEventsURI(String baseUrl, String charge_id) {
+        return null;
+    }
+}

--- a/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
@@ -1,13 +1,15 @@
 package uk.gov.pay.api.service;
 
+import org.apache.commons.lang3.tuple.Pair;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 
 import javax.inject.Inject;
 import javax.ws.rs.core.UriBuilder;
+import java.util.Collections;
+import java.util.List;
 
-import java.net.URI;
-
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
 
 public class ConnectorUriGenerator {
@@ -19,10 +21,37 @@ public class ConnectorUriGenerator {
     }
 
     public String chargesURI(Account account) {
-        return UriBuilder
-                .fromPath(connectorBaseUrlForAccount(account))
-                .path(String.format("/v1/api/accounts/%s/charges", account.getAccountId()))
-                .toString();
+        return buildConnectorUri(account, String.format("/v1/api/accounts/%s/charges", account.getAccountId()));
+    }
+
+    public String chargesURI(Account account, List<Pair<String, String>> queryParams) {
+        return buildConnectorUri(account, String.format("/v1/api/accounts/%s/charges", account.getAccountId()), queryParams);
+    }
+    
+    public String chargeURI(Account account, String chargeId) {
+        String path = String.format("/v1/api/accounts/%s/charges/%s", account.getAccountId(), chargeId);
+        return buildConnectorUri(account, path);
+    }
+
+    public String chargeEventsURI(Account account, String paymentId) {
+        String path = String.format("/v1/api/accounts/%s/charges/%s/events", account.getAccountId(), paymentId);
+        return buildConnectorUri(account, path);
+    }
+
+    private String buildConnectorUri(Account account, String path) {
+        return buildConnectorUri(account, path, Collections.emptyList());
+    }
+    
+    private String buildConnectorUri(Account account, String path, List<Pair<String, String>> queryParams) {
+        UriBuilder builder = UriBuilder.fromPath(connectorBaseUrlForAccount(account)).path(path);
+
+        queryParams.stream().forEach(pair -> {
+            if (isNotBlank(pair.getRight())) {
+                builder.queryParam(pair.getKey(), pair.getValue());
+            }
+        });
+
+        return builder.toString();
     }
 
     private String connectorBaseUrlForAccount(Account account) {
@@ -33,7 +62,8 @@ public class ConnectorUriGenerator {
         return account.getPaymentType().equals(DIRECT_DEBIT);
     }
 
-    public URI getPaymentEventsURI(String baseUrl, String charge_id) {
-        return null;
+    public String cancelURI(Account account, String paymentId) {
+        String path = String.format("/v1/api/accounts/%s/charges/%s/cancel", account.getAccountId(), paymentId);
+        return buildConnectorUri(account, path, Collections.emptyList()).toString();
     }
 }

--- a/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
@@ -18,6 +18,7 @@ import javax.ws.rs.core.Response;
 import static javax.ws.rs.client.Entity.json;
 
 public class CreatePaymentService {
+
     private final String baseUrl;
     private final Client client;
     private final PublicApiUriGenerator publicApiUriGenerator;
@@ -31,7 +32,7 @@ public class CreatePaymentService {
         this.connectorUriGenerator = connectorUriGenerator;
     }
 
-    public PaymentWithAllLinks invoke(Account account, CreatePaymentRequest requestPayload) {
+    public PaymentWithAllLinks create(Account account, CreatePaymentRequest requestPayload) {
         Response connectorResponse = createCharge(account, requestPayload);
 
         if (!createdSuccessfully(connectorResponse)) {

--- a/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
@@ -47,10 +47,10 @@ public class CreatePaymentService {
         return PaymentWithAllLinks.getPaymentWithLinks(
                     account.getPaymentType(),
                     chargeFromResponse,
-                    publicApiUriGenerator.getPaymentURI(baseUrl, chargeFromResponse.getChargeId()),
-                    publicApiUriGenerator.getPaymentEventsURI(baseUrl, chargeFromResponse.getChargeId()),
-                    publicApiUriGenerator.getPaymentCancelURI(baseUrl, chargeFromResponse.getChargeId()),
-                    publicApiUriGenerator.getPaymentRefundsURI(baseUrl, chargeFromResponse.getChargeId()));
+                    publicApiUriGenerator.getPaymentURI(chargeFromResponse.getChargeId()),
+                    publicApiUriGenerator.getPaymentEventsURI(chargeFromResponse.getChargeId()),
+                    publicApiUriGenerator.getPaymentCancelURI(chargeFromResponse.getChargeId()),
+                    publicApiUriGenerator.getPaymentRefundsURI(chargeFromResponse.getChargeId()));
     }
 
     private boolean createdSuccessfully(Response connectorResponse) {

--- a/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
@@ -1,0 +1,79 @@
+package uk.gov.pay.api.service;
+
+import org.apache.http.HttpStatus;
+import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.exception.CreateChargeException;
+import uk.gov.pay.api.model.ChargeFromResponse;
+import uk.gov.pay.api.model.CreatePaymentRequest;
+import uk.gov.pay.api.model.links.PaymentWithAllLinks;
+import uk.gov.pay.api.utils.JsonStringBuilder;
+
+import javax.inject.Inject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.client.Entity.json;
+
+public class CreatePaymentService {
+    private final String baseUrl;
+    private final Client client;
+    private final PublicApiUriGenerator publicApiUriGenerator;
+    private final ConnectorUriGenerator connectorUriGenerator;
+
+    @Inject
+    public CreatePaymentService(Client client, PublicApiConfig configuration, PublicApiUriGenerator publicApiUriGenerator, ConnectorUriGenerator connectorUriGenerator) {
+        this.client = client;
+        this.baseUrl = configuration.getBaseUrl();
+        this.publicApiUriGenerator = publicApiUriGenerator;
+        this.connectorUriGenerator = connectorUriGenerator;
+    }
+
+    public PaymentWithAllLinks invoke(Account account, CreatePaymentRequest requestPayload) {
+        Response connectorResponse = createCharge(account, requestPayload);
+
+        if (!createdSuccessfully(connectorResponse)) {
+            throw new CreateChargeException(connectorResponse);
+        }
+
+        ChargeFromResponse chargeFromResponse = connectorResponse.readEntity(ChargeFromResponse.class);
+        return buildResponseModel(account, chargeFromResponse);
+    }
+
+    private PaymentWithAllLinks buildResponseModel(Account account, ChargeFromResponse chargeFromResponse) {
+        return PaymentWithAllLinks.getPaymentWithLinks(
+                    account.getPaymentType(),
+                    chargeFromResponse,
+                    publicApiUriGenerator.getPaymentURI(baseUrl, chargeFromResponse.getChargeId()),
+                    publicApiUriGenerator.getPaymentEventsURI(baseUrl, chargeFromResponse.getChargeId()),
+                    publicApiUriGenerator.getPaymentCancelURI(baseUrl, chargeFromResponse.getChargeId()),
+                    publicApiUriGenerator.getPaymentRefundsURI(baseUrl, chargeFromResponse.getChargeId()));
+    }
+
+    private boolean createdSuccessfully(Response connectorResponse) {
+        return connectorResponse.getStatus() == HttpStatus.SC_CREATED;
+    }
+
+    private Response createCharge(Account account, CreatePaymentRequest requestPayload) {
+        return client
+                .target(connectorUriGenerator.chargesURI(account))
+                .request()
+                .accept(MediaType.APPLICATION_JSON)
+                .post(buildChargeRequestPayload(requestPayload));
+    }
+
+    private Entity buildChargeRequestPayload(CreatePaymentRequest requestPayload) {
+        int amount = requestPayload.getAmount();
+        String reference = requestPayload.getReference();
+        String description = requestPayload.getDescription();
+        String returnUrl = requestPayload.getReturnUrl();
+        return json(new JsonStringBuilder()
+                .add("amount", amount)
+                .add("reference", reference)
+                .add("description", description)
+                .add("return_url", returnUrl)
+                .build());
+    }
+}

--- a/src/main/java/uk/gov/pay/api/service/PublicApiUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/PublicApiUriGenerator.java
@@ -1,28 +1,39 @@
 package uk.gov.pay.api.service;
 
+import uk.gov.pay.api.app.config.PublicApiConfig;
+
+import javax.inject.Inject;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 
 public class PublicApiUriGenerator {
-    public URI getPaymentURI(String baseUrl, String chargeId) {
+
+    private final String baseUrl;
+
+    @Inject
+    public PublicApiUriGenerator(PublicApiConfig configuration) {
+        this.baseUrl = configuration.getBaseUrl();
+    }
+    
+    public URI getPaymentURI(String chargeId) {
         return UriBuilder.fromUri(baseUrl)
                 .path("/v1/payments/{paymentId}")
                 .build(chargeId);
     }
 
-    public URI getPaymentEventsURI(String baseUrl, String chargeId) {
+    public URI getPaymentEventsURI(String chargeId) {
         return UriBuilder.fromUri(baseUrl)
                 .path("/v1/payments/{paymentId}/events")
                 .build(chargeId);
     }
 
-    public URI getPaymentCancelURI(String baseUrl, String chargeId) {
+    public URI getPaymentCancelURI(String chargeId) {
         return UriBuilder.fromUri(baseUrl)
                 .path("/v1/payments/{paymentId}/cancel")
                 .build(chargeId);
     }
 
-    public URI getPaymentRefundsURI(String baseUrl, String chargeId) {
+    public URI getPaymentRefundsURI(String chargeId) {
         return UriBuilder.fromUri(baseUrl)
                 .path("/v1/payments/{paymentId}/refunds")
                 .build(chargeId);

--- a/src/main/java/uk/gov/pay/api/service/PublicApiUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/PublicApiUriGenerator.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.api.service;
+
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+
+public class PublicApiUriGenerator {
+    public URI getPaymentURI(String baseUrl, String chargeId) {
+        return UriBuilder.fromUri(baseUrl)
+                .path("/v1/payments/{paymentId}")
+                .build(chargeId);
+    }
+
+    public URI getPaymentEventsURI(String baseUrl, String chargeId) {
+        return UriBuilder.fromUri(baseUrl)
+                .path("/v1/payments/{paymentId}/events")
+                .build(chargeId);
+    }
+
+    public URI getPaymentCancelURI(String baseUrl, String chargeId) {
+        return UriBuilder.fromUri(baseUrl)
+                .path("/v1/payments/{paymentId}/cancel")
+                .build(chargeId);
+    }
+
+    public URI getPaymentRefundsURI(String baseUrl, String chargeId) {
+        return UriBuilder.fromUri(baseUrl)
+                .path("/v1/payments/{paymentId}/refunds")
+                .build(chargeId);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
@@ -11,7 +11,6 @@ import static org.eclipse.jetty.util.StringUtil.isBlank;
 import static org.eclipse.jetty.util.StringUtil.isNotBlank;
 import static uk.gov.pay.api.model.PaymentError.Code.SEARCH_PAYMENTS_VALIDATION_ERROR;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
-import static uk.gov.pay.api.resources.PaymentsResource.*;
 import static uk.gov.pay.api.validation.MaxLengthValidator.isValid;
 import static uk.gov.pay.api.validation.PaymentRequestValidator.CARD_BRAND_MAX_LENGTH;
 import static uk.gov.pay.api.validation.PaymentRequestValidator.EMAIL_MAX_LENGTH;
@@ -44,49 +43,49 @@ public class PaymentSearchValidator {
 
     private static void validatePageIfNotNull(String pageNumber, List<String> validationErrors) {
         if (isNotBlank(pageNumber) && (!StringUtils.isNumeric(pageNumber) || Integer.valueOf(pageNumber) < 1)) {
-            validationErrors.add(PAGE);
+            validationErrors.add("page");
         }
     }
 
     private static void validateDisplaySizeIfNotNull(String displaySize, List<String> validationErrors) {
         if (isNotBlank(displaySize) && (!StringUtils.isNumeric(displaySize) || Integer.valueOf(displaySize) < 1 || Integer.valueOf(displaySize) > 500)) {
-            validationErrors.add(DISPLAY_SIZE);
+            validationErrors.add("display_size");
         }
     }
 
     private static void validateToDate(String toDate, List<String> validationErrors) {
         if (!validateDate(toDate)) {
-            validationErrors.add(TO_DATE_KEY);
+            validationErrors.add("to_date");
         }
     }
 
     private static void validateFromDate(String fromDate, List<String> validationErrors) {
         if (!validateDate(fromDate)) {
-            validationErrors.add(FROM_DATE_KEY);
+            validationErrors.add("from_date");
         }
     }
 
     private static void validateReference(String reference, List<String> validationErrors) {
         if (!isValid(reference, REFERENCE_MAX_LENGTH)) {
-            validationErrors.add(REFERENCE_KEY);
+            validationErrors.add("reference");
         }
     }
 
     private static void validateEmail(String email, List<String> validationErrors) {
         if (!isValid(email, EMAIL_MAX_LENGTH)) {
-            validationErrors.add(EMAIL_KEY);
+            validationErrors.add("email");
         }
     }
 
     private static void validateCardBrand(String cardBrand, List<String> validationErrors) {
         if (!isValid(cardBrand, CARD_BRAND_MAX_LENGTH)) {
-            validationErrors.add(CARD_BRAND_KEY);
+            validationErrors.add("card_brand");
         }
     }
 
     private static void validateState(String state, List<String> validationErrors) {
         if (!validateState(state)) {
-            validationErrors.add(STATE_KEY);
+            validationErrors.add("state");
         }
     }
 

--- a/src/test/java/uk/gov/pay/api/auth/AccountAuthenticatorTest.java
+++ b/src/test/java/uk/gov/pay/api/auth/AccountAuthenticatorTest.java
@@ -34,7 +34,7 @@ public class AccountAuthenticatorTest {
     private Response mockResponse;
 
     private final String bearerToken = "aaa";
-    private final String accountName = "accountName";
+    private final String accountId = "accountId";
 
     @Before
     public void setup() {
@@ -55,27 +55,28 @@ public class AccountAuthenticatorTest {
     @Test
     public void shouldReturnValidAccount() {
         Map<String, String> responseEntity = ImmutableMap.of(
-                "account_id", accountName,
+                "account_id", accountId,
                 "token_type", "DIRECT_DEBIT"
         );
         JsonNode response = objectMapper.valueToTree(responseEntity);
         when(mockResponse.getStatus()).thenReturn(OK.getStatusCode());
         when(mockResponse.readEntity(JsonNode.class)).thenReturn(response);
         Optional<Account> maybeAccount = accountAuthenticator.authenticate(bearerToken);
-        Assert.assertThat(maybeAccount.get().getName(), is(accountName));
+        Assert.assertThat(maybeAccount.get().getName(), is(accountId));
+        Assert.assertThat(maybeAccount.get().getAccountId(), is(accountId));
         Assert.assertThat(maybeAccount.get().getPaymentType(), is(DIRECT_DEBIT));
     }
 
     @Test
     public void shouldReturnCCAccount_ifTokenTypeIsMissing() {
         Map<String, String> responseEntity = ImmutableMap.of(
-                "account_id", accountName
+                "account_id", accountId
         );
         JsonNode response = objectMapper.valueToTree(responseEntity);
         when(mockResponse.getStatus()).thenReturn(OK.getStatusCode());
         when(mockResponse.readEntity(JsonNode.class)).thenReturn(response);
         Optional<Account> maybeAccount = accountAuthenticator.authenticate(bearerToken);
-        Assert.assertThat(maybeAccount.get().getName(), is(accountName));
+        Assert.assertThat(maybeAccount.get().getName(), is(accountId));
         Assert.assertThat(maybeAccount.get().getPaymentType(), is(CARD));
     }
 

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -12,12 +12,20 @@ import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.CreatePaymentRequest;
+import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.api.model.links.Link;
+import uk.gov.pay.api.model.links.PaymentWithAllLinks;
+import uk.gov.pay.api.model.links.PostLink;
 import uk.gov.pay.api.pact.PactProviderRule;
 import uk.gov.pay.api.pact.Pacts;
 
 import javax.ws.rs.client.Client;
+import java.util.Collections;
 
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -38,7 +46,7 @@ public class CreatePaymentServiceTest {
     public void setup() {
         when(configuration.getConnectorUrl()).thenReturn(connectorRule.getUrl()); // We will actually send real requests here, which will be intercepted by pact
 
-        when(configuration.getBaseUrl()).thenReturn("http://localhost/"); // Has to match what is in the Pact
+        when(configuration.getBaseUrl()).thenReturn("http://publicapi.test.localhost/"); // Has to match what is in the Pact
 
         // These can be concrete implementations, because they're simple
         publicApiUriGenerator = new PublicApiUriGenerator();
@@ -54,7 +62,21 @@ public class CreatePaymentServiceTest {
     public void testCreatePayment() {
         Account account = new Account("GATEWAY_ACCOUNT_ID", TokenPaymentType.CARD);
         CreatePaymentRequest requestPayload = new CreatePaymentRequest(100, "https://somewhere.gov.uk/rainbow/1", "a reference", "a description");
-        createPaymentService.invoke(account, requestPayload);
+        PaymentWithAllLinks paymentResponse = createPaymentService.invoke(account, requestPayload);
+
+        assertThat(paymentResponse.getPaymentId(), is("ch_ab2341da231434l"));
+        assertThat(paymentResponse.getPayment().getAmount(), is(100L));
+        assertThat(paymentResponse.getPayment().getReference(), is("a reference"));
+        assertThat(paymentResponse.getPayment().getDescription(), is("a description"));
+        assertThat(paymentResponse.getPayment().getEmail(), is(nullValue()));
+        assertThat(paymentResponse.getPayment().getState(), is(new PaymentState("created", false)));
+        assertThat(paymentResponse.getPayment().getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
+        assertThat(paymentResponse.getPayment().getPaymentProvider(), is("Sandbox"));
+        assertThat(paymentResponse.getPayment().getCreatedDate(), is("2016-01-01T12:00:00Z"));
+        assertThat(paymentResponse.getLinks().getSelf(), is(new Link("http://publicapi.test.localhost/v1/payments/ch_ab2341da231434l", "GET")));
+        assertThat(paymentResponse.getLinks().getNextUrl(), is(new Link("http://frontend_connector/charge/token_1234567asdf", "GET")));
+        PostLink expectedLink = new PostLink("http://frontend_connector/charge/", "POST", "application/x-www-form-urlencoded", Collections.singletonMap("chargeTokenId", "token_1234567asdf"));
+        assertThat(paymentResponse.getLinks().getNextUrlPost(), is(expectedLink));
     }
 
 }

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -1,0 +1,61 @@
+package uk.gov.pay.api.service;
+
+import au.com.dius.pact.consumer.PactVerification;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.api.app.RestClientFactory;
+import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.app.config.RestClientConfig;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.model.CreatePaymentRequest;
+import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.api.pact.PactProviderRule;
+import uk.gov.pay.api.pact.Pacts;
+
+import javax.ws.rs.client.Client;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CreatePaymentServiceTest {
+    private CreatePaymentService createPaymentService;
+
+    @Rule
+    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+
+    private Client client;
+
+    @Mock
+    private PublicApiConfig configuration;
+
+    private PublicApiUriGenerator publicApiUriGenerator;
+    private ConnectorUriGenerator connectorUriGenerator;
+    
+    @Before
+    public void setup() {
+        when(configuration.getConnectorUrl()).thenReturn(connectorRule.getUrl()); // We will actually send real requests here, which will be intercepted by pact
+
+        when(configuration.getBaseUrl()).thenReturn("http://localhost/"); // Has to match what is in the Pact
+
+        // These can be concrete implementations, because they're simple
+        publicApiUriGenerator = new PublicApiUriGenerator();
+        connectorUriGenerator = new ConnectorUriGenerator(configuration);
+        client = RestClientFactory.buildClient(new RestClientConfig(false));
+
+        createPaymentService = new CreatePaymentService(client, configuration, publicApiUriGenerator, connectorUriGenerator);
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector"})
+    public void testCreatePayment() {
+        Account account = new Account("GATEWAY_ACCOUNT_ID", TokenPaymentType.CARD);
+        CreatePaymentRequest requestPayload = new CreatePaymentRequest(100, "https://somewhere.gov.uk/rainbow/1", "a reference", "a description");
+        createPaymentService.invoke(account, requestPayload);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -62,7 +62,7 @@ public class CreatePaymentServiceTest {
     public void testCreatePayment() {
         Account account = new Account("GATEWAY_ACCOUNT_ID", TokenPaymentType.CARD);
         CreatePaymentRequest requestPayload = new CreatePaymentRequest(100, "https://somewhere.gov.uk/rainbow/1", "a reference", "a description");
-        PaymentWithAllLinks paymentResponse = createPaymentService.invoke(account, requestPayload);
+        PaymentWithAllLinks paymentResponse = createPaymentService.create(account, requestPayload);
 
         assertThat(paymentResponse.getPaymentId(), is("ch_ab2341da231434l"));
         assertThat(paymentResponse.getPayment().getAmount(), is(100L));

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CreatePaymentServiceTest {
+
     private CreatePaymentService createPaymentService;
 
     @Rule
@@ -46,9 +47,8 @@ public class CreatePaymentServiceTest {
     public void setup() {
         when(configuration.getConnectorUrl()).thenReturn(connectorRule.getUrl()); // We will actually send real requests here, which will be intercepted by pact
 
-        when(configuration.getBaseUrl()).thenReturn("http://publicapi.test.localhost/"); // Has to match what is in the Pact
+        when(configuration.getBaseUrl()).thenReturn("http://publicapi.test.localhost/");
 
-        // These can be concrete implementations, because they're simple
         publicApiUriGenerator = new PublicApiUriGenerator(configuration);
         connectorUriGenerator = new ConnectorUriGenerator(configuration);
         client = RestClientFactory.buildClient(new RestClientConfig(false));

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -64,7 +64,7 @@ public class CreatePaymentServiceTest {
         CreatePaymentRequest requestPayload = new CreatePaymentRequest(100, "https://somewhere.gov.uk/rainbow/1", "a reference", "a description");
         PaymentWithAllLinks paymentResponse = createPaymentService.create(account, requestPayload);
 
-        assertThat(paymentResponse.getPaymentId(), is("ch_ab2341da231434l"));
+        assertThat(paymentResponse.getPayment().getPaymentId(), is("ch_ab2341da231434l"));
         assertThat(paymentResponse.getPayment().getAmount(), is(100L));
         assertThat(paymentResponse.getPayment().getReference(), is("a reference"));
         assertThat(paymentResponse.getPayment().getDescription(), is("a description"));

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -49,7 +49,7 @@ public class CreatePaymentServiceTest {
         when(configuration.getBaseUrl()).thenReturn("http://publicapi.test.localhost/"); // Has to match what is in the Pact
 
         // These can be concrete implementations, because they're simple
-        publicApiUriGenerator = new PublicApiUriGenerator();
+        publicApiUriGenerator = new PublicApiUriGenerator(configuration);
         connectorUriGenerator = new ConnectorUriGenerator(configuration);
         client = RestClientFactory.buildClient(new RestClientConfig(false));
 

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -31,7 +31,6 @@ public class CreatePaymentServiceTest {
 
     @Mock
     private PublicApiConfig configuration;
-
     private PublicApiUriGenerator publicApiUriGenerator;
     private ConnectorUriGenerator connectorUriGenerator;
     

--- a/src/test/resources/pacts/publicapi-connector.json
+++ b/src/test/resources/pacts/publicapi-connector.json
@@ -28,7 +28,7 @@
           "charge_id": "ch_ab2341da231434l",
           "amount": "100",
           "reference": "a reference",
-          "email": "alice.111@mail.fake",
+          "email": null,
           "description": "a description",
           "state": {
             "status": "created",
@@ -39,7 +39,7 @@
           "created_date": "2016-01-01T12:00:00Z",
           "links": [
             {
-              "href": "http://localhost/v1/api/accounts/GATEWAY_ACCOUNT_ID/charges/ch_ab2341da231434l",
+              "href": "http://connector.service.backend/v1/api/accounts/GATEWAY_ACCOUNT_ID/charges/ch_ab2341da231434l",
               "rel": "self",
               "method": "GET"
             },

--- a/src/test/resources/pacts/publicapi-connector.json
+++ b/src/test/resources/pacts/publicapi-connector.json
@@ -1,0 +1,104 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "a create charge request",
+      "request": {
+        "method": "POST",
+        "path": "/v1/api/accounts/GATEWAY_ACCOUNT_ID/charges",
+        "body": {
+          "amount": 100,
+          "reference": "a reference",
+          "description": "a description",
+          "return_url": "https://somewhere.gov.uk/rainbow/1"
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/json",
+          "Location": "/v1/api/accounts/GATEWAY_ACCOUNT_ID/charges/ch_ab2341da231434l"
+        },
+        "body": {
+          "charge_id": "ch_ab2341da231434l",
+          "amount": "100",
+          "reference": "a reference",
+          "email": "alice.111@mail.fake",
+          "description": "a description",
+          "state": {
+            "status": "created",
+            "finished": "false"
+          },
+          "return_url": "https://somewhere.gov.uk/rainbow/1",
+          "payment_provider": "Sandbox",
+          "created_date": "2016-01-01T12:00:00Z",
+          "links": [
+            {
+              "href": "http://localhost/v1/api/accounts/GATEWAY_ACCOUNT_ID/charges/ch_ab2341da231434l",
+              "rel": "self",
+              "method": "GET"
+            },
+            {
+              "href": "http://frontend_connector/charge/token_1234567asdf",
+              "rel": "next_url",
+              "method": "GET"
+            },
+            {
+              "href": "http://frontend_connector/charge/",
+              "rel": "next_url_post",
+              "type": "application/x-www-form-urlencoded",
+              "params": {
+                "chargeTokenId": "token_1234567asdf"
+              },
+              "method": "POST"
+            }
+          ]
+        },
+        "matchingRules": {
+          "body": {
+            "$.charge_id": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.amount": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.reference": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.email": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.description": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.state.status": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.return_url": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.payment_provider": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.created_date": {
+              "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ssZ" }]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
with @heathd 

Extract the body of the 'create payment' api call into a service object. We
followed these principles:

1. 'presentation' concerns such as serialisation of the response and generation
   of headers remain in the Resource
2. issuing the call to connector and parsing the response is done in the service object

We also extracted `PublicApiUriGenerator` and `ConnectorUriGenerator` which are
responsible for generating URIs relating to PublicApi and Connector
respectively. They get the dropwizard app configuration injected to their
constructors.

Finally we created a Pact contract test for the `CreatePaymentService`. Where
possible we've used real objects where they are simple value objects, rather
than using mocks.

## Inline all resource urls and field name constants 

The url paths are almost exclusively used only in one place, which is the
configuration of the resource endpoint. It's much clearer to have the string
literal visible on the resource annotation than to have it obscured by
constant.

We also inlined some constants which define the keys from request payloads.
These are also part of our external API, not likely to change and used only in
one or two places. Again, having a string literal makes the code easier to read
in these cases.

## rename Account.getName() to Account.getAccountId()

the field actually contains the account id, so it's confusing to call it name.

the `getName()` method is used when the Account object represents a principal in the authentication system, so add a `getName()` method which overrides that and delegates to `getAccountId()`.