### PR TITLE
PP-4095 Send language to and return language from connector

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -2,15 +2,17 @@ package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
 
-
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 @ApiModel(value = "CardPayment")
-public class CardPayment extends Payment  {
+public class CardPayment extends Payment {
 
     @JsonProperty("refund_summary")
     private final RefundSummary refundSummary;
@@ -21,21 +23,25 @@ public class CardPayment extends Payment  {
     @JsonProperty("card_details")
     private final CardDetails cardDetails;
 
-
+    @JsonSerialize(using = ToStringSerializer.class)
+    private final SupportedLanguage language;
 
     public CardPayment(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                        String reference, String email, String paymentProvider, String createdDate,
-                       RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails) {
+                       RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
+                       SupportedLanguage language) {
         super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate);
         this.refundSummary = refundSummary;
         this.settlementSummary = settlementSummary;
         this.cardDetails = cardDetails;
         this.paymentType = CARD.getFriendlyName();
+        this.language = language;
     }
 
     /**
      * card brand is no longer a top level charge property. It is now at `card_details.card_brand` attribute
      * We still need to support `v1` clients with a top level card brand attribute to keep support their integrations.
+     *
      * @return
      */
     @ApiModelProperty(value = "Card Brand", example = "Visa", notes = "Deprecated. Please use card_details.card_brand instead")
@@ -60,6 +66,11 @@ public class CardPayment extends Payment  {
         return cardDetails;
     }
 
+    @ApiModelProperty(example = "en")
+    public SupportedLanguage getLanguage() {
+        return language;
+    }
+
     @Override
     public String toString() {
         // Some services put PII in the description, so don’t include it in the stringification
@@ -71,7 +82,9 @@ public class CardPayment extends Payment  {
                 ", state='" + state + '\'' +
                 ", returnUrl='" + returnUrl + '\'' +
                 ", reference='" + reference + '\'' +
+                ", language='" + language.toString() + '\'' +
                 ", createdDate='" + createdDate + '\'' +
                 '}';
     }
+
 }

--- a/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
@@ -3,6 +3,9 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import uk.gov.pay.api.utils.CustomSupportedLanguageDeserializer;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,10 +36,17 @@ public class ChargeFromResponse {
     private CardDetails cardDetails;
 
     private Long amount;
+
     private PaymentState state;
+
     private String description;
+
     private String reference;
+
     private String email;
+
+    @JsonDeserialize(using = CustomSupportedLanguageDeserializer.class)
+    private SupportedLanguage language;
 
     @JsonProperty(value = "created_date")
     private String createdDate;
@@ -69,6 +79,10 @@ public class ChargeFromResponse {
         return email;
     }
 
+    public SupportedLanguage getLanguage() {
+        return language;
+    }
+
     public String getPaymentProvider() {
         return paymentProvider;
     }
@@ -76,6 +90,7 @@ public class ChargeFromResponse {
     /**
      * card brand is no longer a top level charge property. It is now at `card_details.card_brand` attribute
      * We still need to support `v1` clients with a top level card brand attribute to keep support their integrations.
+     *
      * @return
      */
     @JsonProperty("card_brand")

--- a/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
@@ -46,16 +46,16 @@ public class ValidCreatePaymentRequest {
         return description;
     }
 
-    public String getReturnUrl() {
-        return returnUrl;
+    public Optional<String> getReturnUrl() {
+        return Optional.ofNullable(returnUrl);
     }
 
-    public String getAgreementId() {
-        return agreementId;
+    public Optional<String> getAgreementId() {
+        return Optional.ofNullable(agreementId);
     }
 
-    public SupportedLanguage getLanguage() {
-        return language;
+    public Optional<SupportedLanguage> getLanguage() {
+        return Optional.ofNullable(language);
     }
 
     /**

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -13,6 +13,7 @@ import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.model.SettlementSummary;
 import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.net.URI;
 import java.util.List;
@@ -38,10 +39,12 @@ public class PaymentWithAllLinks {
     }
 
     public PaymentWithAllLinks(String chargeId, long amount, PaymentState state, String returnUrl, String description,
-                                String reference, String email, String paymentProvider, String createdDate,
-                                RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails, List<PaymentConnectorResponseLink> paymentConnectorResponseLinks,
-                                URI selfLink, URI paymentEventsUri, URI paymentCancelUri, URI paymentRefundsUri) {
-        this.payment = new CardPayment(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate, refundSummary, settlementSummary, cardDetails);
+                               String reference, String email, String paymentProvider, String createdDate, SupportedLanguage language,
+                               RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
+                               List<PaymentConnectorResponseLink> paymentConnectorResponseLinks, URI selfLink, URI paymentEventsUri, URI paymentCancelUri,
+                               URI paymentRefundsUri) {
+        this.payment = new CardPayment(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate,
+                refundSummary, settlementSummary, cardDetails, language);
         this.links.addSelf(selfLink.toString());
         this.links.addKnownLinksValueOf(paymentConnectorResponseLinks);
         this.links.addEvents(paymentEventsUri.toString());
@@ -92,6 +95,7 @@ public class PaymentWithAllLinks {
                 paymentConnector.getEmail(),
                 paymentConnector.getPaymentProvider(),
                 paymentConnector.getCreatedDate(),
+                paymentConnector.getLanguage(),
                 paymentConnector.getRefundSummary(),
                 paymentConnector.getSettlementSummary(),
                 paymentConnector.getCardDetails(),
@@ -109,7 +113,7 @@ public class PaymentWithAllLinks {
             URI selfLink,
             URI paymentEventsUri,
             URI paymentCancelUri,
-            URI paymentRefundsUri){
+            URI paymentRefundsUri) {
         switch (paymentType) {
             case DIRECT_DEBIT:
                 return PaymentWithAllLinks.valueOf(paymentConnector, selfLink);

--- a/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
@@ -9,6 +9,7 @@ import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.model.SettlementSummary;
 import uk.gov.pay.api.model.links.PaymentLinksForSearch;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.net.URI;
 
@@ -18,10 +19,11 @@ public class PaymentForSearchResult extends CardPayment {
     private PaymentLinksForSearch links = new PaymentLinksForSearch();
 
     public PaymentForSearchResult(String chargeId, long amount, PaymentState state, String returnUrl, String description,
-                                  String reference, String email, String paymentProvider, String createdDate,
+                                  String reference, String email, String paymentProvider, String createdDate, SupportedLanguage language,
                                   RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
                                   URI selfLink, URI paymentEventsLink, URI paymentCancelLink, URI paymentRefundsLink) {
-        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate, refundSummary, settlementSummary, cardDetails);
+        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider,
+                createdDate, refundSummary, settlementSummary, cardDetails, language);
         this.links.addSelf(selfLink.toString());
         this.links.addEvents(paymentEventsLink.toString());
         this.links.addRefunds(paymentRefundsLink.toString());
@@ -48,6 +50,7 @@ public class PaymentForSearchResult extends CardPayment {
                 paymentResult.getEmail(),
                 paymentResult.getPaymentProvider(),
                 paymentResult.getCreatedDate(),
+                paymentResult.getLanguage(),
                 paymentResult.getRefundSummary(),
                 paymentResult.getSettlementSummary(),
                 paymentResult.getCardDetails(),

--- a/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
@@ -13,7 +13,6 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.Optional;
 
 import static javax.ws.rs.client.Entity.json;
 
@@ -57,7 +56,7 @@ public class CreatePaymentService {
 
     private Response createCharge(Account account, ValidCreatePaymentRequest validCreatePaymentRequest) {
         return client
-                .target(connectorUriGenerator.chargesURI(account, validCreatePaymentRequest.getAgreementId()))
+                .target(connectorUriGenerator.chargesURI(account, validCreatePaymentRequest.getAgreementId().orElse(null)))
                 .request()
                 .accept(MediaType.APPLICATION_JSON)
                 .post(buildChargeRequestPayload(validCreatePaymentRequest));
@@ -67,14 +66,12 @@ public class CreatePaymentService {
         int amount = requestPayload.getAmount();
         String reference = requestPayload.getReference();
         String description = requestPayload.getDescription();
-        Optional<String> maybeReturnUrl = Optional.ofNullable(requestPayload.getReturnUrl());
-        Optional<String> maybeAgreementId = Optional.ofNullable(requestPayload.getAgreementId());
         JsonStringBuilder request = new JsonStringBuilder()
                 .add("amount", amount)
                 .add("reference", reference)
                 .add("description", description);
-        maybeReturnUrl.ifPresent(returnUrl -> request.add("return_url", returnUrl));
-        maybeAgreementId.ifPresent(agreementId -> request.add("agreement_id", agreementId));
+        requestPayload.getReturnUrl().ifPresent(returnUrl -> request.add("return_url", returnUrl));
+        requestPayload.getAgreementId().ifPresent(agreementId -> request.add("agreement_id", agreementId));
         return json(request.build());
     }
 }

--- a/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
@@ -42,12 +42,12 @@ public class CreatePaymentService {
 
     private PaymentWithAllLinks buildResponseModel(Account account, ChargeFromResponse chargeFromResponse) {
         return PaymentWithAllLinks.getPaymentWithLinks(
-                    account.getPaymentType(),
-                    chargeFromResponse,
-                    publicApiUriGenerator.getPaymentURI(chargeFromResponse.getChargeId()),
-                    publicApiUriGenerator.getPaymentEventsURI(chargeFromResponse.getChargeId()),
-                    publicApiUriGenerator.getPaymentCancelURI(chargeFromResponse.getChargeId()),
-                    publicApiUriGenerator.getPaymentRefundsURI(chargeFromResponse.getChargeId()));
+                account.getPaymentType(),
+                chargeFromResponse,
+                publicApiUriGenerator.getPaymentURI(chargeFromResponse.getChargeId()),
+                publicApiUriGenerator.getPaymentEventsURI(chargeFromResponse.getChargeId()),
+                publicApiUriGenerator.getPaymentCancelURI(chargeFromResponse.getChargeId()),
+                publicApiUriGenerator.getPaymentRefundsURI(chargeFromResponse.getChargeId()));
     }
 
     private boolean createdSuccessfully(Response connectorResponse) {
@@ -70,6 +70,7 @@ public class CreatePaymentService {
                 .add("amount", amount)
                 .add("reference", reference)
                 .add("description", description);
+        requestPayload.getLanguage().ifPresent(language -> request.add("language", language.toString()));
         requestPayload.getReturnUrl().ifPresent(returnUrl -> request.add("return_url", returnUrl));
         requestPayload.getAgreementId().ifPresent(agreementId -> request.add("agreement_id", agreementId));
         return json(request.build());

--- a/src/main/java/uk/gov/pay/api/utils/CustomSupportedLanguageDeserializer.java
+++ b/src/main/java/uk/gov/pay/api/utils/CustomSupportedLanguageDeserializer.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.api.utils;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import uk.gov.pay.commons.model.SupportedLanguage;
+
+import java.io.IOException;
+
+public class CustomSupportedLanguageDeserializer extends StdDeserializer<SupportedLanguage> {
+
+    public CustomSupportedLanguageDeserializer() {
+        this(null);
+    }
+
+    public CustomSupportedLanguageDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public SupportedLanguage deserialize(JsonParser jsonparser, DeserializationContext context) throws IOException {
+        return SupportedLanguage.fromIso639AlphaTwoCode(jsonparser.getText());
+    }
+}

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentITest.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentITest.java
@@ -9,6 +9,7 @@ import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.utils.DateTimeUtils;
 import uk.gov.pay.api.utils.JsonStringBuilder;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import javax.ws.rs.core.HttpHeaders;
 import java.io.InputStream;
@@ -48,7 +49,8 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, CARD);
 
         connectorMock.respondOk_whenCreateCharge(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID,
-                CREATED, RETURN_URL, DESCRIPTION, REFERENCE, null, PAYMENT_PROVIDER, CREATED_DATE, REFUND_SUMMARY, null, CARD_DETAILS);
+                CREATED, RETURN_URL, DESCRIPTION, REFERENCE, null, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, REFUND_SUMMARY,
+                null, CARD_DETAILS);
 
         String responseBody = postPaymentResponse(API_KEY, SUCCESS_PAYLOAD)
                 .statusCode(201)
@@ -101,7 +103,8 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
 
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondOk_whenCreateCharge(minimumAmount, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID,
-                CREATED, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, REFUND_SUMMARY, null, CARD_DETAILS);
+                CREATED, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH,
+                REFUND_SUMMARY, null, CARD_DETAILS);
 
         postPaymentResponse(API_KEY, paymentPayload(minimumAmount, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL))
                 .statusCode(201)
@@ -129,7 +132,8 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
 
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondOk_whenCreateCharge(amount, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID,
-                CREATED, return_url, description, reference, email, PAYMENT_PROVIDER, CREATED_DATE, REFUND_SUMMARY, null, CARD_DETAILS);
+                CREATED, return_url, description, reference, email, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH,
+                REFUND_SUMMARY, null, CARD_DETAILS);
 
         String body = new JsonStringBuilder()
                 .add("amount", amount)

--- a/src/test/java/uk/gov/pay/api/it/GetPaymentITest.java
+++ b/src/test/java/uk/gov/pay/api/it/GetPaymentITest.java
@@ -10,6 +10,7 @@ import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.model.SettlementSummary;
 import uk.gov.pay.api.utils.ChargeEventBuilder;
 import uk.gov.pay.api.utils.DateTimeUtils;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -56,7 +57,8 @@ public class GetPaymentITest extends PaymentResourceITestBase {
     public void getPayment_ReturnsPayment() {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CAPTURED, RETURN_URL,
-                DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, CHARGE_TOKEN_ID, REFUND_SUMMARY, SETTLEMENT_SUMMARY, CARD_DETAILS);
+                DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, CHARGE_TOKEN_ID, REFUND_SUMMARY, SETTLEMENT_SUMMARY,
+                CARD_DETAILS);
 
         getPaymentResponse(API_KEY, CHARGE_ID)
                 .statusCode(200)
@@ -71,6 +73,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
                 .body("payment_provider", is(PAYMENT_PROVIDER))
                 .body("card_brand", is(CARD_BRAND_LABEL))
                 .body("created_date", is(CREATED_DATE))
+                .body("language", is("en"))
                 .body("refund_summary.status", is("pending"))
                 .body("refund_summary.amount_submitted", is(50))
                 .body("refund_summary.amount_available", is(100))
@@ -139,7 +142,8 @@ public class GetPaymentITest extends PaymentResourceITestBase {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID,
                 new PaymentState("success", true, null, null),
-                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, CHARGE_TOKEN_ID, REFUND_SUMMARY, null, CARD_DETAILS);
+                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, CHARGE_TOKEN_ID, REFUND_SUMMARY,
+                null, CARD_DETAILS);
 
         getPaymentResponse(API_KEY, CHARGE_ID)
                 .statusCode(200)
@@ -151,7 +155,8 @@ public class GetPaymentITest extends PaymentResourceITestBase {
     public void getPayment_ShouldNotIncludeSettlementFieldsIfNull() {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID,
-                CREATED, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, CHARGE_TOKEN_ID, REFUND_SUMMARY, new SettlementSummary(null, null), CARD_DETAILS);
+                CREATED, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, CHARGE_TOKEN_ID, REFUND_SUMMARY,
+                new SettlementSummary(null, null), CARD_DETAILS);
 
         getPaymentResponse(API_KEY, CHARGE_ID)
                 .statusCode(200)

--- a/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
@@ -10,6 +10,7 @@ import uk.gov.pay.api.model.Address;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.utils.DateTimeUtils;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -156,7 +157,8 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
     public void createRefundWithNoRefundAmountAvailable_shouldGetAcceptedResponse() {
         String payload = new GsonBuilder().create().toJson(
                 ImmutableMap.of("amount", AMOUNT));
-        connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, null, null, null, null, null, null, null, null,
+        connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, null, null, null, null, null,
+                null, null, SupportedLanguage.ENGLISH, null,
                 new RefundSummary("available", 9000, 1000), null, CARD_DETAILS);
 
         postRefundRequest(payload);

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.api.it;
 
-
 import com.google.common.collect.ImmutableMap;
 import com.jayway.jsonassert.JsonAssert;
 import com.jayway.restassured.response.ValidatableResponse;
@@ -88,6 +87,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                 .body("results[0].amount", is(DEFAULT_AMOUNT))
                 .body("results[0].payment_provider", is(DEFAULT_PAYMENT_PROVIDER))
                 .body("results[0].payment_id", is("0"))
+                .body("results[0].language", is("en"))
                 .body("results[0]._links.self.method", is("GET"))
                 .body("results[0]._links.self.href", is(paymentLocationFor("0")))
                 .body("results[0]._links.events.href", is(paymentEventsLocationFor("0")))

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterLocalRateLimiterITest.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterLocalRateLimiterITest.java
@@ -22,6 +22,7 @@ import uk.gov.pay.api.utils.DateTimeUtils;
 import uk.gov.pay.api.utils.JsonStringBuilder;
 import uk.gov.pay.api.utils.PublicAuthMockClient;
 import uk.gov.pay.api.utils.mocks.ConnectorMockClient;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.time.ZonedDateTime;
 import java.util.Arrays;
@@ -93,7 +94,7 @@ public class ResourcesFilterLocalRateLimiterITest {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
         connectorMock.respondOk_whenCreateCharge(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID, CREATED,
-                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, REFUND_SUMMARY,
+                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, REFUND_SUMMARY,
                 null, CARD_DETAILS);
     }
 

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterITest.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterITest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.jayway.restassured.response.ValidatableResponse;
 import org.junit.Test;
 import uk.gov.pay.api.it.fixtures.PaymentNavigationLinksFixture;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.util.Arrays;
 import java.util.List;
@@ -20,7 +21,8 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
     public void createPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
 
         connectorMock.respondOk_whenCreateCharge(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID, CREATED,
-                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, REFUND_SUMMARY, null, CARD_DETAILS);
+                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, REFUND_SUMMARY, null,
+                CARD_DETAILS);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> postPaymentResponse(API_KEY, PAYLOAD),
@@ -38,7 +40,8 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
     public void getPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
 
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CREATED,
-                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, CHARGE_TOKEN_ID, REFUND_SUMMARY, null, CARD_DETAILS);
+                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, CHARGE_TOKEN_ID, REFUND_SUMMARY,
+                null, CARD_DETAILS);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> getPaymentResponse(API_KEY, CHARGE_ID),

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import uk.gov.pay.api.utils.DateTimeUtils;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.time.ZonedDateTime;
 import java.util.LinkedList;
@@ -81,6 +82,7 @@ public class PaymentSearchResultBuilder {
         public String charge_id, description, reference, email, created_date;
         public int amount;
         public String gateway_transaction_id, return_url, payment_provider, card_brand;
+        public String language;
         public RefundSummary refund_summary = new RefundSummary();
         public SettlementSummary settlement_summary = new SettlementSummary();
         public CardDetails card_details = new CardDetails();
@@ -130,6 +132,7 @@ public class PaymentSearchResultBuilder {
 
     private String reference = null;
     private String email = null;
+    private String language = SupportedLanguage.ENGLISH.toString();
     private TestPaymentState state = null;
     private String fromDate = null;
     private String toDate = null;
@@ -167,6 +170,11 @@ public class PaymentSearchResultBuilder {
 
     public PaymentSearchResultBuilder withMatchingCardBrand(String cardBrand) {
         this.cardDetails.card_brand = cardBrand;
+        return this;
+    }
+
+    public PaymentSearchResultBuilder withLanguage(SupportedLanguage language) {
+        this.language = language.toString();
         return this;
     }
 
@@ -244,6 +252,7 @@ public class PaymentSearchResultBuilder {
         payment.created_date = DEFAULT_CREATED_DATE;
         payment.return_url = DEFAULT_RETURN_URL;
         payment.payment_provider = DEFAULT_PAYMENT_PROVIDER;
+        payment.language = SupportedLanguage.ENGLISH.toString();
         payment.card_brand = DEFAULT_CARD_BRAND_LABEL;
         payment.card_details.card_brand=DEFAULT_CARD_BRAND_LABEL;
         payment.refund_summary.status = "available";

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsRefundsResourceAmountValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsRefundsResourceAmountValidationITest.java
@@ -8,6 +8,7 @@ import uk.gov.pay.api.it.PaymentResourceITestBase;
 import uk.gov.pay.api.model.Address;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.RefundSummary;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -270,7 +271,8 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
         int amount = 1000;
         String externalChargeId = "charge_12345";
 
-        connectorMock.respondWithChargeFound(amount, GATEWAY_ACCOUNT_ID, externalChargeId, null, null, null, null, null, null, null, null,
+        connectorMock.respondWithChargeFound(amount, GATEWAY_ACCOUNT_ID, externalChargeId, null, null, null, null,
+                null, null, null,  SupportedLanguage.ENGLISH, null,
                 new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000), null, CARD_DETAILS);
         connectorMock.respondBadRequest_whenCreateARefund("full", amount, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, externalChargeId);
 
@@ -294,7 +296,8 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
         int amount = 1000;
         String externalChargeId = "charge_12345";
 
-        connectorMock.respondWithChargeFound(amount, GATEWAY_ACCOUNT_ID, externalChargeId, null, null, null, null, null, null, null, null,
+        connectorMock.respondWithChargeFound(amount, GATEWAY_ACCOUNT_ID, externalChargeId, null, null, null, null,
+                null, null, null, SupportedLanguage.ENGLISH, null,
                 new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000), null, CARD_DETAILS);
         connectorMock.respondBadRequest_whenCreateARefund("pending", amount, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, externalChargeId);
 

--- a/src/test/java/uk/gov/pay/api/json/CreatePaymentRequestDeserializerTest.java
+++ b/src/test/java/uk/gov/pay/api/json/CreatePaymentRequestDeserializerTest.java
@@ -18,8 +18,9 @@ import uk.gov.pay.api.validation.PaymentRequestValidator;
 import uk.gov.pay.api.validation.URLValidator;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
+import java.util.Optional;
+
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static uk.gov.pay.api.matcher.BadRequestExceptionMatcher.aBadRequestExceptionWithError;
@@ -58,7 +59,7 @@ public class CreatePaymentRequestDeserializerTest {
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
+        assertThat(paymentRequest.getReturnUrl().get(), is("https://somewhere.gov.uk/rainbow/1"));
     }
 
     public void deserialize_shouldDeserializeARequestWithEnglishLanguageSuccessfully() throws Exception {
@@ -114,8 +115,8 @@ public class CreatePaymentRequestDeserializerTest {
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl(), is(nullValue()));
-        assertThat(paymentRequest.getAgreementId(), is("abc123"));
+        assertThat(paymentRequest.getReturnUrl(), is(Optional.empty()));
+        assertThat(paymentRequest.getAgreementId().get(), is("abc123"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/model/PaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/model/PaymentTest.java
@@ -23,24 +23,27 @@ public class PaymentTest {
         URI cancelUri = URI.create("http://self.link.com/cancel");
         URI refundsUri = URI.create("http://self.link.com/cancel");
 
-        ChargeFromResponse paymentFromConnector = objectMapper.readValue("{" +
-                "\"email\":\"user@example.com\"," +
-                "\"card_details\":{" +
-                "\"card_brand\": \"Visa\"," +
-                "\"expiry_date\": \"12/19\"," +
-                "\"cardholder_name\": \"Mr. payment\"," +
-                "\"billing_address\": {" +
-                "\"line1\": \"line1\"," +
-                "\"postcode\": \"NR25 6EG\"," +
-                "\"country\": \"UK\"" +
-                "}," +
-                "\"last_digits_card_number\": \"4321\"" +
-                "}," +
-                "\"amount\":500," +
-                "\"state\":{" +
-                "\"status\":\"created\"," +
-                "\"finished\":false" +
-                "}}", ChargeFromResponse.class);
+        // language=JSON
+        ChargeFromResponse paymentFromConnector = objectMapper.readValue("{\n" +
+                "  \"email\": \"user@example.com\",\n" +
+                "  \"card_details\": {\n" +
+                "    \"card_brand\": \"Visa\",\n" +
+                "    \"expiry_date\": \"12/19\",\n" +
+                "    \"cardholder_name\": \"Mr. payment\",\n" +
+                "    \"billing_address\": {\n" +
+                "      \"line1\": \"line1\",\n" +
+                "      \"postcode\": \"NR25 6EG\",\n" +
+                "      \"country\": \"UK\"\n" +
+                "    },\n" +
+                "    \"last_digits_card_number\": \"4321\"\n" +
+                "  },\n" +
+                "  \"amount\": 500,\n" +
+                "  \"language\": \"en\",\n" +
+                "  \"state\": {\n" +
+                "    \"status\": \"created\",\n" +
+                "    \"finished\": false\n" +
+                "  }\n" +
+                "}", ChargeFromResponse.class);
 
         PaymentWithAllLinks payment = PaymentWithAllLinks.valueOf(paymentFromConnector, selfUri, eventsUri, cancelUri, refundsUri);
 

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -20,6 +20,7 @@ import uk.gov.pay.api.service.ConnectorUriGenerator;
 import uk.gov.pay.api.service.CreatePaymentService;
 import uk.gov.pay.api.service.PaymentSearchService;
 import uk.gov.pay.api.service.PublicApiUriGenerator;
+import uk.gov.pay.commons.model.SupportedLanguage;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
@@ -97,6 +98,7 @@ public class PaymentsResourceCreatePaymentTest {
                 "made.up@example.com",
                 "sandbox",
                 "2018-01-01T11:12:13Z",
+                SupportedLanguage.ENGLISH,
                 new RefundSummary(),
                 new SettlementSummary(),
                 new CardDetails("9876", "Anne Onymous", "12/20", cardholderAddress, "visa"),

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -58,7 +58,7 @@ public class CreatePaymentServiceTest {
 
     @Test
     @PactVerification({"connector"})
-    @Pacts(pacts = {"publicapi-connector-create-payment"}, publish = false)
+    @Pacts(pacts = {"publicapi-connector-create-payment"})
     public void testCreatePayment() {
         Account account = new Account("123456", TokenPaymentType.CARD);
         ValidCreatePaymentRequest requestPayload = new ValidCreatePaymentRequest(CreatePaymentRequest.builder()
@@ -89,7 +89,7 @@ public class CreatePaymentServiceTest {
 
     @Test
     @PactVerification({"connector"})
-    @Pacts(pacts = {"publicapi-connector-create-payment-with-language-welsh"}, publish = false)
+    @Pacts(pacts = {"publicapi-connector-create-payment-with-language-welsh"})
     public void testCreatePaymentWithWelshLanguage() {
         Account account = new Account("123456", TokenPaymentType.CARD);
         ValidCreatePaymentRequest requestPayload = new ValidCreatePaymentRequest(CreatePaymentRequest.builder()

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -11,6 +11,7 @@ import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.model.CardPayment;
 import uk.gov.pay.api.model.CreatePaymentRequest;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.TokenPaymentType;
@@ -18,6 +19,7 @@ import uk.gov.pay.api.model.ValidCreatePaymentRequest;
 import uk.gov.pay.api.model.links.Link;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 import uk.gov.pay.api.model.links.PostLink;
+import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.pay.commons.testing.pact.consumers.Pacts;
 
@@ -67,19 +69,22 @@ public class CreatePaymentServiceTest {
                 .build());
 
         PaymentWithAllLinks paymentResponse = createPaymentService.create(account, requestPayload);
+        CardPayment payment = (CardPayment) paymentResponse.getPayment();
 
-        assertThat(paymentResponse.getPayment().getPaymentId(), is("ch_ab2341da231434l"));
-        assertThat(paymentResponse.getPayment().getAmount(), is(100L));
-        assertThat(paymentResponse.getPayment().getReference(), is("a reference"));
-        assertThat(paymentResponse.getPayment().getDescription(), is("a description"));
-        assertThat(paymentResponse.getPayment().getEmail(), is(nullValue()));
-        assertThat(paymentResponse.getPayment().getState(), is(new PaymentState("created", false)));
-        assertThat(paymentResponse.getPayment().getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
-        assertThat(paymentResponse.getPayment().getPaymentProvider(), is("Sandbox"));
-        assertThat(paymentResponse.getPayment().getCreatedDate(), is("2016-01-01T12:00:00Z"));
+        assertThat(payment.getPaymentId(), is("ch_ab2341da231434l"));
+        assertThat(payment.getAmount(), is(100L));
+        assertThat(payment.getReference(), is("a reference"));
+        assertThat(payment.getDescription(), is("a description"));
+        assertThat(payment.getEmail(), is(nullValue()));
+        assertThat(payment.getState(), is(new PaymentState("created", false)));
+        assertThat(payment.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
+        assertThat(payment.getPaymentProvider(), is("Sandbox"));
+        assertThat(payment.getCreatedDate(), is("2016-01-01T12:00:00Z"));
+        assertThat(payment.getLanguage(), is(SupportedLanguage.ENGLISH));
         assertThat(paymentResponse.getLinks().getSelf(), is(new Link("http://publicapi.test.localhost/v1/payments/ch_ab2341da231434l", "GET")));
         assertThat(paymentResponse.getLinks().getNextUrl(), is(new Link("http://frontend_connector/charge/token_1234567asdf", "GET")));
         PostLink expectedLink = new PostLink("http://frontend_connector/charge/", "POST", "application/x-www-form-urlencoded", Collections.singletonMap("chargeTokenId", "token_1234567asdf"));
         assertThat(paymentResponse.getLinks().getNextUrlPost(), is(expectedLink));
     }
+
 }

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -87,4 +87,36 @@ public class CreatePaymentServiceTest {
         assertThat(paymentResponse.getLinks().getNextUrlPost(), is(expectedLink));
     }
 
+    @Test
+    @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector-create-payment-with-language-welsh"}, publish = false)
+    public void testCreatePaymentWithWelshLanguage() {
+        Account account = new Account("123456", TokenPaymentType.CARD);
+        ValidCreatePaymentRequest requestPayload = new ValidCreatePaymentRequest(CreatePaymentRequest.builder()
+                .amount(100)
+                .returnUrl("https://somewhere.gov.uk/rainbow/1")
+                .reference("a reference")
+                .description("a description")
+                .language("cy")
+                .build());
+
+        PaymentWithAllLinks paymentResponse = createPaymentService.create(account, requestPayload);
+        CardPayment payment = (CardPayment) paymentResponse.getPayment();
+
+        assertThat(payment.getPaymentId(), is("ch_ab2341da231434l"));
+        assertThat(payment.getAmount(), is(100L));
+        assertThat(payment.getReference(), is("a reference"));
+        assertThat(payment.getDescription(), is("a description"));
+        assertThat(payment.getEmail(), is(nullValue()));
+        assertThat(payment.getState(), is(new PaymentState("created", false)));
+        assertThat(payment.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
+        assertThat(payment.getPaymentProvider(), is("Sandbox"));
+        assertThat(payment.getCreatedDate(), is("2016-01-01T12:00:00Z"));
+        assertThat(payment.getLanguage(), is(SupportedLanguage.WELSH));
+        assertThat(paymentResponse.getLinks().getSelf(), is(new Link("http://publicapi.test.localhost/v1/payments/ch_ab2341da231434l", "GET")));
+        assertThat(paymentResponse.getLinks().getNextUrl(), is(new Link("http://frontend_connector/charge/token_1234567asdf", "GET")));
+        PostLink expectedLink = new PostLink("http://frontend_connector/charge/", "POST", "application/x-www-form-urlencoded", Collections.singletonMap("chargeTokenId", "token_1234567asdf"));
+        assertThat(paymentResponse.getLinks().getNextUrlPost(), is(expectedLink));
+    }
+
 }

--- a/src/test/resources/pacts/publicapi-connector-create-payment-with-language-welsh.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment-with-language-welsh.json
@@ -1,0 +1,158 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "a create charge request",
+      "providerStates": [
+        {
+          "name": "a gateway account with external id exists",
+          "params": {
+            "gateway_account_id": "123456"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/v1/api/accounts/123456/charges",
+        "body": {
+          "amount": 100,
+          "reference": "a reference",
+          "description": "a description",
+          "return_url": "https://somewhere.gov.uk/rainbow/1",
+          "language": "cy"
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/json",
+          "Location": "/v1/api/accounts/123456/charges/ch_ab2341da231434l"
+        },
+        "body": {
+          "charge_id": "ch_ab2341da231434l",
+          "amount": 100,
+          "reference": "a reference",
+          "description": "a description",
+          "state": {
+            "status": "created",
+            "finished": false
+          },
+          "return_url": "https://somewhere.gov.uk/rainbow/1",
+          "payment_provider": "Sandbox",
+          "created_date": "2016-01-01T12:00:00Z",
+          "language": "cy",
+          "links": [
+            {
+              "href": "http://connector.service.backend/v1/api/accounts/123456/charges/ch_ab2341da231434l",
+              "rel": "self",
+              "method": "GET"
+            },
+            {
+              "rel": "refunds",
+              "href": "url"
+            },
+            {
+              "href": "http://frontend_connector/charge/token_1234567asdf",
+              "rel": "next_url",
+              "method": "GET"
+            },
+            {
+              "href": "http://frontend_connector/charge/",
+              "rel": "next_url_post",
+              "type": "application/x-www-form-urlencoded",
+              "params": {
+                "chargeTokenId": "token_1234567asdf"
+              },
+              "method": "POST"
+            }
+          ]
+        },
+        "matchingRules": {
+          "header": {
+            "Location": {
+              "matchers": [
+                {
+                  "regex": "https*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/[a-z0-9]*"
+                }
+              ]
+            }
+          },
+          "body": {
+            "$.links[0].href": {
+              "matchers": [
+                {
+                  "regex": "https*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/[a-z0-9]*"
+                }
+              ]
+            },
+            "$.links[1].href": {
+              "matchers": [
+                {"match": "type"}
+              ]
+            },
+            "$.links[2].href": {
+              "matchers": [
+                {"match": "type"}
+              ]
+            },
+            "$.links[2].params.chargeTokenId": {
+              "matchers": [
+                {"match": "type"}
+              ]
+            },
+            "$.links[3].href": {
+              "matchers": [
+                {"match": "type"}
+              ]
+            },
+            "$.links[3].params.chargeTokenId": {
+              "matchers": [
+                {"match": "type"}
+              ]
+            },
+            "$.charge_id": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.amount": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.reference": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.email": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.description": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.state.status": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.return_url": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.payment_provider": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.created_date": {
+              "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}

--- a/src/test/resources/pacts/publicapi-connector-create-payment.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment.json
@@ -44,6 +44,7 @@
           "return_url": "https://somewhere.gov.uk/rainbow/1",
           "payment_provider": "Sandbox",
           "created_date": "2016-01-01T12:00:00Z",
+          "language": "en",
           "links": [
             {
               "href": "http://connector.service.backend/v1/api/accounts/123456/charges/ch_ab2341da231434l",


### PR DESCRIPTION
When processing a create card payment request, send the supplied `"language"` to connector if it passes validation i.e. is `"en"` (English) or `"cy"` (Welsh). If no `"language"` is supplied, do not include a `"language"` field in the request to connector (connector will default to English).

When retrieving a card payment via either the `/v1/payments/{paymentId}` endpoint, the `/v1/payments` search endpoint, or in response to a create payment request, include a `"language" : "en"` or `"language": "cy"` field depending on what connector sends us.

Commits:
1. Make getters in `ValidCreatePaymentRequest` return `Optional`s if appropriate
2. Include `"language"` field when returning a card payment (updates existing create payment Pact test)
3. Send `"language"` field to connector when creating a payment if appropriate (adds new Pact for creating a payment with `"language": "cy"`)

with @DanailMinchev, @danworth