### PR TITLE
Bau add pact testing

### DIFF
--- a/src/test/java/uk/gov/pay/api/it/pact/PaymentBaseTest.java
+++ b/src/test/java/uk/gov/pay/api/it/pact/PaymentBaseTest.java
@@ -1,19 +1,27 @@
 package uk.gov.pay.api.it.pact;
 
+import org.junit.Rule;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.api.pact.PactProviderRule;
 import uk.gov.pay.api.utils.DateTimeUtils;
 
 import java.time.ZonedDateTime;
 
 public abstract class PaymentBaseTest {
-    private static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
+    protected static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
     protected static final String PAYMENTS_PATH = "/v1/payments/";
     protected static final String RETURN_URL = "https://example.com/return";
     protected static final PaymentState CREATED = new PaymentState("created", false, null, null);
     protected static final String CREATED_DATE = DateTimeUtils.toUTCDateString(TIMESTAMP);
     protected static final String EMAIL = "pact-test@example.com";
-    protected static final String SANDBOX_PAYMENT_PROVIDER = "Sandbox";
+    protected static final String SANDBOX_PAYMENT_PROVIDER = "sandbox";
+    protected static final String REFERENCE = "a reference";
+    protected static final String DESCRIPTION = "a description";
+    protected static final int AMOUNT = 100;
+
+    @Rule
+    public PactProviderRule publicAuth = new PactProviderRule("publicauth", this);
 
     protected String paymentLocationFor(String chargeId) {
         return "http://publicapi.url" + PAYMENTS_PATH + chargeId;

--- a/src/test/java/uk/gov/pay/api/it/pact/PaymentBaseTest.java
+++ b/src/test/java/uk/gov/pay/api/it/pact/PaymentBaseTest.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.api.it.pact;
+
+import uk.gov.pay.api.model.PaymentState;
+import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.api.utils.DateTimeUtils;
+
+import java.time.ZonedDateTime;
+
+public abstract class PaymentBaseTest {
+    private static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
+    protected static final String PAYMENTS_PATH = "/v1/payments/";
+    protected static final String RETURN_URL = "https://example.com/return";
+    protected static final PaymentState CREATED = new PaymentState("created", false, null, null);
+    protected static final String CREATED_DATE = DateTimeUtils.toUTCDateString(TIMESTAMP);
+    protected static final String EMAIL = "pact-test@example.com";
+    protected static final String SANDBOX_PAYMENT_PROVIDER = "Sandbox";
+
+    protected String paymentLocationFor(String chargeId) {
+        return "http://publicapi.url" + PAYMENTS_PATH + chargeId;
+    }
+
+    protected String frontendUrlFor(TokenPaymentType paymentType) {
+        return "http://frontend_" + paymentType.toString().toLowerCase() + "/charge/";
+    }
+}

--- a/src/test/java/uk/gov/pay/api/it/pact/card/CardPaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/it/pact/card/CardPaymentTest.java
@@ -1,0 +1,99 @@
+package uk.gov.pay.api.it.pact.card;
+
+import au.com.dius.pact.consumer.PactVerification;
+import com.jayway.restassured.response.ValidatableResponse;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.apache.http.client.fluent.Executor;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.pay.api.app.PublicApi;
+import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.it.pact.PaymentBaseTest;
+import uk.gov.pay.api.pact.PactProviderRule;
+import uk.gov.pay.api.pact.Pacts;
+import uk.gov.pay.api.utils.ApiKeyGenerator;
+import uk.gov.pay.api.utils.DateTimeUtils;
+
+import static com.jayway.restassured.RestAssured.given;
+import static com.jayway.restassured.http.ContentType.JSON;
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.Is.is;
+
+public class CardPaymentTest extends PaymentBaseTest {
+    private static final String PAYMENT_ID = "some_test_id";
+    private static final String CAPTURE_SUBMIT_TIME = DateTimeUtils.toUTCDateString(TIMESTAMP.plusMinutes(1L));
+    private static final String CAPTURED_DATE = TIMESTAMP.plusMinutes(5L).toLocalDate().toString();
+
+    @Rule
+    public PactProviderRule connector = new PactProviderRule("connector", this);
+    
+    @Rule
+    public DropwizardAppRule<PublicApiConfig> app = new DropwizardAppRule<>(
+            PublicApi.class,
+            resourceFilePath("config/test-config.yaml"),
+            config("connectorUrl", "http://localhost:" + connector.getConfig().getPort()),
+            config("publicAuthUrl", "http://localhost:" + publicAuth.getConfig().getPort() + "/v1/auth"));
+
+    @Test
+    @PactVerification({"connector", "publicauth"})
+    @Pacts(pacts = {"publicapi-publicauth-card", "publicapi-connector"})
+    public void getPayment() {
+        String bearerToken = ApiKeyGenerator.apiKeyValueOf("TEST_BEARER_CARD", "qwer9yuhgf");
+
+        getPaymentResponse(bearerToken)
+                .statusCode(200)
+                .contentType(JSON)
+                .body("payment_id", is(PAYMENT_ID))
+                .body("amount", is(AMOUNT))
+                .body("reference", is(REFERENCE))
+                .body("gateway_transaction_id", is(nullValue()))
+                .body("description", is(DESCRIPTION))
+                .body("state.status", is("success"))
+                .body("state.finished", is(true))
+                .body("return_url", is(RETURN_URL))
+                .body("email", is(EMAIL))
+                .body("payment_provider", is(SANDBOX_PAYMENT_PROVIDER))
+                .body("created_date", is(CREATED_DATE))
+                .body("refund_summary.status", is("available"))
+                .body("refund_summary.amount_available", is(100))
+                .body("refund_summary.amount_submitted", is(0))
+                .body("settlement_summary.capture_submit_time", is(CAPTURE_SUBMIT_TIME))
+                .body("settlement_summary.captured_date", is(CAPTURED_DATE))
+                .body("card_details.last_digits_card_number", is("4242"))
+                .body("card_details.cardholder_name", is("Test"))
+                .body("card_details.expiry_date", is("01/21"))
+                .body("card_details.billing_address.line1", is("Test line 1"))
+                .body("card_details.billing_address.line2", is("Test line 2"))
+                .body("card_details.billing_address.postcode", is("EC11AA"))
+                .body("card_details.billing_address.city", is("London"))
+                .body("card_details.billing_address.county", is(nullValue()))
+                .body("card_details.billing_address.city", is("London"))
+                .body("card_details.billing_address.country", is("GB"))
+                .body("card_details.card_brand", is("Visa"))
+                .body("card_brand", is("Visa"))
+                .body("_links.self.method", is("GET"))
+                .body("_links.self.href", is(paymentLocationFor(PAYMENT_ID)))
+                .body("_links.refunds.method", is("GET"))
+                .body("_links.refunds.href", is(paymentLocationFor(PAYMENT_ID) + "/refunds"))
+                .extract().body();
+    }
+
+    private ValidatableResponse getPaymentResponse(String bearerToken) {
+        return given().port(app.getLocalPort())
+                .accept(JSON)
+                .contentType(JSON)
+                .header(AUTHORIZATION, "Bearer " + bearerToken)
+                .get("/v1/payments/" + PAYMENT_ID)
+                .then();
+    }
+
+    // Close idle connections - see https://github.com/DiUS/pact-jvm/issues/342
+    @After
+    public void teardown() {
+        Executor.closeIdleConnections();
+    }
+}

--- a/src/test/java/uk/gov/pay/api/it/pact/directdebit/DirectDebitPaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/it/pact/directdebit/DirectDebitPaymentTest.java
@@ -29,11 +29,8 @@ import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
 
 public class DirectDebitPaymentTest extends PaymentBaseTest {
 
-    private static final int AMOUNT = 100;
     private static final String CHARGE_ID = "ch_ab2341da231434l";
     private static final String CHARGE_TOKEN_ID = "token_1234567asdf";
-    private static final String REFERENCE = "a reference";
-    private static final String DESCRIPTION = "a description";
     private static final String SUCCESS_PAYLOAD = paymentPayload(AMOUNT, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL);
 
     //Must use same secret set int configured test-config.xml
@@ -43,9 +40,6 @@ public class DirectDebitPaymentTest extends PaymentBaseTest {
     
     @Rule
     public PactProviderRule directDebitConnector = new PactProviderRule("direct-debit-connector", this);
-    
-    @Rule
-    public PactProviderRule publicAuth = new PactProviderRule("publicauth", this);
     
     @Rule 
     public DropwizardAppRule<PublicApiConfig> app = new DropwizardAppRule<>(

--- a/src/test/java/uk/gov/pay/api/it/pact/directdebit/DirectDebitPaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/it/pact/directdebit/DirectDebitPaymentTest.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.api.it;
+package uk.gov.pay.api.it.pact.directdebit;
 
 import au.com.dius.pact.consumer.PactVerification;
 import com.jayway.jsonassert.JsonAssert;
@@ -10,16 +10,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.api.app.PublicApi;
 import uk.gov.pay.api.app.config.PublicApiConfig;
-import uk.gov.pay.api.model.PaymentState;
-import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.api.it.pact.PaymentBaseTest;
 import uk.gov.pay.api.pact.PactProviderRule;
 import uk.gov.pay.api.pact.Pacts;
 import uk.gov.pay.api.utils.ApiKeyGenerator;
-import uk.gov.pay.api.utils.DateTimeUtils;
 import uk.gov.pay.api.utils.JsonStringBuilder;
 
 import javax.ws.rs.core.HttpHeaders;
-import java.time.ZonedDateTime;
 
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.http.ContentType.JSON;
@@ -30,19 +27,13 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
 
-public class DirectDebitPaymentTest {
+public class DirectDebitPaymentTest extends PaymentBaseTest {
 
-    private static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
     private static final int AMOUNT = 100;
     private static final String CHARGE_ID = "ch_ab2341da231434l";
     private static final String CHARGE_TOKEN_ID = "token_1234567asdf";
-    private static final PaymentState CREATED = new PaymentState("created", false, null, null);
-    private static final String PAYMENT_PROVIDER = "Sandbox";
-    private static final String RETURN_URL = "https://somewhere.gov.uk/rainbow/1";
     private static final String REFERENCE = "a reference";
-    private static final String EMAIL = "alice.111@mail.fake";
     private static final String DESCRIPTION = "a description";
-    private static final String CREATED_DATE = DateTimeUtils.toUTCDateString(TIMESTAMP);
     private static final String SUCCESS_PAYLOAD = paymentPayload(AMOUNT, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL);
 
     //Must use same secret set int configured test-config.xml
@@ -66,7 +57,7 @@ public class DirectDebitPaymentTest {
     
     @Test
     @PactVerification({"direct-debit-connector", "publicauth"})
-    @Pacts(pacts = {"publicapi-publicauth", "publicapi-direct-debit-connector"})
+    @Pacts(pacts = {"publicapi-publicauth-direct-debit", "publicapi-direct-debit-connector"})
     public void createPayment() {
         String responseBody = postPaymentResponse(API_KEY, SUCCESS_PAYLOAD)
                 .statusCode(201)
@@ -79,7 +70,7 @@ public class DirectDebitPaymentTest {
                 .body("state.status", is(CREATED.getStatus()))
                 .body("return_url", is(RETURN_URL))
                 .body("email", is(EMAIL))
-                .body("payment_provider", is(PAYMENT_PROVIDER))
+                .body("payment_provider", is(SANDBOX_PAYMENT_PROVIDER))
                 .body("created_date", is(CREATED_DATE))
                 .body("_links.self.href", is(paymentLocationFor(CHARGE_ID)))
                 .body("_links.self.method", is("GET"))
@@ -121,14 +112,6 @@ public class DirectDebitPaymentTest {
                 .add("description", description)
                 .add("return_url", returnUrl)
                 .build();
-    }
-
-    String paymentLocationFor(String chargeId) {
-        return "http://publicapi.url" + PAYMENTS_PATH + chargeId;
-    }
-
-    String frontendUrlFor(TokenPaymentType paymentType) {
-        return "http://frontend_"+paymentType.toString().toLowerCase()+"/charge/";
     }
 
     // Close idle connections - see https://github.com/DiUS/pact-jvm/issues/342

--- a/src/test/resources/pacts/publicapi-connector.json
+++ b/src/test/resources/pacts/publicapi-connector.json
@@ -1,0 +1,115 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "get a charge",
+      "request": {
+        "method": "GET",
+        "path": "/v1/api/accounts/GATEWAY_ACCOUNT_ID/charges/some_test_id"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "amount": "100",
+          "state": {
+            "finished": "true",
+            "status": "success"
+          },
+          "description": "a description",
+          "reference": "a reference",
+          "charge_id": "some_test_id",
+          "email": "pact-test@example.com",
+          "gateway_transaction_id": "",
+          "return_url": "https://example.com/return",
+          "payment_provider": "sandbox",
+          "created_date": "2016-01-01T12:00:00Z",
+          "refund_summary": {
+            "status": "available",
+            "amount_available": 100,
+            "amount_submitted": 0
+          },
+          "settlement_summary": {
+            "capture_submit_time": "2016-01-01T12:01:00Z",
+            "captured_date": "2016-01-01"
+          },
+          "card_details": {
+            "last_digits_card_number": "4242",
+            "cardholder_name": "Test",
+            "expiry_date": "01/21",
+            "billing_address": {
+              "line1": "Test line 1",
+              "line2": "Test line 2",
+              "postcode": "EC11AA",
+              "city": "London",
+              "county": null,
+              "country": "GB"
+            },
+            "card_brand": "Visa"
+          },
+          "links": [
+            {
+              "rel": "self",
+              "method": "GET",
+              "href": "https://localhost/v1/api/accounts/GATEWAY_ACCOUNT_ID/charges/some_test_id"
+            },
+            {
+              "rel": "refunds",
+              "method": "GET",
+              "href": "https://localhost/v1/api/accounts/GATEWAY_ACCOUNT_ID/charges/some_test_id/refunds"
+            }
+          ]
+        },
+        "matchingRules": {
+          "body": {
+            "$.charge_id": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.amount": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.reference": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.email": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.description": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.state.status": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.return_url": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.payment_provider": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.created_date": {
+              "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ssZ" }]
+            },
+            "$.card_details.card_brand": {
+              "matchers": [{ "match": "type" }]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}

--- a/src/test/resources/pacts/publicapi-direct-debit-connector.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector.json
@@ -35,7 +35,7 @@
             "finished": "false"
           },
           "return_url": "https://example.com/return",
-          "payment_provider": "Sandbox",
+          "payment_provider": "sandbox",
           "created_date": "2016-01-01T12:00:00Z",
           "links": [
             {

--- a/src/test/resources/pacts/publicapi-direct-debit-connector.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector.json
@@ -15,7 +15,7 @@
           "amount": 100,
           "reference": "a reference",
           "description": "a description",
-          "return_url": "https://somewhere.gov.uk/rainbow/1"
+          "return_url": "https://example.com/return"
         }
       },
       "response": {
@@ -28,13 +28,13 @@
           "charge_id": "ch_ab2341da231434l",
           "amount": "100",
           "reference": "a reference",
-          "email": "alice.111@mail.fake",
+          "email": "pact-test@example.com",
           "description": "a description",
           "state": {
             "status": "created",
             "finished": "false"
           },
-          "return_url": "https://somewhere.gov.uk/rainbow/1",
+          "return_url": "https://example.com/return",
           "payment_provider": "Sandbox",
           "created_date": "2016-01-01T12:00:00Z",
           "links": [

--- a/src/test/resources/pacts/publicapi-publicauth-card.json
+++ b/src/test/resources/pacts/publicapi-publicauth-card.json
@@ -1,0 +1,55 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "publicauth"
+  },
+  "interactions": [
+    {
+      "description": "a CARD gateway authorization request",
+      "providerStates": [
+        {
+          "name": "A bearer token exists",
+          "params": {
+            "type": "CARD",
+            "id": "37n0t6hm9s33nokqat7s7i46rsgtucnv"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/auth",
+        "headers": {
+          "Authorization": "Bearer TEST_BEARER_CARD37n0t6hm9s33nokqat7s7i46rsgtucnv"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "account_id": "GATEWAY_ACCOUNT_ID",
+          "token_type": "CARD"
+        },
+        "matchingRules": {
+          "$.body.account_id": {
+            "match": "type"
+          },
+          "$.body.token_type": {
+            "match": "type"
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}

--- a/src/test/resources/pacts/publicapi-publicauth-direct-debit.json
+++ b/src/test/resources/pacts/publicapi-publicauth-direct-debit.json
@@ -8,6 +8,15 @@
   "interactions": [
     {
       "description": "an authorization request",
+      "providerStates": [
+        {
+          "name": "A bearer token exists",
+          "params": {
+            "type": "DIRECT_DEBIT",
+            "id": "p837h5j7oje0huchp4ocibv1qq534lmn"
+          }
+        }
+      ],
       "request": {
         "method": "GET",
         "path": "/v1/auth",


### PR DESCRIPTION
## WHAT
Added Pac test for `getPayment` for cards

## HOW 
* Added separate json files for CARD and DIRECT_DEBIT tokens as Pact gets confused is using the
same path for different interactions. Next step is to set the state in Povider in order to merge these
two files
* Added `publicapi-connector` json file for getting a charge from connector
* Extracted common field into a base class, so it can be reused
* Added directories for each payment type, for easier navigation around


