### PR TITLE
PP-3680 Changed event_external_id to event_id in DD Event Search result.

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/links/directdebit/DirectDebitEvent.java
+++ b/src/main/java/uk/gov/pay/api/model/links/directdebit/DirectDebitEvent.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.api.model.links.directdebit;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -10,11 +9,9 @@ import uk.gov.pay.api.utils.CustomDateSerializer;
 
 import java.time.ZonedDateTime;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public class DirectDebitEvent {
     
-    @JsonProperty("external_id")
     private String externalId;
 
     @JsonProperty("event")
@@ -38,7 +35,8 @@ public class DirectDebitEvent {
     public Links getLinks() {
         return links;
     }
-
+    
+    @JsonProperty("event_id")
     public String getExternalId() {
         return externalId;
     }
@@ -64,7 +62,8 @@ public class DirectDebitEvent {
     public ZonedDateTime getEventDate() {
         return eventDate;
     }
-
+    
+    @JsonProperty("external_id")
     public void setExternalId(String externalId) {
         this.externalId = externalId;
     }

--- a/src/test/java/uk/gov/pay/api/it/GetDirectDebitEventsTest.java
+++ b/src/test/java/uk/gov/pay/api/it/GetDirectDebitEventsTest.java
@@ -65,7 +65,7 @@ public class GetDirectDebitEventsTest {
                 .contentType(JSON)
                 .body("count", is(2))
                 .body("results", hasSize(2))
-                .body("results[0].external_id", is("201"))
+                .body("results[0].event_id", is("201"))
                 .body("results[0].event_date", is("2018-03-13T10:00:04.666Z"))
                 .body("results[0].event", is("PAYMENT_ACKNOWLEDGED_BY_PROVIDER"))
                 .body("results[0].event_type", is("CHARGE"))


### PR DESCRIPTION
- Also return null for empty elements rather than omitting them e.g. links.payment


