### PR TITLE
PP-4073: 429 response code and specify classes to use for swagger.json

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -418,8 +418,13 @@
                         <apiSource>
                             <springmvc>false</springmvc>
                             <locations>
-                                <location>uk.gov.pay.api.resources</location>
+                                <location>uk.gov.pay.api.resources.PaymentRefundsResource</location>
+                                <location>uk.gov.pay.api.resources.PaymentsResource</location>
                             </locations>
+                            <apiModelPropertyAccessExclusions>
+                                <apiModelPropertyAccessExclusion>agreementId</apiModelPropertyAccessExclusion>
+                                <apiModelPropertyAccessExclusion>language</apiModelPropertyAccessExclusion>
+                            </apiModelPropertyAccessExclusions>
                             <schemes>
                                 <scheme>https</scheme>
                             </schemes>

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
@@ -5,7 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.filter.ratelimit.RateLimitException;
 import uk.gov.pay.api.filter.ratelimit.RateLimiter;
-
+import uk.gov.pay.api.resources.error.ApiErrorResponse.Code;
 import javax.inject.Inject;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -16,10 +16,8 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static uk.gov.pay.api.model.PaymentError.Code;
-import static uk.gov.pay.api.model.PaymentError.aPaymentError;
+import static uk.gov.pay.api.resources.error.ApiErrorResponse.anApiErrorResponse;
 
 /**
  * Allow only a certain number of requests from the same source (given by the Authorization Header)
@@ -69,7 +67,7 @@ public class RateLimiterFilter implements Filter {
         response.setStatus(TOO_MANY_REQUESTS_STATUS_CODE);
         response.setContentType(APPLICATION_JSON);
         response.setCharacterEncoding(UTF8_CHARACTER_ENCODING);
-        response.getWriter().print(objectMapper.writeValueAsString(aPaymentError(Code.TOO_MANY_REQUESTS_ERROR)));
+        response.getWriter().print(objectMapper.writeValueAsString(anApiErrorResponse(Code.TOO_MANY_REQUESTS_ERROR)));
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -24,6 +24,7 @@ public class CardPayment extends Payment {
     private final CardDetails cardDetails;
 
     @JsonSerialize(using = ToStringSerializer.class)
+    @ApiModelProperty(name = "language", access = "language") // named to exclude from swagger.json for now
     private final SupportedLanguage language;
 
     public CardPayment(String chargeId, long amount, PaymentState state, String returnUrl, String description,

--- a/src/main/java/uk/gov/pay/api/model/PaymentState.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentState.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@ApiModel(value="PaymentState", description = "A structure representing the current state of the payment in its lifecycle.")
+@ApiModel(value = "PaymentState", description = "A structure representing the current state of the payment in its lifecycle.")
 public class PaymentState {
     @JsonProperty("status")
     private String status;
@@ -27,10 +27,10 @@ public class PaymentState {
 
     public static PaymentState createPaymentState(JsonNode node) {
         return new PaymentState(
-            node.get("status").asText(),
-            node.get("finished").asBoolean(),
-            node.has("message") ? node.get("message").asText() : null,
-            node.has("code") ? node.get("code").asText() : null
+                node.get("status").asText(),
+                node.get("finished").asBoolean(),
+                node.has("message") ? node.get("message").asText() : null,
+                node.has("code") ? node.get("code").asText() : null
         );
     }
 
@@ -48,22 +48,22 @@ public class PaymentState {
         this.code = code;
     }
 
-    @ApiModelProperty(value = "Current progress of the payment in its lifecycle", required=true, example = "created")
+    @ApiModelProperty(value = "Current progress of the payment in its lifecycle", example = "created")
     public String getStatus() {
         return status;
     }
 
-    @ApiModelProperty(value = "Whether the payment has finished", required = true)
+    @ApiModelProperty(value = "Whether the payment has finished")
     public boolean isFinished() {
         return finished;
     }
 
-    @ApiModelProperty(value = "What went wrong with the Payment if it finished with an error - English message", required = true, example = "User cancelled the payment")
+    @ApiModelProperty(value = "What went wrong with the Payment if it finished with an error - English message", example = "User cancelled the payment")
     public String getMessage() {
         return message;
     }
 
-    @ApiModelProperty(value = "What went wrong with the Payment if it finished with an error - error code", required = true, example = "P010")
+    @ApiModelProperty(value = "What went wrong with the Payment if it finished with an error - error code", example = "P010")
     public String getCode() {
         return code;
     }

--- a/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.util.Objects;
@@ -50,10 +51,12 @@ public class ValidCreatePaymentRequest {
         return Optional.ofNullable(returnUrl);
     }
 
+    @ApiModelProperty(name = "agreementId", access = "agreementId")
     public Optional<String> getAgreementId() {
         return Optional.ofNullable(agreementId);
     }
 
+    @ApiModelProperty(name = "language", access = "language")
     public Optional<SupportedLanguage> getLanguage() {
         return Optional.ofNullable(language);
     }

--- a/src/main/java/uk/gov/pay/api/resources/AgreementsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/AgreementsResource.java
@@ -7,16 +7,6 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import java.net.URI;
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
@@ -26,7 +16,19 @@ import uk.gov.pay.api.model.directdebit.agreement.AgreementError;
 import uk.gov.pay.api.model.directdebit.agreement.CreateAgreementRequest;
 import uk.gov.pay.api.model.directdebit.agreement.CreateAgreementResponse;
 import uk.gov.pay.api.model.directdebit.agreement.GetAgreementResponse;
+import uk.gov.pay.api.resources.error.ApiErrorResponse;
 import uk.gov.pay.api.service.AgreementService;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -60,6 +62,7 @@ public class AgreementsResource {
             @ApiResponse(code = 200, message = "OK", response = GetAgreementResponse.class),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = AgreementError.class),
+            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = AgreementError.class)})
     public Response getPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
             @PathParam("agreementId") String agreementId) {
@@ -83,6 +86,7 @@ public class AgreementsResource {
             @ApiResponse(code = 201, message = "Created", response = CreateAgreementResponse.class),
             @ApiResponse(code = 400, message = "Bad request", response = PaymentError.class),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
+            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response createNewAgreement(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                        @ApiParam(value = "requestPayload", required = true) CreateAgreementRequest createAgreementRequest) {

--- a/src/main/java/uk/gov/pay/api/resources/DirectDebitEventsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/DirectDebitEventsResource.java
@@ -9,6 +9,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.links.directdebit.DirectDebitEventsResponse;
+import uk.gov.pay.api.resources.error.ApiErrorResponse;
 import uk.gov.pay.api.service.ConnectorUriGenerator;
 import uk.gov.pay.api.service.DirectDebitEventService;
 import uk.gov.pay.api.validation.DirectDebitEventSearchValidator;
@@ -53,7 +54,8 @@ public class DirectDebitEventsResource {
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK", response = List.class),
-            @ApiResponse(code = 401, message = "Credentials are required to access this resource")})
+            @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
+            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class)})
     public Response getDirectDebitEvents(
             @ApiParam(value = "accountId", hidden = true) @Auth Account account,
             @QueryParam("to_date") String toDate,

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -24,6 +24,7 @@ import uk.gov.pay.api.model.RefundFromConnector;
 import uk.gov.pay.api.model.RefundResponse;
 import uk.gov.pay.api.model.RefundsFromConnector;
 import uk.gov.pay.api.model.RefundsResponse;
+import uk.gov.pay.api.resources.error.ApiErrorResponse;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -91,6 +92,7 @@ public class PaymentRefundsResource {
             @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
+            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response getRefunds(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                @PathParam(PATH_PAYMENT_KEY) String paymentId) {
@@ -126,6 +128,7 @@ public class PaymentRefundsResource {
             @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
+            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response getRefundById(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                   @PathParam(PATH_PAYMENT_KEY) String paymentId,
@@ -161,6 +164,7 @@ public class PaymentRefundsResource {
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
             @ApiResponse(code = 412, message = "Refund amount available mismatch"),
+            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response submitRefund(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                  @ApiParam(value = "paymentId", required = true) @PathParam(PATH_PAYMENT_KEY) String paymentId,

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -21,6 +21,7 @@ import uk.gov.pay.api.model.PaymentEvents;
 import uk.gov.pay.api.model.ValidCreatePaymentRequest;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 import uk.gov.pay.api.model.search.card.PaymentSearchResults;
+import uk.gov.pay.api.resources.error.ApiErrorResponse;
 import uk.gov.pay.api.service.ConnectorUriGenerator;
 import uk.gov.pay.api.service.CreatePaymentService;
 import uk.gov.pay.api.service.PaymentSearchService;
@@ -85,6 +86,7 @@ public class PaymentsResource {
             @ApiResponse(code = 200, message = "OK", response = PaymentWithAllLinks.class),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
+            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response getPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                @PathParam("paymentId") String paymentId) {
@@ -128,6 +130,7 @@ public class PaymentsResource {
             @ApiResponse(code = 200, message = "OK", response = PaymentEvents.class),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
+            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response getPaymentEvents(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                      @PathParam("paymentId") String paymentId) {
@@ -174,6 +177,7 @@ public class PaymentsResource {
             @ApiResponse(code = 200, message = "OK", response = PaymentSearchResults.class),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 422, message = "Invalid parameters: from_date, to_date, status, display_size. See Public API documentation for the correct data formats", response = PaymentError.class),
+            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response searchPayments(@ApiParam(value = "accountId", hidden = true)
                                    @Auth Account account,
@@ -193,7 +197,7 @@ public class PaymentsResource {
                                    @QueryParam("page") String pageNumber,
                                    @ApiParam(value = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)", hidden = false)
                                    @QueryParam("display_size") String displaySize,
-                                   @ApiParam(value = "Direct Debit Agreement Id", hidden = false)
+                                   @ApiParam(value = "Direct Debit Agreement Id", hidden = true)
                                    @QueryParam("agreement_id") String agreementId,
                                    @Context UriInfo uriInfo) {
 
@@ -222,6 +226,7 @@ public class PaymentsResource {
             @ApiResponse(code = 400, message = "Bad request", response = PaymentError.class),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 422, message = "Invalid attribute value: description. Must be less than or equal to 255 characters length", response = PaymentError.class),
+            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response createNewPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                      @ApiParam(value = "requestPayload", required = true) ValidCreatePaymentRequest validCreatePaymentRequest) {
@@ -255,6 +260,7 @@ public class PaymentsResource {
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
             @ApiResponse(code = 409, message = "Conflict", response = PaymentError.class),
+            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)
     })
     public Response cancelPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,

--- a/src/main/java/uk/gov/pay/api/resources/error/ApiErrorResponse.java
+++ b/src/main/java/uk/gov/pay/api/resources/error/ApiErrorResponse.java
@@ -1,0 +1,65 @@
+package uk.gov.pay.api.resources.error;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static java.lang.String.format;
+
+@ApiModel(value = "ErrorResponse", description = "An error response")
+@JsonInclude(NON_NULL)
+public class ApiErrorResponse {
+
+    public enum Code {
+
+        TOO_MANY_REQUESTS_ERROR("P0900", "Too many requests");
+
+        private String value;
+        private String format;
+
+        Code(String value, String format) {
+            this.value = value;
+            this.format = format;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        public String getFormat() {
+            return format;
+        }
+    }
+
+    private final Code code;
+    private final String description;
+
+    public static ApiErrorResponse anApiErrorResponse(Code code, Object... parameters) {
+        return new ApiErrorResponse(code, parameters);
+    }
+
+    private ApiErrorResponse(Code code, Object... parameters) {
+        this.code = code;
+        this.description = format(code.getFormat(), parameters);
+    }
+
+    @ApiModelProperty(example = "P0900")
+    public String getCode() {
+        return code.value();
+    }
+
+    @ApiModelProperty(example = "Too many requests")
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String toString() {
+        return "ApiErrorResponse{" +
+                "code=" + code.value() +
+                ", name=" + code +
+                ", description='" + description + '\'' +
+                '}';
+    }
+}

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -12,209 +12,6 @@
   } ],
   "schemes" : [ "https" ],
   "paths" : {
-    "/healthcheck" : {
-      "get" : {
-        "operationId" : "healthCheck",
-        "produces" : [ "application/json" ],
-        "responses" : {
-          "default" : {
-            "description" : "successful operation"
-          }
-        }
-      }
-    },
-    "/request-denied" : {
-      "get" : {
-        "operationId" : "requestDeniedGet",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "x-naxsi_sig",
-          "in" : "header",
-          "required" : false,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "default" : {
-            "description" : "successful operation"
-          }
-        }
-      },
-      "post" : {
-        "operationId" : "requestDeniedPost",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "x-naxsi_sig",
-          "in" : "header",
-          "required" : false,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "default" : {
-            "description" : "successful operation"
-          }
-        }
-      },
-      "put" : {
-        "operationId" : "requestDeniedPut",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "x-naxsi_sig",
-          "in" : "header",
-          "required" : false,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "default" : {
-            "description" : "successful operation"
-          }
-        }
-      },
-      "delete" : {
-        "operationId" : "requestDeniedDelete",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "x-naxsi_sig",
-          "in" : "header",
-          "required" : false,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "default" : {
-            "description" : "successful operation"
-          }
-        }
-      }
-    },
-    "/v1/agreements" : {
-      "post" : {
-        "summary" : "Create a new agreement",
-        "description" : "Create a new agreement",
-        "operationId" : "newAgreement",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "in" : "body",
-          "name" : "body",
-          "description" : "requestPayload",
-          "required" : true,
-          "schema" : {
-            "$ref" : "#/definitions/CreateAgreementRequest"
-          }
-        } ],
-        "responses" : {
-          "201" : {
-            "description" : "Created",
-            "schema" : {
-              "$ref" : "#/definitions/CreateAgreementResponse"
-            }
-          },
-          "400" : {
-            "description" : "Bad request",
-            "schema" : {
-              "$ref" : "#/definitions/PaymentError"
-            }
-          },
-          "401" : {
-            "description" : "Credentials are required to access this resource"
-          },
-          "500" : {
-            "description" : "Downstream system error",
-            "schema" : {
-              "$ref" : "#/definitions/PaymentError"
-            }
-          }
-        }
-      }
-    },
-    "/v1/agreements/{agreementId}" : {
-      "get" : {
-        "summary" : "Find agreement by ID",
-        "description" : "Return information about the payment The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "getPayment",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "agreementId",
-          "in" : "path",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/CreateAgreementResponse"
-            }
-          },
-          "401" : {
-            "description" : "Credentials are required to access this resource"
-          },
-          "404" : {
-            "description" : "Not found",
-            "schema" : {
-              "$ref" : "#/definitions/AgreementError"
-            }
-          },
-          "500" : {
-            "description" : "Downstream system error",
-            "schema" : {
-              "$ref" : "#/definitions/AgreementError"
-            }
-          }
-        }
-      }
-    },
-    "/v1/events" : {
-      "get" : {
-        "summary" : "Get direct debit events",
-        "description" : "The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "getDirectDebitEvents",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "to_date",
-          "in" : "query",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "from_date",
-          "in" : "query",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "display_size",
-          "in" : "query",
-          "description" : "Defaults to a maximum of 500",
-          "required" : false,
-          "type" : "integer",
-          "format" : "int32"
-        }, {
-          "name" : "page",
-          "in" : "query",
-          "required" : false,
-          "type" : "integer",
-          "format" : "int32"
-        }, {
-          "name" : "agreement_id",
-          "in" : "query",
-          "description" : "ID of associated agreement",
-          "required" : false,
-          "type" : "string"
-        }, {
-          "name" : "payment_id",
-          "in" : "query",
-          "description" : "ID of associated payment",
-          "required" : false,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK"
-          },
-          "401" : {
-            "description" : "Credentials are required to access this resource"
-          }
-        }
-      }
-    },
     "/v1/payments" : {
       "get" : {
         "summary" : "Search payments",
@@ -270,12 +67,6 @@
           "description" : "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)",
           "required" : false,
           "type" : "string"
-        }, {
-          "name" : "agreement_id",
-          "in" : "query",
-          "description" : "Direct Debit Agreement Id",
-          "required" : false,
-          "type" : "string"
         } ],
         "responses" : {
           "200" : {
@@ -291,6 +82,12 @@
             "description" : "Invalid parameters: from_date, to_date, status, display_size. See Public API documentation for the correct data formats",
             "schema" : {
               "$ref" : "#/definitions/PaymentError"
+            }
+          },
+          "429" : {
+            "description" : "Too many requests",
+            "schema" : {
+              "$ref" : "#/definitions/ErrorResponse"
             }
           },
           "500" : {
@@ -313,7 +110,7 @@
           "description" : "requestPayload",
           "required" : true,
           "schema" : {
-            "$ref" : "#/definitions/CreatePaymentRequest"
+            "$ref" : "#/definitions/ValidCreatePaymentRequest"
           }
         } ],
         "responses" : {
@@ -336,6 +133,12 @@
             "description" : "Invalid attribute value: description. Must be less than or equal to 255 characters length",
             "schema" : {
               "$ref" : "#/definitions/PaymentError"
+            }
+          },
+          "429" : {
+            "description" : "Too many requests",
+            "schema" : {
+              "$ref" : "#/definitions/ErrorResponse"
             }
           },
           "500" : {
@@ -373,6 +176,12 @@
             "description" : "Not found",
             "schema" : {
               "$ref" : "#/definitions/PaymentError"
+            }
+          },
+          "429" : {
+            "description" : "Too many requests",
+            "schema" : {
+              "$ref" : "#/definitions/ErrorResponse"
             }
           },
           "500" : {
@@ -421,6 +230,12 @@
               "$ref" : "#/definitions/PaymentError"
             }
           },
+          "429" : {
+            "description" : "Too many requests",
+            "schema" : {
+              "$ref" : "#/definitions/ErrorResponse"
+            }
+          },
           "500" : {
             "description" : "Downstream system error",
             "schema" : {
@@ -458,6 +273,12 @@
               "$ref" : "#/definitions/PaymentError"
             }
           },
+          "429" : {
+            "description" : "Too many requests",
+            "schema" : {
+              "$ref" : "#/definitions/ErrorResponse"
+            }
+          },
           "500" : {
             "description" : "Downstream system error",
             "schema" : {
@@ -491,6 +312,12 @@
             "description" : "Not found",
             "schema" : {
               "$ref" : "#/definitions/PaymentError"
+            }
+          },
+          "429" : {
+            "description" : "Too many requests",
+            "schema" : {
+              "$ref" : "#/definitions/ErrorResponse"
             }
           },
           "500" : {
@@ -539,6 +366,12 @@
           "412" : {
             "description" : "Refund amount available mismatch"
           },
+          "429" : {
+            "description" : "Too many requests",
+            "schema" : {
+              "$ref" : "#/definitions/ErrorResponse"
+            }
+          },
           "500" : {
             "description" : "Downstream system error",
             "schema" : {
@@ -577,6 +410,12 @@
             "description" : "Not found",
             "schema" : {
               "$ref" : "#/definitions/PaymentError"
+            }
+          },
+          "429" : {
+            "description" : "Too many requests",
+            "schema" : {
+              "$ref" : "#/definitions/ErrorResponse"
             }
           },
           "500" : {
@@ -620,45 +459,6 @@
         }
       },
       "description" : "A structure representing the billing address of a card"
-    },
-    "AgreementError" : {
-      "type" : "object",
-      "properties" : {
-        "field" : {
-          "type" : "string",
-          "example" : "return_url"
-        },
-        "code" : {
-          "type" : "string",
-          "example" : "P0102"
-        },
-        "description" : {
-          "type" : "string",
-          "example" : "Invalid attribute value: return_url. Must be a valid url."
-        }
-      },
-      "description" : "An Agreement Error response"
-    },
-    "AgreementLinks" : {
-      "type" : "object",
-      "properties" : {
-        "self" : {
-          "description" : "self",
-          "readOnly" : true,
-          "$ref" : "#/definitions/Link"
-        },
-        "next_url" : {
-          "description" : "next_url",
-          "readOnly" : true,
-          "$ref" : "#/definitions/Link"
-        },
-        "next_url_post" : {
-          "description" : "next_url_post",
-          "readOnly" : true,
-          "$ref" : "#/definitions/PostLink"
-        }
-      },
-      "description" : "self and next links of an Agreement"
     },
     "CardDetails" : {
       "type" : "object",
@@ -717,87 +517,6 @@
         }
       } ]
     },
-    "CreateAgreementRequest" : {
-      "type" : "object",
-      "required" : [ "agreement_type", "return_url" ],
-      "properties" : {
-        "return_url" : {
-          "type" : "string",
-          "example" : "https://service-name.gov.uk/transactions/12345",
-          "description" : "agreement return url",
-          "readOnly" : true
-        },
-        "agreement_type" : {
-          "type" : "string",
-          "example" : "ON_DEMAND",
-          "description" : "agreement type",
-          "readOnly" : true,
-          "enum" : [ "ON_DEMAND", "ONE_OFF" ]
-        },
-        "reference" : {
-          "type" : "string",
-          "example" : "test_service_reference",
-          "description" : "agreement reference",
-          "readOnly" : true
-        }
-      },
-      "description" : "The Payload to create a new Agreement"
-    },
-    "CreateAgreementResponse" : {
-      "type" : "object",
-      "required" : [ "_links", "agreement_id", "agreement_type", "created_date", "provider_id", "return_url", "state" ],
-      "properties" : {
-        "agreement_id" : {
-          "type" : "string",
-          "example" : "jhjcvaiqlediuhh23d89hd3",
-          "description" : "agreement id",
-          "readOnly" : true
-        },
-        "agreement_type" : {
-          "type" : "string",
-          "example" : "ON_DEMAND",
-          "description" : "agreement type",
-          "readOnly" : true,
-          "enum" : [ "ON_DEMAND", "ONE_OFF" ]
-        },
-        "provider_id" : {
-          "type" : "string",
-          "example" : "jhjcvaiqlediuhh23d89hd3",
-          "description" : "provider id",
-          "readOnly" : true
-        },
-        "reference" : {
-          "type" : "string",
-          "example" : "test_service_reference",
-          "description" : "agreement reference",
-          "readOnly" : true
-        },
-        "return_url" : {
-          "type" : "string",
-          "example" : "https://service-name.gov.uk/transactions/12345",
-          "description" : "service return url",
-          "readOnly" : true
-        },
-        "created_date" : {
-          "type" : "string",
-          "description" : "agreement created date",
-          "readOnly" : true
-        },
-        "state" : {
-          "type" : "string",
-          "example" : "CREATED",
-          "description" : "agreement state",
-          "readOnly" : true,
-          "enum" : [ "CREATED", "STARTED", "PENDING", "SUBMITTED", "ACTIVE", "INACTIVE", "CANCELLED" ]
-        },
-        "_links" : {
-          "description" : "links",
-          "readOnly" : true,
-          "$ref" : "#/definitions/AgreementLinks"
-        }
-      },
-      "description" : "The Agreement Payload to create a new Agreement"
-    },
     "CreatePaymentRefundRequest" : {
       "type" : "object",
       "required" : [ "amount" ],
@@ -822,49 +541,26 @@
       },
       "description" : "The Payment Refund Request Payload"
     },
-    "CreatePaymentRequest" : {
-      "type" : "object",
-      "required" : [ "amount", "description", "reference" ],
-      "properties" : {
-        "amount" : {
-          "type" : "integer",
-          "format" : "int32",
-          "example" : 12000,
-          "description" : "amount in pence",
-          "minimum" : 1,
-          "maximum" : 10000000
-        },
-        "reference" : {
-          "type" : "string",
-          "example" : "12345",
-          "description" : "payment reference"
-        },
-        "description" : {
-          "type" : "string",
-          "example" : "New passport application",
-          "description" : "payment description"
-        },
-        "return_url" : {
-          "type" : "string",
-          "example" : "https://service-name.gov.uk/transactions/12345",
-          "description" : "service return url",
-          "readOnly" : true
-        },
-        "agreement_id" : {
-          "type" : "string",
-          "example" : "33890b55-b9ea-4e2f-90fd-77ae0e9009e2\n",
-          "description" : "ID of the agreement being used to collect the payment",
-          "readOnly" : true
-        }
-      },
-      "description" : "The Payment Request Payload"
-    },
     "DirectDebitPayment" : {
       "allOf" : [ {
         "$ref" : "#/definitions/Payment"
       }, {
         "type" : "object"
       } ]
+    },
+    "ErrorResponse" : {
+      "type" : "object",
+      "properties" : {
+        "code" : {
+          "type" : "string",
+          "example" : "P0900"
+        },
+        "description" : {
+          "type" : "string",
+          "example" : "Too many requests"
+        }
+      },
+      "description" : "An error response"
     },
     "Link" : {
       "type" : "object",
@@ -1079,7 +775,6 @@
     },
     "PaymentState" : {
       "type" : "object",
-      "required" : [ "code", "finished", "message", "status" ],
       "properties" : {
         "status" : {
           "type" : "string",
@@ -1186,6 +881,24 @@
         }
       },
       "description" : "A structure representing information about a settlement"
+    },
+    "ValidCreatePaymentRequest" : {
+      "type" : "object",
+      "properties" : {
+        "amount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "reference" : {
+          "type" : "string"
+        },
+        "description" : {
+          "type" : "string"
+        },
+        "returnUrl" : {
+          "type" : "string"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
PP-4073: limit which classes are exported to swagger docs. 
  -  Configured swagger-maven-plugin to exclude direct debit related endpoints and fields (as we don't want to publish these yet) while generating api docs.
**_with @heathd_** 

PP-4073: Add 429 response code to resource endpoints
   - Added 429 response code to all applicable endpoints.


## 
swagger.json file generated should now 
 - exclude direct debit related api documentation and 
 - contain 429 responses for all endpoints published
