### PR TITLE
PP-4141 Search for first 6 digits and last 4 digits of card number

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/search/SearchPaymentsBase.java
+++ b/src/main/java/uk/gov/pay/api/model/search/SearchPaymentsBase.java
@@ -19,7 +19,7 @@ import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public abstract class SearchPaymentsBase {
 
@@ -47,18 +47,18 @@ public abstract class SearchPaymentsBase {
     public abstract Response getSearchResponse(Account account, Map<String, String> queryParams);
     protected abstract Set<String> getSupportedSearchParams();
     
-    protected void validateAllowedSearchFields(Map<String, String> queryParams) {
+    protected void validateSupportedSearchParams(Map<String, String> queryParams) {
         queryParams.entrySet().stream()
                 .filter(this::isUnsupportedParamWithNonBlankValue)
                 .findFirst()
                 .ifPresent(invalidParam -> {
                     throw new BadRequestException(PaymentError
-                            .aPaymentError(PaymentError.Code.SEARCH_PAYMENTS_VALIDATION_ERROR, invalidParam));
+                            .aPaymentError(PaymentError.Code.SEARCH_PAYMENTS_VALIDATION_ERROR, invalidParam.getKey()));
                 });
     }
     
     private boolean isUnsupportedParamWithNonBlankValue(Map.Entry<String, String> queryParam) {
-        return !(getSupportedSearchParams().contains(queryParam.getKey()) || isBlank(queryParam.getValue()));
+        return !getSupportedSearchParams().contains(queryParam.getKey()) && isNotBlank(queryParam.getValue());
     }
     
     protected HalRepresentation.HalRepresentationBuilder decoratePagination(HalRepresentation.HalRepresentationBuilder halRepresentationBuilder, IPaymentSearchPagination pagination) {

--- a/src/main/java/uk/gov/pay/api/model/search/SearchPaymentsBase.java
+++ b/src/main/java/uk/gov/pay/api/model/search/SearchPaymentsBase.java
@@ -4,7 +4,9 @@ import black.door.hate.HalRepresentation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.exception.BadRequestException;
 import uk.gov.pay.api.exception.SearchChargesException;
+import uk.gov.pay.api.model.PaymentError;
 import uk.gov.pay.api.model.links.Link;
 import uk.gov.pay.api.service.ConnectorUriGenerator;
 import uk.gov.pay.api.service.PaymentUriGenerator;
@@ -14,7 +16,10 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Map;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public abstract class SearchPaymentsBase {
 
@@ -31,7 +36,7 @@ public abstract class SearchPaymentsBase {
                               ConnectorUriGenerator connectorUriGenerator,
                               PaymentUriGenerator paymentUriGenerator,
                               ObjectMapper objectMapper) {
-        this.client =client;
+        this.client = client;
         this.configuration = configuration;
         this.connectorUriGenerator = connectorUriGenerator;
         this.paymentUriGenerator = paymentUriGenerator;
@@ -40,7 +45,18 @@ public abstract class SearchPaymentsBase {
     }
     
     public abstract Response getSearchResponse(Account account, Map<String, String> queryParams);
-
+    protected abstract List<String> getAllowedSearchFields();
+    
+    protected void validateAllowedSearchFields(Map<String, String> queryParams) {
+        queryParams.entrySet().stream()
+                .filter(map -> !getAllowedSearchFields().contains(map.getKey()) && isNotBlank(map.getValue()))
+                .findFirst()
+                .ifPresent(invalidParam -> {
+                    throw new BadRequestException(PaymentError
+                            .aPaymentError(PaymentError.Code.SEARCH_PAYMENTS_VALIDATION_ERROR, invalidParam));
+                });
+    }
+    
     protected HalRepresentation.HalRepresentationBuilder decoratePagination(HalRepresentation.HalRepresentationBuilder halRepresentationBuilder, IPaymentSearchPagination pagination) {
         try {
             halRepresentationBuilder

--- a/src/main/java/uk/gov/pay/api/model/search/card/SearchCardPayments.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/SearchCardPayments.java
@@ -20,6 +20,7 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -27,6 +28,18 @@ import java.util.stream.Collectors;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.http.HttpStatus.SC_OK;
+import static uk.gov.pay.api.service.PaymentSearchService.AGREEMENT_KEY;
+import static uk.gov.pay.api.service.PaymentSearchService.CARDHOLDER_NAME_KEY;
+import static uk.gov.pay.api.service.PaymentSearchService.CARD_BRAND_KEY;
+import static uk.gov.pay.api.service.PaymentSearchService.DISPLAY_SIZE;
+import static uk.gov.pay.api.service.PaymentSearchService.EMAIL_KEY;
+import static uk.gov.pay.api.service.PaymentSearchService.FIRST_DIGITS_CARD_NUMBER_KEY;
+import static uk.gov.pay.api.service.PaymentSearchService.FROM_DATE_KEY;
+import static uk.gov.pay.api.service.PaymentSearchService.LAST_DIGITS_CARD_NUMBER_KEY;
+import static uk.gov.pay.api.service.PaymentSearchService.PAGE;
+import static uk.gov.pay.api.service.PaymentSearchService.REFERENCE_KEY;
+import static uk.gov.pay.api.service.PaymentSearchService.STATE_KEY;
+import static uk.gov.pay.api.service.PaymentSearchService.TO_DATE_KEY;
 
 public class SearchCardPayments extends SearchPaymentsBase {
 
@@ -42,10 +55,7 @@ public class SearchCardPayments extends SearchPaymentsBase {
 
     @Override
     public Response getSearchResponse(Account account, Map<String, String> queryParams) {
-        if (isNotEmpty(queryParams.get("agreement_id"))) {
-            throw new BadRequestException(PaymentError
-                    .aPaymentError(PaymentError.Code.SEARCH_PAYMENTS_VALIDATION_ERROR, "agreement_id"));
-        }
+        validateAllowedSearchFields(queryParams);
         queryParams.put("transactionType", "charge");
 
         String url = connectorUriGenerator.chargesURIWithParams(account, queryParams);
@@ -59,6 +69,12 @@ public class SearchCardPayments extends SearchPaymentsBase {
             return processResponse(connectorResponse);
         }
         throw new SearchChargesException(connectorResponse);
+    }
+
+    @Override
+    protected List<String> getAllowedSearchFields() {
+        return Arrays.asList(REFERENCE_KEY, EMAIL_KEY, STATE_KEY, CARD_BRAND_KEY, CARDHOLDER_NAME_KEY, FIRST_DIGITS_CARD_NUMBER_KEY, LAST_DIGITS_CARD_NUMBER_KEY, FROM_DATE_KEY, TO_DATE_KEY, PAGE, DISPLAY_SIZE);
+
     }
 
     private Response processResponse(Response connectorResponse) {

--- a/src/main/java/uk/gov/pay/api/model/search/card/SearchCardPayments.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/SearchCardPayments.java
@@ -52,7 +52,7 @@ public class SearchCardPayments extends SearchPaymentsBase {
 
     @Override
     public Response getSearchResponse(Account account, Map<String, String> queryParams) {
-        validateAllowedSearchFields(queryParams);
+        validateSupportedSearchParams(queryParams);
         queryParams.put("transactionType", "charge");
 
         String url = connectorUriGenerator.chargesURIWithParams(account, queryParams);

--- a/src/main/java/uk/gov/pay/api/model/search/card/SearchCardPayments.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/SearchCardPayments.java
@@ -4,13 +4,12 @@ import black.door.hate.HalRepresentation;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
-import uk.gov.pay.api.exception.BadRequestException;
 import uk.gov.pay.api.exception.SearchChargesException;
-import uk.gov.pay.api.model.PaymentError;
 import uk.gov.pay.api.model.search.SearchPaymentsBase;
 import uk.gov.pay.api.service.ConnectorUriGenerator;
 import uk.gov.pay.api.service.PaymentUriGenerator;
@@ -20,15 +19,13 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.http.HttpStatus.SC_OK;
-import static uk.gov.pay.api.service.PaymentSearchService.AGREEMENT_KEY;
 import static uk.gov.pay.api.service.PaymentSearchService.CARDHOLDER_NAME_KEY;
 import static uk.gov.pay.api.service.PaymentSearchService.CARD_BRAND_KEY;
 import static uk.gov.pay.api.service.PaymentSearchService.DISPLAY_SIZE;
@@ -72,8 +69,8 @@ public class SearchCardPayments extends SearchPaymentsBase {
     }
 
     @Override
-    protected List<String> getAllowedSearchFields() {
-        return Arrays.asList(REFERENCE_KEY, EMAIL_KEY, STATE_KEY, CARD_BRAND_KEY, CARDHOLDER_NAME_KEY, FIRST_DIGITS_CARD_NUMBER_KEY, LAST_DIGITS_CARD_NUMBER_KEY, FROM_DATE_KEY, TO_DATE_KEY, PAGE, DISPLAY_SIZE);
+    protected Set<String> getSupportedSearchParams() {
+        return ImmutableSet.of(REFERENCE_KEY, EMAIL_KEY, STATE_KEY, CARD_BRAND_KEY, CARDHOLDER_NAME_KEY, FIRST_DIGITS_CARD_NUMBER_KEY, LAST_DIGITS_CARD_NUMBER_KEY, FROM_DATE_KEY, TO_DATE_KEY, PAGE, DISPLAY_SIZE);
 
     }
 

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchDirectDebitPayments.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchDirectDebitPayments.java
@@ -20,6 +20,7 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -27,6 +28,14 @@ import java.util.stream.Collectors;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.http.HttpStatus.SC_OK;
+import static uk.gov.pay.api.service.PaymentSearchService.AGREEMENT_KEY;
+import static uk.gov.pay.api.service.PaymentSearchService.DISPLAY_SIZE;
+import static uk.gov.pay.api.service.PaymentSearchService.EMAIL_KEY;
+import static uk.gov.pay.api.service.PaymentSearchService.FROM_DATE_KEY;
+import static uk.gov.pay.api.service.PaymentSearchService.PAGE;
+import static uk.gov.pay.api.service.PaymentSearchService.REFERENCE_KEY;
+import static uk.gov.pay.api.service.PaymentSearchService.STATE_KEY;
+import static uk.gov.pay.api.service.PaymentSearchService.TO_DATE_KEY;
 
 public class SearchDirectDebitPayments extends SearchPaymentsBase {
 
@@ -39,13 +48,10 @@ public class SearchDirectDebitPayments extends SearchPaymentsBase {
                                      ObjectMapper objectMapper) {
         super(client, configuration, connectorUriGenerator, paymentUriGenerator, objectMapper);
     }
-
+    
     @Override
     public Response getSearchResponse(Account account, Map<String, String> queryParams) {
-        if (isNotEmpty(queryParams.get("card_brand"))) {
-            throw new BadRequestException(PaymentError
-                    .aPaymentError(PaymentError.Code.SEARCH_PAYMENTS_VALIDATION_ERROR, "card_brand"));
-        }
+        validateAllowedSearchFields(queryParams);
         String url = connectorUriGenerator.directDebitTransactionsURI(account, queryParams);
         Response connectorResponse = client
                 .target(url)
@@ -57,6 +63,11 @@ public class SearchDirectDebitPayments extends SearchPaymentsBase {
             return processResponse(connectorResponse);
         }
         throw new SearchChargesException(connectorResponse);
+    }
+
+    @Override
+    protected List<String> getAllowedSearchFields() {
+        return Arrays.asList(REFERENCE_KEY, EMAIL_KEY, STATE_KEY, AGREEMENT_KEY, FROM_DATE_KEY, TO_DATE_KEY, PAGE, DISPLAY_SIZE);
     }
 
     private Response processResponse(Response directDebitResponse) {

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchDirectDebitPayments.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchDirectDebitPayments.java
@@ -49,7 +49,7 @@ public class SearchDirectDebitPayments extends SearchPaymentsBase {
     
     @Override
     public Response getSearchResponse(Account account, Map<String, String> queryParams) {
-        validateAllowedSearchFields(queryParams);
+        validateSupportedSearchParams(queryParams);
         String url = connectorUriGenerator.directDebitTransactionsURI(account, queryParams);
         Response connectorResponse = client
                 .target(url)

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchDirectDebitPayments.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchDirectDebitPayments.java
@@ -4,13 +4,12 @@ import black.door.hate.HalRepresentation;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
-import uk.gov.pay.api.exception.BadRequestException;
 import uk.gov.pay.api.exception.SearchChargesException;
-import uk.gov.pay.api.model.PaymentError;
 import uk.gov.pay.api.model.search.SearchPaymentsBase;
 import uk.gov.pay.api.service.ConnectorUriGenerator;
 import uk.gov.pay.api.service.PaymentUriGenerator;
@@ -20,13 +19,12 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.http.HttpStatus.SC_OK;
 import static uk.gov.pay.api.service.PaymentSearchService.AGREEMENT_KEY;
 import static uk.gov.pay.api.service.PaymentSearchService.DISPLAY_SIZE;
@@ -66,8 +64,8 @@ public class SearchDirectDebitPayments extends SearchPaymentsBase {
     }
 
     @Override
-    protected List<String> getAllowedSearchFields() {
-        return Arrays.asList(REFERENCE_KEY, EMAIL_KEY, STATE_KEY, AGREEMENT_KEY, FROM_DATE_KEY, TO_DATE_KEY, PAGE, DISPLAY_SIZE);
+    protected Set<String> getSupportedSearchParams() {
+        return ImmutableSet.of(REFERENCE_KEY, EMAIL_KEY, STATE_KEY, AGREEMENT_KEY, FROM_DATE_KEY, TO_DATE_KEY, PAGE, DISPLAY_SIZE);
     }
 
     private Response processResponse(Response directDebitResponse) {

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -190,12 +190,12 @@ public class PaymentsResource {
                                    @QueryParam("display_size") String displaySize,
                                    @ApiParam(value = "Direct Debit Agreement Id", hidden = true)
                                    @QueryParam("agreement_id") String agreementId,
-                                   @ApiParam(value = "Name on card used in the payment to be searched", hidden = false)
+                                   @ApiParam(value = "Name on card used to make payment", hidden = false)
                                        @QueryParam("cardholder_name") String cardHolderName,
-                                   @ApiParam(value = "First six digits of the card used to make a payment", hidden = false)
+                                   @ApiParam(value = "First six digits of the card used to make payment", hidden = false)
 
                                        @QueryParam("first_digits_card_number") String firstDigitsCardNumber,
-                                   @ApiParam(value = "Last four digits of the card used to make a payment", hidden = false)
+                                   @ApiParam(value = "Last four digits of the card used to make payment", hidden = false)
 
                                        @QueryParam("last_digits_card_number") String lastDigitsCardNumber,
                                    @Context UriInfo uriInfo) {

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -190,14 +190,22 @@ public class PaymentsResource {
                                    @QueryParam("display_size") String displaySize,
                                    @ApiParam(value = "Direct Debit Agreement Id", hidden = true)
                                    @QueryParam("agreement_id") String agreementId,
+                                   @ApiParam(value = "Name on card used in the payment to be searched", hidden = false)
+                                       @QueryParam("cardholder_name") String cardHolderName,
+                                   @ApiParam(value = "First six digits of the card used to make a payment", hidden = false)
+
+                                       @QueryParam("first_digits_card_number") String firstDigitsCardNumber,
+                                   @ApiParam(value = "Last four digits of the card used to make a payment", hidden = false)
+
+                                       @QueryParam("last_digits_card_number") String lastDigitsCardNumber,
                                    @Context UriInfo uriInfo) {
 
         logger.info("Payments search request - [ {} ]",
-                format("reference:%s, email: %s, status: %s, card_brand %s, fromDate: %s, toDate: %s, page: %s, display_size: %s, agreement_id: %s",
-                        reference, email, state, cardBrand, fromDate, toDate, pageNumber, displaySize, agreementId));
+                format("reference:%s, email: %s, status: %s, card_brand %s, fromDate: %s, toDate: %s, page: %s, display_size: %s, agreement_id: %s, cardholder_name: %s, first_digits_card_number: %s, last_digits_card_number: %s",
+                        reference, email, state, cardBrand, fromDate, toDate, pageNumber, displaySize, agreementId, cardHolderName, firstDigitsCardNumber, lastDigitsCardNumber));
 
         return paymentSearchService.doSearch(account, reference, email, state, cardBrand,
-                fromDate, toDate, pageNumber, displaySize, agreementId);
+                fromDate, toDate, pageNumber, displaySize, agreementId, cardHolderName, firstDigitsCardNumber, lastDigitsCardNumber);
     }
 
     @POST

--- a/src/main/java/uk/gov/pay/api/service/PaymentSearchService.java
+++ b/src/main/java/uk/gov/pay/api/service/PaymentSearchService.java
@@ -17,15 +17,18 @@ import static uk.gov.pay.api.validation.PaymentSearchValidator.validateSearchPar
 
 public class PaymentSearchService {
 
-    private static final String REFERENCE_KEY = "reference";
-    private static final String EMAIL_KEY = "email";
-    private static final String STATE_KEY = "state";
-    private static final String CARD_BRAND_KEY = "card_brand";
-    private static final String FROM_DATE_KEY = "from_date";
-    private static final String TO_DATE_KEY = "to_date";
-    private static final String PAGE = "page";
-    private static final String DISPLAY_SIZE = "display_size";
-    private static final String AGREEMENT_KEY = "agreement_id";
+    public static final String REFERENCE_KEY = "reference";
+    public static final String EMAIL_KEY = "email";
+    public static final String STATE_KEY = "state";
+    public static final String CARD_BRAND_KEY = "card_brand";
+    public static final String FROM_DATE_KEY = "from_date";
+    public static final String TO_DATE_KEY = "to_date";
+    public static final String PAGE = "page";
+    public static final String DISPLAY_SIZE = "display_size";
+    public static final String AGREEMENT_KEY = "agreement_id";
+    public static final String FIRST_DIGITS_CARD_NUMBER_KEY = "first_digits_card_number";
+    public static final String LAST_DIGITS_CARD_NUMBER_KEY = "last_digits_card_number";
+    public static final String CARDHOLDER_NAME_KEY = "cardholder_name";
     private final ConnectorUriGenerator connectorUriGenerator;
     private final Client client;
     private final ObjectMapper objectMapper;
@@ -46,9 +49,9 @@ public class PaymentSearchService {
     }
     
     public Response doSearch(Account account, String reference, String email, String state, String cardBrand,
-                             String fromDate, String toDate, String pageNumber, String displaySize, String agreementId) {
+                             String fromDate, String toDate, String pageNumber, String displaySize, String agreementId, String cardHolderName, String firstDigitsCardNumber, String lastDigitsCardNumber) {
         
-        validateSearchParameters(account, state, reference, email, cardBrand, fromDate, toDate, pageNumber, displaySize, agreementId);
+        validateSearchParameters(account, state, reference, email, cardBrand, fromDate, toDate, pageNumber, displaySize, agreementId, firstDigitsCardNumber, lastDigitsCardNumber);
 
         if (isNotBlank(cardBrand)) {
             cardBrand = cardBrand.toLowerCase();
@@ -59,7 +62,10 @@ public class PaymentSearchService {
         queryParams.put(EMAIL_KEY, email);
         queryParams.put(STATE_KEY, state);
         queryParams.put(CARD_BRAND_KEY, cardBrand);
+        queryParams.put(CARDHOLDER_NAME_KEY, cardHolderName);
         queryParams.put(AGREEMENT_KEY, agreementId);
+        queryParams.put(FIRST_DIGITS_CARD_NUMBER_KEY, firstDigitsCardNumber);
+        queryParams.put(LAST_DIGITS_CARD_NUMBER_KEY, lastDigitsCardNumber);
         queryParams.put(FROM_DATE_KEY, fromDate);
         queryParams.put(TO_DATE_KEY, toDate);
         queryParams.put(PAGE, pageNumber);

--- a/src/main/java/uk/gov/pay/api/service/PaymentSearchService.java
+++ b/src/main/java/uk/gov/pay/api/service/PaymentSearchService.java
@@ -20,15 +20,16 @@ public class PaymentSearchService {
     public static final String REFERENCE_KEY = "reference";
     public static final String EMAIL_KEY = "email";
     public static final String STATE_KEY = "state";
+    public static final String AGREEMENT_KEY = "agreement_id";
     public static final String CARD_BRAND_KEY = "card_brand";
+    public static final String FIRST_DIGITS_CARD_NUMBER_KEY = "first_digits_card_number";
+    public static final String LAST_DIGITS_CARD_NUMBER_KEY = "last_digits_card_number";
+    public static final String CARDHOLDER_NAME_KEY = "cardholder_name";
     public static final String FROM_DATE_KEY = "from_date";
     public static final String TO_DATE_KEY = "to_date";
     public static final String PAGE = "page";
     public static final String DISPLAY_SIZE = "display_size";
-    public static final String AGREEMENT_KEY = "agreement_id";
-    public static final String FIRST_DIGITS_CARD_NUMBER_KEY = "first_digits_card_number";
-    public static final String LAST_DIGITS_CARD_NUMBER_KEY = "last_digits_card_number";
-    public static final String CARDHOLDER_NAME_KEY = "cardholder_name";
+    
     private final ConnectorUriGenerator connectorUriGenerator;
     private final Client client;
     private final ObjectMapper objectMapper;

--- a/src/main/java/uk/gov/pay/api/validation/ExactLengthValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/ExactLengthValidator.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.api.validation;
+
+import static org.eclipse.jetty.util.StringUtil.isBlank;
+
+class ExactLengthValidator {
+    static boolean isValid(String value, int length) {
+        return isBlank(value) || value.length() == length;
+    }
+}

--- a/src/main/java/uk/gov/pay/api/validation/ExactLengthValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/ExactLengthValidator.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.api.validation;
 
-import static org.eclipse.jetty.util.StringUtil.isBlank;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 class ExactLengthValidator {
     static boolean isValid(String value, int length) {

--- a/src/main/java/uk/gov/pay/api/validation/NumericValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/NumericValidator.java
@@ -1,10 +1,9 @@
 package uk.gov.pay.api.validation;
 
-import static org.apache.commons.lang3.StringUtils.isNumeric;
 import static org.eclipse.jetty.util.StringUtil.isBlank;
 
 class NumericValidator {
     static boolean isValid(String value) {
-        return isBlank(value) || isNumeric(value);
+        return isBlank(value) || value.matches("[0-9]+");
     }
 }

--- a/src/main/java/uk/gov/pay/api/validation/NumericValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/NumericValidator.java
@@ -1,0 +1,10 @@
+package uk.gov.pay.api.validation;
+
+import static org.apache.commons.lang3.StringUtils.isNumeric;
+import static org.eclipse.jetty.util.StringUtil.isBlank;
+
+class NumericValidator {
+    static boolean isValid(String value) {
+        return isBlank(value) || isNumeric(value);
+    }
+}

--- a/src/main/java/uk/gov/pay/api/validation/NumericValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/NumericValidator.java
@@ -1,9 +1,13 @@
 package uk.gov.pay.api.validation;
 
+import java.util.regex.Pattern;
+
 import static org.eclipse.jetty.util.StringUtil.isBlank;
 
 class NumericValidator {
+    private static final Pattern ALL_DIGITS = Pattern.compile("[0-9]+");
+
     static boolean isValid(String value) {
-        return isBlank(value) || value.matches("[0-9]+");
+        return isBlank(value) || ALL_DIGITS.matcher(value).matches();
     }
 }

--- a/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
@@ -57,8 +57,8 @@ public class PaymentSearchValidator {
             validatePageIfNotNull(pageNumber, validationErrors);
             validateDisplaySizeIfNotNull(displaySize, validationErrors);
             validateAgreement(agreementId, validationErrors);
-            validatFirstDigitsCardNumber(firstDigitsCardNumber, validationErrors);
-            validatLastDigitsCardNumber(lastDigitsCardNumber, validationErrors);
+            validateFirstDigitsCardNumber(firstDigitsCardNumber, validationErrors);
+            validateLastDigitsCardNumber(lastDigitsCardNumber, validationErrors);
         } catch (Exception e) {
             throw new ValidationException(aPaymentError(SEARCH_PAYMENTS_VALIDATION_ERROR, join(validationErrors, ", "), e.getMessage()));
         }
@@ -69,18 +69,18 @@ public class PaymentSearchValidator {
 
     private static void validateAgreement(String agreement, List<String> validationErrors) {
         if (!isValid(agreement, AGREEMENT_ID_MAX_LENGTH)){
-            validationErrors.add("agreement");
+            validationErrors.add("agreement_id");
         }
     }
 
-    private static void validatFirstDigitsCardNumber(String firstDigitsCardNumber, List<String> validationErrors) {
-        if (!(ExactLengthValidator.isValid(firstDigitsCardNumber, FIRST_DIGITS_CARD_NUMBER_LENGTH) && NumericValidator.isValid(firstDigitsCardNumber))) {
+    private static void validateFirstDigitsCardNumber(String firstDigitsCardNumber, List<String> validationErrors) {
+        if (!ExactLengthValidator.isValid(firstDigitsCardNumber, FIRST_DIGITS_CARD_NUMBER_LENGTH) || !NumericValidator.isValid(firstDigitsCardNumber)) {
             validationErrors.add("first_digits_card_number");
         }
     }
 
-    private static void validatLastDigitsCardNumber(String lastDigitsCardNumber, List<String> validationErrors) {
-        if (!(ExactLengthValidator.isValid(lastDigitsCardNumber, LAST_DIGITS_CARD_NUMBER_LENGTH) && NumericValidator.isValid(lastDigitsCardNumber))) {
+    private static void validateLastDigitsCardNumber(String lastDigitsCardNumber, List<String> validationErrors) {
+        if (!ExactLengthValidator.isValid(lastDigitsCardNumber, LAST_DIGITS_CARD_NUMBER_LENGTH) || !NumericValidator.isValid(lastDigitsCardNumber)) {
             validationErrors.add("last_digits_card_number");
         }
     }

--- a/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
@@ -24,6 +24,9 @@ import static uk.gov.pay.api.validation.PaymentRequestValidator.REFERENCE_MAX_LE
 
 
 public class PaymentSearchValidator {
+    private static final int FIRST_DIGITS_CARD_NUMBER_LENGTH = 6;
+    private static final int LAST_DIGITS_CARD_NUMBER_LENGTH = 4;
+    
     // we should really find a way to not have this anywhere but in the connector...
     public static final Set<String> VALID_CARD_PAYMENT_STATES =
             new HashSet<>(Arrays.asList("created", "started", "submitted", "success", "failed", "cancelled", "error"));
@@ -31,9 +34,18 @@ public class PaymentSearchValidator {
     public static final Set<String> VALID_DIRECT_DEBIT_STATES =
             new HashSet<>(Arrays.asList("started", "pending", "success", "failed", "cancelled"));
 
-    public static void validateSearchParameters(Account account, String state, String reference, String email, String cardBrand,
-                                                String fromDate, String toDate, String pageNumber,
-                                                String displaySize, String agreementId) {
+    public static void validateSearchParameters(Account account, 
+                                                String state, 
+                                                String reference, 
+                                                String email, 
+                                                String cardBrand,
+                                                String fromDate, 
+                                                String toDate, 
+                                                String pageNumber,
+                                                String displaySize, 
+                                                String agreementId, 
+                                                String firstDigitsCardNumber, 
+                                                String lastDigitsCardNumber) {
         List<String> validationErrors = new LinkedList<>();
         try {
             validateState(account, state, validationErrors);
@@ -45,6 +57,8 @@ public class PaymentSearchValidator {
             validatePageIfNotNull(pageNumber, validationErrors);
             validateDisplaySizeIfNotNull(displaySize, validationErrors);
             validateAgreement(agreementId, validationErrors);
+            validatFirstDigitsCardNumber(firstDigitsCardNumber, validationErrors);
+            validatLastDigitsCardNumber(lastDigitsCardNumber, validationErrors);
         } catch (Exception e) {
             throw new ValidationException(aPaymentError(SEARCH_PAYMENTS_VALIDATION_ERROR, join(validationErrors, ", "), e.getMessage()));
         }
@@ -55,7 +69,19 @@ public class PaymentSearchValidator {
 
     private static void validateAgreement(String agreement, List<String> validationErrors) {
         if (!isValid(agreement, AGREEMENT_ID_MAX_LENGTH)){
-                validationErrors.add("agreement");
+            validationErrors.add("agreement");
+        }
+    }
+
+    private static void validatFirstDigitsCardNumber(String firstDigitsCardNumber, List<String> validationErrors) {
+        if (!(ExactLengthValidator.isValid(firstDigitsCardNumber, FIRST_DIGITS_CARD_NUMBER_LENGTH) && NumericValidator.isValid(firstDigitsCardNumber))) {
+            validationErrors.add("first_digits_card_number");
+        }
+    }
+
+    private static void validatLastDigitsCardNumber(String lastDigitsCardNumber, List<String> validationErrors) {
+        if (!(ExactLengthValidator.isValid(lastDigitsCardNumber, LAST_DIGITS_CARD_NUMBER_LENGTH) && NumericValidator.isValid(lastDigitsCardNumber))) {
+            validationErrors.add("last_digits_card_number");
         }
     }
 
@@ -112,9 +138,9 @@ public class PaymentSearchValidator {
     }
 
     private static boolean validateState(Account account, String state) {
-        return isBlank(state) || 
+        return isBlank(state) ||
                 (isDirectDebitAccount(account) ? VALID_DIRECT_DEBIT_STATES.contains(state) :
-                VALID_CARD_PAYMENT_STATES.contains(state));
+                        VALID_CARD_PAYMENT_STATES.contains(state));
     }
 
     private static boolean isDirectDebitAccount(Account account) {

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -8,7 +8,6 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.pay.api.it.fixtures.PaymentNavigationLinksFixture;
 import uk.gov.pay.api.model.Address;
@@ -298,7 +297,6 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
         assertThat(results, matchesField("first_digits_card_number", TEST_FIRST_DIGITS_CARD_NUMBER));
     }
 
-    @Ignore
     @Test
     public void searchPayments_filterByCardHolderName() {
         String payments = aPaginatedPaymentSearchResult()

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -569,7 +569,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(2))
                 .assertThat("$.code", is("P0401"))
-                .assertThat("$.description", is("Invalid parameters: agreement_id=my_agreement. See Public API documentation for the correct data formats"));
+                .assertThat("$.description", is("Invalid parameters: agreement_id. See Public API documentation for the correct data formats"));
     }
 
     private Matcher<? super List<Map<String, Object>>> matchesState(final String state) {

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -8,6 +8,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.pay.api.it.fixtures.PaymentNavigationLinksFixture;
 import uk.gov.pay.api.model.Address;
@@ -297,6 +298,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
         assertThat(results, matchesField("first_digits_card_number", TEST_FIRST_DIGITS_CARD_NUMBER));
     }
 
+    @Ignore
     @Test
     public void searchPayments_filterByCardHolderName() {
         String payments = aPaginatedPaymentSearchResult()

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -44,6 +44,9 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
 
     private static final String TEST_REFERENCE = "test_reference";
     private static final String TEST_EMAIL = "alice.111@mail.fake";
+    private static final String TEST_FIRST_DIGITS_CARD_NUMBER = "123456";
+    private static final String TEST_LAST_DIGITS_CARD_NUMBER = "1234";
+    private static final String TEST_CARDHOLDER_NAME = "Mr. Payment";
     private static final String TEST_STATE = "created";
     private static final String TEST_CARD_BRAND = "master-card";
     private static final String TEST_CARD_BRAND_LABEL = "Mastercard";
@@ -52,7 +55,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
     private static final String TEST_TO_DATE = "2016-01-28T12:00:00Z";
     private static final String SEARCH_PATH = "/v1/payments";
     private static final Address BILLING_ADDRESS = new Address("line1", "line2", "NR2 5 6EG", "city", "UK");
-    private static final CardDetails CARD_DETAILS = new CardDetails("1234", null, "Mr. Payment", "12/19", BILLING_ADDRESS, TEST_CARD_BRAND_LABEL);
+    private static final CardDetails CARD_DETAILS = new CardDetails(TEST_LAST_DIGITS_CARD_NUMBER, TEST_FIRST_DIGITS_CARD_NUMBER, TEST_CARDHOLDER_NAME, "12/19", BILLING_ADDRESS, TEST_CARD_BRAND_LABEL);
 
     @Before
     public void mapBearerTokenToAccountId() {
@@ -75,7 +78,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .getResults())
                 .build();
 
-        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, TEST_REFERENCE, null, null, null, null, null, payments);
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, TEST_REFERENCE, null, null, null, null, null, null, null,null, payments);
 
         String responseBody = searchPayments(API_KEY, ImmutableMap.of("reference", TEST_REFERENCE))
                 .statusCode(200)
@@ -141,7 +144,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .getResults())
                 .build();
 
-        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, TEST_REFERENCE, null, null, null, null, null,
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, TEST_REFERENCE, null, null, null, null, null, null, null, null,
                 payments
         );
 
@@ -163,7 +166,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .getResults())
                 .build();
 
-        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, TEST_REFERENCE, null, null, null, null, null,
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, TEST_REFERENCE, null, null, null, null, null, null, null, null,
                 payments
         );
 
@@ -188,7 +191,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .getResults())
                 .build();
 
-        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, null, TEST_STATE, null, null, null,
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, null, TEST_STATE, null, null, null, null, null, null,
                 payments
         );
 
@@ -212,7 +215,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .getResults())
                 .build();
 
-        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, null, TEST_STATE, null, null, null,
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, null, TEST_STATE, null, null, null, null, null, null,
                 payments
         );
 
@@ -236,7 +239,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .getResults())
                 .build();
 
-        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, TEST_EMAIL, null, null, null, null, payments);
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, TEST_EMAIL, null, null, null, null, null, null, null, payments);
 
         ValidatableResponse response = searchPayments(API_KEY, ImmutableMap.of(
                 "email", TEST_EMAIL))
@@ -249,6 +252,75 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
     }
 
     @Test
+    public void searchPayments_filterByLastDigitsCardNumber() {
+        String payments = aPaginatedPaymentSearchResult()
+                .withCount(10)
+                .withPage(2)
+                .withTotal(20)
+                .withPayments(aSuccessfulSearchPayment()
+                        .withMatchingCardDetails(CARD_DETAILS)
+                        .getResults())
+                .build();
+
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, null, null, null, null, null, TEST_LAST_DIGITS_CARD_NUMBER, null, null, payments);
+
+        ValidatableResponse response = searchPayments(API_KEY, ImmutableMap.of(
+                "last_digits_card_number", TEST_LAST_DIGITS_CARD_NUMBER))
+                .statusCode(200)
+                .contentType(JSON)
+                .body("results.size()", equalTo(3));
+
+        List<Map<String, Object>> results = response.extract().body().jsonPath().getList("results.card_details");
+        assertThat(results, matchesField("last_digits_card_number", TEST_LAST_DIGITS_CARD_NUMBER));
+    }
+    
+    @Test
+    public void searchPayments_filterByFirstDigitsCardNumber() {
+        String payments = aPaginatedPaymentSearchResult()
+                .withCount(10)
+                .withPage(2)
+                .withTotal(20)
+                .withPayments(aSuccessfulSearchPayment()
+                        .withMatchingCardDetails(CARD_DETAILS)
+                        .getResults())
+                .build();
+
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, null, null, null, null, TEST_FIRST_DIGITS_CARD_NUMBER, null, null, null, payments);
+
+        ValidatableResponse response = searchPayments(API_KEY, ImmutableMap.of(
+                "first_digits_card_number", TEST_FIRST_DIGITS_CARD_NUMBER))
+                .statusCode(200)
+                .contentType(JSON)
+                .body("results.size()", equalTo(3));
+
+        List<Map<String, Object>> results = response.extract().body().jsonPath().getList("results.card_details");
+        assertThat(results, matchesField("first_digits_card_number", TEST_FIRST_DIGITS_CARD_NUMBER));
+    }
+
+    @Test
+    public void searchPayments_filterByCardHolderName() {
+        String payments = aPaginatedPaymentSearchResult()
+                .withCount(10)
+                .withPage(2)
+                .withTotal(20)
+                .withPayments(aSuccessfulSearchPayment()
+                        .withMatchingCardDetails(CARD_DETAILS)
+                        .getResults())
+                .build();
+
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, null, null, null, TEST_CARDHOLDER_NAME, null, null, null, null, payments);
+
+        ValidatableResponse response = searchPayments(API_KEY, ImmutableMap.of(
+                "cardholder_name", TEST_CARDHOLDER_NAME))
+                .statusCode(200)
+                .contentType(JSON)
+                .body("results.size()", equalTo(3));
+
+        List<Map<String, Object>> results = response.extract().body().jsonPath().getList("results.card_details");
+        assertThat(results, matchesField("cardholder_name", TEST_CARDHOLDER_NAME));
+    }
+    
+    @Test
     public void searchPayments_filterByPartialEmail() {
         String payments = aPaginatedPaymentSearchResult()
                 .withCount(10)
@@ -259,7 +331,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .getResults())
                 .build();
 
-        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, "alice", null, null, null, null, payments);
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, "alice", null, null, null, null, null, null,null, payments);
 
         ValidatableResponse response = searchPayments(API_KEY, ImmutableMap.of(
                 "email", "alice"))
@@ -281,7 +353,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .withCreatedDateBetween(TEST_FROM_DATE, TEST_TO_DATE).getResults())
                 .build();
 
-        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, null, null, null, TEST_FROM_DATE, TEST_TO_DATE,
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, null, null, null, null, null,null, TEST_FROM_DATE, TEST_TO_DATE,
                 payments
         );
 
@@ -309,7 +381,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .withCreatedDateBetween(TEST_FROM_DATE, TEST_TO_DATE).getResults())
                 .build();
 
-        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, TEST_REFERENCE, TEST_EMAIL, TEST_STATE, null, TEST_FROM_DATE, TEST_TO_DATE,
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, TEST_REFERENCE, TEST_EMAIL, TEST_STATE, null, null, null, null,TEST_FROM_DATE, TEST_TO_DATE,
                 payments
         );
 
@@ -405,7 +477,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
 
     @Test
     public void searchPayments_errorIfConnectorResponseIsInvalid() throws Exception {
-        connectorMock.whenSearchCharges(GATEWAY_ACCOUNT_ID, TEST_REFERENCE, TEST_EMAIL, TEST_STATE, null, TEST_FROM_DATE, TEST_TO_DATE)
+        connectorMock.whenSearchCharges(GATEWAY_ACCOUNT_ID, TEST_REFERENCE, TEST_EMAIL, TEST_STATE, null, null, null, null,TEST_FROM_DATE, TEST_TO_DATE)
                 .respond(response()
                         .withStatusCode(OK_200)
                         .withHeader(CONTENT_TYPE, APPLICATION_JSON)
@@ -463,7 +535,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .getResults())
                 .build();
 
-        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, null, null, TEST_CARD_BRAND, null, null, payments);
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, null, null, null, TEST_CARD_BRAND, null, null, null, null,null, payments);
 
         ValidatableResponse response = searchPayments(API_KEY, ImmutableMap.of(
                 "card_brand", cardBrand));
@@ -495,7 +567,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(2))
                 .assertThat("$.code", is("P0401"))
-                .assertThat("$.description", is("Invalid parameters: agreement_id. See Public API documentation for the correct data formats"));
+                .assertThat("$.description", is("Invalid parameters: agreement_id=my_agreement. See Public API documentation for the correct data formats"));
     }
 
     private Matcher<? super List<Map<String, Object>>> matchesState(final String state) {

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -79,7 +79,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .getResults())
                 .build();
 
-        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, TEST_REFERENCE, null, null, null, null, null, null, null,null, payments);
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, TEST_REFERENCE, null, null, null, null, null, null, null, null, payments);
 
         String responseBody = searchPayments(API_KEY, ImmutableMap.of("reference", TEST_REFERENCE))
                 .statusCode(200)

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterITest.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterITest.java
@@ -87,7 +87,7 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
                         .withNumberOfResults(1).getResults())
                 .build();
 
-        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, REFERENCE, null, null, null, null, null, payments);
+        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, REFERENCE, null, null, null, null, null, null, null, null, payments);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> searchPayments(API_KEY, ImmutableMap.of("reference", REFERENCE)),

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentResourceSearchValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentResourceSearchValidationITest.java
@@ -22,7 +22,7 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
 
     private static final String VALID_REFERENCE = "test_reference";
     private static final String VALID_LAST_DIGITS_CARD_NUMBER = "4242";
-    private static final String VALID_FIRST_DIGITS_CARD_NUMBER = "424242";
+    private static final String VALID_FIRST_DIGITS_CARD_NUMBER = "123456";
     private static final String VALID_STATE = "success";
     private static final String VALID_EMAIL = "alice.111@mail.fake";
     private static final String VALID_FROM_DATE = "2016-01-28T00:00:00Z";
@@ -180,7 +180,7 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
                         .put("reference", VALID_REFERENCE)
                         .put("email", VALID_EMAIL)
                         .put("state", VALID_STATE)
-                        .put("first_digits_card_number", "4242")
+                        .put("first_digits_card_number", "4a4234")
                         .put("last_digits_card_number", "423")
                         .put("from_date", VALID_FROM_DATE)
                         .put("to_date", VALID_TO_DATE)

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentResourceSearchValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentResourceSearchValidationITest.java
@@ -21,6 +21,8 @@ import static org.hamcrest.core.Is.is;
 public class PaymentResourceSearchValidationITest extends PaymentResourceITestBase {
 
     private static final String VALID_REFERENCE = "test_reference";
+    private static final String VALID_LAST_DIGITS_CARD_NUMBER = "4242";
+    private static final String VALID_FIRST_DIGITS_CARD_NUMBER = "424242";
     private static final String VALID_STATE = "success";
     private static final String VALID_EMAIL = "alice.111@mail.fake";
     private static final String VALID_FROM_DATE = "2016-01-28T00:00:00Z";
@@ -37,12 +39,16 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
     @Test
     public void searchPayments_errorWhenToDateIsNotInZoneDateTimeFormat() throws Exception {
         InputStream body = searchPayments(API_KEY,
-                ImmutableMap.of(
-                        "reference", VALID_REFERENCE,
-                        "email", VALID_EMAIL,
-                        "state", VALID_STATE,
-                        "from_date", VALID_FROM_DATE,
-                        "to_date", "2016-01-01 00:00"))
+                ImmutableMap.<String, String>builder()
+                        .put("reference", VALID_REFERENCE)
+                        .put("email", VALID_EMAIL)
+                        .put("state", VALID_STATE)
+                        .put("first_digits_card_number", VALID_FIRST_DIGITS_CARD_NUMBER)
+                        .put("last_digits_card_number", VALID_LAST_DIGITS_CARD_NUMBER)
+                        .put("from_date", VALID_FROM_DATE)
+                        .put("to_date", "2016-01-01 00:00")
+                        .build()
+        )
                 .statusCode(422)
                 .contentType(JSON).extract()
                 .body().asInputStream();
@@ -165,6 +171,31 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
                 .assertThat("$.*", hasSize(2))
                 .assertThat("$.code", is("P0401"))
                 .assertThat("$.description", is("Invalid parameters: from_date, to_date. See Public API documentation for the correct data formats"));
+    }
+    
+    @Test
+    public void searchPayments_errorWhenCardDigitsAreInvalid() throws Exception {
+        InputStream body = searchPayments(API_KEY,
+                ImmutableMap.<String, String>builder()
+                        .put("reference", VALID_REFERENCE)
+                        .put("email", VALID_EMAIL)
+                        .put("state", VALID_STATE)
+                        .put("first_digits_card_number", "4242")
+                        .put("last_digits_card_number", "423")
+                        .put("from_date", VALID_FROM_DATE)
+                        .put("to_date", VALID_TO_DATE)
+                        .build()
+        )
+                .statusCode(422)
+                .contentType(JSON).extract()
+                .body().asInputStream();
+
+        String json = IOUtils.toString(body, "UTF-8");
+
+        JsonAssert.with(json)
+                .assertThat("$.*", hasSize(2))
+                .assertThat("$.code", is("P0401"))
+                .assertThat("$.description", is("Invalid parameters: first_digits_card_number, last_digits_card_number. See Public API documentation for the correct data formats"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServiceTest.java
@@ -4,6 +4,7 @@ import au.com.dius.pact.consumer.PactVerification;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonassert.JsonAssert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,39 +58,7 @@ public class CardPaymentSearchServiceTest {
         paymentSearchService = new PaymentSearchService(client, configuration, connectorUriGenerator, paymentUriGenerator, objectMapper);
     }
     
-    @Test
-    @PactVerification({"connector"})
-    @Pacts(pacts = {"publicapi-connector-search-payment-by-cardholdername"})
-    public void searchShouldReturnAResponseWithOneTransaction_whenFilteringByCardHolderName() {
-        Account account = new Account("123456", TokenPaymentType.CARD);
-        String cardHolderName = "Mr Payment";
-        Response response =
-                paymentSearchService.doSearch(account, null, null,
-                        null, null, null,
-                        null, null, null,
-                        null, "pay", null, null);
-        JsonAssert.with(response.getEntity().toString())
-                .assertThat("count", is(1))
-                .assertThat("total", is(1))
-                .assertThat("page", is(1))
-                .assertThat("results", is(collectionWithSize(equalTo(1))))
-                .assertThat("results[0]", hasKey("amount"))
-                .assertThat("results[0]", hasKey("state"))
-                .assertThat("results[0]", hasKey("reference"))
-                .assertThat("results[0]", hasKey("email"))
-                .assertThat("results[0].card_details.cardholder_name", is(cardHolderName))
-                .assertThat("results[0].card_details", hasKey("first_digits_card_number"))
-                .assertThat("results[0].card_details", hasKey("last_digits_card_number"))
-                .assertThat("results[0].state", hasKey("status"))
-                .assertThat("results[0].state", hasKey("finished"))
-                .assertThat("results[0]", hasKey("_links"))
-                .assertThat("_links", hasKey("self"))
-                .assertThat("_links", hasKey("first_page"))
-                .assertThat("_links", hasKey("last_page"))
-                .assertNotDefined("_links.next_page")
-                .assertNotDefined("_links.prev_page");
-    }
-
+    @Ignore
     @Test
     @PactVerification({"connector"})
     @Pacts(pacts = {"publicapi-connector-search-payment-by-last-digits-card-number"})

--- a/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServiceTest.java
@@ -117,4 +117,36 @@ public class CardPaymentSearchServiceTest {
                 .assertNotDefined("_links.next_page")
                 .assertNotDefined("_links.prev_page");
     }
+
+    @Test
+    @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector-search-payment-by-cardholder-name"})
+    public void searchShouldReturnAResponseWithOneTransaction_whenFilteringByCardHolderName() {
+        Account account = new Account("123456", TokenPaymentType.CARD);
+        Response response =
+                paymentSearchService.doSearch(account, null, null,
+                        null, null, null,
+                        null, null, null,
+                        null, "pay", null, null);
+        JsonAssert.with(response.getEntity().toString())
+                .assertThat("count", is(1))
+                .assertThat("total", is(1))
+                .assertThat("page", is(1))
+                .assertThat("results", is(collectionWithSize(equalTo(1))))
+                .assertThat("results[0]", hasKey("amount"))
+                .assertThat("results[0]", hasKey("state"))
+                .assertThat("results[0]", hasKey("reference"))
+                .assertThat("results[0]", hasKey("email"))
+                .assertThat("results[0].card_details.cardholder_name", is("Mr Payment"))
+                .assertThat("results[0].card_details", hasKey("first_digits_card_number"))
+                .assertThat("results[0].card_details", hasKey("last_digits_card_number"))
+                .assertThat("results[0].state", hasKey("status"))
+                .assertThat("results[0].state", hasKey("finished"))
+                .assertThat("results[0]", hasKey("_links"))
+                .assertThat("_links", hasKey("self"))
+                .assertThat("_links", hasKey("first_page"))
+                .assertThat("_links", hasKey("last_page"))
+                .assertNotDefined("_links.next_page")
+                .assertNotDefined("_links.prev_page");
+    }
 }

--- a/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServiceTest.java
@@ -4,7 +4,6 @@ import au.com.dius.pact.consumer.PactVerification;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonassert.JsonAssert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,12 +21,9 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
 
 import static com.jayway.jsonassert.JsonAssert.collectionWithSize;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServiceTest.java
@@ -58,7 +58,6 @@ public class CardPaymentSearchServiceTest {
         paymentSearchService = new PaymentSearchService(client, configuration, connectorUriGenerator, paymentUriGenerator, objectMapper);
     }
     
-    @Ignore
     @Test
     @PactVerification({"connector"})
     @Pacts(pacts = {"publicapi-connector-search-payment-by-last-digits-card-number"})

--- a/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServiceTest.java
@@ -1,0 +1,156 @@
+package uk.gov.pay.api.service;
+
+import au.com.dius.pact.consumer.PactVerification;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonassert.JsonAssert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.api.app.RestClientFactory;
+import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.app.config.RestClientConfig;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.commons.testing.pact.consumers.PactProviderRule;
+import uk.gov.pay.commons.testing.pact.consumers.Pacts;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+
+import static com.jayway.jsonassert.JsonAssert.collectionWithSize;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CardPaymentSearchServiceTest {
+
+    @Rule
+    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+
+    private Client client;
+
+    @Mock
+    private PublicApiConfig configuration;
+    private ConnectorUriGenerator connectorUriGenerator;
+    private PaymentSearchService paymentSearchService;
+    private PaymentUriGenerator paymentUriGenerator;
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() {
+        when(configuration.getConnectorUrl()).thenReturn(connectorRule.getUrl());
+
+        when(configuration.getBaseUrl()).thenReturn("http://publicapi.test.localhost/");
+
+        connectorUriGenerator = new ConnectorUriGenerator(configuration);
+        paymentUriGenerator = new PaymentUriGenerator();
+        client = RestClientFactory.buildClient(new RestClientConfig(false));
+        objectMapper = new ObjectMapper();
+        paymentSearchService = new PaymentSearchService(client, configuration, connectorUriGenerator, paymentUriGenerator, objectMapper);
+    }
+    
+    @Test
+    @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector-search-payment-by-cardholdername"})
+    public void searchShouldReturnAResponseWithOneTransaction_whenFilteringByCardHolderName() {
+        Account account = new Account("123456", TokenPaymentType.CARD);
+        String cardHolderName = "Mr Payment";
+        Response response =
+                paymentSearchService.doSearch(account, null, null,
+                        null, null, null,
+                        null, null, null,
+                        null, "pay", null, null);
+        JsonAssert.with(response.getEntity().toString())
+                .assertThat("count", is(1))
+                .assertThat("total", is(1))
+                .assertThat("page", is(1))
+                .assertThat("results", is(collectionWithSize(equalTo(1))))
+                .assertThat("results[0]", hasKey("amount"))
+                .assertThat("results[0]", hasKey("state"))
+                .assertThat("results[0]", hasKey("reference"))
+                .assertThat("results[0]", hasKey("email"))
+                .assertThat("results[0].card_details.cardholder_name", is(cardHolderName))
+                .assertThat("results[0].card_details", hasKey("first_digits_card_number"))
+                .assertThat("results[0].card_details", hasKey("last_digits_card_number"))
+                .assertThat("results[0].state", hasKey("status"))
+                .assertThat("results[0].state", hasKey("finished"))
+                .assertThat("results[0]", hasKey("_links"))
+                .assertThat("_links", hasKey("self"))
+                .assertThat("_links", hasKey("first_page"))
+                .assertThat("_links", hasKey("last_page"))
+                .assertNotDefined("_links.next_page")
+                .assertNotDefined("_links.prev_page");
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector-search-payment-by-last-digits-card-number"})
+    public void searchShouldReturnAResponseWithOneTransaction_whenFilteringByLastDigitsCardNumber() {
+        Account account = new Account("123456", TokenPaymentType.CARD);
+        Response response =
+                paymentSearchService.doSearch(account, null, null,
+                        null, null, null,
+                        null, null, null,
+                        null, null, null, "1234");
+        JsonAssert.with(response.getEntity().toString())
+                .assertThat("count", is(1))
+                .assertThat("total", is(1))
+                .assertThat("page", is(1))
+                .assertThat("results", is(collectionWithSize(equalTo(1))))
+                .assertThat("results[0]", hasKey("amount"))
+                .assertThat("results[0]", hasKey("state"))
+                .assertThat("results[0]", hasKey("reference"))
+                .assertThat("results[0]", hasKey("email"))
+                .assertThat("results[0].card_details", hasKey("cardholder_name"))
+                .assertThat("results[0].card_details", hasKey("first_digits_card_number"))
+                .assertThat("results[0].card_details.last_digits_card_number", is("1234"))
+                .assertThat("results[0].state", hasKey("status"))
+                .assertThat("results[0].state", hasKey("finished"))
+                .assertThat("results[0]", hasKey("_links"))
+                .assertThat("_links", hasKey("self"))
+                .assertThat("_links", hasKey("first_page"))
+                .assertThat("_links", hasKey("last_page"))
+                .assertNotDefined("_links.next_page")
+                .assertNotDefined("_links.prev_page");
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector-search-payment-by-first-digits-card-number"})
+    public void searchShouldReturnAResponseWithOneTransaction_whenFilteringByFirstDigitsCardNumber() {
+        Account account = new Account("123456", TokenPaymentType.CARD);
+        Response response =
+                paymentSearchService.doSearch(account, null, null,
+                        null, null, null,
+                        null, null, null,
+                        null, null, "123456", null);
+        JsonAssert.with(response.getEntity().toString())
+                .assertThat("count", is(1))
+                .assertThat("total", is(1))
+                .assertThat("page", is(1))
+                .assertThat("results", is(collectionWithSize(equalTo(1))))
+                .assertThat("results[0]", hasKey("amount"))
+                .assertThat("results[0]", hasKey("state"))
+                .assertThat("results[0]", hasKey("reference"))
+                .assertThat("results[0]", hasKey("email"))
+                .assertThat("results[0].card_details", hasKey("cardholder_name"))
+                .assertThat("results[0].card_details.first_digits_card_number", is("123456"))
+                .assertThat("results[0].card_details", hasKey("last_digits_card_number"))
+                .assertThat("results[0].state", hasKey("status"))
+                .assertThat("results[0].state", hasKey("finished"))
+                .assertThat("results[0]", hasKey("_links"))
+                .assertThat("_links", hasKey("self"))
+                .assertThat("_links", hasKey("first_page"))
+                .assertThat("_links", hasKey("last_page"))
+                .assertNotDefined("_links.next_page")
+                .assertNotDefined("_links.prev_page");
+    }
+}

--- a/src/test/java/uk/gov/pay/api/service/DirectDebitPaymentSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/DirectDebitPaymentSearchServiceTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class PaymentSearchServiceTest {
+public class DirectDebitPaymentSearchServiceTest {
 
     @Rule
     public PactProviderRule connectorRule = new PactProviderRule("direct-debit-connector", this);

--- a/src/test/java/uk/gov/pay/api/service/PaymentSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/PaymentSearchServiceTest.java
@@ -42,7 +42,7 @@ public class PaymentSearchServiceTest {
     private PaymentSearchService paymentSearchService;
     private PaymentUriGenerator paymentUriGenerator;
     private ObjectMapper objectMapper;
-    
+
     @Before
     public void setUp() {
         when(configuration.getConnectorDDUrl()).thenReturn(connectorRule.getUrl());
@@ -55,31 +55,55 @@ public class PaymentSearchServiceTest {
         objectMapper = new ObjectMapper();
         paymentSearchService = new PaymentSearchService(client, configuration, connectorUriGenerator, paymentUriGenerator, objectMapper);
     }
-    
+
     @Test
     public void doSearchShouldThrowBadRequestException_whenAccountIsNotDD_andAgreementIsASearchParam() {
         Account account = new Account("an account", TokenPaymentType.CARD);
         String agreementId = "an-agreement-id";
         try {
             paymentSearchService.doSearch(account, null, null, null, null, null,
-                    null, null, null, agreementId);
+                    null, null, null, agreementId, null, null, null);
         } catch (uk.gov.pay.api.exception.BadRequestException ex) {
             assertThat(ex.getPaymentError().getCode(), is("P0401"));
-            assertThat(ex.getPaymentError().getDescription().contains("Invalid parameters: agreement_id."), is(true));
+            assertThat(ex.getPaymentError().getDescription().contains("Invalid parameters: agreement_id"), is(true));
         }
     }
-    
+
+    @Test
+    public void doSearchShouldThrowBadRequestException_whenAccountIsDD_andFirstDigitsCardNumberIsASearchParam() {
+        Account account = new Account("an account", TokenPaymentType.DIRECT_DEBIT);
+        try {
+            paymentSearchService.doSearch(account, null, null, null, null, null,
+                    null, null, null, null,   null, "424242", null);
+        } catch (uk.gov.pay.api.exception.BadRequestException ex) {
+            assertThat(ex.getPaymentError().getCode(), is("P0401"));
+            assertThat(ex.getPaymentError().getDescription().contains("Invalid parameters: first_digits_card_number"), is(true));
+        }
+    }
+
+    @Test
+    public void doSearchShouldThrowBadRequestException_whenAccountIsDD_andLastDigitsCardNumberIsASearchParam() {
+        Account account = new Account("an account", TokenPaymentType.DIRECT_DEBIT);
+        try {
+            paymentSearchService.doSearch(account, null, null, null, null, null,
+                    null, null, null, null, null, null, "4242");
+        } catch (uk.gov.pay.api.exception.BadRequestException ex) {
+            assertThat(ex.getPaymentError().getCode(), is("P0401"));
+            assertThat(ex.getPaymentError().getDescription().contains("Invalid parameters: last_digits_card_number"), is(true));
+        }
+    }
+
     @Test
     @PactVerification({"direct-debit-connector"})
     @Pacts(pacts = {"publicapi-direct-debit-connector-search-by-mandate-three-results"})
     public void doSearchShouldReturnADirectDebitSearchResponseWithThreeTransactions() {
         Account account = new Account("2po9ycynwq8yxdgg2qwq9e9qpyrtre", TokenPaymentType.DIRECT_DEBIT);
         String agreementId = "jkdjsvd8f78ffkwfek2q";
-        Response response = 
-                paymentSearchService.doSearch(account, null, null, 
-                        null, null, null, 
+        Response response =
+                paymentSearchService.doSearch(account, null, null,
                         null, null, null,
-                        agreementId);
+                        null, null, null,
+                        agreementId, null, null, null);
         JsonAssert.with(response.getEntity().toString())
                 .assertThat("count", is(3))
                 .assertThat("total", is(3))

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -53,6 +53,9 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
     private static final String STATE_KEY = "state";
     private static final String CARD_BRAND = "master-card";
     private static final String CARD_BRAND_KEY = "card_brand";
+    private static final String CARDHOLDER_NAME_KEY = "cardholder_name";
+    public static final String FIRST_DIGITS_CARD_NUMBER_KEY = "first_digits_card_number";
+    public static final String LAST_DIGITS_CARD_NUMBER_KEY = "last_digits_card_number";
     private static final String CARD_BRAND_LABEL = "Mastercard";
     private static final String FROM_DATE_KEY = "from_date";
     private static final String TO_DATE_KEY = "to_date";
@@ -166,8 +169,8 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                 );
     }
 
-    public void respondOk_whenSearchCharges(String accountId, String reference, String email, String state, String cardBrand, String fromDate, String toDate, String expectedResponse) {
-        whenSearchCharges(accountId, reference, email, state, cardBrand, fromDate, toDate)
+    public void respondOk_whenSearchCharges(String accountId, String reference, String email, String state, String cardBrand, String cardHolderName, String firstDigitsCardNumber, String lastDigitsCardNumber, String fromDate, String toDate, String expectedResponse) {
+        whenSearchCharges(accountId, reference, email, state, cardBrand, cardHolderName, firstDigitsCardNumber, lastDigitsCardNumber, fromDate, toDate)
                 .respond(response()
                         .withStatusCode(OK_200)
                         .withHeader(CONTENT_TYPE, APPLICATION_JSON)
@@ -177,7 +180,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
     }
 
     public void respondOk_whenSearchChargesWithPageAndSize(String accountId, String reference, String email, String page, String displaySize, String expectedResponse) {
-        whenSearchCharges(accountId, reference, email, null, null, null, null, page, displaySize)
+        whenSearchCharges(accountId, reference, email, null, null, null, null, null, null, null, page, displaySize)
                 .respond(response()
                         .withStatusCode(OK_200)
                         .withHeader(CONTENT_TYPE, APPLICATION_JSON)
@@ -370,20 +373,20 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
         );
     }
 
-    public ForwardChainExpectation whenSearchCharges(String gatewayAccountId, String reference, String email, String state, String cardBrand, String fromDate, String toDate) {
-        return whenSearchCharges(gatewayAccountId, reference, email, state, cardBrand, fromDate, toDate, null, null);
+    public ForwardChainExpectation whenSearchCharges(String gatewayAccountId, String reference, String email, String state, String cardBrand, String cardHolderName, String firstDigitsCardNumber, String lastDigitsCardNumber, String fromDate, String toDate) {
+        return whenSearchCharges(gatewayAccountId, reference, email, state, cardBrand, cardHolderName, firstDigitsCardNumber, lastDigitsCardNumber, fromDate, toDate, null, null);
     }
 
-    public ForwardChainExpectation whenSearchCharges(String gatewayAccountId, String reference, String email, String state, String cardBrand, String fromDate, String toDate, String page, String displaySize) {
+    public ForwardChainExpectation whenSearchCharges(String gatewayAccountId, String reference, String email, String state, String cardBrand, String cardHolderName, String firstDigitsCardNumber, String lastDigitsCardNumber, String fromDate, String toDate, String page, String displaySize) {
         return mockClient.when(request()
                 .withMethod(GET)
                 .withPath(format(CONNECTOR_MOCK_CHARGES_PATH, gatewayAccountId))
                 .withHeader(ACCEPT, APPLICATION_JSON)
-                .withQueryStringParameters(notNullQueryParamsFrom(reference, email, state, cardBrand, fromDate, toDate, page, displaySize))
+                .withQueryStringParameters(notNullQueryParamsFrom(reference, email, state, cardBrand, cardHolderName, firstDigitsCardNumber, lastDigitsCardNumber, fromDate, toDate, page, displaySize))
         );
     }
 
-    private Parameter[] notNullQueryParamsFrom(String reference, String email, String state, String cardBrand, String fromDate, String toDate, String page, String displaySize) {
+    private Parameter[] notNullQueryParamsFrom(String reference, String email, String state, String cardBrand, String cardHolderName, String firstDigitsCardNumber, String lastDigitsCardNumber, String fromDate, String toDate, String page, String displaySize) {
         List<Parameter> params = newArrayList();
         if (isNotBlank(reference)) {
             params.add(Parameter.param(REFERENCE_KEY, reference));
@@ -396,6 +399,15 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
         }
         if (isNotBlank(cardBrand)) {
             params.add(Parameter.param(CARD_BRAND_KEY, CARD_BRAND.toLowerCase()));
+        }
+        if (isNotBlank(cardHolderName)) {
+            params.add(Parameter.param(CARDHOLDER_NAME_KEY, cardHolderName));
+        }
+        if (isNotBlank(firstDigitsCardNumber)) {
+            params.add(Parameter.param(FIRST_DIGITS_CARD_NUMBER_KEY, firstDigitsCardNumber));
+        }
+        if (isNotBlank(lastDigitsCardNumber)) {
+            params.add(Parameter.param(LAST_DIGITS_CARD_NUMBER_KEY, lastDigitsCardNumber));
         }
         if (isNotBlank(fromDate)) {
             params.add(Parameter.param(FROM_DATE_KEY, fromDate));

--- a/src/test/java/uk/gov/pay/api/validation/PaymentSearchValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/PaymentSearchValidatorTest.java
@@ -23,111 +23,111 @@ public class PaymentSearchValidatorTest {
     public void validateParams_shouldSuccessValidation() {
         PaymentSearchValidator.validateSearchParameters(account,"success", "ref", SUCCESSFUL_TEST_EMAIL, 
                 "", "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", 
-                "1", "1", "");
+                "1", "1", "", "424242", "4242");
     }
 
     @Test
-    public void validateParams_reference_shouldGiveAnErrorValidation() throws Exception {
+    public void validateParams_reference_shouldGiveAnErrorValidation() {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: reference. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters(account,"success", randomAlphanumeric(500), 
                 SUCCESSFUL_TEST_EMAIL, "", "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", 
-                "1", "1", "");
+                "1", "1", "", "424242", "4242");
     }
 
     @Test
-    public void validateParams_email_shouldGiveAnErrorValidation() throws Exception {
+    public void validateParams_email_shouldGiveAnErrorValidation() {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: email. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters(account,"success", "ref", UNSUCCESSFUL_TEST_EMAIL, 
                 "", "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", 
-                "1", "1", "");
+                "1", "1", "", "424242", "4242");
     }
 
     @Test
-    public void validateParams_state_shouldGiveAnErrorValidation() throws Exception {
+    public void validateParams_state_shouldGiveAnErrorValidation() {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters(account,"invalid", "ref", SUCCESSFUL_TEST_EMAIL, 
                 "", "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "1", 
-                "1", "");
+                "1", "", "424242", "4242");
     }
 
     @Test
-    public void validateParams_toDate_shouldGiveAnErrorValidation() throws Exception {
+    public void validateParams_toDate_shouldGiveAnErrorValidation() {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: to_date. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters(account,"success", "ref", SUCCESSFUL_TEST_EMAIL, 
                 "", "2016-01-25T13:23:55Z", "2016-01-25T13-23:55Z", 
-                "1", "1", "");
+                "1", "1", "", "424242", "4242");
     }
 
     @Test
-    public void validateParams_fromDate_shouldGiveAnErrorValidation() throws Exception {
+    public void validateParams_fromDate_shouldGiveAnErrorValidation() {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: from_date. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters(account,"success", "ref", SUCCESSFUL_TEST_EMAIL, 
                 "", "2016-01-25T13-23:55Z", "2016-01-25T13:23:55Z", 
-                "1", "1", "");
+                "1", "1", "", "424242", "4242");
     }
 
     @Test
-    public void validateParams_shouldGiveAnErrorValidation_forAllParams() throws Exception {
+    public void validateParams_shouldGiveAnErrorValidation_forAllParams() {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size, agreement. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters(account,"invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, 
                 "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", 
-                "-1", "-1", INVALID_LENGTH_AGREEMENT);
+                "-1", "-1", INVALID_LENGTH_AGREEMENT, "424242", "4242");
     }
 
     @Test
-    public void validateParams_shouldGiveAnErrorValidation_forZeroPageDisplay() throws Exception {
+    public void validateParams_shouldGiveAnErrorValidation_forZeroPageDisplay() {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters(account,"invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, 
                 "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", 
-                "0", "0", "");
+                "0", "0", "", "424242", "4242");
     }
 
     @Test
-    public void validateParams_shouldGiveAnErrorValidation_forMaxedOutValuesPageDisplaySize() throws Exception {
+    public void validateParams_shouldGiveAnErrorValidation_forMaxedOutValuesPageDisplaySize() {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters(account,"invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, 
                 "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", 
-                String.valueOf(Integer.MAX_VALUE+1), String.valueOf(Integer.MAX_VALUE+1), "");
+                String.valueOf(Integer.MAX_VALUE+1), String.valueOf(Integer.MAX_VALUE+1), "", "424242", "4242");
     }
 
     @Test
-    public void validateParams_shouldNotGiveAnErrorValidation_ForMissingPageDisplaySize() throws Exception {
+    public void validateParams_shouldNotGiveAnErrorValidation_ForMissingPageDisplaySize() {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters(account,"invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, 
                 "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", 
-                null, null, "");
+                null, null, "", "424242", "4242");
     }
 
     @Test
-    public void validateParams_shouldGiveAnErrorValidation_forToLargePageDisplay() throws Exception {
+    public void validateParams_shouldGiveAnErrorValidation_forToLargePageDisplay() {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters(account,"invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, 
                 "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", 
-                "0", "501", "");
+                "0", "501", "", "424242", "4242");
     }
 
     @Test
-    public void validateParams_shouldNotGiveAnErrorValidation_ForNonNumberPageAndSize() throws Exception {
+    public void validateParams_shouldNotGiveAnErrorValidation_ForNonNumberPageAndSize() {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters(account,"invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, 
                 "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", 
-                "non-numeric-page", "non-numeric-size", "");
+                "non-numeric-page", "non-numeric-size", "", "424242", "4242");
     }
 
     @Test
-    public void validateParams_card_brand_shouldGiveAnErrorValidation() throws Exception {
+    public void validateParams_card_brand_shouldGiveAnErrorValidation() {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: card_brand. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters(account,"success", "ref", SUCCESSFUL_TEST_EMAIL, 
                 UNSUCCESSFUL_TEST_CARD_BRAND, "2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", 
-                "1", "1", "");
+                "1", "1", "", "424242", "4242");
     }
     
     @Test
-    public void validateParams_shouldGiveAnError_forTooLongMandate() throws Exception {
+    public void validateParams_shouldGiveAnError_forTooLongMandate() {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: agreement. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters(account,"", "", "", 
                 "", "", "", 
-                "","", INVALID_LENGTH_AGREEMENT);
+                "","", INVALID_LENGTH_AGREEMENT, "424242", "4242");
     }
     
     @Test
@@ -135,7 +135,7 @@ public class PaymentSearchValidatorTest {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters(account,"pending", "", "",
                 "", "", "",
-                "","", "");
+                "","", "", "424242", "4242");
     }
 
     @Test
@@ -144,6 +144,42 @@ public class PaymentSearchValidatorTest {
         PaymentSearchValidator.validateSearchParameters(new Account("an account", TokenPaymentType.DIRECT_DEBIT),
                 "created", "", "",
                 "", "", "",
-                "","", "");
+                "","", "", "", "");
+    }
+
+    @Test
+    public void validateParams_shouldGiveAnError_forWrongLengthFirstDigits() {
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: first_digits_card_number. See Public API documentation for the correct data formats"));
+        PaymentSearchValidator.validateSearchParameters(account,
+                "created", "", "",
+                "", "", "",
+                "","", "", "424", "");
+    }
+    
+    @Test
+    public void validateParams_shouldGiveAnError_forInvalidFirstDigits() {
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: first_digits_card_number. See Public API documentation for the correct data formats"));
+        PaymentSearchValidator.validateSearchParameters(account,
+                "", "", "",
+                "", "", "",
+                "","", "", "42424b", "");
+    }
+
+    @Test
+    public void validateParams_shouldGiveAnError_forWrongLengthLastDigits() {
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: last_digits_card_number. See Public API documentation for the correct data formats"));
+        PaymentSearchValidator.validateSearchParameters(account,
+                "", "", "",
+                "", "", "",
+                "","", "", "", "422");
+    }
+
+    @Test
+    public void validateParams_shouldGiveAnError_forInvalidLastDigits() {
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: last_digits_card_number. See Public API documentation for the correct data formats"));
+        PaymentSearchValidator.validateSearchParameters(account,
+                "", "", "",
+                "", "", "",
+                "","", "", "", "422a");
     }
 }

--- a/src/test/java/uk/gov/pay/api/validation/PaymentSearchValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/PaymentSearchValidatorTest.java
@@ -68,7 +68,7 @@ public class PaymentSearchValidatorTest {
 
     @Test
     public void validateParams_shouldGiveAnErrorValidation_forAllParams() {
-        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size, agreement. See Public API documentation for the correct data formats"));
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: state, reference, email, from_date, to_date, page, display_size, agreement_id. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters(account,"invalid", randomAlphanumeric(500), UNSUCCESSFUL_TEST_EMAIL, 
                 "", "2016-01-25T13-23:55Z", "2016-01-25T13-23:55Z", 
                 "-1", "-1", INVALID_LENGTH_AGREEMENT, "424242", "4242");
@@ -124,7 +124,7 @@ public class PaymentSearchValidatorTest {
     
     @Test
     public void validateParams_shouldGiveAnError_forTooLongMandate() {
-        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: agreement. See Public API documentation for the correct data formats"));
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: agreement_id. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters(account,"", "", "", 
                 "", "", "", 
                 "","", INVALID_LENGTH_AGREEMENT, "424242", "4242");
@@ -166,6 +166,24 @@ public class PaymentSearchValidatorTest {
     }
 
     @Test
+    public void validateParams_shouldGiveAnError_forNegativeFirstDigits() {
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: first_digits_card_number. See Public API documentation for the correct data formats"));
+        PaymentSearchValidator.validateSearchParameters(account,
+                "", "", "",
+                "", "", "",
+                "","", "", "-42422", "");
+    }
+
+    @Test
+    public void validateParams_shouldGiveAnError_forNonArabicFirstDigits() {
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: first_digits_card_number. See Public API documentation for the correct data formats"));
+        PaymentSearchValidator.validateSearchParameters(account,
+                "", "", "",
+                "", "", "",
+                "","", "", "१२३१२३", "");
+    }
+
+    @Test
     public void validateParams_shouldGiveAnError_forWrongLengthLastDigits() {
         expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: last_digits_card_number. See Public API documentation for the correct data formats"));
         PaymentSearchValidator.validateSearchParameters(account,
@@ -181,5 +199,23 @@ public class PaymentSearchValidatorTest {
                 "", "", "",
                 "", "", "",
                 "","", "", "", "422a");
+    }
+
+    @Test
+    public void validateParams_shouldGiveAnError_forNegativeLastDigits() {
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: last_digits_card_number. See Public API documentation for the correct data formats"));
+        PaymentSearchValidator.validateSearchParameters(account,
+                "", "", "",
+                "", "", "",
+                "","", "", "", "-433");
+    }
+
+    @Test
+    public void validateParams_shouldGiveAnError_forNonArabicLastDigits() {
+        expectedException.expect(aValidationExceptionContaining("P0401", "Invalid parameters: last_digits_card_number. See Public API documentation for the correct data formats"));
+        PaymentSearchValidator.validateSearchParameters(account,
+                "", "", "",
+                "", "", "",
+                "","", "", "", "१२३२");
     }
 }

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-cardholder-name.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-cardholder-name.json
@@ -1,0 +1,226 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "a search payment request",
+      "providerStates": [
+        {
+          "name": "a charge with card details exists",
+          "params": {
+            "charge_id": "charge8133029783750964639",
+            "gateway_account_id": "123456",
+            "cardholder_name": "Mr Payment",
+            "first_digits_card_number": "123456",
+            "last_digits_card_number": "1234"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/api/accounts/123456/charges",
+        "query": {
+          "cardholder_name": ["pay"],
+          "transactionType": ["charge"]
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "page": 1,
+          "total": 1,
+          "count": 1,
+          "results": [
+            {
+              "amount": 100,
+              "state": {
+                "finished": false,
+                "status": "created"
+              },
+              "description": "Test description",
+              "reference": "aReference",
+              "language": "en",
+              "links": [
+                {
+                  "rel": "self",
+                  "method": "GET",
+                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639"
+                },
+                {
+                  "rel": "refunds",
+                  "method": "GET",
+                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639/refunds"
+                },
+                {
+                  "rel": "next_url",
+                  "method": "GET",
+                  "href": "http://Frontend/secure/ae749781-6562-4e0e-8f56-32d9639079dc"
+                },
+                {
+                  "rel": "next_url_post",
+                  "method": "POST",
+                  "href": "http://Frontend/secure",
+                  "type": "application/x-www-form-urlencoded",
+                  "params": {
+                    "chargeTokenId": "ae749781-6562-4e0e-8f56-32d9639079dc"
+                  }
+                }
+              ],
+              "charge_id": "charge8133029783750964639",
+              "return_url": "aReturnUrl",
+              "email": "test@test.com",
+              "payment_provider": "sandbox",
+              "created_date": "2018-09-22T10:13:16.067Z",
+              "refund_summary": {
+                "status": "pending",
+                "user_external_id": null,
+                "amount_available": 100,
+                "amount_submitted": 0
+              },
+              "settlement_summary": {
+                "capture_submit_time": null,
+                "captured_date": null
+              },
+              "card_details": {
+                "last_digits_card_number": "1234",
+                "first_digits_card_number": "123456",
+                "cardholder_name": "Mr Payment",
+                "expiry_date": "08/23",
+                "billing_address": {
+                  "line1": "aFirstAddress",
+                  "line2": "aSecondLine",
+                  "postcode": "aPostCode",
+                  "city": "aCity",
+                  "county": "aCounty",
+                  "country": "aCountry"
+                },
+                "card_brand": "Visa"
+              },
+              "delayed_capture": true
+            }
+          ],
+          "_links": {
+            "self": {
+              "href": "http://connector.service.backend/v1/api/accounts/123456/charges?page=1&display_size=500&cardholder_name=pay"
+            },
+            "last_page": {
+              "href": "http://connector.service.backend/v1/api/accounts/123456/charges?page=1&display_size=500&cardholder_name=pay"
+            },
+            "first_page": {
+              "href": "http://connector.service.backend/v1/api/accounts/123456/charges?page=1&display_size=500&cardholder_name=pay"
+            }
+          }
+        },
+        "matchingRules": {
+          "body": {
+            "$.results[*].links[0].href": {
+              "matchers": [
+                {
+                  "regex": "https.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/charge8133029783750964639"
+                }
+              ]
+            },
+            "$.results[*].links[1].href": {
+              "matchers": [
+                {
+                  "regex": "https.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/charge8133029783750964639\/refunds"
+                }
+              ]
+            },
+            "$.results[*].links[2].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/secure\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.results[*].links[3].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/secure"
+                }
+              ]
+            },
+            "$.results[*].links[3].params.chargeTokenId": {
+              "matchers": [
+                {"match": "type"}
+              ]
+            },
+            "$._links.self.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\\?page=1&display_size=500&cardholder_name=pay"
+                }
+              ]
+            },
+            "$._links.last_page.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\\?page=1&display_size=500&cardholder_name=pay"
+                }
+              ]
+            },
+            "$._links.first_page.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\\?page=1&display_size=500&cardholder_name=pay"
+                }
+              ]
+            },
+            "$.results[*].card_details.cardholder_name": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].card_details.first_digits_card_number": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].card_details.last_digits_card_number": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].charge_id": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].amount": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].reference": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].email": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].description": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].state.status": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].return_url": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].payment_provider": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].created_date": {
+              "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-first-digits-card-number.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-first-digits-card-number.json
@@ -1,0 +1,226 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "a search payment request",
+      "providerStates": [
+        {
+          "name": "a charge with card details exists",
+          "params": {
+            "charge_id": "charge8133029783750964639",
+            "gateway_account_id": "123456",
+            "cardholder_name": "Mr Payment",
+            "first_digits_card_number": "123456",
+            "last_digits_card_number": "1234"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/api/accounts/123456/charges",
+        "query": {
+          "first_digits_card_number": ["123456"],
+          "transactionType": ["charge"]
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "page": 1,
+          "total": 1,
+          "count": 1,
+          "results": [
+            {
+              "amount": 100,
+              "state": {
+                "finished": false,
+                "status": "created"
+              },
+              "description": "Test description",
+              "reference": "aReference",
+              "language": "en",
+              "links": [
+                {
+                  "rel": "self",
+                  "method": "GET",
+                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639"
+                },
+                {
+                  "rel": "refunds",
+                  "method": "GET",
+                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639/refunds"
+                },
+                {
+                  "rel": "next_url",
+                  "method": "GET",
+                  "href": "http://Frontend/secure/ae749781-6562-4e0e-8f56-32d9639079dc"
+                },
+                {
+                  "rel": "next_url_post",
+                  "method": "POST",
+                  "href": "http://Frontend/secure",
+                  "type": "application/x-www-form-urlencoded",
+                  "params": {
+                    "chargeTokenId": "ae749781-6562-4e0e-8f56-32d9639079dc"
+                  }
+                }
+              ],
+              "charge_id": "charge8133029783750964639",
+              "return_url": "aReturnUrl",
+              "email": "test@test.com",
+              "payment_provider": "sandbox",
+              "created_date": "2018-09-22T10:13:16.067Z",
+              "refund_summary": {
+                "status": "pending",
+                "user_external_id": null,
+                "amount_available": 100,
+                "amount_submitted": 0
+              },
+              "settlement_summary": {
+                "capture_submit_time": null,
+                "captured_date": null
+              },
+              "card_details": {
+                "last_digits_card_number": "1234",
+                "first_digits_card_number": "123456",
+                "cardholder_name": "Mr Payment",
+                "expiry_date": "08/23",
+                "billing_address": {
+                  "line1": "aFirstAddress",
+                  "line2": "aSecondLine",
+                  "postcode": "aPostCode",
+                  "city": "aCity",
+                  "county": "aCounty",
+                  "country": "aCountry"
+                },
+                "card_brand": "Visa"
+              },
+              "delayed_capture": true
+            }
+          ],
+          "_links": {
+            "self": {
+              "href": "http://connector.service.backend/v1/api/accounts/123456/charges?page=1&display_size=500&first_digits_card_number=123456"
+            },
+            "last_page": {
+              "href": "http://connector.service.backend/v1/api/accounts/123456/charges?page=1&display_size=500&first_digits_card_number=123456"
+            },
+            "first_page": {
+              "href": "http://connector.service.backend/v1/api/accounts/123456/charges?page=1&display_size=500&first_digits_card_number=123456"
+            }
+          }
+        },
+        "matchingRules": {
+          "body": {
+            "$.results[*].links[0].href": {
+              "matchers": [
+                {
+                  "regex": "https.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/charge8133029783750964639"
+                }
+              ]
+            },
+            "$.results[*].links[1].href": {
+              "matchers": [
+                {
+                  "regex": "https.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/charge8133029783750964639\/refunds"
+                }
+              ]
+            },
+            "$.results[*].links[2].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/secure\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.results[*].links[3].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/secure"
+                }
+              ]
+            },
+            "$.results[*].links[3].params.chargeTokenId": {
+              "matchers": [
+                {"match": "type"}
+              ]
+            },
+            "$._links.self.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\?page=1&display_size=500&first_digits_card_number=123456"
+                }
+              ]
+            },
+            "$._links.last_page.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\?page=1&display_size=500&first_digits_card_number=123456"
+                }
+              ]
+            },
+            "$._links.first_page.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\?page=1&display_size=500&first_digits_card_number=123456"
+                }
+              ]
+            },
+            "$.results[*].card_details.cardholder_name": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].card_details.first_digits_card_number": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].card_details.last_digits_card_number": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].charge_id": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].amount": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].reference": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].email": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].description": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].state.status": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].return_url": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].payment_provider": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].created_date": {
+              "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-first-digits-card-number.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-first-digits-card-number.json
@@ -156,21 +156,21 @@
             "$._links.self.href": {
               "matchers": [
                 {
-                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\?page=1&display_size=500&first_digits_card_number=123456"
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\\?page=1&display_size=500&first_digits_card_number=123456"
                 }
               ]
             },
             "$._links.last_page.href": {
               "matchers": [
                 {
-                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\?page=1&display_size=500&first_digits_card_number=123456"
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\\?page=1&display_size=500&first_digits_card_number=123456"
                 }
               ]
             },
             "$._links.first_page.href": {
               "matchers": [
                 {
-                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\?page=1&display_size=500&first_digits_card_number=123456"
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\\?page=1&display_size=500&first_digits_card_number=123456"
                 }
               ]
             },

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-last-digits-card-number.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-last-digits-card-number.json
@@ -156,21 +156,21 @@
             "$._links.self.href": {
               "matchers": [
                 {
-                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\?page=1&display_size=500&last_digits_card_number=1234"
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\\?page=1&display_size=500&last_digits_card_number=1234"
                 }
               ]
             },
             "$._links.last_page.href": {
               "matchers": [
                 {
-                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\?page=1&display_size=500&last_digits_card_number=1234"
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\\?page=1&display_size=500&last_digits_card_number=1234"
                 }
               ]
             },
             "$._links.first_page.href": {
               "matchers": [
                 {
-                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\?page=1&display_size=500&last_digits_card_number=1234"
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\\?page=1&display_size=500&last_digits_card_number=1234"
                 }
               ]
             },

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-last-digits-card-number.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-last-digits-card-number.json
@@ -1,0 +1,226 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "a search payment request",
+      "providerStates": [
+        {
+          "name": "a charge with card details exists",
+          "params": {
+            "charge_id": "charge8133029783750964639",
+            "gateway_account_id": "123456",
+            "cardholder_name": "Mr Payment",
+            "first_digits_card_number": "123456",
+            "last_digits_card_number": "1234"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/api/accounts/123456/charges",
+        "query": {
+          "last_digits_card_number": ["1234"],
+          "transactionType": ["charge"]
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "page": 1,
+          "total": 1,
+          "count": 1,
+          "results": [
+            {
+              "amount": 100,
+              "state": {
+                "finished": false,
+                "status": "created"
+              },
+              "description": "Test description",
+              "reference": "aReference",
+              "language": "en",
+              "links": [
+                {
+                  "rel": "self",
+                  "method": "GET",
+                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639"
+                },
+                {
+                  "rel": "refunds",
+                  "method": "GET",
+                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639/refunds"
+                },
+                {
+                  "rel": "next_url",
+                  "method": "GET",
+                  "href": "http://Frontend/secure/ae749781-6562-4e0e-8f56-32d9639079dc"
+                },
+                {
+                  "rel": "next_url_post",
+                  "method": "POST",
+                  "href": "http://Frontend/secure",
+                  "type": "application/x-www-form-urlencoded",
+                  "params": {
+                    "chargeTokenId": "ae749781-6562-4e0e-8f56-32d9639079dc"
+                  }
+                }
+              ],
+              "charge_id": "charge8133029783750964639",
+              "return_url": "aReturnUrl",
+              "email": "test@test.com",
+              "payment_provider": "sandbox",
+              "created_date": "2018-09-22T10:13:16.067Z",
+              "refund_summary": {
+                "status": "pending",
+                "user_external_id": null,
+                "amount_available": 100,
+                "amount_submitted": 0
+              },
+              "settlement_summary": {
+                "capture_submit_time": null,
+                "captured_date": null
+              },
+              "card_details": {
+                "last_digits_card_number": "1234",
+                "first_digits_card_number": "123456",
+                "cardholder_name": "Mr Payment",
+                "expiry_date": "08/23",
+                "billing_address": {
+                  "line1": "aFirstAddress",
+                  "line2": "aSecondLine",
+                  "postcode": "aPostCode",
+                  "city": "aCity",
+                  "county": "aCounty",
+                  "country": "aCountry"
+                },
+                "card_brand": "Visa"
+              },
+              "delayed_capture": true
+            }
+          ],
+          "_links": {
+            "self": {
+              "href": "http://connector.service.backend/v1/api/accounts/123456/charges?page=1&display_size=500&last_digits_card_number=1234"
+            },
+            "last_page": {
+              "href": "http://connector.service.backend/v1/api/accounts/123456/charges?page=1&display_size=500&last_digits_card_number=1234"
+            },
+            "first_page": {
+              "href": "http://connector.service.backend/v1/api/accounts/123456/charges?page=1&display_size=500&last_digits_card_number=1234"
+            }
+          }
+        },
+        "matchingRules": {
+          "body": {
+            "$.results[*].links[0].href": {
+              "matchers": [
+                {
+                  "regex": "https.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/charge8133029783750964639"
+                }
+              ]
+            },
+            "$.results[*].links[1].href": {
+              "matchers": [
+                {
+                  "regex": "https.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/charge8133029783750964639\/refunds"
+                }
+              ]
+            },
+            "$.results[*].links[2].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/secure\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.results[*].links[3].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/secure"
+                }
+              ]
+            },
+            "$.results[*].links[3].params.chargeTokenId": {
+              "matchers": [
+                {"match": "type"}
+              ]
+            },
+            "$._links.self.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\?page=1&display_size=500&last_digits_card_number=1234"
+                }
+              ]
+            },
+            "$._links.last_page.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\?page=1&display_size=500&last_digits_card_number=1234"
+                }
+              ]
+            },
+            "$._links.first_page.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\?page=1&display_size=500&last_digits_card_number=1234"
+                }
+              ]
+            },
+            "$.results[*].card_details.cardholder_name": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].card_details.first_digits_card_number": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].card_details.last_digits_card_number": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].charge_id": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].amount": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].reference": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].email": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].description": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].state.status": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].return_url": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].payment_provider": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].created_date": {
+              "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -70,19 +70,19 @@
         }, {
           "name" : "cardholder_name",
           "in" : "query",
-          "description" : "Name on card used in the payment to be searched",
+          "description" : "Name on card used to make payment",
           "required" : false,
           "type" : "string"
         }, {
           "name" : "first_digits_card_number",
           "in" : "query",
-          "description" : "First six digits of the card used to make a payment",
+          "description" : "First six digits of the card used to make payment",
           "required" : false,
           "type" : "string"
         }, {
           "name" : "last_digits_card_number",
           "in" : "query",
-          "description" : "Last four digits of the card used to make a payment",
+          "description" : "Last four digits of the card used to make payment",
           "required" : false,
           "type" : "string"
         } ],

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -67,6 +67,24 @@
           "description" : "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)",
           "required" : false,
           "type" : "string"
+        }, {
+          "name" : "cardholder_name",
+          "in" : "query",
+          "description" : "Name on card used in the payment to be searched",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "first_digits_card_number",
+          "in" : "query",
+          "description" : "First six digits of the card used to make a payment",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "last_digits_card_number",
+          "in" : "query",
+          "description" : "Last four digits of the card used to make a payment",
+          "required" : false,
+          "type" : "string"
         } ],
         "responses" : {
           "200" : {


### PR DESCRIPTION
## WHAT
- Added support for searching for first 6 digits and last 4 digits of card number
- Both of those have to be numeric and not empty to be valid. We return a bad request if any of those parameters are invalid. If not specified (ie. `""`) we ignore the query params


