### PR TITLE
BAU : fix create payment api field name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -424,6 +424,7 @@
                             <apiModelPropertyAccessExclusions>
                                 <apiModelPropertyAccessExclusion>agreementId</apiModelPropertyAccessExclusion>
                                 <apiModelPropertyAccessExclusion>language</apiModelPropertyAccessExclusion>
+                                <apiModelPropertyAccessExclusion>delayedCapture</apiModelPropertyAccessExclusion>
                             </apiModelPropertyAccessExclusions>
                             <schemes>
                                 <scheme>https</scheme>

--- a/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
@@ -14,12 +15,20 @@ import java.util.StringJoiner;
  **/
 public class ValidCreatePaymentRequest {
 
+    @ApiModelProperty(value = "amount in pence", required = true, allowableValues = "range[1, 10000000]", example = "12000")
     private final int amount;
+    @ApiModelProperty(value = "payment reference", required = true, example = "12345")
     private final String reference;
-    private final String description;
+    @ApiModelProperty(name = "return_url", value = "service return url", required = true, example = "https://service-name.gov.uk/transactions/12345")
     private String returnUrl;
+    @ApiModelProperty(value = "payment description", required = true, example = "New passport application")
+    private final String description;
+    @ApiModelProperty(name = "agreement_id", value = "ID of the agreement being used to collect the payment", required = false, example = "33890b55-b9ea-4e2f-90fd-77ae0e9009e2")
     private String agreementId;
+    @ApiModelProperty(value = "ISO-639-1 Alpha-2 code of a supported language to use on the payment pages", required = false, example = "en")
     private SupportedLanguage language;
+    @ApiModelProperty(value = "delayed capture flag", required = false, example = "false" )
+    @JsonProperty("delayed_capture")
     private Boolean delayedCapture;
 
     public ValidCreatePaymentRequest(CreatePaymentRequest createPaymentRequest) {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -890,22 +890,30 @@
     },
     "ValidCreatePaymentRequest" : {
       "type" : "object",
+      "required" : [ "amount", "description", "reference", "return_url" ],
       "properties" : {
         "amount" : {
           "type" : "integer",
-          "format" : "int32"
+          "format" : "int32",
+          "example" : 12000,
+          "description" : "amount in pence",
+          "minimum" : 1,
+          "maximum" : 10000000
         },
         "reference" : {
-          "type" : "string"
+          "type" : "string",
+          "example" : "12345",
+          "description" : "payment reference"
+        },
+        "return_url" : {
+          "type" : "string",
+          "example" : "https://service-name.gov.uk/transactions/12345",
+          "description" : "service return url"
         },
         "description" : {
-          "type" : "string"
-        },
-        "returnUrl" : {
-          "type" : "string"
-        },
-        "delayedCapture" : {
-          "type" : "boolean"
+          "type" : "string",
+          "example" : "New passport application",
+          "description" : "payment description"
         }
       }
     }


### PR DESCRIPTION
## WHAT
API docs
- **Fix**: updated field name 'returnUrl' to 'return_url' (create payment API)
- Added description and examples for **ValidateCreatePaymentRequest** fields


