### PR TITLE
PP-4036 Fix - Return redis connection to pool

### DIFF
--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimiter.java
@@ -13,7 +13,6 @@ public class RateLimiter {
 
     @Inject
     public RateLimiter(LocalRateLimiter localRateLimiter, RedisRateLimiter redisRateLimiter) {
-
         this.localRateLimiter = localRateLimiter;
         this.redisRateLimiter = redisRateLimiter;
     }

--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
@@ -49,14 +49,17 @@ public class RedisRateLimiter {
     }
 
     synchronized private Long updateAllowance(String key) {
-
         String derivedKey = getKeyForWindow(key);
-        Long count = getResource().incr(derivedKey);
-
-        if (count == 1) {
-            getResource().expire(derivedKey, perMillis / 1000);
+        
+        try (Jedis jedis = getResource()) {
+            Long count = jedis.incr(derivedKey);
+            
+            if (count == 1) {
+                jedis.expire(derivedKey, perMillis / 1000);
+            }
+            return count;
         }
-        return count;
+
     }
 
     private Jedis getResource() {

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -40,7 +40,7 @@ redis:
   # Enables SSL connection. (default: false)  ???
   ssl: false
   # The configured timeout (in milliseconds) for redis connections in the connection pool.  (default: 2000)
-  timeout: 500
+  timeout: 2000
 
 allowHttpForReturnUrl: ${ALLOW_HTTP_FOR_RETURN_URL:-false}
 


### PR DESCRIPTION
Jedis doesn't return connection to the connection pool automatically. The connection need to be closed explicitly to return to the pool. Try with resources on Jedis will invoke Jedis.close() that actually returns connection to pool (only when Jedis is obtained from pool which is the case ). 
