### PR TITLE
Remove rate limit audit

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
@@ -77,7 +77,6 @@ public class PublicApiModule extends AbstractModule {
         return new LocalRateLimiter(
                 configuration.getRateLimiterConfig().getNoOfReqPerNode(),
                 configuration.getRateLimiterConfig().getNoOfReqForPostPerNode(),
-                configuration.getRateLimiterConfig().getAuditRate(),
                 configuration.getRateLimiterConfig().getPerMillis()
         );
     }

--- a/src/main/java/uk/gov/pay/api/app/config/RateLimiterConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/RateLimiterConfig.java
@@ -19,9 +19,6 @@ public class RateLimiterConfig extends Configuration {
     @Min(1)
     private int noOfReqForPostPerNode;
 
-    @Min(1)
-    private int auditRate;
-
     @Min(500)
     @Max(60000)
     private int perMillis;
@@ -32,10 +29,6 @@ public class RateLimiterConfig extends Configuration {
 
     public int getPerMillis() {
         return perMillis;
-    }
-
-    public int getAuditRate() {
-        return auditRate;
     }
 
     public int getNoOfReqForPost() {

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
@@ -52,8 +52,6 @@ public class RateLimiterFilter implements Filter {
         final String authorization = ((HttpServletRequest) request).getHeader("Authorization");
         final String method = ((HttpServletRequest) request).getMethod();
 
-        rateLimiter.auditRateOf(method + "-" + authorization);
-
         try {
             rateLimiter.checkRateOf(method + "-" + authorization, method);
             chain.doFilter(request, response);

--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimiter.java
@@ -26,10 +26,4 @@ public class RateLimiter {
             localRateLimiter.checkRateOf(key, method);
         }
     }
-
-    public void auditRateOf(String key) {
-        localRateLimiter.auditRateOf(key);
-    }
-
-
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -32,7 +32,6 @@ rateLimiter:  # rate = noOfReq per perMillis
   noOfReqPerNode: ${RATE_LIMITER_VALUE_PER_NODE:-25}  # per public api instance, if Redis is unavailable
   noOfReqForPostPerNode: ${RATE_LIMITER_VALUE_PER_NODE_POST:-5}  # per public api instance, if Redis is unavailable
   perMillis: ${RATE_LIMITER_PER_MILLIS:-1000}
-  auditRate: ${RATE_LIMITER_AUDIT_VALUE:-4}
 
 redis:
   # The redis server's address; required.

--- a/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
@@ -78,12 +78,4 @@ public class RateLimiterFilterTest {
         verify(mockPrinter).print("{\"code\":\"P0900\",\"description\":\"Too many requests\"}");
         verifyNoMoreInteractions(mockResponse);
     }
-
-    @Test
-    public void shouldLogRequest_ForAuditRate() throws Exception {
-
-        rateLimiterFilter.doFilter(mockPostRequest, mockResponse, mockFilterChain);
-
-        verify(rateLimiter).auditRateOf("POST-" + authorization);
-    }
 }

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/LocalRateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/LocalRateLimiterTest.java
@@ -30,7 +30,7 @@ public class LocalRateLimiterTest {
     public void rateLimiterSetTo_2CallsPerSecond_shouldAllow2ConsecutiveCallsWithSameKeys() throws Exception {
 
         String key = "key1";
-        localRateLimiter = new LocalRateLimiter(2, 2, 1, 1000);
+        localRateLimiter = new LocalRateLimiter(2, 2, 1000);
 
         localRateLimiter.checkRateOf(key, POST);
         localRateLimiter.checkRateOf(key, POST);
@@ -40,7 +40,7 @@ public class LocalRateLimiterTest {
     public void rateLimiterSetTo_1CallPer300Millis_shouldAFailWhen2ConsecutiveCallsWithSameKeysAreMade() throws Exception {
 
         String key = "key2";
-        localRateLimiter = new LocalRateLimiter(1, 1, 1, 300);
+        localRateLimiter = new LocalRateLimiter(1, 1, 300);
 
         localRateLimiter.checkRateOf(key, POST);
 
@@ -52,7 +52,7 @@ public class LocalRateLimiterTest {
     public void rateLimiterSetTo_3CallsPerSecond_shouldAllowMakingOnly3CallsWithSameKey() throws Exception {
 
         String key = "key3";
-        localRateLimiter = new LocalRateLimiter(3, 3, 1, 1000);
+        localRateLimiter = new LocalRateLimiter(3, 3, 1000);
 
         ExecutorService executor = Executors.newFixedThreadPool(3);
 

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -33,7 +33,6 @@ rateLimiter:
   noOfReqForPost: 1
   noOfReqPerNode: 1
   noOfReqForPostPerNode: 1
-  auditRate: 4
 
 redis:
   endpoint: localhost:6379


### PR DESCRIPTION
This was a temporary piece of functionality to help us set a sensible rate
limit. We no longer need it. If we do require it in furure it is simple to
re-implement, and it would neeed to be redone to take account of new Redis
backed rate limiting anyway.