### PR TITLE
PP-4005 Segment rate limit by method

### DIFF
--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
@@ -53,14 +53,14 @@ public class RateLimiterFilter implements Filter {
         final String method = ((HttpServletRequest) request).getMethod();
 
         rateLimiter.auditRateOf(method + "-" + authorization);
-        
+
         try {
-            rateLimiter.checkRateOf(authorization);
+            rateLimiter.checkRateOf(method + "-" + authorization);
             chain.doFilter(request, response);
         } catch (RateLimitException e) {
             LOGGER.info("Rate limit reached for current service. Sending response '429 Too Many Requests'");
             setTooManyRequestsError((HttpServletResponse) response);
-        }
+        } 
     }
 
     private void setTooManyRequestsError(HttpServletResponse response) throws IOException {

--- a/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
@@ -44,25 +44,28 @@ public class RateLimiterFilterTest {
 
 
     @Test
-    public void shouldProcessFilterChain_whenRateLimiterDoesNotThrowARateLimiterException() throws Exception {
+    public void shouldProcessFilterChain_whenRateLimiterDoesNotThrowARateLimiterException_forPOST() throws Exception {
 
         String authorization = "Bearer whateverAuthorizationToken";
         when(mockRequest.getHeader("Authorization")).thenReturn(authorization);
+        when(mockRequest.getMethod()).thenReturn("POST");
+
 
         rateLimiterFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
-        verify(rateLimiter).checkRateOf(authorization);
+        verify(rateLimiter).checkRateOf("POST-" + authorization);
         verify(mockFilterChain, times(1)).doFilter(mockRequest, mockResponse);
     }
-
+    
     @Test
     public void shouldRejectRequest_with429ResponseError__whenRateLimiterThrowsRateLimiterException() throws Exception {
 
         // given
         String authorization = "Bearer whateverAuthorizationToken";
         when(mockRequest.getHeader("Authorization")).thenReturn(authorization);
+        when(mockRequest.getMethod()).thenReturn("POST");
 
-        doThrow(RateLimitException.class).when(rateLimiter).checkRateOf(authorization);
+        doThrow(RateLimitException.class).when(rateLimiter).checkRateOf("POST-" + authorization);
 
         PrintWriter mockPrinter = mock(PrintWriter.class);
         when(mockResponse.getWriter()).thenReturn(mockPrinter);


### PR DESCRIPTION
In order to more precisely rate limit the different parts of
public api, this commit passes a concatenation of method and
api key as rate limiting key. This will mean GET requests cannot impinge
on POSTs, so if a service does a batch of GETs it won't block the
mor eimportant process of creating new payments. This is a small
change in right direction, rather than a total solution.

We may want to set different rates for POSTs and GETs at some point,
but this is not currently required.