### PR TITLE
PP-3680 Adding validation for display_size

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/links/directdebit/DirectDebitEvent.java
+++ b/src/main/java/uk/gov/pay/api/model/links/directdebit/DirectDebitEvent.java
@@ -20,10 +20,7 @@ public class DirectDebitEvent {
     @JsonProperty("event")
     private String event;
 
-    @JsonProperty("mandate_external_id")
     private String mandateExternalId;
-
-    @JsonProperty("transaction_external_id")
     private String transactionExternalId;
 
     @JsonProperty("event_type")
@@ -50,10 +47,12 @@ public class DirectDebitEvent {
         return event;
     }
 
+    @JsonProperty("agreement_id")
     public String getMandateExternalId() {
         return mandateExternalId;
     }
 
+    @JsonProperty("payment_id")
     public String getTransactionExternalId() {
         return transactionExternalId;
     }
@@ -74,10 +73,12 @@ public class DirectDebitEvent {
         this.event = event;
     }
 
+    @JsonProperty("mandate_external_id")
     public void setMandateExternalId(String mandateExternalId) {
         this.mandateExternalId = mandateExternalId;
     }
 
+    @JsonProperty("transaction_external_id")
     public void setTransactionExternalId(String transactionExternalId) {
         this.transactionExternalId = transactionExternalId;
     }

--- a/src/main/java/uk/gov/pay/api/resources/DirectDebitEventsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/DirectDebitEventsResource.java
@@ -67,7 +67,7 @@ public class DirectDebitEventsResource {
             @QueryParam("payment_id") String paymentId
     ) {
 
-        DirectDebitEventSearchValidator.validateSearchParameters(toDate, fromDate);
+        DirectDebitEventSearchValidator.validateSearchParameters(toDate, fromDate, displaySize);
         String uri = connectorUriGenerator.eventsURI(account, parseDate(toDate), parseDate(fromDate), page, displaySize, agreementId, paymentId);
         DirectDebitEventsResponse response = directDebitEventService.getResponse(uri);
         return Response.ok(response).build();

--- a/src/main/java/uk/gov/pay/api/validation/DirectDebitEventSearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/DirectDebitEventSearchValidator.java
@@ -12,16 +12,23 @@ import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 
 public class DirectDebitEventSearchValidator {
 
-    public static void validateSearchParameters(String fromDate, String toDate) {
+    public static void validateSearchParameters(String fromDate, String toDate, Integer displaySize) {
         List<String> validationErrors = new LinkedList<>();
         try {
             validateAfterDate(fromDate, validationErrors);
             validateBeforeDate(toDate, validationErrors);
+            validateDisplaySizeIfNotNull(displaySize, validationErrors);
         } catch (Exception e) {
             throw new ValidationException(aPaymentError(SEARCH_PAYMENTS_VALIDATION_ERROR, join(validationErrors, ", "), e.getMessage()));
         }
         if (!validationErrors.isEmpty()) {
             throw new ValidationException(aPaymentError(SEARCH_PAYMENTS_VALIDATION_ERROR, join(validationErrors, ", ")));
+        }
+    }
+    
+    private static void validateDisplaySizeIfNotNull(Integer displaySize, List<String> validationErrors) {
+        if (displaySize != null && (displaySize < 1 || displaySize > 500)) {
+            validationErrors.add("display_size");
         }
     }
 

--- a/src/test/java/uk/gov/pay/api/it/GetDirectDebitEventsTest.java
+++ b/src/test/java/uk/gov/pay/api/it/GetDirectDebitEventsTest.java
@@ -69,6 +69,8 @@ public class GetDirectDebitEventsTest {
                 .body("results[0].event_date", is("2018-03-13T10:00:04.666Z"))
                 .body("results[0].event", is("PAYMENT_ACKNOWLEDGED_BY_PROVIDER"))
                 .body("results[0].event_type", is("CHARGE"))
+                .body("results[0].agreement_id", is("1"))
+                .body("results[0].payment_id", is("4"))
                 .body("results[0]._links.agreement", is(app.getConfiguration().getBaseUrl() + "v1/agreements/1"))
                 .body("results[0]._links.payment", is(app.getConfiguration().getBaseUrl() + "v1/payments/4"))
                 .body("_links.next_page", isEmptyOrNullString())

--- a/src/test/java/uk/gov/pay/api/validation/DirectDebitEventSearchValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/DirectDebitEventSearchValidatorTest.java
@@ -1,0 +1,48 @@
+package uk.gov.pay.api.validation;
+
+
+import org.junit.Test;
+import uk.gov.pay.api.exception.ValidationException;
+
+import java.time.ZonedDateTime;
+
+import static org.junit.Assert.assertTrue;
+
+public class DirectDebitEventSearchValidatorTest {
+    
+    
+    @Test
+    public void shouldPassValidation() {
+        DirectDebitEventSearchValidator.validateSearchParameters(ZonedDateTime.now().toString(), ZonedDateTime.now().toString(), 1);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void shouldFailWithInvalidDisplaySize() {
+        try {
+            DirectDebitEventSearchValidator.validateSearchParameters(ZonedDateTime.now().toString(), ZonedDateTime.now().toString(), 501);
+        } catch (ValidationException ex) {
+            assertTrue(ex.getPaymentError().getDescription().contains("display_size"));
+            throw ex;
+        }
+    }
+
+    @Test(expected = ValidationException.class)
+    public void shouldFailWithInvalidToDate() {
+        try {
+            DirectDebitEventSearchValidator.validateSearchParameters("Invalid date string", ZonedDateTime.now().toString(), 1);
+        } catch (ValidationException ex) {
+            assertTrue(ex.getPaymentError().getDescription().contains("to_date"));
+            throw ex;
+        }
+    }
+
+    @Test(expected = ValidationException.class)
+    public void shouldFailWithInvalidFromDate() {
+        try {
+            DirectDebitEventSearchValidator.validateSearchParameters(ZonedDateTime.now().toString(), "Invalid date string", 1);
+        } catch (ValidationException ex) {
+            assertTrue(ex.getPaymentError().getDescription().contains("from_date"));
+            throw ex;
+        }
+    }
+}


### PR DESCRIPTION
- Added validation for display_size, future work may want to refactor validation
into a common reusable class. Also may be prudent to refactor ValidationException to be less payment specific in future.
- Separated serialization and deserialization for mandateId and transactionId
on DDEvent to permit correct setting of names in json.
- Created and updated tests to check for correct naming convention on DDEvent and validation.