### PR TITLE
PP-4106 Enable Pact tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,8 +98,8 @@ pipeline {
                 env.PACT_TAG = gitBranchName()
             }
             ws('contract-tests-wp') {
-                //runPactProviderTests("pay-direct-debit-connector", "${env.PACT_TAG}")
-                //runPactProviderTests("pay-connector", "${env.PACT_TAG}")
+                runPactProviderTests("pay-direct-debit-connector", "${env.PACT_TAG}")
+                runPactProviderTests("pay-connector", "${env.PACT_TAG}")
             }
         }
         post {


### PR DESCRIPTION
## WHAT

- Pact tests were temporary disabled to fix connector master (see https://github.com/alphagov/pay-publicapi/pull/259), now we can uncomment `runPactProviderTests` lines
