### PR TITLE
PP-3845: Don't publish pacts for which there are no provider tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>uk.gov.pay</groupId>
             <artifactId>testing</artifactId>
-            <version>1.0.0-3</version>
+            <version>1.0.0-4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/uk/gov/pay/api/it/directdebit/pact/DirectDebitPaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/it/directdebit/pact/DirectDebitPaymentTest.java
@@ -64,7 +64,8 @@ public class DirectDebitPaymentTest extends PaymentResourceITestBase {
     
     @Test
     @PactVerification({"direct-debit-connector", "publicauth"})
-    @Pacts(pacts = {"publicapi-publicauth", "publicapi-direct-debit-connector"})
+    @Pacts(pacts = {"publicapi-direct-debit-connector"})
+    @Pacts(pacts = {"publicapi-publicauth"}, publish = false)
     public void createPayment() {
         String responseBody = postPaymentResponse(API_KEY, SUCCESS_PAYLOAD)
                 .statusCode(201)

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -58,7 +58,7 @@ public class CreatePaymentServiceTest {
 
     @Test
     @PactVerification({"connector"})
-    @Pacts(pacts = {"publicapi-connector"})
+    @Pacts(pacts = {"publicapi-connector"}, publish = false)
     public void testCreatePayment() {
         Account account = new Account("GATEWAY_ACCOUNT_ID", TokenPaymentType.CARD);
         CreatePaymentRequest requestPayload = new CreatePaymentRequest(100, "https://somewhere.gov.uk/rainbow/1", "a reference", "a description");


### PR DESCRIPTION
PP-3845 is about checking pact compatibility between publicapi and
direct-debit-connector; however we currently also publish pacts for publicauth
and connector, and these have no provider tests written for them yet, and
therefore no pact verifications. We need to disable publishing them so the
pact-broker has no knowledge of them and can check pact compatibility between
publicapi and direct-debit-connector only.

@oswaldquek

