### PR TITLE
PP-4036 Unregister redis from health check

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -117,6 +117,9 @@ public class PublicApi extends Application<PublicApiConfig> {
         attachExceptionMappersTo(environment.jersey());
 
         initialiseMetrics(configuration, environment);
+
+        //health check removed as redis is not a mandatory dependency
+        environment.healthChecks().unregister("redis");
     }
 
     /**


### PR DESCRIPTION
Removed redis from health checks as it is not a mandatory dependency.  