### PR TITLE
PP 4005 - Separate rate limits for GET and POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ Then the script creates a keystore (KEYSTORE_FILE) in a separate directory (KEYS
 
 ## Rate limiter and Authorization filters setup
 
-These ara the variables related to Public API filters.
+These are the variables related to Public API filters.
 
 | Variable                    | required         |  Description                               |
 | --------------------------- | -----------------| ------------------------------------------ |
-| RATE_LIMITER_VALUE          | No (Default 3)   | Number of requests allowed per time defined by RATE_LIMITER_PER_MILLIS |
+| RATE_LIMITER_VALUE          | No (Default 3)   | Number of requests (other than POST) allowed per time defined by RATE_LIMITER_PER_MILLIS |
+| RATE_LIMITER_VALUE_POST     | No (Default 3)   | Number of POST requests allowed per time defined by RATE_LIMITER_PER_MILLIS |
 | RATE_LIMITER_PER_MILLIS     | No (Default 1000)| Rate limiter time window |
 | TOKEN_API_HMAC_SECRET       | Yes              | Hmac secret to be used to validate that the given token is genuine (Api Key = Token + Hmac (Token, Secret) |
 

--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
@@ -64,6 +64,9 @@ public class PublicApiModule extends AbstractModule {
 
     @Provides
     public RateLimiter provideRateLimiter() {
-        return new RateLimiter(configuration.getRateLimiterConfig().getRate(), configuration.getRateLimiterConfig().getAuditRate(), configuration.getRateLimiterConfig().getPerMillis());
+        return new RateLimiter(configuration.getRateLimiterConfig().getRate(), 
+                configuration.getRateLimiterConfig().getRateForPost(),
+                configuration.getRateLimiterConfig().getAuditRate(), 
+                configuration.getRateLimiterConfig().getPerMillis());
     }
 }

--- a/src/main/java/uk/gov/pay/api/app/config/RateLimiterConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/RateLimiterConfig.java
@@ -10,6 +10,9 @@ public class RateLimiterConfig extends Configuration {
     private int rate;
 
     @Min(1)
+    private int rateForPost;
+
+    @Min(1)
     private int auditRate;
 
     @Min(500)
@@ -25,5 +28,9 @@ public class RateLimiterConfig extends Configuration {
 
     public int getAuditRate() {
         return auditRate;
+    }
+
+    public int getRateForPost() {
+        return rateForPost;
     }
 }

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiter.java
@@ -13,13 +13,18 @@ public class RateLimiter {
     private static final Logger LOGGER = LoggerFactory.getLogger(RateLimiter.class);
 
     private final int rate;
+    private final int rateForPost;
+    
+    private static final String METHOD_POST = "POST";
+    
     private final int auditRate;
     private final int perMillis;
     private final Cache<String, RateLimit> cache;
     private final Cache<String, RateLimit> auditCache;
 
-    public RateLimiter(int rate, int auditRate, int perMillis) {
+    public RateLimiter(int rate, int rateForPost, int auditRate, int perMillis) {
         this.rate = rate;
+        this.rateForPost = rateForPost;
         this.auditRate = auditRate;
         this.perMillis = perMillis;
         this.cache = CacheBuilder.newBuilder()
@@ -31,14 +36,21 @@ public class RateLimiter {
                 .build();
     }
 
-    void checkRateOf(String key) throws RateLimitException {
+    void checkRateOf(String key, String method) throws RateLimitException {
         try {
-            cache.get(key, () -> new RateLimit(rate, perMillis)).updateAllowance();
+            cache.get(key, () -> new RateLimit(getRateForMethod(method), perMillis)).updateAllowance();
         } catch (ExecutionException e) {
             //ExecutionException is thrown when the valueLoader throws a checked exception.
             //We just create a new instance so no exceptions will be thrown, this should never happen.
             LOGGER.error("Unexpected error creating a Rate Limiter object in cache", e);
         }
+    }
+    
+    private int getRateForMethod(String method){
+        if(METHOD_POST.equals(method)){
+            return rateForPost;
+        }
+        return rate;
     }
 
     void auditRateOf(String key) {

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
@@ -55,7 +55,7 @@ public class RateLimiterFilter implements Filter {
         rateLimiter.auditRateOf(method + "-" + authorization);
 
         try {
-            rateLimiter.checkRateOf(method + "-" + authorization);
+            rateLimiter.checkRateOf(method + "-" + authorization, method);
             chain.doFilter(request, response);
         } catch (RateLimitException e) {
             LOGGER.info("Rate limit reached for current service. Sending response '429 Too Many Requests'");

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -27,7 +27,8 @@ jerseyClientConfig:
   disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS}
 
 rateLimiter:
-  rate: ${RATE_LIMITER_VALUE:-25}
+  rate: ${RATE_LIMITER_VALUE:-25}  # the rate is for all requests except POST
+  rateForPost: ${RATE_LIMITER_VALUE_POST:-5}
   perMillis: ${RATE_LIMITER_PER_MILLIS:-1000}
   auditRate: ${RATE_LIMITTER_AUDIT_VALUE:-4}
 

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -29,6 +29,7 @@ jerseyClientConfig:
 
 rateLimiter:
   rate: 1
+  rateForPost: 1
   auditRate: 4
   perMillis: 1000
 


### PR DESCRIPTION
Changes to set different rate limits for GET and POST methods. 

GET requests : revert back to 25 requests/second/node
POST requests : keep current limit of 5 request/second/node