### PR TITLE
PP-3679 Add DD search by agreement to PaymentResource

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/IPaymentSearchPagination.java
+++ b/src/main/java/uk/gov/pay/api/model/IPaymentSearchPagination.java
@@ -1,0 +1,10 @@
+package uk.gov.pay.api.model;
+
+import uk.gov.pay.api.model.links.PaymentSearchNavigationLinks;
+
+public interface IPaymentSearchPagination {
+    int getCount();
+    int getTotal();
+    int getPage();
+    PaymentSearchNavigationLinks getLinks();
+}

--- a/src/main/java/uk/gov/pay/api/model/directdebit/DDPaymentState.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/DDPaymentState.java
@@ -1,0 +1,68 @@
+package uk.gov.pay.api.model.directdebit;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Objects;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@ApiModel(value="DDPaymentState", description = "A structure representing the current state of the direct debit transaction in its lifecycle.")
+public class DDPaymentState {
+    @JsonProperty("status")
+    private String status;
+
+    @JsonProperty("finished")
+    private boolean finished;
+
+    public static DDPaymentState createPaymentState(JsonNode node) {
+        return new DDPaymentState(
+            node.get("status").asText(),
+            node.get("finished").asBoolean()
+        );
+    }
+
+    public DDPaymentState() {
+    }
+    
+    public DDPaymentState(String status, boolean finished) {
+        this.status = status;
+        this.finished = finished;
+    }
+
+    @ApiModelProperty(value = "Current progress of the payment in its lifecycle", required=true, example = "created")
+    public String getStatus() {
+        return status;
+    }
+
+    @ApiModelProperty(value = "Whether the payment has finished", required = true)
+    public boolean isFinished() {
+        return finished;
+    }
+    
+    @Override
+    public String toString() {
+        return "PaymentState{" +
+                "status='" + status + '\'' +
+                ", finished='" + finished + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DDPaymentState that = (DDPaymentState) o;
+        return finished == that.finished &&
+                Objects.equals(status, that.status);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(status, finished);
+    }
+}

--- a/src/main/java/uk/gov/pay/api/model/directdebit/search/DDSearchResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/search/DDSearchResponse.java
@@ -1,28 +1,29 @@
-package uk.gov.pay.api.model;
+package uk.gov.pay.api.model.directdebit.search;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.api.model.IPaymentSearchPagination;
 import uk.gov.pay.api.model.links.PaymentSearchNavigationLinks;
 
 import java.util.List;
 
-public class PaymentSearchResponse implements IPaymentSearchPagination {
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DDSearchResponse implements IPaymentSearchPagination {
 
     @JsonProperty("total")
     private int total;
-
     @JsonProperty("count")
     private int count;
-
     @JsonProperty("page")
     private int page;
-
     @JsonProperty("results")
-    private List<ChargeFromResponse> payments;
-
+    private List<DDTransactionFromResponse> payments;
     @JsonProperty("_links")
     private PaymentSearchNavigationLinks links = new PaymentSearchNavigationLinks();
-
-    public List<ChargeFromResponse> getPayments() {
+    
+    public List<DDTransactionFromResponse> getPayments() {
         return payments;
     }
     @Override

--- a/src/main/java/uk/gov/pay/api/model/directdebit/search/DDTransactionForSearch.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/search/DDTransactionForSearch.java
@@ -1,0 +1,74 @@
+package uk.gov.pay.api.model.directdebit.search;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.api.model.directdebit.DDPaymentState;
+import uk.gov.pay.api.model.directdebit.search.links.DDTransactionLinksForSearch;
+
+import java.net.URI;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DDTransactionForSearch {
+
+    private Long amount;
+    @JsonProperty("transaction_id")
+    private String transactionId;
+    private DDPaymentState state;
+    private String description;
+    private String reference;
+    private final String email;
+    private final String name;
+    @JsonProperty(value = "created_date")
+    private String createdDate;
+    @JsonProperty("links")
+    private DDTransactionLinksForSearch links = new DDTransactionLinksForSearch();
+    
+    
+    
+    private DDTransactionForSearch(Long amount, String transactionId, DDPaymentState state, String description, 
+                                   String reference, String email, String name, String createdDate, URI selfLink) {
+        this.amount = amount;
+        this.transactionId = transactionId;
+        this.state = state;
+        this.description = description;
+        this.reference = reference;
+        this.createdDate = createdDate;
+        this.email = email;
+        this.name = name;
+        links.addSelf(selfLink.toString());
+    }
+
+    public Long getAmount() { return amount; }
+
+    public String getTransactionId() { return transactionId; }
+
+    public DDPaymentState getState() { return state; }
+
+    public String getDescription() { return description; }
+
+    public String getReference() { return reference; }
+
+    public String getEmail() { return email; }
+
+    public String getName() { return name; }
+
+    public String getCreatedDate() { return createdDate; }
+
+    public DDTransactionLinksForSearch getLinks() { return links; }
+    
+    public static DDTransactionForSearch valueOf(DDTransactionFromResponse forSearch, URI selfLink) {
+        return new DDTransactionForSearch(
+                forSearch.getAmount(),
+                forSearch.getTransactionId(),
+                forSearch.getState(),
+                forSearch.getDescription(),
+                forSearch.getReference(),
+                forSearch.getEmail(),
+                forSearch.getName(),
+                forSearch.getCreatedDate(),
+                selfLink
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/api/model/directdebit/search/DDTransactionFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/search/DDTransactionFromResponse.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.api.model.directdebit.search;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.api.model.PaymentConnectorResponseLink;
+import uk.gov.pay.api.model.directdebit.DDPaymentState;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DDTransactionFromResponse {
+    private Long amount;
+    @JsonProperty("transaction_id")
+    private String transactionId;
+    private DDPaymentState state;
+    private String description;
+    private String reference;
+    private String email;
+    private String name;
+    @JsonProperty(value = "created_date")
+    private String createdDate;
+    @JsonProperty("_links")
+    private List<PaymentConnectorResponseLink> links = new ArrayList<>();
+
+    public Long getAmount() { return amount; }
+
+    public String getTransactionId() { return transactionId; }
+
+    public DDPaymentState getState() { return state; }
+
+    public String getDescription() { return description; }
+
+    public String getReference() { return reference; }
+
+    public String getEmail() { return email; }
+
+    public String getName() { return name; }
+
+    public String getCreatedDate() { return createdDate; }
+
+    public List<PaymentConnectorResponseLink> getLinks() { return links; }
+}

--- a/src/main/java/uk/gov/pay/api/model/directdebit/search/links/DDTransactionLinksForSearch.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/search/links/DDTransactionLinksForSearch.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.api.model.directdebit.search.links;
+
+import uk.gov.pay.api.model.links.Link;
+
+import static javax.ws.rs.HttpMethod.GET;
+
+public class DDTransactionLinksForSearch {
+    private Link self;
+
+    public void addSelf(String href) { this.self = new Link(href, GET); }
+
+    public Link getSelf() { return self; }
+}

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -199,21 +199,11 @@ public class PaymentsResource {
                                    @Context UriInfo uriInfo) {
 
         logger.info("Payments search request - [ {} ]",
-                format("reference:%s, email: %s, status: %s, card_brand %s, fromDate: %s, toDate: %s, page: %s, display_size: %s",
-                        reference, email, state, cardBrand, fromDate, toDate, pageNumber, displaySize));
+                format("reference:%s, email: %s, status: %s, card_brand %s, fromDate: %s, toDate: %s, page: %s, display_size: %s, agreement: %s",
+                        reference, email, state, cardBrand, fromDate, toDate, pageNumber, displaySize, agreement));
         
-        HalRepresentation halRepresentation = paymentSearchService
-                .doSearch(account, 
-                        reference, 
-                        email,
-                        state,
-                        cardBrand,
-                        fromDate,
-                        toDate,
-                        pageNumber,
-                        displaySize,
-                        agreement);
-        return Response.ok(halRepresentation.toString()).build();
+        return  paymentSearchService.doSearch(account, reference, email, state, cardBrand, 
+                fromDate, toDate, pageNumber, displaySize, agreement);
     }
     
     @POST

--- a/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
@@ -37,6 +37,11 @@ public class ConnectorUriGenerator {
         String path = String.format("/v1/api/accounts/%s/charges/%s/events", account.getAccountId(), paymentId);
         return buildConnectorUri(account, path);
     }
+    
+    public String directDebitTransactionsURI(Account account, List<Pair<String, String>> queryParams) {
+        String path = String.format("/v1/api/accounts/%s/transactions/view", account.getAccountId());
+        return buildConnectorUri(account, path, queryParams);
+    }
 
     private String buildConnectorUri(Account account, String path) {
         return buildConnectorUri(account, path, Collections.emptyList());

--- a/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
@@ -4,7 +4,11 @@ import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.api.exception.ValidationException;
 import uk.gov.pay.api.utils.DateTimeUtils;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 
 import static org.apache.commons.lang3.StringUtils.join;
 import static org.eclipse.jetty.util.StringUtil.isBlank;
@@ -12,6 +16,7 @@ import static org.eclipse.jetty.util.StringUtil.isNotBlank;
 import static uk.gov.pay.api.model.PaymentError.Code.SEARCH_PAYMENTS_VALIDATION_ERROR;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 import static uk.gov.pay.api.validation.MaxLengthValidator.isValid;
+import static uk.gov.pay.api.validation.PaymentRequestValidator.AGREEMENT_ID_MAX_LENGTH;
 import static uk.gov.pay.api.validation.PaymentRequestValidator.CARD_BRAND_MAX_LENGTH;
 import static uk.gov.pay.api.validation.PaymentRequestValidator.EMAIL_MAX_LENGTH;
 import static uk.gov.pay.api.validation.PaymentRequestValidator.REFERENCE_MAX_LENGTH;
@@ -22,7 +27,9 @@ public class PaymentSearchValidator {
     public static final Set<String> VALID_STATES =
             new HashSet<>(Arrays.asList("created", "started", "submitted", "success", "failed", "cancelled", "error"));
 
-    public static void validateSearchParameters(String state, String reference, String email, String cardBrand, String fromDate, String toDate, String pageNumber, String displaySize) {
+    public static void validateSearchParameters(String state, String reference, String email, String cardBrand, 
+                                                String fromDate, String toDate, String pageNumber, 
+                                                String displaySize, String agreement) {
         List<String> validationErrors = new LinkedList<>();
         try {
             validateState(state, validationErrors);
@@ -33,11 +40,18 @@ public class PaymentSearchValidator {
             validateToDate(toDate, validationErrors);
             validatePageIfNotNull(pageNumber, validationErrors);
             validateDisplaySizeIfNotNull(displaySize, validationErrors);
+            validateAgreement(agreement, validationErrors);
         } catch (Exception e) {
             throw new ValidationException(aPaymentError(SEARCH_PAYMENTS_VALIDATION_ERROR, join(validationErrors, ", "), e.getMessage()));
         }
         if (!validationErrors.isEmpty()) {
             throw new ValidationException(aPaymentError(SEARCH_PAYMENTS_VALIDATION_ERROR, join(validationErrors, ", ")));
+        }
+    }
+
+    private static void validateAgreement(String agreement, List<String> validationErrors) {
+        if (!isValid(agreement, AGREEMENT_ID_MAX_LENGTH)){
+                validationErrors.add("agreement");
         }
     }
 

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -474,6 +474,19 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                 .assertThat("$.description", is("Page not found"));
 
     }
+    
+    @Test
+    public void searchPayments_withMandateId_whenCardPayment_shouldReturnABadRequestResponse() throws Exception{
+        InputStream body = searchPayments(API_KEY,
+                ImmutableMap.of("agreement", "my_agreement"))
+                .statusCode(400)
+                .contentType(JSON).extract()
+                .body().asInputStream();
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(2))
+                .assertThat("$.code", is("P0401"))
+                .assertThat("$.description", is("Invalid parameters: agreement. See Public API documentation for the correct data formats"));
+    }
 
     private Matcher<? super List<Map<String, Object>>> matchesState(final String state) {
         return new TypeSafeMatcher<List<Map<String, Object>>>() {

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFiltersITest.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFiltersITest.java
@@ -261,7 +261,6 @@ public class ResourcesFiltersITest extends PaymentResourceITestBase {
             @Override
             protected boolean matchesSafely(ValidatableResponse validatableResponse) {
                 ExtractableResponse<Response> extract = validatableResponse.extract();
-                System.out.println("extract.body().asString() = " + extract.body().asString());
                 return extract.statusCode() == statusCode
                         && publicApiErrorCode.equals(extract.body().<String>path("code"))
                         && expectedDescription.equals(extract.body().<String>path("description"));

--- a/src/test/java/uk/gov/pay/api/service/PaymentSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/PaymentSearchServiceTest.java
@@ -1,36 +1,57 @@
 package uk.gov.pay.api.service;
 
+import au.com.dius.pact.consumer.PactVerification;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonassert.JsonAssert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.commons.testing.pact.consumers.PactProviderRule;
+import uk.gov.pay.commons.testing.pact.consumers.Pacts;
 
 import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
 
+import static com.jayway.jsonassert.JsonAssert.collectionWithSize;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PaymentSearchServiceTest {
 
-    @Mock
-    private PaymentSearchService paymentSearchService;
-    @Mock
+    @Rule
+    public PactProviderRule connectorRule = new PactProviderRule("direct-debit-connector", this);
+
     private Client client;
+
     @Mock
     private PublicApiConfig configuration;
     private ConnectorUriGenerator connectorUriGenerator;
+    private PaymentSearchService paymentSearchService;
     private PaymentUriGenerator paymentUriGenerator;
     private ObjectMapper objectMapper;
+    
     @Before
     public void setUp() {
+        when(configuration.getConnectorDDUrl()).thenReturn(connectorRule.getUrl());
+
+        when(configuration.getBaseUrl()).thenReturn("http://publicapi.test.localhost/");
+
         connectorUriGenerator = new ConnectorUriGenerator(configuration);
         paymentUriGenerator = new PaymentUriGenerator();
+        client = RestClientFactory.buildClient(new RestClientConfig(false));
         objectMapper = new ObjectMapper();
         paymentSearchService = new PaymentSearchService(client, configuration, connectorUriGenerator, paymentUriGenerator, objectMapper);
     }
@@ -46,5 +67,37 @@ public class PaymentSearchServiceTest {
             assertThat(ex.getPaymentError().getCode(), is("P0401"));
             assertThat(ex.getPaymentError().getDescription().contains("Invalid parameters: agreement."), is(true));
         }
+    }
+    
+    @Test
+    @PactVerification({"direct-debit-connector"})
+    @Pacts(pacts = {"publicapi-direct-debit-connector-search-by-mandate-three-results"})
+    public void doSearchShouldReturnADirectDebitSearchResponseWithThreeTransactions() {
+        Account account = new Account("2po9ycynwq8yxdgg2qwq9e9qpyrtre", TokenPaymentType.DIRECT_DEBIT);
+        String agreementId = "jkdjsvd8f78ffkwfek2q";
+        Response response = 
+                paymentSearchService.doSearch(account, null, null, 
+                        null, null, null, 
+                        null, null, null,
+                        agreementId);
+        JsonAssert.with(response.getEntity().toString())
+                .assertThat("count", is(3))
+                .assertThat("total", is(3))
+                .assertThat("page", is(1))
+                .assertThat("results", is(collectionWithSize(equalTo(3))))
+                .assertThat("results[0]", hasKey("amount"))
+                .assertThat("results[1]", hasKey("state"))
+                .assertThat("results[2]", hasKey("reference"))
+                .assertThat("results[2]", hasKey("name"))
+                .assertThat("results[1]", hasKey("email"))
+                .assertThat("results[0].state", hasKey("status"))
+                .assertThat("results[2].state", hasKey("finished"))
+                .assertThat("results[0]", hasKey("links"))
+                .assertThat("_links", hasKey("self"))
+                .assertThat("_links", hasKey("first_page"))
+                .assertThat("_links", hasKey("last_page"))
+                .assertThat("_links.self.href", containsString(agreementId))
+                .assertNotDefined("_links.next_page")
+                .assertNotDefined("_links.prev_page");
     }
 }

--- a/src/test/java/uk/gov/pay/api/validation/PaymentSearchValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/PaymentSearchValidatorTest.java
@@ -14,81 +14,116 @@ public class PaymentSearchValidatorTest {
     private static final String SUCCESSFUL_TEST_EMAIL = "alice.111@mail.fake";
     private static final String UNSUCCESSFUL_TEST_EMAIL = randomAlphanumeric(255) + "@mail.fake";
     private static final String UNSUCCESSFULL_TEST_CARD_BRAND = "123456789012345678901";
+    private static final String INVALID_LENGTH_AGREEMENT = randomAlphanumeric(27);
 
     @Test
     public void validateParams_shouldSuccessValidation() {
-        PaymentSearchValidator.validateSearchParameters("success", "ref", SUCCESSFUL_TEST_EMAIL, "", "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "1", "1");
+        PaymentSearchValidator.validateSearchParameters("success", "ref", SUCCESSFUL_TEST_EMAIL, 
+                "", "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", 
+                "1", "1", "");
     }
 
     @Test
     public void validateParams_reference_shouldGiveAnErrorValidation() throws Exception {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: reference. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("success", randomAlphanumeric(500), SUCCESSFUL_TEST_EMAIL, "", "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "1", "1");
+        PaymentSearchValidator.validateSearchParameters("success", randomAlphanumeric(500), 
+                SUCCESSFUL_TEST_EMAIL, "", "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", 
+                "1", "1", "");
     }
 
     @Test
     public void validateParams_email_shouldGiveAnErrorValidation() throws Exception {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: email. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("success", "ref", UNSUCCESSFUL_TEST_EMAIL, "", "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "1", "1");
+        PaymentSearchValidator.validateSearchParameters("success", "ref", UNSUCCESSFUL_TEST_EMAIL, 
+                "", "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", 
+                "1", "1", "");
     }
 
     @Test
     public void validateParams_state_shouldGiveAnErrorValidation() throws Exception {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("invalid", "ref", SUCCESSFUL_TEST_EMAIL, "", "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "1", "1");
+        PaymentSearchValidator.validateSearchParameters("invalid", "ref", SUCCESSFUL_TEST_EMAIL, 
+                "", "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "1", 
+                "1", "");
     }
 
     @Test
     public void validateParams_toDate_shouldGiveAnErrorValidation() throws Exception {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: to_date. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("success", "ref", SUCCESSFUL_TEST_EMAIL, "", "2016-01-25T13:23:55Z", "2016-01-25T13-23:55Z", "1", "1");
+        PaymentSearchValidator.validateSearchParameters("success", "ref", SUCCESSFUL_TEST_EMAIL, 
+                "", "2016-01-25T13:23:55Z", "2016-01-25T13-23:55Z", 
+                "1", "1", "");
     }
 
     @Test
     public void validateParams_fromDate_shouldGiveAnErrorValidation() throws Exception {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: from_date. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("success", "ref", SUCCESSFUL_TEST_EMAIL, "", "2016-01-25T13-23:55Z", "2016-01-25T13:23:55Z", "1", "1");
+        PaymentSearchValidator.validateSearchParameters("success", "ref", SUCCESSFUL_TEST_EMAIL, 
+                "", "2016-01-25T13-23:55Z", "2016-01-25T13:23:55Z", 
+                "1", "1", "");
     }
 
     @Test
     public void validateParams_shouldGiveAnErrorValidation_forAllParams() throws Exception {
-        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", "-1", "-1");
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size, agreement. See Public API documentation for the correct data formats"));
+        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, 
+                "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", 
+                "-1", "-1", INVALID_LENGTH_AGREEMENT);
     }
 
     @Test
     public void validateParams_shouldGiveAnErrorValidation_forZeroPageDisplay() throws Exception {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", "0", "0");
+        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, 
+                "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", 
+                "0", "0", "");
     }
 
     @Test
     public void validateParams_shouldGiveAnErrorValidation_forMaxedOutValuesPageDisplaySize() throws Exception {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", String.valueOf(Integer.MAX_VALUE+1), String.valueOf(Integer.MAX_VALUE+1));
+        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, 
+                "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", 
+                String.valueOf(Integer.MAX_VALUE+1), String.valueOf(Integer.MAX_VALUE+1), "");
     }
 
     @Test
     public void validateParams_shouldNotGiveAnErrorValidation_ForMissingPageDisplaySize() throws Exception {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", null, null);
+        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, 
+                "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", 
+                null, null, "");
     }
 
     @Test
     public void validateParams_shouldGiveAnErrorValidation_forToLargePageDisplay() throws Exception {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", "0", "501");
+        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, 
+                "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", 
+                "0", "501", "");
     }
 
     @Test
     public void validateParams_shouldNotGiveAnErrorValidation_ForNonNumberPageAndSize() throws Exception {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", "non-numeric-page", "non-numeric-size");
+        PaymentSearchValidator.validateSearchParameters("invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, 
+                "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", 
+                "non-numeric-page", "non-numeric-size", "");
     }
 
     @Test
     public void validateParams_card_brand_shouldGiveAnErrorValidation() throws Exception {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: card_brand. See Public API documentation for the correct data formats"));
-        PaymentSearchValidator.validateSearchParameters("success", "ref", SUCCESSFUL_TEST_EMAIL, UNSUCCESSFULL_TEST_CARD_BRAND, "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "1", "1");
+        PaymentSearchValidator.validateSearchParameters("success", "ref", SUCCESSFUL_TEST_EMAIL, 
+                UNSUCCESSFULL_TEST_CARD_BRAND, "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", 
+                "1", "1", "");
+    }
+    
+    @Test
+    public void validateParams_shouldGiveAnError_forTooLongMandate() throws Exception {
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: agreement. See Public API documentation for the correct data formats"));
+        PaymentSearchValidator.validateSearchParameters("", "", "", 
+                "", "", "", 
+                "","", INVALID_LENGTH_AGREEMENT);
     }
 }

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-search-by-mandate-three-results.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-search-by-mandate-three-results.json
@@ -1,0 +1,269 @@
+{
+  "provider": {
+    "name": "direct-debit-connector"
+  },
+  "consumer": {
+    "name": "publicapi"
+  },
+  "interactions": [
+    {
+      "description": "search transactions",
+      "providerStates": [
+        {
+          "name": "three transaction records exist",
+          "params": {
+            "gateway_account_id": "2po9ycynwq8yxdgg2qwq9e9qpyrtre",
+            "agreement": "jkdjsvd8f78ffkwfek2q"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/transactions/view",
+        "query": {
+          "agreement": [
+            "jkdjsvd8f78ffkwfek2q"
+          ]
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "total": 3,
+          "count": 3,
+          "page": 1,
+          "results": [
+            {
+              "amount": 1234,
+              "transaction_id": "askd87sfnsadn489nfd8ddnv",
+              "name": "J. Citizen",
+              "email": "j.citizen@mail.fake",
+              "state": {
+                "status": "success",
+                "finished": "true"
+              },
+              "description": "A payment made for crossing the bridge the first time",
+              "reference": "MBK1969Qw",
+              "created_date": "2018-06-09T02:48:56Z",
+              "links": [
+                {
+                  "rel": "self",
+                  "method": "GET",
+                  "href": "http://localhost:1234/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/charges/askd87sfnsadn489nfd8ddnvdk"
+                }
+              ]
+            },
+            {
+              "amount": 1245,
+              "transaction_id": "askd87sfnsadn489nfd8ddnvprq",
+              "name": "J. Citizen",
+              "email": "j.citizen@mail.fake",
+              "state": {
+                "status": "pending",
+                "finished": "false"
+              },
+              "description": "A payment made for crossing the bridge the second time",
+              "reference": "MBK1969Qw",
+              "created_date": "2018-06-11T19:40:56Z",
+              "links": [
+                {
+                  "rel": "self",
+                  "method": "GET",
+                  "href": "http://localhost:1234/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/charges/askd87sfnsadn489nfd8ddnvprq"
+                }
+              ]
+            },
+            {
+              "amount": 1256,
+              "transaction_id": "askd87sfnsadn489nfd8ddt64e",
+              "name": "J. Citizen",
+              "email": "j.citizen@mail.fake",
+              "state": {
+                "status": "cancelled",
+                "finished": "true"
+              },
+              "description": "A payment made for crossing the bridge the third time",
+              "reference": "MBK1969Qw",
+              "created_date": "2018-06-19T10:40:56Z",
+              "links": [
+                {
+                  "rel": "self",
+                  "method": "GET",
+                  "href": "http://localhost:1234/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/charges/askd87sfnsadn489nfd8ddt64e"
+                }
+              ]
+            }
+          ],
+          "_links": {
+            "self": {
+              "href": "http://localhost:1234/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/transaction/view?agreement=jkdjsvd8f78ffkwfek2q&page=1&display_size=500"
+            },
+            "last_page": {
+              "href": "http://localhost:1234/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/transaction/view?agreement=jkdjsvd8f78ffkwfek2q&page=1&display_size=500"
+            },
+            "first_page": {
+              "href": "http://localhost:1234/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/transaction/view?agreement=jkdjsvd8f78ffkwfek2q&page=1&display_size=500"
+            }
+          }
+        },
+        "matchingRules": {
+          "header": {
+            "Location": {
+              "matchers": [
+                {
+                  "regex": "http:\/\/.*\/v1\/api\/accounts\/2po9ycynwq8yxdgg2qwq9e9qpyrtre\/transactions\/view*"
+                }
+              ]
+            }
+          },
+          "body": {
+            "$.total": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.count": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.page": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].name": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].email": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].amount": {
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.results[*].transaction_id": {
+              "matchers": [
+                {
+                  "regex": "[a-z0-9]*"
+                }
+              ]
+            },
+            "$.results[*].state.status": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].state.finished": {
+              "combine": "OR",
+              "matchers": [
+                {
+                  "match": "include",
+                  "value": "true"
+                },
+                {
+                  "match": "include",
+                  "value": "false"
+                }
+              ]
+            },
+            "$.results[*].description": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].reference": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].created_date": {
+              "matchers": [
+                {
+                  "match": "date",
+                  "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+                }
+              ]
+            },
+            "$.results[*].links[0].href": {
+              "matchers": [
+                {
+                  "regex": "http:\/\/.*\/v1\/api\/accounts\/2po9ycynwq8yxdgg2qwq9e9qpyrtre\/charges\/[a-z0-9]*"
+                }
+              ]
+            },
+            "$.results[*].links[0].rel": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].links[0].method": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$._links.self": {
+              "matchers": [
+                {
+                  "regex": "http:\/\/.*\/v1\/api\/accounts\/2po9ycynwq8yxdgg2qwq9e9qpyrtre\/transactions\/view.*"
+                }
+              ]
+            },
+            "$._links.first_page": {
+              "matchers": [
+                {
+                  "regex": "http:\/\/.*\/v1\/api\/accounts\/2po9ycynwq8yxdgg2qwq9e9qpyrtre\/transactions\/view.*"
+                }
+              ]
+            },
+            "$._links.last_page": {
+              "matchers": [
+                {
+                  "regex": "http:\/\/.*\/v1\/api\/accounts\/2po9ycynwq8yxdgg2qwq9e9qpyrtre\/transactions\/view.*"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
Refactor `PaymentsResource` to use `PaymentSearchService`. This is needed so we can implement `Pact` test(s).
Implement Direct Debit search. Use pact testing to test the DD search instead of mocks.
Search is based on `Account` type. This is needed as the nature of the backend response is differ for connector and direct-debit-connector. Instead of trying to make existing `PaymentForSearchResult` generic we opted to separate the searches and thus introduced `DDSearchResponse`.

- introduce `IPaymentSearchPagination` for simplified pagination building.
- add dd search to PaymentSearchService
- add relevant PoJos (`DDSearchResponse`, `DDTransactionFromResponse`,  `DDTransactionForSearch`, etc)
- add Response process from back end responses
- add Pact test


