### PR TITLE
PP-4095 Add language to CreatePaymentRequest object

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
@@ -13,12 +13,14 @@ public class CreatePaymentRequest {
     public static final String REFERENCE_FIELD_NAME = "reference";
     public static final String DESCRIPTION_FIELD_NAME = "description";
     public static final String AGREEMENT_ID_FIELD_NAME = "agreement_id";
+    public static final String LANGUAGE_FIELD_NAME = "language";
 
-    private int amount;
-    private String returnUrl;
-    private String reference;
-    private String description;
-    private String agreementId;
+    private final int amount;
+    private final String returnUrl;
+    private final String reference;
+    private final String description;
+    private final String agreementId;
+    private final String language;
 
     public static class CreatePaymentRequestBuilder {
         private int amount;
@@ -26,6 +28,7 @@ public class CreatePaymentRequest {
         private String reference;
         private String description;
         private String agreementId;
+        private String language;
 
         public CreatePaymentRequestBuilder amount(int amount) {
             this.amount = amount;
@@ -52,8 +55,13 @@ public class CreatePaymentRequest {
             return this;
         }
 
+        public CreatePaymentRequestBuilder language(String language) {
+            this.language = language;
+            return this;
+        }
+
         public CreatePaymentRequest build() {
-            return new CreatePaymentRequest(amount, returnUrl, reference, description, agreementId);
+            return new CreatePaymentRequest(this);
         }
     }
 
@@ -61,12 +69,13 @@ public class CreatePaymentRequest {
         return new CreatePaymentRequestBuilder();
     }
 
-    private CreatePaymentRequest(int amount, String returnUrl, String reference, String description, String agreementId) {
-        this.amount = amount;
-        this.returnUrl = returnUrl;
-        this.reference = reference;
-        this.description = description;
-        this.agreementId = agreementId;
+    private CreatePaymentRequest(CreatePaymentRequestBuilder createPaymentRequestBuilder) {
+        this.amount = createPaymentRequestBuilder.amount;
+        this.returnUrl = createPaymentRequestBuilder.returnUrl;
+        this.reference = createPaymentRequestBuilder.reference;
+        this.description = createPaymentRequestBuilder.description;
+        this.agreementId = createPaymentRequestBuilder.agreementId;
+        this.language = createPaymentRequestBuilder.language;
     }
 
     @ApiModelProperty(value = "amount in pence", required = true, allowableValues = "range[1, 10000000]", example = "12000")
@@ -96,6 +105,12 @@ public class CreatePaymentRequest {
         return agreementId;
     }
 
+    @ApiModelProperty(value = "ISO-639-1 Alpha-2 code of a supported language to use on the payment pages", required = false, example = "en")
+    @JsonProperty(LANGUAGE_FIELD_NAME)
+    public String getLanguage() {
+        return language;
+    }
+
     public boolean hasReturnUrl() {
         return StringUtils.isNotBlank(returnUrl);
     }
@@ -112,6 +127,7 @@ public class CreatePaymentRequest {
                 ", returnUrl='" + returnUrl + '\'' +
                 ", reference='" + reference + '\'' +
                 ", agreement_id='" + agreementId + '\'' +
+                ", language='" + language + '\'' +
                 '}';
     }
 

--- a/src/test/java/uk/gov/pay/api/json/RequestJsonParserTest.java
+++ b/src/test/java/uk/gov/pay/api/json/RequestJsonParserTest.java
@@ -24,12 +24,12 @@ public class RequestJsonParserTest {
 
     @Test
     public void parsePaymentRequest_withReturnUrl_shouldParseSuccessfully() throws Exception {
-
-        String payload = "{" +
-                "  \"amount\" : -1000," +
-                "  \"reference\" : \"Some reference\"," +
-                "  \"description\" : \"Some description\"," +
-                "  \"return_url\" : \"https://somewhere.gov.uk/rainbow/1\"" +
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": -1000,\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"description\": \"Some description\",\n" +
+                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
                 "}";
 
         JsonNode jsonNode = objectMapper.readTree(payload);
@@ -44,13 +44,36 @@ public class RequestJsonParserTest {
     }
 
     @Test
-    public void parsePaymentRequest_withAgreementId_shouldParseSuccessfully() throws Exception {
+    public void parsePaymentRequest_withReturnUrlAndLanguage_shouldParseSuccessfully() throws Exception {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": -1000,\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"description\": \"Some description\",\n" +
+                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\",\n" +
+                "  \"language\": \"en\"\n" +
+                "}";
 
-        String payload = "{" +
-                "  \"amount\" : -1000," +
-                "  \"reference\" : \"Some reference\"," +
-                "  \"description\" : \"Some description\"," +
-                "  \"agreement_id\" : \"abcdef1234567890abcedf1234\"" +
+        JsonNode jsonNode = objectMapper.readTree(payload);
+
+        CreatePaymentRequest createPaymentRequest = parsePaymentRequest(jsonNode);
+
+        assertThat(createPaymentRequest, is(notNullValue()));
+        assertThat(createPaymentRequest.getAmount(), is(-1000));
+        assertThat(createPaymentRequest.getReference(), is("Some reference"));
+        assertThat(createPaymentRequest.getDescription(), is("Some description"));
+        assertThat(createPaymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
+        assertThat(createPaymentRequest.getLanguage(), is("en"));
+    }
+
+    @Test
+    public void parsePaymentRequest_withAgreementId_shouldParseSuccessfully() throws Exception {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": -1000,\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"description\": \"Some description\",\n" +
+                "  \"agreement_id\": \"abcdef1234567890abcedf1234\"\n" +
                 "}";
 
         JsonNode jsonNode = objectMapper.readTree(payload);
@@ -67,9 +90,9 @@ public class RequestJsonParserTest {
 
     @Test
     public void parsePaymentRefundRequest_shouldParseSuccessfully() throws Exception {
-
-        String payload = "{" +
-                "  \"amount\" : 1000" +
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": 1000\n" +
                 "}";
 
         JsonNode jsonNode = objectMapper.readTree(payload);
@@ -81,13 +104,13 @@ public class RequestJsonParserTest {
     }
 
     @Test
-    public void parsePaymentRequest_whenExpectedStringFieldIsNotAString() throws Exception {
-
-        String payload = "{" +
-                "  \"amount\" : -1000," +
-                "  \"reference\" : 1234," +
-                "  \"description\" : \"Some description\"," +
-                "  \"return_url\" : \"https://somewhere.gov.uk/rainbow/1\"" +
+    public void parsePaymentRequest_whenReferenceFieldIsNotAString() throws Exception {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": -1000,\n" +
+                "  \"reference\": 1234,\n" +
+                "  \"description\": \"Some description\",\n" +
+                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
                 "}";
 
         JsonNode jsonNode = objectMapper.readTree(payload);
@@ -98,13 +121,48 @@ public class RequestJsonParserTest {
     }
 
     @Test
-    public void parsePaymentRequest_whenIsNotAStringReturnUrl_shouldOverrideFormattingErrorMessage() throws Exception {
+    public void parsePaymentRequest_whenDescriptionFieldIsNotAString() throws Exception {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": -1000,\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"description\": 1234,\n" +
+                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
+                "}";
 
-        String payload = "{" +
-                "  \"amount\" : -1000," +
-                "  \"reference\" : \"Some reference\"," +
-                "  \"description\" : \"Some description\"," +
-                "  \"return_url\" : 1234" +
+        JsonNode jsonNode = objectMapper.readTree(payload);
+
+        expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: description. Must be a valid string format"));
+
+        parsePaymentRequest(jsonNode);
+    }
+
+    @Test
+    public void parsePaymentRequest_whenLanguageFieldIsNotAString() throws Exception {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": -1000,\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"description\": \"Some description\",\n" +
+                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\",\n" +
+                "  \"language\": 0\n" +
+                "}";
+
+        JsonNode jsonNode = objectMapper.readTree(payload);
+
+        expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: language. Must be \"en\" or \"cy\""));
+
+        parsePaymentRequest(jsonNode);
+    }
+
+    @Test
+    public void parsePaymentRequest_whenReturnUrlIsNotAString_shouldOverrideFormattingErrorMessage() throws Exception {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": -1000,\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"description\": \"Some description\",\n" +
+                "  \"return_url\": 1234\n" +
                 "}";
 
         JsonNode jsonNode = objectMapper.readTree(payload);
@@ -115,13 +173,13 @@ public class RequestJsonParserTest {
     }
 
     @Test
-    public void parsePaymentRequest_whenAFieldIsNullValue() throws Exception {
-
-        String payload = "{" +
-                "  \"amount\" : -1000," +
-                "  \"reference\" : null," +
-                "  \"description\" : \"Some description\"," +
-                "  \"return_url\" : 1234" +
+    public void parsePaymentRequest_whenReferenceFieldIsNullValue() throws Exception {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": -1000,\n" +
+                "  \"reference\": null,\n" +
+                "  \"description\": \"Some description\",\n" +
+                "  \"return_url\": 1234\n" +
                 "}";
 
         JsonNode jsonNode = objectMapper.readTree(payload);
@@ -132,10 +190,45 @@ public class RequestJsonParserTest {
     }
 
     @Test
-    public void parsePaymentRefundRequest_whenAFieldIsNullValue() throws Exception {
+    public void parsePaymentRequest_whenDescriptionFieldIsNullValue() throws Exception {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": -1000,\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"description\": null,\n" +
+                "  \"return_url\": 1234\n" +
+                "}";
 
-        String payload = "{" +
-                "  \"amount\" : null" +
+        JsonNode jsonNode = objectMapper.readTree(payload);
+
+        expectedException.expect(aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: description"));
+
+        parsePaymentRequest(jsonNode);
+    }
+
+    @Test
+    public void parsePaymentRequest_whenLanguageFieldIsNullValue() throws Exception {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": -1000,\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"description\": \"Some description\",\n" +
+                "  \"return_url\": 1234,\n" +
+                "  \"language\": null\n" +
+                "}";
+
+        JsonNode jsonNode = objectMapper.readTree(payload);
+
+        expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: language. Must be \"en\" or \"cy\""));
+
+        parsePaymentRequest(jsonNode);
+    }
+
+    @Test
+    public void parsePaymentRefundRequest_whenAmountFieldIsNullValue() throws Exception {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": null\n" +
                 "}";
 
         JsonNode jsonNode = objectMapper.readTree(payload);
@@ -146,12 +239,28 @@ public class RequestJsonParserTest {
     }
 
     @Test
-    public void parsePaymentRequest_whenAFieldIsMissing() throws Exception {
+    public void parsePaymentRequest_whenAmountFieldIsMissing() throws Exception {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"description\": \"Some description\",\n" +
+                "  \"return_url\": 1234\n" +
+                "}";
 
-        String payload = "{" +
-                "  \"amount\" : -1000," +
-                "  \"description\" : \"Some description\"," +
-                "  \"return_url\" : 1234" +
+        JsonNode jsonNode = objectMapper.readTree(payload);
+
+        expectedException.expect(aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: amount"));
+
+        parsePaymentRequest(jsonNode);
+    }
+
+    @Test
+    public void parsePaymentRequest_whenReferenceFieldIsMissing() throws Exception {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": -1000,\n" +
+                "  \"description\": \"Some description\",\n" +
+                "  \"return_url\": 1234\n" +
                 "}";
 
         JsonNode jsonNode = objectMapper.readTree(payload);
@@ -162,8 +271,24 @@ public class RequestJsonParserTest {
     }
 
     @Test
-    public void parsePaymentRefundRequest_whenAFieldIsMissing() throws Exception {
+    public void parsePaymentRequest_whenDescriptionFieldIsMissing() throws Exception {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": -1000,\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"return_url\": 1234\n" +
+                "}";
 
+        JsonNode jsonNode = objectMapper.readTree(payload);
+
+        expectedException.expect(aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: description"));
+
+        parsePaymentRequest(jsonNode);
+    }
+
+    @Test
+    public void parsePaymentRefundRequest_whenAmountFieldIsMissing() throws Exception {
+        // language=JSON
         String payload = "{}";
 
         JsonNode jsonNode = objectMapper.readTree(payload);
@@ -175,11 +300,11 @@ public class RequestJsonParserTest {
 
     @Test
     public void parsePaymentRequest_withNoAgreementId_whenReturnUrlIsMissing() throws Exception {
-
-        String payload = "{" +
-                "  \"amount\" : -1000," +
-                "  \"reference\" : \"Some reference\"," +
-                "  \"description\" : \"Some description\"" + 
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": -1000,\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"description\": \"Some description\"\n" +
                 "}";
 
         JsonNode jsonNode = objectMapper.readTree(payload);


### PR DESCRIPTION
- Add optional language to `CreatePaymentRequest`
- Deserialise the `"language"` field from the JSON into the object, checking that it’s a string and returning an P0102 “Invalid attribute value” error if it isn’t
- As language is optional, don’t return a P0101 “Missing mandatory attribute” error if the JSON explicitly contains `"language": null`, instead return a P0102 error
- No validation that the field actually contains a supported language yet
- The language in not yet sent to connector when creating the payment

with @DanailMinchev