### PR TITLE
Make pact with connector less restrictive

### DIFF
--- a/src/test/resources/pacts/publicapi-connector-create-payment.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment.json
@@ -34,13 +34,12 @@
         },
         "body": {
           "charge_id": "ch_ab2341da231434l",
-          "amount": "100",
+          "amount": 100,
           "reference": "a reference",
-          "email": null,
           "description": "a description",
           "state": {
             "status": "created",
-            "finished": "false"
+            "finished": false
           },
           "return_url": "https://somewhere.gov.uk/rainbow/1",
           "payment_provider": "Sandbox",
@@ -50,6 +49,10 @@
               "href": "http://connector.service.backend/v1/api/accounts/123456/charges/ch_ab2341da231434l",
               "rel": "self",
               "method": "GET"
+            },
+            {
+              "rel": "refunds",
+              "href": "url"
             },
             {
               "href": "http://frontend_connector/charge/token_1234567asdf",
@@ -68,7 +71,48 @@
           ]
         },
         "matchingRules": {
+          "header": {
+            "Location": {
+              "matchers": [
+                {
+                  "regex": "https*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/[a-z0-9]*"
+                }
+              ]
+            }
+          },
           "body": {
+            "$.links[0].href": {
+              "matchers": [
+                {
+                  "regex": "https*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/[a-z0-9]*"
+                }
+              ]
+            },
+            "$.links[1].href": {
+              "matchers": [
+                {"match": "type"}
+              ]
+            },
+            "$.links[2].href": {
+              "matchers": [
+                {"match": "type"}
+              ]
+            },
+            "$.links[2].params.chargeTokenId": {
+              "matchers": [
+                {"match": "type"}
+              ]
+            },
+            "$.links[3].href": {
+              "matchers": [
+                {"match": "type"}
+              ]
+            },
+            "$.links[3].params.chargeTokenId": {
+              "matchers": [
+                {"match": "type"}
+              ]
+            },
             "$.charge_id": {
               "matchers": [{"match": "type"}]
             },
@@ -94,7 +138,7 @@
               "matchers": [{"match": "type"}]
             },
             "$.created_date": {
-              "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ssZ" }]
+              "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
             }
           }
         }


### PR DESCRIPTION
Stipulating the form of expected links seems rather pointless, and probably too
restrictive from a contract point of view. PublicApi should not care if we
completely change the front end url, for example.