### PR TITLE
PP-4106 Delayed capture connector integration

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -24,19 +24,24 @@ public class CardPayment extends Payment {
     private final CardDetails cardDetails;
 
     @JsonSerialize(using = ToStringSerializer.class)
-    @ApiModelProperty(name = "language", access = "language") // named to exclude from swagger.json for now
+    @ApiModelProperty(name = "language", access = "language")
     private final SupportedLanguage language;
+
+    @JsonProperty("delayed_capture")
+    @ApiModelProperty(name = "delayed_capture", access = "delayed_capture")
+    private final boolean delayedCapture;
 
     public CardPayment(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                        String reference, String email, String paymentProvider, String createdDate,
                        RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
-                       SupportedLanguage language) {
+                       SupportedLanguage language, boolean delayedCapture) {
         super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate);
         this.refundSummary = refundSummary;
         this.settlementSummary = settlementSummary;
         this.cardDetails = cardDetails;
         this.paymentType = CARD.getFriendlyName();
         this.language = language;
+        this.delayedCapture = delayedCapture;
     }
 
     /**
@@ -72,6 +77,11 @@ public class CardPayment extends Payment {
         return language;
     }
 
+    @ApiModelProperty(value = "delayed capture flag", example = "false")
+    public boolean getDelayedCapture() {
+        return delayedCapture;
+    }
+
     @Override
     public String toString() {
         // Some services put PII in the description, so don’t include it in the stringification
@@ -84,6 +94,7 @@ public class CardPayment extends Payment {
                 ", returnUrl='" + returnUrl + '\'' +
                 ", reference='" + reference + '\'' +
                 ", language='" + language.toString() + '\'' +
+                ", delayedCapture=" + delayedCapture +
                 ", createdDate='" + createdDate + '\'' +
                 '}';
     }

--- a/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
@@ -48,6 +48,9 @@ public class ChargeFromResponse {
     @JsonDeserialize(using = CustomSupportedLanguageDeserializer.class)
     private SupportedLanguage language;
 
+    @JsonProperty(value = "delayed_capture")
+    private boolean delayedCapture;
+
     @JsonProperty(value = "created_date")
     private String createdDate;
 
@@ -81,6 +84,10 @@ public class ChargeFromResponse {
 
     public SupportedLanguage getLanguage() {
         return language;
+    }
+
+    public boolean getDelayedCapture() {
+        return delayedCapture;
     }
 
     public String getPaymentProvider() {

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -40,11 +40,11 @@ public class PaymentWithAllLinks {
 
     public PaymentWithAllLinks(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                                String reference, String email, String paymentProvider, String createdDate, SupportedLanguage language,
-                               RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
+                               boolean delayedCapture, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
                                List<PaymentConnectorResponseLink> paymentConnectorResponseLinks, URI selfLink, URI paymentEventsUri, URI paymentCancelUri,
                                URI paymentRefundsUri) {
         this.payment = new CardPayment(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate,
-                refundSummary, settlementSummary, cardDetails, language);
+                refundSummary, settlementSummary, cardDetails, language, delayedCapture);
         this.links.addSelf(selfLink.toString());
         this.links.addKnownLinksValueOf(paymentConnectorResponseLinks);
         this.links.addEvents(paymentEventsUri.toString());
@@ -96,6 +96,7 @@ public class PaymentWithAllLinks {
                 paymentConnector.getPaymentProvider(),
                 paymentConnector.getCreatedDate(),
                 paymentConnector.getLanguage(),
+                paymentConnector.getDelayedCapture(),
                 paymentConnector.getRefundSummary(),
                 paymentConnector.getSettlementSummary(),
                 paymentConnector.getCardDetails(),

--- a/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
@@ -20,10 +20,10 @@ public class PaymentForSearchResult extends CardPayment {
 
     public PaymentForSearchResult(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                                   String reference, String email, String paymentProvider, String createdDate, SupportedLanguage language,
-                                  RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
+                                  boolean delayedCapture, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
                                   URI selfLink, URI paymentEventsLink, URI paymentCancelLink, URI paymentRefundsLink) {
         super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider,
-                createdDate, refundSummary, settlementSummary, cardDetails, language);
+                createdDate, refundSummary, settlementSummary, cardDetails, language, delayedCapture);
         this.links.addSelf(selfLink.toString());
         this.links.addEvents(paymentEventsLink.toString());
         this.links.addRefunds(paymentRefundsLink.toString());
@@ -51,6 +51,7 @@ public class PaymentForSearchResult extends CardPayment {
                 paymentResult.getPaymentProvider(),
                 paymentResult.getCreatedDate(),
                 paymentResult.getLanguage(),
+                paymentResult.getDelayedCapture(),
                 paymentResult.getRefundSummary(),
                 paymentResult.getSettlementSummary(),
                 paymentResult.getCardDetails(),

--- a/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
@@ -73,6 +73,7 @@ public class CreatePaymentService {
         requestPayload.getLanguage().ifPresent(language -> request.add("language", language.toString()));
         requestPayload.getReturnUrl().ifPresent(returnUrl -> request.add("return_url", returnUrl));
         requestPayload.getAgreementId().ifPresent(agreementId -> request.add("agreement_id", agreementId));
+        requestPayload.getDelayedCapture().ifPresent(delayedCapture -> request.add("delayed_capture", delayedCapture));
         return json(request.build());
     }
 }

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentITest.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentITest.java
@@ -45,11 +45,10 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void createCardPayment() {
-
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, CARD);
 
         connectorMock.respondOk_whenCreateCharge(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID,
-                CREATED, RETURN_URL, DESCRIPTION, REFERENCE, null, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, REFUND_SUMMARY,
+                CREATED, RETURN_URL, DESCRIPTION, REFERENCE, null, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, true, REFUND_SUMMARY,
                 null, CARD_DETAILS);
 
         String responseBody = postPaymentResponse(API_KEY, SUCCESS_PAYLOAD)
@@ -66,6 +65,7 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
                 .body("payment_provider", is(PAYMENT_PROVIDER))
                 .body("card_brand", is(CARD_BRAND_LABEL))
                 .body("created_date", is(CREATED_DATE))
+                .body("delayed_capture", is(true))
                 .body("refund_summary.status", is("pending"))
                 .body("refund_summary.amount_submitted", is(50))
                 .body("refund_summary.amount_available", is(100))
@@ -98,13 +98,12 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void createPayment_withMinimumAmount() {
-
         int minimumAmount = 1;
 
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondOk_whenCreateCharge(minimumAmount, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID,
                 CREATED, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH,
-                REFUND_SUMMARY, null, CARD_DETAILS);
+                false, REFUND_SUMMARY, null, CARD_DETAILS);
 
         postPaymentResponse(API_KEY, paymentPayload(minimumAmount, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL))
                 .statusCode(201)
@@ -123,7 +122,6 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void createPayment_withAllFieldsUpToMaxLengthBoundaries_shouldBeAccepted() {
-
         int amount = 10000000;
         String reference = randomAlphanumeric(255);
         String description = randomAlphanumeric(255);
@@ -133,7 +131,7 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondOk_whenCreateCharge(amount, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID,
                 CREATED, return_url, description, reference, email, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH,
-                REFUND_SUMMARY, null, CARD_DETAILS);
+                false, REFUND_SUMMARY, null, CARD_DETAILS);
 
         String body = new JsonStringBuilder()
                 .add("amount", amount)
@@ -160,7 +158,6 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void createPayment_responseWith500_whenConnectorResponseIsAnUnrecognisedError() throws Exception {
-
         String gatewayAccountId = "1234567";
         String errorMessage = "something went wrong";
 
@@ -183,7 +180,6 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void createPayment_responseWith500_whenTokenForGatewayAccountIsValidButConnectorResponseIsNotFound() {
-
         String notFoundGatewayAccountId = "9876545";
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, notFoundGatewayAccountId);
 

--- a/src/test/java/uk/gov/pay/api/it/GetPaymentITest.java
+++ b/src/test/java/uk/gov/pay/api/it/GetPaymentITest.java
@@ -57,7 +57,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
     public void getPayment_ReturnsPayment() {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CAPTURED, RETURN_URL,
-                DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, CHARGE_TOKEN_ID, REFUND_SUMMARY, SETTLEMENT_SUMMARY,
+                DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, true, CHARGE_TOKEN_ID, REFUND_SUMMARY, SETTLEMENT_SUMMARY,
                 CARD_DETAILS);
 
         getPaymentResponse(API_KEY, CHARGE_ID)
@@ -74,6 +74,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
                 .body("card_brand", is(CARD_BRAND_LABEL))
                 .body("created_date", is(CREATED_DATE))
                 .body("language", is("en"))
+                .body("delayed_capture", is(true))
                 .body("refund_summary.status", is("pending"))
                 .body("refund_summary.amount_submitted", is(50))
                 .body("refund_summary.amount_available", is(100))
@@ -142,7 +143,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID,
                 new PaymentState("success", true, null, null),
-                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, CHARGE_TOKEN_ID, REFUND_SUMMARY,
+                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, false, CHARGE_TOKEN_ID, REFUND_SUMMARY,
                 null, CARD_DETAILS);
 
         getPaymentResponse(API_KEY, CHARGE_ID)
@@ -155,7 +156,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
     public void getPayment_ShouldNotIncludeSettlementFieldsIfNull() {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID,
-                CREATED, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, CHARGE_TOKEN_ID, REFUND_SUMMARY,
+                CREATED, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, false, CHARGE_TOKEN_ID, REFUND_SUMMARY,
                 new SettlementSummary(null, null), CARD_DETAILS);
 
         getPaymentResponse(API_KEY, CHARGE_ID)
@@ -176,7 +177,6 @@ public class GetPaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void getPayment_returns404_whenConnectorRespondsWith404() throws IOException {
-
         String paymentId = "ds2af2afd3df112";
         String errorMessage = "backend-error-message";
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
@@ -195,7 +195,6 @@ public class GetPaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void getPayment_returns500_whenConnectorRespondsWithResponseOtherThan200Or404() throws IOException {
-
         String paymentId = "ds2af2afd3df112";
         String errorMessage = "backend-error-message";
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
@@ -239,7 +238,6 @@ public class GetPaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void getPaymentEvents_returns404_whenConnectorRespondsWith404() throws IOException {
-
         String paymentId = "ds2af2afd3df112";
         String errorMessage = "backend-error-message";
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
@@ -258,7 +256,6 @@ public class GetPaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void getPaymentEvents_returns500_whenConnectorRespondsWithResponseOtherThan200Or404() throws IOException {
-
         String paymentId = "ds2af2afd3df112";
         String errorMessage = "backend-error-message";
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);

--- a/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
@@ -33,12 +33,11 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
     private static final String REFUND_ID = "111999";
     private static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
     private static final String CREATED_DATE = DateTimeUtils.toUTCDateString(TIMESTAMP);
-    private static final Address BILLING_ADDRESS = new Address("line1","line2","NR2 5 6EG","city","UK");
-    private static final CardDetails CARD_DETAILS = new CardDetails("1234","Mr. Payment","12/19", BILLING_ADDRESS,"Visa");
+    private static final Address BILLING_ADDRESS = new Address("line1", "line2", "NR2 5 6EG", "city", "UK");
+    private static final CardDetails CARD_DETAILS = new CardDetails("1234", "Mr. Payment", "12/19", BILLING_ADDRESS, "Visa");
 
     @Test
     public void getRefundById_shouldGetValidResponse() {
-
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWithGetRefundById(GATEWAY_ACCOUNT_ID, CHARGE_ID, REFUND_ID, AMOUNT, REFUND_AMOUNT_AVAILABLE, "available", CREATED_DATE);
 
@@ -55,7 +54,6 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void getRefundById_shouldGetNonAuthorized_whenPublicAuthRespondsUnauthorised() {
-
         publicAuthMock.respondUnauthorised();
 
         getPaymentRefundByIdResponse(API_KEY, CHARGE_ID, REFUND_ID)
@@ -64,7 +62,6 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void getRefundById_shouldReturnNotFound_whenRefundDoesNotExist() {
-
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondRefundNotFound(GATEWAY_ACCOUNT_ID, CHARGE_ID, "unknown-refund-id");
 
@@ -77,7 +74,6 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void getRefundById_returns500_whenConnectorRespondsWithResponseOtherThan200Or404() {
-
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondRefundWithError(GATEWAY_ACCOUNT_ID, CHARGE_ID, REFUND_ID);
 
@@ -90,7 +86,6 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void getRefunds_shouldGetValidResponse() {
-
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
         PaymentRefundJsonFixture refund_1 = new PaymentRefundJsonFixture(100L, CREATED_DATE, "100", "available", new ArrayList<>());
@@ -123,7 +118,6 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void getRefunds_shouldGetValidResponse_whenListReturnedIsEmpty() {
-
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWithGetAllRefunds(GATEWAY_ACCOUNT_ID, CHARGE_ID);
 
@@ -138,7 +132,6 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void getRefunds_shouldGetNonAuthorized_whenPublicAuthRespondsUnauthorised() {
-
         publicAuthMock.respondUnauthorised();
 
         getPaymentRefundsResponse(API_KEY, CHARGE_ID)
@@ -158,7 +151,7 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
         String payload = new GsonBuilder().create().toJson(
                 ImmutableMap.of("amount", AMOUNT));
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, null, null, null, null, null,
-                null, null, SupportedLanguage.ENGLISH, null,
+                null, null, SupportedLanguage.ENGLISH, false, null,
                 new RefundSummary("available", 9000, 1000), null, CARD_DETAILS);
 
         postRefundRequest(payload);
@@ -183,7 +176,6 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void createRefund_shouldGetNonAuthorized_whenPublicAuthRespondsUnauthorised() {
-
         publicAuthMock.respondUnauthorised();
 
         postRefunds("{\"amount\": 1000}")

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -53,6 +53,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
     private static final String SEARCH_PATH = "/v1/payments";
     private static final Address BILLING_ADDRESS = new Address("line1", "line2", "NR2 5 6EG", "city", "UK");
     private static final CardDetails CARD_DETAILS = new CardDetails("1234", "Mr. Payment", "12/19", BILLING_ADDRESS, TEST_CARD_BRAND_LABEL);
+
     @Before
     public void mapBearerTokenToAccountId() {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
@@ -69,6 +70,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .withMatchingReference(TEST_REFERENCE)
                         .withMatchingCardBrand(TEST_CARD_BRAND_LABEL)
                         .withMatchingCardDetails(CARD_DETAILS)
+                        .withDelayedCapture(true)
                         .withNumberOfResults(1)
                         .getResults())
                 .build();
@@ -88,6 +90,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                 .body("results[0].payment_provider", is(DEFAULT_PAYMENT_PROVIDER))
                 .body("results[0].payment_id", is("0"))
                 .body("results[0].language", is("en"))
+                .body("results[0].delayed_capture", is(true))
                 .body("results[0]._links.self.method", is("GET"))
                 .body("results[0]._links.self.href", is(paymentLocationFor("0")))
                 .body("results[0]._links.events.href", is(paymentEventsLocationFor("0")))
@@ -149,7 +152,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
     }
 
     @Test
-    public void searchPayments_filterByFullReference() throws Exception {
+    public void searchPayments_filterByFullReference() {
         String payments = aPaginatedPaymentSearchResult()
                 .withCount(10)
                 .withPage(2)
@@ -174,7 +177,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
 
 
     @Test
-    public void searchPayments_filterByState() throws Exception {
+    public void searchPayments_filterByState() {
         String payments = aPaginatedPaymentSearchResult()
                 .withCount(10)
                 .withPage(2)
@@ -198,7 +201,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
     }
 
     @Test
-    public void searchPayments_filterByStateLowercase() throws Exception {
+    public void searchPayments_filterByStateLowercase() {
         String payments = aPaginatedPaymentSearchResult()
                 .withCount(10)
                 .withPage(2)
@@ -222,7 +225,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
     }
 
     @Test
-    public void searchPayments_filterByEmail() throws Exception {
+    public void searchPayments_filterByEmail() {
         String payments = aPaginatedPaymentSearchResult()
                 .withCount(10)
                 .withPage(2)
@@ -245,7 +248,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
     }
 
     @Test
-    public void searchPayments_filterByPartialEmail() throws Exception {
+    public void searchPayments_filterByPartialEmail() {
         String payments = aPaginatedPaymentSearchResult()
                 .withCount(10)
                 .withPage(2)
@@ -268,7 +271,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
     }
 
     @Test
-    public void searchPayments_filterFromAndToDates() throws Exception {
+    public void searchPayments_filterFromAndToDates() {
         String payments = aPaginatedPaymentSearchResult()
                 .withCount(10)
                 .withPage(2)
@@ -277,7 +280,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .withCreatedDateBetween(TEST_FROM_DATE, TEST_TO_DATE).getResults())
                 .build();
 
-        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null,  null, null, null, TEST_FROM_DATE, TEST_TO_DATE,
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, null, null, null, TEST_FROM_DATE, TEST_TO_DATE,
                 payments
         );
 
@@ -293,7 +296,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
     }
 
     @Test
-    public void searchPayments_filterByReferenceEmailStateAndFromToDates() throws Exception {
+    public void searchPayments_filterByReferenceEmailStateAndFromToDates() {
         String payments = aPaginatedPaymentSearchResult()
                 .withCount(10)
                 .withPage(2)
@@ -310,11 +313,11 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
         );
 
         ValidatableResponse response = searchPayments(API_KEY, ImmutableMap.of(
-                    "reference", TEST_REFERENCE,
-                    "email", TEST_EMAIL,
-                    "state", TEST_STATE,
-                    "from_date", TEST_FROM_DATE,
-                    "to_date", TEST_TO_DATE))
+                "reference", TEST_REFERENCE,
+                "email", TEST_EMAIL,
+                "state", TEST_STATE,
+                "from_date", TEST_FROM_DATE,
+                "to_date", TEST_TO_DATE))
                 .statusCode(200)
                 .contentType(JSON)
                 .body("results.size()", equalTo(3));
@@ -328,7 +331,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
     }
 
     @Test
-    public void searchPayments_getsPaginatedResultsFromConnector() throws Exception {
+    public void searchPayments_getsPaginatedResultsFromConnector() {
 
         PaymentNavigationLinksFixture links = new PaymentNavigationLinksFixture()
                 .withPrevLink("http://server:port/path?query=prev&from_date=2016-01-01T23:59:59Z")
@@ -425,7 +428,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
     }
 
     @Test
-    public void searchPayments_filterByCardBrand() throws Exception {
+    public void searchPayments_filterByCardBrand() {
         ValidatableResponse response = getResultForSearchByCardBrand(TEST_CARD_BRAND);
         response
                 .statusCode(200)
@@ -437,7 +440,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
     }
 
     @Test
-    public void searchPayments_filterByCardBrandMixedCase() throws Exception {
+    public void searchPayments_filterByCardBrandMixedCase() {
 
         ValidatableResponse response = getResultForSearchByCardBrand(TEST_CARD_BRAND_MIXED_CASE);
         response
@@ -449,7 +452,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
         assertThat(results, matchesField("card_brand", TEST_CARD_BRAND_LABEL));
     }
 
-    private ValidatableResponse getResultForSearchByCardBrand(String cardBrand){
+    private ValidatableResponse getResultForSearchByCardBrand(String cardBrand) {
         String payments = aPaginatedPaymentSearchResult()
                 .withCount(1)
                 .withPage(1)
@@ -480,9 +483,9 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                 .assertThat("$.description", is("Page not found"));
 
     }
-    
+
     @Test
-    public void searchPayments_withMandateId_whenCardPayment_shouldReturnABadRequestResponse() throws Exception{
+    public void searchPayments_withMandateId_whenCardPayment_shouldReturnABadRequestResponse() throws Exception {
         InputStream body = searchPayments(API_KEY,
                 ImmutableMap.of("agreement_id", "my_agreement"))
                 .statusCode(400)

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterLocalRateLimiterITest.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterLocalRateLimiterITest.java
@@ -94,8 +94,8 @@ public class ResourcesFilterLocalRateLimiterITest {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
         connectorMock.respondOk_whenCreateCharge(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID, CREATED,
-                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, REFUND_SUMMARY,
-                null, CARD_DETAILS);
+                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH,
+                false, REFUND_SUMMARY, null, CARD_DETAILS);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterITest.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterITest.java
@@ -21,8 +21,8 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
     public void createPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
 
         connectorMock.respondOk_whenCreateCharge(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID, CREATED,
-                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, REFUND_SUMMARY, null,
-                CARD_DETAILS);
+                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH,
+                false, REFUND_SUMMARY, null, CARD_DETAILS);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> postPaymentResponse(API_KEY, PAYLOAD),
@@ -40,8 +40,8 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
     public void getPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
 
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CREATED,
-                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, CHARGE_TOKEN_ID, REFUND_SUMMARY,
-                null, CARD_DETAILS);
+                RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH,
+                false, CHARGE_TOKEN_ID, REFUND_SUMMARY, null, CARD_DETAILS);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> getPaymentResponse(API_KEY, CHARGE_ID),

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
@@ -57,14 +57,15 @@ public class PaymentSearchResultBuilder {
         public Address billing_address;
         public String card_brand;
 
-        public CardDetails(){}
+        public CardDetails() {
+        }
 
         public CardDetails(uk.gov.pay.api.model.CardDetails cardDetails) {
             this.last_digits_card_number = cardDetails.getLastDigitsCardNumber();
             this.cardholder_name = cardDetails.getCardHolderName();
             this.expiry_date = cardDetails.getExpiryDate();
             this.card_brand = cardDetails.getCardBrand();
-            this.billing_address =  new Address(cardDetails.getBillingAddress());
+            this.billing_address = new Address(cardDetails.getBillingAddress());
         }
     }
 
@@ -73,16 +74,19 @@ public class PaymentSearchResultBuilder {
         public long amount_available;
         public long amount_submitted;
     }
+
     private static class SettlementSummary {
         public String capture_submit_time;
         public String captured_date;
     }
+
     private static class TestPayment {
         public TestPaymentState state;
         public String charge_id, description, reference, email, created_date;
         public int amount;
         public String gateway_transaction_id, return_url, payment_provider, card_brand;
         public String language;
+        public boolean delayed_capture;
         public RefundSummary refund_summary = new RefundSummary();
         public SettlementSummary settlement_summary = new SettlementSummary();
         public CardDetails card_details = new CardDetails();
@@ -133,6 +137,7 @@ public class PaymentSearchResultBuilder {
     private String reference = null;
     private String email = null;
     private String language = SupportedLanguage.ENGLISH.toString();
+    private boolean delayedCapture;
     private TestPaymentState state = null;
     private String fromDate = null;
     private String toDate = null;
@@ -175,6 +180,11 @@ public class PaymentSearchResultBuilder {
 
     public PaymentSearchResultBuilder withLanguage(SupportedLanguage language) {
         this.language = language.toString();
+        return this;
+    }
+
+    public PaymentSearchResultBuilder withDelayedCapture(boolean delayedCapture) {
+        this.delayedCapture = delayedCapture;
         return this;
     }
 
@@ -235,6 +245,8 @@ public class PaymentSearchResultBuilder {
             defaultPaymentResult.card_brand = cardDetails.card_brand;
         }
 
+        defaultPaymentResult.delayed_capture = delayedCapture;
+
         return defaultPaymentResult;
     }
 
@@ -253,8 +265,9 @@ public class PaymentSearchResultBuilder {
         payment.return_url = DEFAULT_RETURN_URL;
         payment.payment_provider = DEFAULT_PAYMENT_PROVIDER;
         payment.language = SupportedLanguage.ENGLISH.toString();
+        payment.delayed_capture = false;
         payment.card_brand = DEFAULT_CARD_BRAND_LABEL;
-        payment.card_details.card_brand=DEFAULT_CARD_BRAND_LABEL;
+        payment.card_details.card_brand = DEFAULT_CARD_BRAND_LABEL;
         payment.refund_summary.status = "available";
         payment.refund_summary.amount_available = 100;
         payment.refund_summary.amount_submitted = 300;

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsRefundsResourceAmountValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsRefundsResourceAmountValidationITest.java
@@ -22,8 +22,8 @@ import static org.hamcrest.core.Is.is;
 public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourceITestBase {
 
     private static final int REFUND_AMOUNT_AVAILABLE = 9000;
-    private static final Address BILLING_ADDRESS = new Address("line1","line2","NR2 5 6EG","city","UK");
-    private static final CardDetails CARD_DETAILS = new CardDetails("1234","Mr. Payment","12/19", BILLING_ADDRESS,"Visa");
+    private static final Address BILLING_ADDRESS = new Address("line1", "line2", "NR2 5 6EG", "city", "UK");
+    private static final CardDetails CARD_DETAILS = new CardDetails("1234", "Mr. Payment", "12/19", BILLING_ADDRESS, "Visa");
 
     @Before
     public void setUpBearerToken() {
@@ -32,9 +32,9 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
 
     @Test
     public void createPaymentRefund_responseWith422_whenAmountIsNegative() throws IOException {
-
-        String payload = "{" +
-                "  \"amount\" : -123" +
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": -123\n" +
                 "}";
 
         InputStream body = postPaymentRefundAndThen(API_KEY, "chargeId", payload)
@@ -52,9 +52,9 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
 
     @Test
     public void createPaymentRefund_responseWith422_whenAmountIsBiggerThanTheMaximumAllowed() throws IOException {
-
-        String payload = "{" +
-                "  \"amount\" : 10000001" +
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": 10000001\n" +
                 "}";
 
         InputStream body = postPaymentRefundAndThen(API_KEY, "chargeId", payload)
@@ -72,9 +72,9 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
 
     @Test
     public void createPaymentRefund_responseWith400_whenAmountFieldHasNullValue() throws IOException {
-
-        String payload = "{" +
-                "  \"amount\" : null" +
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": null\n" +
                 "}";
 
         InputStream body = postPaymentRefundAndThen(API_KEY, "chargeId", payload)
@@ -93,9 +93,9 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
 
     @Test
     public void createPaymentRefund_responseWith400_whenAmountFieldIsNotNumeric() throws IOException {
-
-        String payload = "{" +
-                "  \"amount\" : \"hola world!\"" +
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": \"hola world!\"\n" +
                 "}";
 
         InputStream body = postPaymentRefundAndThen(API_KEY, "chargeId", payload)
@@ -113,9 +113,11 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
 
     @Test
     public void createPaymentRefund_responseWith400_whenAmountFieldIsNotAValidJsonField() throws IOException {
-
-        String payload = "{" +
-                "  \"amount\" : { \"whatever\": 1 }" +
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": {\n" +
+                "    \"whatever\": 1\n" +
+                "  }\n" +
                 "}";
 
         InputStream body = postPaymentRefundAndThen(API_KEY, "chargeId", payload)
@@ -133,9 +135,9 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
 
     @Test
     public void createPaymentRefund_responseWith400_whenAmountFieldIsBlank() throws IOException {
-
-        String payload = "{" +
-                "  \"amount\" : \"    \"" +
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": \"    \"\n" +
                 "}";
 
         InputStream body = postPaymentRefundAndThen(API_KEY, "chargeId", payload)
@@ -153,7 +155,7 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
 
     @Test
     public void createPaymentRefund_responseWith400_whenAmountFieldIsMissing() throws IOException {
-
+        // language=JSON
         String payload = "{}";
 
         InputStream body = postPaymentRefundAndThen(API_KEY, "chargeId", payload)
@@ -171,9 +173,9 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
 
     @Test
     public void createPaymentRefund_responseWith400_whenAmountIsHexadecimal() throws IOException {
-
-        String payload = "{" +
-                "  \"amount\" : 0x1000" +
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": 0x1000\n" +
                 "}";
 
         InputStream body = postPaymentRefundAndThen(API_KEY, "chargeId", payload)
@@ -190,9 +192,9 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
 
     @Test
     public void createPaymentRefund_responseWith400_whenAmountIsBinary() throws IOException {
-
-        String payload = "{" +
-                "  \"amount\" : 0B101" +
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": 0B101\n" +
                 "}";
 
         InputStream body = postPaymentRefundAndThen(API_KEY, "chargeId", payload)
@@ -209,9 +211,9 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
 
     @Test
     public void createPaymentRefund_responseWith400_whenAmountIsOctal() throws IOException {
-
-        String payload = "{" +
-                "  \"amount\" : 017" +
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": 017\n" +
                 "}";
 
         InputStream body = postPaymentRefundAndThen(API_KEY, "chargeId", payload)
@@ -228,9 +230,9 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
 
     @Test
     public void createPaymentRefund_responseWith400_whenAmountIsNullByteEncoded() throws IOException {
-
-        String payload = "{" +
-                "  \"amount\" : %00" +
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": %00\n" +
                 "}";
 
         InputStream body = postPaymentRefundAndThen(API_KEY, "chargeId", payload)
@@ -247,9 +249,9 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
 
     @Test
     public void createPaymentRefund_responseWith400_whenAmountIsFloat() throws IOException {
-
-        String payload = "{" +
-                "  \"amount\" : 27.55" +
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": 27.55\n" +
                 "}";
 
         InputStream body = postPaymentRefundAndThen(API_KEY, "chargeId", payload)
@@ -267,12 +269,11 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
 
     @Test
     public void createPaymentRefund_responseWith400_whenConnectorResponseIsErrorDueToAmountRequestedIsNotAvailableForRefund() throws IOException {
-
         int amount = 1000;
         String externalChargeId = "charge_12345";
 
         connectorMock.respondWithChargeFound(amount, GATEWAY_ACCOUNT_ID, externalChargeId, null, null, null, null,
-                null, null, null,  SupportedLanguage.ENGLISH, null,
+                null, null, null, SupportedLanguage.ENGLISH, false, null,
                 new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000), null, CARD_DETAILS);
         connectorMock.respondBadRequest_whenCreateARefund("full", amount, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, externalChargeId);
 
@@ -292,12 +293,11 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
 
     @Test
     public void createPaymentRefund_responseWith400_whenConnectorResponseIsErrorDueToChargeStatusMakesPaymentNonRefundable() throws IOException {
-
         int amount = 1000;
         String externalChargeId = "charge_12345";
 
         connectorMock.respondWithChargeFound(amount, GATEWAY_ACCOUNT_ID, externalChargeId, null, null, null, null,
-                null, null, null, SupportedLanguage.ENGLISH, null,
+                null, null, null, SupportedLanguage.ENGLISH, false, null,
                 new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000), null, CARD_DETAILS);
         connectorMock.respondBadRequest_whenCreateARefund("pending", amount, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, externalChargeId);
 

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -99,7 +99,7 @@ public class PaymentsResourceCreatePaymentTest {
                 "sandbox",
                 "2018-01-01T11:12:13Z",
                 SupportedLanguage.ENGLISH,
-                Boolean.FALSE,
+                false,
                 new RefundSummary(),
                 new SettlementSummary(),
                 new CardDetails("9876", "Anne Onymous", "12/20", cardholderAddress, "visa"),

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -99,6 +99,7 @@ public class PaymentsResourceCreatePaymentTest {
                 "sandbox",
                 "2018-01-01T11:12:13Z",
                 SupportedLanguage.ENGLISH,
+                Boolean.FALSE,
                 new RefundSummary(),
                 new SettlementSummary(),
                 new CardDetails("9876", "Anne Onymous", "12/20", cardholderAddress, "visa"),

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -81,6 +81,40 @@ public class CreatePaymentServiceTest {
         assertThat(payment.getPaymentProvider(), is("Sandbox"));
         assertThat(payment.getCreatedDate(), is("2016-01-01T12:00:00Z"));
         assertThat(payment.getLanguage(), is(SupportedLanguage.ENGLISH));
+        assertThat(payment.getDelayedCapture(), is(false));
+        assertThat(paymentResponse.getLinks().getSelf(), is(new Link("http://publicapi.test.localhost/v1/payments/ch_ab2341da231434l", "GET")));
+        assertThat(paymentResponse.getLinks().getNextUrl(), is(new Link("http://frontend_connector/charge/token_1234567asdf", "GET")));
+        PostLink expectedLink = new PostLink("http://frontend_connector/charge/", "POST", "application/x-www-form-urlencoded", Collections.singletonMap("chargeTokenId", "token_1234567asdf"));
+        assertThat(paymentResponse.getLinks().getNextUrlPost(), is(expectedLink));
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector-create-payment-with-delayed-capture-true"})
+    public void testCreatePaymentWithDelayedCaptureEqualsTrue() {
+        Account account = new Account("123456", TokenPaymentType.CARD);
+        ValidCreatePaymentRequest requestPayload = new ValidCreatePaymentRequest(CreatePaymentRequest.builder()
+                .amount(100)
+                .returnUrl("https://somewhere.gov.uk/rainbow/1")
+                .reference("a reference")
+                .description("a description")
+                .delayedCapture(Boolean.TRUE)
+                .build());
+
+        PaymentWithAllLinks paymentResponse = createPaymentService.create(account, requestPayload);
+        CardPayment payment = (CardPayment) paymentResponse.getPayment();
+
+        assertThat(payment.getPaymentId(), is("ch_ab2341da231434l"));
+        assertThat(payment.getAmount(), is(100L));
+        assertThat(payment.getReference(), is("a reference"));
+        assertThat(payment.getDescription(), is("a description"));
+        assertThat(payment.getEmail(), is(nullValue()));
+        assertThat(payment.getState(), is(new PaymentState("created", false)));
+        assertThat(payment.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
+        assertThat(payment.getPaymentProvider(), is("Sandbox"));
+        assertThat(payment.getCreatedDate(), is("2016-01-01T12:00:00Z"));
+        assertThat(payment.getLanguage(), is(SupportedLanguage.ENGLISH));
+        assertThat(payment.getDelayedCapture(), is(true));
         assertThat(paymentResponse.getLinks().getSelf(), is(new Link("http://publicapi.test.localhost/v1/payments/ch_ab2341da231434l", "GET")));
         assertThat(paymentResponse.getLinks().getNextUrl(), is(new Link("http://frontend_connector/charge/token_1234567asdf", "GET")));
         PostLink expectedLink = new PostLink("http://frontend_connector/charge/", "POST", "application/x-www-form-urlencoded", Collections.singletonMap("chargeTokenId", "token_1234567asdf"));

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -63,7 +63,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
 
     private String buildChargeResponse(long amount, String chargeId, PaymentState state, String returnUrl, String description,
                                        String reference, String email, String paymentProvider, String gatewayTransactionId, String createdDate,
-                                       SupportedLanguage language, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
+                                       SupportedLanguage language, boolean delayedCapture, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
                                        ImmutableMap<?, ?>... links) {
         JsonStringBuilder jsonStringBuilder = new JsonStringBuilder()
                 .add("charge_id", chargeId)
@@ -77,6 +77,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                 .add("card_brand", CARD_BRAND_LABEL)
                 .add("created_date", createdDate)
                 .add("language", language.toString())
+                .add("delayed_capture", delayedCapture)
                 .add("links", asList(links))
                 .add("refund_summary", refundSummary)
                 .add("settlement_summary", settlementSummary)
@@ -124,7 +125,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
 
     public void respondOk_whenCreateCharge(int amount, String gatewayAccountId, String chargeId, String chargeTokenId, PaymentState state, String returnUrl,
                                            String description, String reference, String email, String paymentProvider, String createdDate,
-                                           SupportedLanguage language, RefundSummary refundSummary, SettlementSummary settlementSummary,
+                                           SupportedLanguage language, boolean delayedCapture, RefundSummary refundSummary, SettlementSummary settlementSummary,
                                            CardDetails cardDetails) {
 
         whenCreateCharge(amount, gatewayAccountId, returnUrl, description, reference)
@@ -144,6 +145,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                                 null,
                                 createdDate,
                                 language,
+                                delayedCapture,
                                 refundSummary,
                                 settlementSummary,
                                 cardDetails,
@@ -201,10 +203,10 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
 
     public void respondWithChargeFound(long amount, String gatewayAccountId, String chargeId, PaymentState state, String returnUrl,
                                        String description, String reference, String email, String paymentProvider, String createdDate,
-                                       SupportedLanguage language, String chargeTokenId, RefundSummary refundSummary, SettlementSummary settlementSummary,
+                                       SupportedLanguage language, boolean delayedCapture, String chargeTokenId, RefundSummary refundSummary, SettlementSummary settlementSummary,
                                        CardDetails cardDetails) {
         String chargeResponseBody = buildChargeResponse(amount, chargeId, state, returnUrl,
-                description, reference, email, paymentProvider, gatewayAccountId, createdDate, language, refundSummary, settlementSummary, cardDetails,
+                description, reference, email, paymentProvider, gatewayAccountId, createdDate, language, delayedCapture, refundSummary, settlementSummary, cardDetails,
                 validGetLink(chargeLocation(gatewayAccountId, chargeId), "self"),
                 validGetLink(chargeLocation(gatewayAccountId, chargeId) + "/refunds", "refunds"),
                 validGetLink(nextUrl(chargeId), "next_url"), validPostLink(nextUrlPost(), "next_url_post", "application/x-www-form-urlencoded",

--- a/src/test/resources/pacts/publicapi-connector-create-payment-with-delayed-capture-true.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment-with-delayed-capture-true.json
@@ -7,7 +7,7 @@
   },
   "interactions": [
     {
-      "description": "a create charge request",
+      "description": "a create charge request with delayed capture",
       "providerStates": [
         {
           "name": "a gateway account with external id exists",
@@ -23,7 +23,8 @@
           "amount": 100,
           "reference": "a reference",
           "description": "a description",
-          "return_url": "https://somewhere.gov.uk/rainbow/1"
+          "return_url": "https://somewhere.gov.uk/rainbow/1",
+          "delayed_capture": true
         }
       },
       "response": {
@@ -45,7 +46,7 @@
           "payment_provider": "Sandbox",
           "created_date": "2016-01-01T12:00:00Z",
           "language": "en",
-          "delayed_capture": false,
+          "delayed_capture": true,
           "links": [
             {
               "href": "http://connector.service.backend/v1/api/accounts/123456/charges/ch_ab2341da231434l",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -508,6 +508,12 @@
             "readOnly" : true,
             "$ref" : "#/definitions/CardDetails"
           },
+          "delayed_capture" : {
+            "type" : "boolean",
+            "example" : false,
+            "description" : "delayed capture flag",
+            "readOnly" : true
+          },
           "card_brand" : {
             "type" : "string",
             "example" : "Visa",
@@ -897,6 +903,9 @@
         },
         "returnUrl" : {
           "type" : "string"
+        },
+        "delayedCapture" : {
+          "type" : "boolean"
         }
       }
     }


### PR DESCRIPTION
## WHAT

- Add `delayedCapture` property to the card model
- Make the call to connector include the `delayed_capture` field if appropriate
- Ensure the Public API endpoints for creating payments and retrieving payments return the `delayed_capture` field

The next PR will have Pact tests

with @SandorArpa 