### PR TITLE
PP-4250 FB - add cancel payment contract test

### DIFF
--- a/src/main/java/uk/gov/pay/api/service/CancelPaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CancelPaymentService.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.api.service;
+
+import org.apache.http.HttpStatus;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.exception.CancelChargeException;
+
+import javax.inject.Inject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+
+public class CancelPaymentService {
+
+    private final Client client;
+    private final ConnectorUriGenerator connectorUriGenerator;
+
+    @Inject
+    public CancelPaymentService(Client client, ConnectorUriGenerator connectorUriGenerator) {
+        this.client = client;
+        this.connectorUriGenerator = connectorUriGenerator;
+    }
+
+    public Response cancel(Account account, String chargeId) {
+        Response connectorResponse = client
+                .target(connectorUriGenerator.cancelURI(account, chargeId))
+                .request()
+                .post(Entity.json("{}"));
+
+        if (connectorResponse.getStatus() == HttpStatus.SC_NO_CONTENT) {
+            connectorResponse.close();
+            return Response.noContent().build();
+        }
+
+        throw new CancelChargeException(connectorResponse);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -16,6 +16,7 @@ import uk.gov.pay.api.model.SettlementSummary;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.ValidCreatePaymentRequest;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
+import uk.gov.pay.api.service.CancelPaymentService;
 import uk.gov.pay.api.service.CapturePaymentService;
 import uk.gov.pay.api.service.ConnectorUriGenerator;
 import uk.gov.pay.api.service.CreatePaymentService;
@@ -60,6 +61,9 @@ public class PaymentsResourceCreatePaymentTest {
 
     @Mock
     private CapturePaymentService capturePaymentService;
+    
+    @Mock
+    private CancelPaymentService cancelPaymentService;
 
     private final String paymentUri = "https://my.link/v1/payments/abc123";
 
@@ -71,7 +75,8 @@ public class PaymentsResourceCreatePaymentTest {
                 publicApiUriGenerator,
                 connectorUriGenerator,
                 getPaymentService,
-                capturePaymentService);
+                capturePaymentService,
+                cancelPaymentService);
         when(publicApiUriGenerator.getPaymentURI(anyString())).thenReturn(URI.create(paymentUri));
     }
 

--- a/src/test/java/uk/gov/pay/api/service/CancelPaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CancelPaymentServiceTest.java
@@ -1,0 +1,57 @@
+package uk.gov.pay.api.service;
+
+import au.com.dius.pact.consumer.PactVerification;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.api.app.RestClientFactory;
+import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.app.config.RestClientConfig;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.commons.testing.pact.consumers.PactProviderRule;
+import uk.gov.pay.commons.testing.pact.consumers.Pacts;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CancelPaymentServiceTest {
+    
+    private final String CHARGE_ID = "charge8133029783750964639";
+    private final Account ACCOUNT = new Account("123456", TokenPaymentType.CARD);
+    
+    private CancelPaymentService cancelPaymentService;
+    
+    @Rule
+    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+
+    @Mock
+    private PublicApiConfig mockConfiguration;
+    
+    @Before
+    public void setUp() {
+        when(mockConfiguration.getConnectorUrl()).thenReturn(connectorRule.getUrl());
+
+        ConnectorUriGenerator connectorUriGenerator = new ConnectorUriGenerator(mockConfiguration);
+        Client client = RestClientFactory.buildClient(new RestClientConfig(false));
+        cancelPaymentService = new CancelPaymentService(client, connectorUriGenerator);
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector-cancel-payment-with-created-state"})
+    public void cancelAPaymentWithCreatedState() {
+        
+        Response cancelPaymentResponse = cancelPaymentService.cancel(ACCOUNT, CHARGE_ID);
+
+        assertThat(cancelPaymentResponse.getStatus(), is(204));
+    }
+}

--- a/src/test/resources/pacts/publicapi-connector-cancel-payment-with-created-state.json
+++ b/src/test/resources/pacts/publicapi-connector-cancel-payment-with-created-state.json
@@ -1,0 +1,37 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "cancel a charge in created state",
+      "providerStates": [
+        {
+          "name": "a charge with card details exists",
+          "params": {
+            "gateway_account_id": "123456",
+            "charge_id": "charge8133029783750964639"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/v1/api/accounts/123456/charges/charge8133029783750964639/cancel"
+      },
+      "response": {
+        "status": 204
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
## WHAT
- add a contract test for cancelling a payment

## HOW 

- refactor code to use a service for cancel payments
- wire in CancelPaymentService
- add pact file
- add pact test

with @cobainc0



