### PR TITLE
PP-3933: Upgrade Dropwizard from 1.2.5 to 1.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>pay-publicapi</artifactId>
 
     <properties>
-        <dropwizard.version>1.2.5</dropwizard.version>
+        <dropwizard.version>1.2.8</dropwizard.version>
         <guice.version>4.2.0</guice.version>
         <mockserver.version>3.10.4</mockserver.version>
         <swagger.jersey2.version>1.5.20</swagger.jersey2.version>


### PR DESCRIPTION
## WHAT
Upgrade Dropwizard from 1.2.5 to 1.2.8

This upgrades Jackson from 2.9.5 to 2.9.6 and Jetty from 9.4.10 to 9.4.11