### PR TITLE
PP-3493 Ignore unknown properties in RefundSummary

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/RefundSummary.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundSummary.java
@@ -1,10 +1,12 @@
 package uk.gov.pay.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel(value="RefundSummary", description = "A structure representing the refunds availability")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class RefundSummary {
 
     private String status;


### PR DESCRIPTION
## WHAT
 - We are going to add `user_external_id` to the Refund Summary in connector, but
   we don't necessarily want to serialise that (as of now, at least) in publicapi

