### PR TITLE
PP-4005 Rate filter audit

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
@@ -64,6 +64,6 @@ public class PublicApiModule extends AbstractModule {
 
     @Provides
     public RateLimiter provideRateLimiter() {
-        return new RateLimiter(configuration.getRateLimiterConfig().getRate(), configuration.getRateLimiterConfig().getPerMillis());
+        return new RateLimiter(configuration.getRateLimiterConfig().getRate(), configuration.getRateLimiterConfig().getAuditRate(), configuration.getRateLimiterConfig().getPerMillis());
     }
 }

--- a/src/main/java/uk/gov/pay/api/app/config/RateLimiterConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/RateLimiterConfig.java
@@ -9,6 +9,9 @@ public class RateLimiterConfig extends Configuration {
     @Min(1)
     private int rate;
 
+    @Min(1)
+    private int auditRate;
+
     @Min(500)
     private int perMillis;
 
@@ -18,5 +21,9 @@ public class RateLimiterConfig extends Configuration {
 
     public int getPerMillis() {
         return perMillis;
+    }
+
+    public int getAuditRate() {
+        return auditRate;
     }
 }

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiter.java
@@ -46,8 +46,7 @@ public class RateLimiter {
             auditCache.get(key, () -> new RateLimit(auditRate, perMillis)).updateAllowance();
         } catch (RateLimitException e) {
             LOGGER.info(String.format(
-                    "Rate limit reached for rate limit key %s using rate of %d requests per %d ms",
-                    key,
+                    "Rate limit reached for a service using rate of %d requests per %d ms",
                     auditRate,
                     perMillis)
             );

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiter.java
@@ -13,13 +13,20 @@ public class RateLimiter {
     private static final Logger LOGGER = LoggerFactory.getLogger(RateLimiter.class);
 
     private final int rate;
+    private final int auditRate;
     private final int perMillis;
     private final Cache<String, RateLimit> cache;
+    private final Cache<String, RateLimit> auditCache;
 
-    public RateLimiter(int rate, int perMillis) {
+    public RateLimiter(int rate, int auditRate, int perMillis) {
         this.rate = rate;
+        this.auditRate = auditRate;
         this.perMillis = perMillis;
         this.cache = CacheBuilder.newBuilder()
+                .expireAfterAccess(perMillis, TimeUnit.MILLISECONDS)
+                .build();
+
+        this.auditCache = CacheBuilder.newBuilder()
                 .expireAfterAccess(perMillis, TimeUnit.MILLISECONDS)
                 .build();
     }
@@ -27,6 +34,23 @@ public class RateLimiter {
     void checkRateOf(String key) throws RateLimitException {
         try {
             cache.get(key, () -> new RateLimit(rate, perMillis)).updateAllowance();
+        } catch (ExecutionException e) {
+            //ExecutionException is thrown when the valueLoader throws a checked exception.
+            //We just create a new instance so no exceptions will be thrown, this should never happen.
+            LOGGER.error("Unexpected error creating a Rate Limiter object in cache", e);
+        }
+    }
+
+    void auditRateOf(String key) {
+        try {
+            auditCache.get(key, () -> new RateLimit(auditRate, perMillis)).updateAllowance();
+        } catch (RateLimitException e) {
+            LOGGER.info(String.format(
+                    "Rate limit reached for rate limit key %s using rate of %d requests per %d ms",
+                    key,
+                    auditRate,
+                    perMillis)
+            );
         } catch (ExecutionException e) {
             //ExecutionException is thrown when the valueLoader throws a checked exception.
             //We just create a new instance so no exceptions will be thrown, this should never happen.

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
@@ -50,6 +50,10 @@ public class RateLimiterFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 
         final String authorization = ((HttpServletRequest) request).getHeader("Authorization");
+        final String method = ((HttpServletRequest) request).getMethod();
+
+        rateLimiter.auditRateOf(method + "-" + authorization);
+        
         try {
             rateLimiter.checkRateOf(authorization);
             chain.doFilter(request, response);

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -29,6 +29,7 @@ jerseyClientConfig:
 rateLimiter:
   rate: ${RATE_LIMITER_VALUE:-25}
   perMillis: ${RATE_LIMITER_PER_MILLIS:-1000}
+  auditRate: ${RATE_LIMITTER_AUDIT_VALUE:-4}
 
 allowHttpForReturnUrl: ${ALLOW_HTTP_FOR_RETURN_URL:-false}
 

--- a/src/test/java/uk/gov/pay/api/filter/RateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/RateLimiterTest.java
@@ -25,14 +25,14 @@ public class RateLimiterTest {
 
     @Test
     public void rateLimiterSetTo_1CallPerSecond_shouldAllowSingleCall() throws Exception {
-        RateLimiter rateLimiter = new RateLimiter(1, 1000);
+        RateLimiter rateLimiter = new RateLimiter(1, 1, 1000);
         rateLimiter.checkRateOf("1");
     }
 
     @Test
     public void rateLimiterSetTo_2CallsPerSecond_shouldAllow2ConsecutiveCallsWithSameKeys() throws Exception {
 
-        RateLimiter rateLimiter = new RateLimiter(2, 1000);
+        RateLimiter rateLimiter = new RateLimiter(2, 1, 1000);
 
         rateLimiter.checkRateOf("2");
         rateLimiter.checkRateOf("2");
@@ -40,7 +40,7 @@ public class RateLimiterTest {
 
     @Test
     public void rateLimiterSetTo_2CallsPerSecond_shouldAFailWhen3ConsecutiveCallsWithSameKeysAreMade() throws Exception {
-        RateLimiter rateLimiter = new RateLimiter(2, 1000);
+        RateLimiter rateLimiter = new RateLimiter(2, 1, 1000);
 
         rateLimiter.checkRateOf("3");
         rateLimiter.checkRateOf("3");
@@ -52,7 +52,7 @@ public class RateLimiterTest {
     @Test
     public void rateLimiterSetTo_2CallsPer300Millis_shouldAllowMaking3CallsWithinTheAllowedTimeWithSameKey() throws Exception {
 
-        RateLimiter rateLimiter = new RateLimiter(2, 300);
+        RateLimiter rateLimiter = new RateLimiter(2, 1, 300);
 
         rateLimiter.checkRateOf("4");
         rateLimiter.checkRateOf("4");
@@ -63,7 +63,7 @@ public class RateLimiterTest {
 
     @Test
     public void rateLimiterSetTo_2CallsPer500Millis_shouldAllowMakingACallPerSecondWithSameKey() throws Exception {
-        RateLimiter rateLimiter = new RateLimiter(2, 500);
+        RateLimiter rateLimiter = new RateLimiter(2, 1, 500);
 
         rateLimiter.checkRateOf("5");
         Thread.sleep(250);
@@ -81,7 +81,7 @@ public class RateLimiterTest {
     @Test
     public void rateLimiterSetTo_2CallsPer300Millis_shouldAllowMakingOnly2CallsWithSameKey() throws Exception {
 
-        final RateLimiter rateLimiter = new RateLimiter(2, 300);
+        final RateLimiter rateLimiter = new RateLimiter(2, 1, 300);
 
         ExecutorService executor = Executors.newFixedThreadPool(3);
 
@@ -125,7 +125,7 @@ public class RateLimiterTest {
     @Test
     public void rateLimiterSetTo_2CallsPerSecond_shouldNotAllowMakingAThirdCallsWithSameKey() throws Exception {
 
-        RateLimiter rateLimiter = new RateLimiter(2, 1000);
+        RateLimiter rateLimiter = new RateLimiter(2, 1, 1000);
 
         rateLimiter.checkRateOf("6");
         Thread.sleep(910);
@@ -140,5 +140,15 @@ public class RateLimiterTest {
 
         Thread.sleep(900);
         rateLimiter.checkRateOf("6");
+    }
+
+    @Test
+    public void rateLimiter_shouldAuditWithoutThrowingException() throws Exception {
+
+        RateLimiter rateLimiter = new RateLimiter(2, 1, 1000);
+
+        rateLimiter.auditRateOf("6");
+        Thread.sleep(910);
+        rateLimiter.auditRateOf("6");
     }
 }

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -29,6 +29,7 @@ jerseyClientConfig:
 
 rateLimiter:
   rate: 1
+  auditRate: 4
   perMillis: 1000
 
 allowHttpForReturnUrl: false


### PR DESCRIPTION
Added new method 'auditRateOf' to RateLimiterFilter to log no of transactions/second for service. This will help to find out optimal rate against current rate of `25tx/s` for each node .  

Does not effect current functionality but does additional logging if `tx/s > 4`

We have chosen `4 tx/s` from inspecting logs to see what kind of load a single service generates. MTP can generate up to about `7/8 tx/s`, but since this will be spread over 3 nodes, the 'normal' rate limit per service will be `12 tx/s`, which should be fine. However there may be cases where the effective limit becomes equal to the limit per node (i.e. if all requests for a particular service were directed at one node). Therefore the purpose of auditing the limit in this manner is to establish whether, and how often, a limit of `4 tx/s` per node would affect MTP (or any other service).

with @kbottla 