### PR TITLE
PP-4095 Validate language in create payment request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <jackson.version>2.9.6</jackson.version>
         <logback.version>1.2.3</logback.version>
         <docker-client.version>8.11.2</docker-client.version>
+        <pay-java-commons.version>1.0.0-7</pay-java-commons.version>
         <pact.version>3.5.16</pact.version>
         <PACT_BROKER_URL/>
         <PACT_BROKER_USERNAME/>
@@ -36,6 +37,11 @@
     </repositories>
 
     <dependencies>
+        <dependency>
+            <groupId>uk.gov.pay</groupId>
+            <artifactId>model</artifactId>
+            <version>${pay-java-commons.version}</version>
+        </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
@@ -112,7 +118,7 @@
         <dependency>
             <groupId>uk.gov.pay</groupId>
             <artifactId>testing</artifactId>
-            <version>1.0.0-4</version>
+            <version>${pay-java-commons.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
@@ -14,7 +14,7 @@ import uk.gov.pay.api.filter.ratelimit.RedisRateLimiter;
 import uk.gov.pay.api.json.CreatePaymentRefundRequestDeserializer;
 import uk.gov.pay.api.json.CreatePaymentRequestDeserializer;
 import uk.gov.pay.api.model.CreatePaymentRefundRequest;
-import uk.gov.pay.api.model.CreatePaymentRequest;
+import uk.gov.pay.api.model.ValidCreatePaymentRequest;
 import uk.gov.pay.api.validation.PaymentRefundRequestValidator;
 import uk.gov.pay.api.validation.PaymentRequestValidator;
 import uk.gov.pay.api.validation.URLValidator;
@@ -55,7 +55,7 @@ public class PublicApiModule extends AbstractModule {
         CreatePaymentRefundRequestDeserializer paymentRefundRequestDeserializer = new CreatePaymentRefundRequestDeserializer(new PaymentRefundRequestValidator());
 
         SimpleModule publicApiDeserializationModule = new SimpleModule("publicApiDeserializationModule");
-        publicApiDeserializationModule.addDeserializer(CreatePaymentRequest.class, paymentRequestDeserializer);
+        publicApiDeserializationModule.addDeserializer(ValidCreatePaymentRequest.class, paymentRequestDeserializer);
         publicApiDeserializationModule.addDeserializer(CreatePaymentRefundRequest.class, paymentRefundRequestDeserializer);
 
         objectMapper.configure(DeserializationFeature.ACCEPT_FLOAT_AS_INT, false);

--- a/src/main/java/uk/gov/pay/api/json/CreatePaymentRequestDeserializer.java
+++ b/src/main/java/uk/gov/pay/api/json/CreatePaymentRequestDeserializer.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import uk.gov.pay.api.exception.BadRequestException;
 import uk.gov.pay.api.model.CreatePaymentRequest;
+import uk.gov.pay.api.model.ValidCreatePaymentRequest;
 import uk.gov.pay.api.validation.PaymentRequestValidator;
 
 import java.io.IOException;
@@ -14,7 +15,7 @@ import static uk.gov.pay.api.json.RequestJsonParser.parsePaymentRequest;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_PARSING_ERROR;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 
-public class CreatePaymentRequestDeserializer extends StdDeserializer<CreatePaymentRequest> {
+public class CreatePaymentRequestDeserializer extends StdDeserializer<ValidCreatePaymentRequest> {
 
     private PaymentRequestValidator validator;
 
@@ -24,7 +25,7 @@ public class CreatePaymentRequestDeserializer extends StdDeserializer<CreatePaym
     }
 
     @Override
-    public CreatePaymentRequest deserialize(JsonParser parser, DeserializationContext context) {
+    public ValidCreatePaymentRequest deserialize(JsonParser parser, DeserializationContext context) {
         CreatePaymentRequest paymentRequest;
         try {
             JsonNode json = parser.readValueAsTree();
@@ -34,6 +35,7 @@ public class CreatePaymentRequestDeserializer extends StdDeserializer<CreatePaym
         }
 
         validator.validate(paymentRequest);
-        return paymentRequest;
+
+        return new ValidCreatePaymentRequest(paymentRequest);
     }
 }

--- a/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
+++ b/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
@@ -5,6 +5,7 @@ import uk.gov.pay.api.exception.BadRequestException;
 import uk.gov.pay.api.model.CreatePaymentRefundRequest;
 import uk.gov.pay.api.model.CreatePaymentRequest;
 import uk.gov.pay.api.model.PaymentError;
+import uk.gov.pay.api.validation.LanguageValidator;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static uk.gov.pay.api.model.CreatePaymentRefundRequest.REFUND_AMOUNT_AVAILABLE;
@@ -34,7 +35,7 @@ class RequestJsonParser {
 
         if (paymentRequest.has(LANGUAGE_FIELD_NAME)) {
             String language = parseString(paymentRequest, LANGUAGE_FIELD_NAME, false,
-                    aPaymentError(LANGUAGE_FIELD_NAME, CREATE_PAYMENT_VALIDATION_ERROR, "Must be \"en\" or \"cy\""));
+                    aPaymentError(LANGUAGE_FIELD_NAME, CREATE_PAYMENT_VALIDATION_ERROR, LanguageValidator.ERROR_MESSAGE));
             createPaymentRequestBuilder.language(language);
         }
 

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
@@ -119,6 +119,10 @@ public class CreatePaymentRequest {
         return StringUtils.isNotBlank(agreementId);
     }
 
+    public boolean hasLanguage() {
+        return StringUtils.isNotBlank(language);
+    }
+
     @Override
     public String toString() {
         // Some services put PII in the description, so don’t include it in the stringification

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
@@ -5,6 +5,9 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Optional;
+import java.util.StringJoiner;
+
 @ApiModel(value = "CreatePaymentRequest", description = "The Payment Request Payload")
 public class CreatePaymentRequest {
 
@@ -123,16 +126,19 @@ public class CreatePaymentRequest {
         return StringUtils.isNotBlank(language);
     }
 
+    /**
+     * This looks JSONesque but is not identical to the received request
+     */
     @Override
     public String toString() {
         // Some services put PII in the description, so don’t include it in the stringification
-        return "CreatePaymentRequest{" +
-                "amount=" + amount +
-                ", returnUrl='" + returnUrl + '\'' +
-                ", reference='" + reference + '\'' +
-                ", agreement_id='" + agreementId + '\'' +
-                ", language='" + language + '\'' +
-                '}';
+        StringJoiner joiner = new StringJoiner(", ", "{", "}");
+        joiner.add("amount: ").add(String.valueOf(amount));
+        joiner.add("reference: ").add(reference);
+        Optional.ofNullable(returnUrl).ifPresent(value -> joiner.add("return_url: ").add(value));
+        Optional.ofNullable(agreementId).ifPresent(value -> joiner.add("agreement_id: ").add(value));
+        Optional.ofNullable(language).ifPresent(value -> joiner.add("language: ").add(value));
+        return joiner.toString();
     }
 
 }

--- a/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
@@ -1,0 +1,59 @@
+package uk.gov.pay.api.model;
+
+import uk.gov.pay.commons.model.SupportedLanguage;
+
+import java.util.Objects;
+
+/**
+ * A create payment request that has been validated successfully
+ * Note that this class does not actually do any validation itself:
+ * do that yourself before constructing an instance of this object
+ **/
+public class ValidCreatePaymentRequest {
+
+    private final int amount;
+    private final String reference;
+    private final String description;
+    private String returnUrl;
+    private String agreementId;
+    private SupportedLanguage language;
+
+    public ValidCreatePaymentRequest(CreatePaymentRequest createPaymentRequest) {
+        amount = Objects.requireNonNull(createPaymentRequest.getAmount());
+        reference = Objects.requireNonNull(createPaymentRequest.getReference());
+        description = Objects.requireNonNull(createPaymentRequest.getDescription());
+
+        returnUrl = createPaymentRequest.getReturnUrl();
+        agreementId = createPaymentRequest.getAgreementId();
+
+        String createPaymentRequestLanguage = createPaymentRequest.getLanguage();
+        if (createPaymentRequestLanguage != null) {
+            language = SupportedLanguage.fromIso639AlphaTwoCode(createPaymentRequestLanguage);
+        }
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    public String getAgreementId() {
+        return agreementId;
+    }
+
+    public SupportedLanguage getLanguage() {
+        return language;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
@@ -3,6 +3,8 @@ package uk.gov.pay.api.model;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.util.Objects;
+import java.util.Optional;
+import java.util.StringJoiner;
 
 /**
  * A create payment request that has been validated successfully
@@ -54,6 +56,21 @@ public class ValidCreatePaymentRequest {
 
     public SupportedLanguage getLanguage() {
         return language;
+    }
+
+    /**
+     * This looks JSONesque but is not identical to the received request
+     */
+    @Override
+    public String toString() {
+        // Some services put PII in the description, so don’t include it in the stringification
+        StringJoiner joiner = new StringJoiner(", ", "{", "}");
+        joiner.add("amount: ").add(String.valueOf(amount));
+        joiner.add("reference: ").add(reference);
+        Optional.ofNullable(returnUrl).ifPresent(value -> joiner.add("return_url: ").add(value));
+        Optional.ofNullable(agreementId).ifPresent(value -> joiner.add("agreement_id: ").add(value));
+        Optional.ofNullable(language).ifPresent(value -> joiner.add("language: ").add(value.toString()));
+        return joiner.toString();
     }
 
 }

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -225,7 +225,7 @@ public class PaymentsResource {
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response createNewPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                      @ApiParam(value = "requestPayload", required = true) ValidCreatePaymentRequest validCreatePaymentRequest) {
-        logger.info("Payment create request - [ {} ]", validCreatePaymentRequest);
+        logger.info("Payment create request passed validation and parsed to {}", validCreatePaymentRequest);
 
         PaymentWithAllLinks createdPayment = createPaymentService.create(account, validCreatePaymentRequest);
 

--- a/src/main/java/uk/gov/pay/api/validation/LanguageValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/LanguageValidator.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.api.validation;
+
+import uk.gov.pay.commons.model.SupportedLanguage;
+
+import java.util.Arrays;
+
+public class LanguageValidator {
+
+    public static final String ERROR_MESSAGE = "Must be \"en\" or \"cy\"";
+
+    static boolean isValid(String value) {
+        return Arrays.stream(SupportedLanguage.values()).anyMatch(supportedLanguage -> supportedLanguage.toString().equals(value));
+    }
+
+}

--- a/src/main/java/uk/gov/pay/api/validation/PaymentRequestValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/PaymentRequestValidator.java
@@ -5,7 +5,12 @@ import uk.gov.pay.api.model.CreatePaymentRequest;
 import uk.gov.pay.api.model.PaymentError;
 
 import static java.lang.String.format;
-import static uk.gov.pay.api.model.CreatePaymentRequest.*;
+import static uk.gov.pay.api.model.CreatePaymentRequest.AGREEMENT_ID_FIELD_NAME;
+import static uk.gov.pay.api.model.CreatePaymentRequest.AMOUNT_FIELD_NAME;
+import static uk.gov.pay.api.model.CreatePaymentRequest.DESCRIPTION_FIELD_NAME;
+import static uk.gov.pay.api.model.CreatePaymentRequest.LANGUAGE_FIELD_NAME;
+import static uk.gov.pay.api.model.CreatePaymentRequest.REFERENCE_FIELD_NAME;
+import static uk.gov.pay.api.model.CreatePaymentRequest.RETURN_URL_FIELD_NAME;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_VALIDATION_ERROR;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 
@@ -35,10 +40,16 @@ public class PaymentRequestValidator {
     public void validate(CreatePaymentRequest paymentRequest) {
         if (paymentRequest.hasAgreementId()) {
             validateAgreementId(paymentRequest.getAgreementId());
-        } 
+        }
+
         if (paymentRequest.hasReturnUrl()) {
             validateReturnUrl(paymentRequest.getReturnUrl());
         }
+
+        if (paymentRequest.hasLanguage()) {
+            validateLanguage(paymentRequest.getLanguage());
+        }
+
         validateAmount(paymentRequest.getAmount());
         validateReference(paymentRequest.getReference());
         validateDescription(paymentRequest.getDescription());
@@ -75,9 +86,15 @@ public class PaymentRequestValidator {
                 aPaymentError(DESCRIPTION_FIELD_NAME, CREATE_PAYMENT_VALIDATION_ERROR, format(CONSTRAINT_MESSAGE_STRING_TEMPLATE, DESCRIPTION_MAX_LENGTH)));
     }
 
+    private void validateLanguage(String language) {
+        validate(LanguageValidator.isValid(language),
+                aPaymentError(LANGUAGE_FIELD_NAME, CREATE_PAYMENT_VALIDATION_ERROR, LanguageValidator.ERROR_MESSAGE));
+    }
+
     private static void validate(boolean condition, PaymentError error) {
         if (!condition) {
             throw new ValidationException(error);
         }
     }
+
 }

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceLanguageValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceLanguageValidationITest.java
@@ -1,0 +1,202 @@
+package uk.gov.pay.api.it.validation;
+
+import com.jayway.jsonassert.JsonAssert;
+import com.jayway.restassured.response.ValidatableResponse;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.api.it.PaymentResourceITestBase;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static com.jayway.restassured.RestAssured.given;
+import static com.jayway.restassured.http.ContentType.JSON;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+
+public class PaymentsResourceLanguageValidationITest extends PaymentResourceITestBase {
+
+    @Before
+    public void setUpBearerToken() {
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+    }
+
+    @Test
+    public void createPayment_responseWith422_whenLanguageIsNotSupported() throws IOException {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": 9900,\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"description\": \"Some description\",\n" +
+                "  \"return_url\": \"https://example.com\",\n" +
+                "  \"language\": \"fr\"\n" +
+                "}";
+
+        InputStream body = postPaymentResponse(API_KEY, payload)
+                .statusCode(422)
+                .contentType(JSON)
+                .extract()
+                .body().asInputStream();
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(3))
+                .assertThat("$.field", is("language"))
+                .assertThat("$.code", is("P0102"))
+                .assertThat("$.description", is("Invalid attribute value: language. Must be \"en\" or \"cy\""));
+    }
+
+    @Test
+    public void createPayment_responseWith400_whenLanguageIsNumeric() throws IOException {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": 9900,\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"description\": \"Some description\",\n" +
+                "  \"return_url\": \"https://example.com\",\n" +
+                "  \"language\": 1337\n" +
+                "}";
+
+        InputStream body = postPaymentResponse(API_KEY, payload)
+                .statusCode(400)
+                .contentType(JSON)
+                .extract()
+                .body().asInputStream();
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(3))
+                .assertThat("$.field", is("language"))
+                .assertThat("$.code", is("P0102"))
+                .assertThat("$.description", is("Invalid attribute value: language. Must be \"en\" or \"cy\""));
+    }
+
+    @Test
+    public void createPayment_responseWith400_whenLanguageIsEmpty() throws IOException {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": 9900,\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"description\": \"Some description\",\n" +
+                "  \"return_url\": \"https://example.com\",\n" +
+                "  \"language\": \"\"\n" +
+                "}";
+
+        InputStream body = postPaymentResponse(API_KEY, payload)
+                .statusCode(400)
+                .contentType(JSON)
+                .extract()
+                .body().asInputStream();
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(3))
+                .assertThat("$.field", is("language"))
+                .assertThat("$.code", is("P0102"))
+                .assertThat("$.description", is("Invalid attribute value: language. Must be \"en\" or \"cy\""));
+    }
+
+    @Test
+    public void createPayment_responseWith400_whenLanguageIsBlank() throws IOException {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": 9900,\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"description\": \"Some description\",\n" +
+                "  \"return_url\": \"https://example.com\",\n" +
+                "  \"language\": \" \"\n" +
+                "}";
+
+        InputStream body = postPaymentResponse(API_KEY, payload)
+                .statusCode(400)
+                .contentType(JSON)
+                .extract()
+                .body().asInputStream();
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(3))
+                .assertThat("$.field", is("language"))
+                .assertThat("$.code", is("P0102"))
+                .assertThat("$.description", is("Invalid attribute value: language. Must be \"en\" or \"cy\""));
+    }
+
+    @Test
+    public void createPayment_responseWith400_whenLanguageIsNull() throws IOException {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": 9900,\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"description\": \"Some description\",\n" +
+                "  \"return_url\": \"https://example.com\",\n" +
+                "  \"language\": null\n" +
+                "}";
+
+        InputStream body = postPaymentResponse(API_KEY, payload)
+                .statusCode(400)
+                .contentType(JSON)
+                .extract()
+                .body().asInputStream();
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(3))
+                .assertThat("$.field", is("language"))
+                .assertThat("$.code", is("P0102"))
+                .assertThat("$.description", is("Invalid attribute value: language. Must be \"en\" or \"cy\""));
+    }
+
+    @Test
+    public void createPayment_responseWith400_whenLanguageHasNotAValidJsonValue() throws IOException {
+        String payload = "{" +
+                "  \"amount\" : 9900," +
+                "  \"reference\" : \"Some reference\"," +
+                "  \"description\" : \"Some description\"," +
+                "  \"return_url\" : \"https://example.com\"," +
+                "  \"language\" : " +
+                "}";
+
+        InputStream body = postPaymentResponse(API_KEY, payload)
+                .statusCode(400)
+                .contentType(JSON)
+                .extract()
+                .body().asInputStream();
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(2))
+                .assertThat("$.code", is("P0197"))
+                .assertThat("$.description", is("Unable to parse JSON"));
+    }
+
+    @Test
+    public void createPayment_responseWith400_whenLanguageFieldIsNotExpectedJsonField() throws IOException {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": 9900,\n" +
+                "  \"language\": {\n" +
+                "    \"whatever\": 1\n" +
+                "  },\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"description\": \"Some description\",\n" +
+                "  \"return_url\": \"https://example.com\"\n" +
+                "}";
+
+        InputStream body = postPaymentResponse(API_KEY, payload)
+                .statusCode(400)
+                .contentType(JSON)
+                .extract()
+                .body().asInputStream();
+
+        JsonAssert.with(body)
+                .assertThat("$.*", hasSize(3))
+                .assertThat("$.field", is("language"))
+                .assertThat("$.code", is("P0102"))
+                .assertThat("$.description", is("Invalid attribute value: language. Must be \"en\" or \"cy\""));
+    }
+
+    private ValidatableResponse postPaymentResponse(String bearerToken, String payload) {
+        return given().port(app.getLocalPort())
+                .body(payload)
+                .accept(JSON)
+                .contentType(JSON)
+                .header(AUTHORIZATION, "Bearer " + bearerToken)
+                .post(PAYMENTS_PATH)
+                .then();
+    }
+}

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -14,6 +14,7 @@ import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.model.SettlementSummary;
 import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.api.model.ValidCreatePaymentRequest;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 import uk.gov.pay.api.service.ConnectorUriGenerator;
 import uk.gov.pay.api.service.CreatePaymentService;
@@ -66,12 +67,12 @@ public class PaymentsResourceCreatePaymentTest {
     @Test
     public void createNewPayment_withCardPayment_invokesCreatePaymentService() throws Exception {
         final Account account = new Account("foo", TokenPaymentType.CARD);
-        final CreatePaymentRequest createPaymentRequest = CreatePaymentRequest.builder()
+        final ValidCreatePaymentRequest createPaymentRequest = new ValidCreatePaymentRequest(CreatePaymentRequest.builder()
                 .amount(100)
                 .returnUrl("https://somewhere.test")
                 .reference("my_ref")
                 .description("New Passport")
-                .build();
+                .build());
         PaymentWithAllLinks injectedResponse = aSuccessfullyCreatedPayment();
 
         when(createPaymentService.create(account, createPaymentRequest)).thenReturn(injectedResponse);

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -14,6 +14,7 @@ import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.CreatePaymentRequest;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.api.model.ValidCreatePaymentRequest;
 import uk.gov.pay.api.model.links.Link;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 import uk.gov.pay.api.model.links.PostLink;
@@ -58,12 +59,12 @@ public class CreatePaymentServiceTest {
     @Pacts(pacts = {"publicapi-connector-create-payment"}, publish = false)
     public void testCreatePayment() {
         Account account = new Account("123456", TokenPaymentType.CARD);
-        CreatePaymentRequest requestPayload = CreatePaymentRequest.builder()
+        ValidCreatePaymentRequest requestPayload = new ValidCreatePaymentRequest(CreatePaymentRequest.builder()
                 .amount(100)
                 .returnUrl("https://somewhere.gov.uk/rainbow/1")
                 .reference("a reference")
                 .description("a description")
-                .build();
+                .build());
 
         PaymentWithAllLinks paymentResponse = createPaymentService.create(account, requestPayload);
 

--- a/src/test/java/uk/gov/pay/api/validation/PaymentRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/PaymentRequestValidatorTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.api.exception.ValidationException;
 import uk.gov.pay.api.model.CreatePaymentRequest;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 
@@ -23,88 +24,107 @@ public class PaymentRequestValidatorTest {
 
     @Test
     public void validParameters_withReturnUrl_shouldSuccessValue() {
-        CreatePaymentRequest createPaymentRequest = createPaymentRequestWithReturnUrl(VALID_AMOUNT, VALID_RETURN_URL, VALID_REFERENCE, VALID_DESCRIPTION);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().build();
         paymentRequestValidator.validate(createPaymentRequest);
     }
 
     @Test
     public void validParameters_withAgreementId_shouldSuccessValue() {
-        CreatePaymentRequest createPaymentRequest = createPaymentRequestWithAgreementId(VALID_AMOUNT, VALID_REFERENCE, VALID_DESCRIPTION, VALID_AGREEMENT_ID);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().build();
+        paymentRequestValidator.validate(createPaymentRequest);
+    }
+
+    @Test
+    public void validParameters_withEnglishLanguage_shouldSuccessValue() {
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().language(SupportedLanguage.ENGLISH.toString()).build();
+        paymentRequestValidator.validate(createPaymentRequest);
+    }
+
+    @Test
+    public void validParameters_withWelshLanguage_shouldSuccessValue() {
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().language(SupportedLanguage.WELSH.toString()).build();
+        paymentRequestValidator.validate(createPaymentRequest);
+    }
+
+    @Test
+    public void validateUnsupportedLanguage_shouldFailValue() {
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().language("unsupported language").build();
+        expectedException.expect(ValidationException.class);
         paymentRequestValidator.validate(createPaymentRequest);
     }
 
     @Test
     public void validateMinimumAmount_shouldSuccessValue() {
-        CreatePaymentRequest createPaymentRequest = createPaymentRequestWithReturnUrl(PaymentRequestValidator.AMOUNT_MIN_VALUE, VALID_RETURN_URL, VALID_REFERENCE, VALID_DESCRIPTION);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().amount(PaymentRequestValidator.AMOUNT_MIN_VALUE).build();
         paymentRequestValidator.validate(createPaymentRequest);
     }
 
     @Test
     public void validateMinimumAmount_shouldFailValue() {
-        CreatePaymentRequest createPaymentRequest = createPaymentRequestWithReturnUrl(PaymentRequestValidator.AMOUNT_MIN_VALUE - 1, VALID_RETURN_URL, VALID_REFERENCE, VALID_DESCRIPTION);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().amount(PaymentRequestValidator.AMOUNT_MIN_VALUE - 1).build();
         expectedException.expect(ValidationException.class);
         paymentRequestValidator.validate(createPaymentRequest);
     }
 
     @Test
     public void validateMaximumAmount_shouldSuccessValue() {
-        CreatePaymentRequest createPaymentRequest = createPaymentRequestWithReturnUrl(PaymentRequestValidator.AMOUNT_MAX_VALUE, VALID_RETURN_URL, VALID_REFERENCE, VALID_DESCRIPTION);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().amount(PaymentRequestValidator.AMOUNT_MAX_VALUE).build();
         paymentRequestValidator.validate(createPaymentRequest);
     }
 
     @Test
     public void validateMaximumAmount_shouldFailValue() {
-        CreatePaymentRequest paymentRequest = createPaymentRequestWithReturnUrl(PaymentRequestValidator.AMOUNT_MAX_VALUE + 1, VALID_RETURN_URL, VALID_REFERENCE, VALID_DESCRIPTION);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().amount(PaymentRequestValidator.AMOUNT_MAX_VALUE + 1).build();
         expectedException.expect(ValidationException.class);
-        paymentRequestValidator.validate(paymentRequest);
+        paymentRequestValidator.validate(createPaymentRequest);
     }
 
     @Test
     public void validateReturnUrlMaxLength_shouldFailValue() {
         String invalidMaxLengthReturnUrl = "https://" + randomAlphanumeric(PaymentRequestValidator.URL_MAX_LENGTH) + ".com/";
-        CreatePaymentRequest paymentRequest = createPaymentRequestWithReturnUrl(VALID_AMOUNT, invalidMaxLengthReturnUrl, VALID_REFERENCE, VALID_DESCRIPTION);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().returnUrl(invalidMaxLengthReturnUrl).build();
         expectedException.expect(ValidationException.class);
-        paymentRequestValidator.validate(paymentRequest);
+        paymentRequestValidator.validate(createPaymentRequest);
     }
 
     @Test
     public void validateReturnUrlNotHttps_shouldFailValue() {
         String validHttpOnlyUrl = "http://www.example.com/";
-        CreatePaymentRequest paymentRequest = createPaymentRequestWithReturnUrl(VALID_AMOUNT, validHttpOnlyUrl, VALID_REFERENCE, VALID_DESCRIPTION);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().returnUrl(validHttpOnlyUrl).build();
         expectedException.expect(ValidationException.class);
-        paymentRequestValidator.validate(paymentRequest);
+        paymentRequestValidator.validate(createPaymentRequest);
     }
 
     @Test
     public void validateReferenceMaxLength_shouldFailValue() {
         String invalidMaxLengthReference = randomAlphanumeric(PaymentRequestValidator.REFERENCE_MAX_LENGTH + 1);
-        CreatePaymentRequest paymentRequest = createPaymentRequestWithReturnUrl(VALID_AMOUNT, VALID_RETURN_URL, invalidMaxLengthReference, VALID_DESCRIPTION);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().reference(invalidMaxLengthReference).build();
         expectedException.expect(ValidationException.class);
-        paymentRequestValidator.validate(paymentRequest);
+        paymentRequestValidator.validate(createPaymentRequest);
     }
 
     @Test
     public void validateDescriptionMaxLength_shouldFailValue() {
         String invalidMaxLengthDescription = randomAlphanumeric(PaymentRequestValidator.DESCRIPTION_MAX_LENGTH + 1);
-        CreatePaymentRequest paymentRequest = createPaymentRequestWithReturnUrl(VALID_AMOUNT, VALID_RETURN_URL, VALID_REFERENCE, invalidMaxLengthDescription);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().description(invalidMaxLengthDescription).build();
         expectedException.expect(ValidationException.class);
-        paymentRequestValidator.validate(paymentRequest);
+        paymentRequestValidator.validate(createPaymentRequest);
     }
 
     @Test
     public void validateAgreementIdMaxLength_shouldFailValue() {
         String invalidMaxLengthAgreementId = randomAlphanumeric(PaymentRequestValidator.AGREEMENT_ID_MAX_LENGTH + 1);
-        CreatePaymentRequest paymentRequest = createPaymentRequestWithAgreementId(VALID_AMOUNT, VALID_REFERENCE, VALID_DESCRIPTION, invalidMaxLengthAgreementId);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().agreementId(invalidMaxLengthAgreementId).build();
         expectedException.expect(ValidationException.class);
-        paymentRequestValidator.validate(paymentRequest);
+        paymentRequestValidator.validate(createPaymentRequest);
     }
 
-    private static CreatePaymentRequest createPaymentRequestWithReturnUrl(int amount, String returnUrl, String reference, String description) {
-        return CreatePaymentRequest.builder().amount(amount).returnUrl(returnUrl).reference(reference).description(description).build();
+    private static CreatePaymentRequest.CreatePaymentRequestBuilder createPaymentRequestBuilderWithReturnUrl() {
+        return CreatePaymentRequest.builder().amount(VALID_AMOUNT).returnUrl(VALID_RETURN_URL).reference(VALID_REFERENCE).description(VALID_DESCRIPTION);
     }
 
-    private static CreatePaymentRequest createPaymentRequestWithAgreementId(int amount, String reference, String description, String agreementId) {
-        return CreatePaymentRequest.builder().amount(amount).reference(reference).description(description).agreementId(agreementId).build();
+    private static CreatePaymentRequest.CreatePaymentRequestBuilder createPaymentRequestBuilderWithAgreementId() {
+        return CreatePaymentRequest.builder().amount(VALID_AMOUNT).agreementId(VALID_AGREEMENT_ID).reference(VALID_REFERENCE).description(VALID_DESCRIPTION);
     }
 
 }


### PR DESCRIPTION
- Reject create payment requests with a `"language"` that is not `"en"` or `"cy"`
- After validating a `CreatePaymentRequest` object, convert it to a new `ValidCreatePaymentRequest` object for the rest of its time in the system — because we know its fields are valid, we can use more specific types like the `SupportedLanguage` enum rather than JSON-compatible types like String
- Tests, lots of tests
- Still not actually sending the language to connector when creating a payment

with @DanailMinchev