### PR TITLE
[DO NOT MERGE] Use Swagger Inflector. hmmm....

### DIFF
--- a/inflector.yaml
+++ b/inflector.yaml
@@ -1,0 +1,5 @@
+swaggerUrl: ./swagger/swagger.json
+controllerPackage: uk.gov.pay.api.middleware
+modelPackage: uk.gov.pay.api.model
+entityProcessors:
+  - json

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
     <artifactId>pay-publicapi</artifactId>
 
     <properties>
+        <inflector-version>1.0.16</inflector-version>
         <dropwizard.version>1.3.5</dropwizard.version>
         <guice.version>4.2.0</guice.version>
         <guava.version>25.1-jre</guava.version>
@@ -37,6 +38,33 @@
     </repositories>
 
     <dependencies>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-inflector</artifactId>
+            <version>${inflector-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>uk.gov.pay</groupId>
             <artifactId>model</artifactId>

--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
@@ -49,6 +49,13 @@ public class PublicApiConfig extends Configuration {
     @JsonProperty("rateLimiter")
     private RateLimiterConfig rateLimiterConfig;
 
+    @NotNull
+    private String config;
+
+    public String getConfig() {
+        return config;
+    }
+
     public String getBaseUrl() {
         return baseUrl;
     }

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
@@ -5,7 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.filter.ratelimit.RateLimitException;
 import uk.gov.pay.api.filter.ratelimit.RateLimiter;
-import uk.gov.pay.api.resources.error.ApiErrorResponse.Code;
+import uk.gov.pay.api.model.ErrorResponse.Code;
 import javax.inject.Inject;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -17,7 +17,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static uk.gov.pay.api.resources.error.ApiErrorResponse.anApiErrorResponse;
+import static uk.gov.pay.api.model.ErrorResponse.anApiErrorResponse;
 
 /**
  * Allow only a certain number of requests from the same source (given by the Authorization Header)

--- a/src/main/java/uk/gov/pay/api/middleware/Payments.java
+++ b/src/main/java/uk/gov/pay/api/middleware/Payments.java
@@ -1,0 +1,52 @@
+package uk.gov.pay.api.middleware;
+
+import io.swagger.inflector.models.RequestContext;
+import io.swagger.inflector.models.ResponseContext;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.auth.AccountAuthenticator;
+import uk.gov.pay.api.model.ValidCreatePaymentRequest;
+import uk.gov.pay.api.resources.PaymentsResource;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import java.util.Optional;
+
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+
+@Singleton
+public class Payments {
+    
+    private final PaymentsResource paymentsResource;
+    private final AccountAuthenticator accountAuthenticator;
+
+    @Inject
+    public Payments(PaymentsResource paymentsResource, AccountAuthenticator accountAuthenticator) {
+        this.paymentsResource = paymentsResource;
+        this.accountAuthenticator = accountAuthenticator;
+    }
+
+    public ResponseContext createNewPayment(RequestContext request, ValidCreatePaymentRequest validCreatePaymentRequest) {
+        String token = request.getHeaders().getFirst(AUTHORIZATION);
+        Optional<Account> account = accountAuthenticator.authenticate(getCredentials(token));
+        return paymentsResource.createNewPayment(account.get(), validCreatePaymentRequest);
+    }
+
+    private String getCredentials(String header) {
+        if (header == null) {
+            return null;
+        }
+
+        final int space = header.indexOf(' ');
+        if (space <= 0) {
+            return null;
+        }
+
+        final String method = header.substring(0, space);
+        if (!"Bearer".equalsIgnoreCase(method)) {
+            return null;
+        }
+
+        return header.substring(space + 1);
+    }
+}

--- a/src/main/java/uk/gov/pay/api/model/ErrorResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/ErrorResponse.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.api.resources.error;
+package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
@@ -9,7 +9,7 @@ import static java.lang.String.format;
 
 @ApiModel(value = "ErrorResponse", description = "An error response")
 @JsonInclude(NON_NULL)
-public class ApiErrorResponse {
+public class ErrorResponse {
 
     public enum Code {
 
@@ -35,11 +35,11 @@ public class ApiErrorResponse {
     private final Code code;
     private final String description;
 
-    public static ApiErrorResponse anApiErrorResponse(Code code, Object... parameters) {
-        return new ApiErrorResponse(code, parameters);
+    public static ErrorResponse anApiErrorResponse(Code code, Object... parameters) {
+        return new ErrorResponse(code, parameters);
     }
 
-    private ApiErrorResponse(Code code, Object... parameters) {
+    private ErrorResponse(Code code, Object... parameters) {
         this.code = code;
         this.description = format(code.getFormat(), parameters);
     }

--- a/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
@@ -15,19 +15,13 @@ import java.util.StringJoiner;
  **/
 public class ValidCreatePaymentRequest {
 
-    @ApiModelProperty(value = "amount in pence", required = true, allowableValues = "range[1, 10000000]", example = "12000")
-    private final int amount;
-    @ApiModelProperty(value = "payment reference", required = true, example = "12345")
-    private final String reference;
-    @ApiModelProperty(name = "return_url", value = "service return url", required = true, example = "https://service-name.gov.uk/transactions/12345")
+    private int amount;
+    private String reference;
+    @JsonProperty("return_url")
     private String returnUrl;
-    @ApiModelProperty(value = "payment description", required = true, example = "New passport application")
-    private final String description;
-    @ApiModelProperty(name = "agreement_id", value = "ID of the agreement being used to collect the payment", required = false, example = "33890b55-b9ea-4e2f-90fd-77ae0e9009e2")
+    private String description;
     private String agreementId;
-    @ApiModelProperty(value = "ISO-639-1 Alpha-2 code of a supported language to use on the payment pages", required = false, example = "en")
     private SupportedLanguage language;
-    @ApiModelProperty(value = "delayed capture flag", required = false, example = "false" )
     @JsonProperty("delayed_capture")
     private Boolean delayedCapture;
 
@@ -47,6 +41,25 @@ public class ValidCreatePaymentRequest {
         delayedCapture = createPaymentRequest.getDelayedCapture();
     }
 
+    public ValidCreatePaymentRequest() {
+    }
+
+    public void setReturnUrl(String returnUrl) {
+        this.returnUrl = returnUrl;
+    }
+
+    public void setAgreementId(String agreementId) {
+        this.agreementId = agreementId;
+    }
+
+    public void setLanguage(SupportedLanguage language) {
+        this.language = language;
+    }
+
+    public void setDelayedCapture(Boolean delayedCapture) {
+        this.delayedCapture = delayedCapture;
+    }
+
     public int getAmount() {
         return amount;
     }
@@ -63,17 +76,14 @@ public class ValidCreatePaymentRequest {
         return Optional.ofNullable(returnUrl);
     }
 
-    @ApiModelProperty(name = "agreementId", access = "agreementId")
     public Optional<String> getAgreementId() {
         return Optional.ofNullable(agreementId);
     }
 
-    @ApiModelProperty(name = "language", access = "language")
     public Optional<SupportedLanguage> getLanguage() {
         return Optional.ofNullable(language);
     }
 
-    @ApiModelProperty(name = "delayedCapture", access = "delayedCapture")
     public Optional<Boolean> getDelayedCapture() {
         return Optional.ofNullable(delayedCapture);
     }

--- a/src/main/java/uk/gov/pay/api/resources/AgreementsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/AgreementsResource.java
@@ -16,7 +16,7 @@ import uk.gov.pay.api.model.directdebit.agreement.AgreementError;
 import uk.gov.pay.api.model.directdebit.agreement.CreateAgreementRequest;
 import uk.gov.pay.api.model.directdebit.agreement.CreateAgreementResponse;
 import uk.gov.pay.api.model.directdebit.agreement.GetAgreementResponse;
-import uk.gov.pay.api.resources.error.ApiErrorResponse;
+import uk.gov.pay.api.model.ErrorResponse;
 import uk.gov.pay.api.service.AgreementService;
 
 import javax.inject.Inject;
@@ -62,7 +62,7 @@ public class AgreementsResource {
             @ApiResponse(code = 200, message = "OK", response = GetAgreementResponse.class),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = AgreementError.class),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
+            @ApiResponse(code = 429, message = "Too many requests", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = AgreementError.class)})
     public Response getPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
             @PathParam("agreementId") String agreementId) {
@@ -86,7 +86,7 @@ public class AgreementsResource {
             @ApiResponse(code = 201, message = "Created", response = CreateAgreementResponse.class),
             @ApiResponse(code = 400, message = "Bad request", response = PaymentError.class),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
+            @ApiResponse(code = 429, message = "Too many requests", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response createNewAgreement(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                        @ApiParam(value = "requestPayload", required = true) CreateAgreementRequest createAgreementRequest) {

--- a/src/main/java/uk/gov/pay/api/resources/DirectDebitEventsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/DirectDebitEventsResource.java
@@ -9,7 +9,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.links.directdebit.DirectDebitEventsResponse;
-import uk.gov.pay.api.resources.error.ApiErrorResponse;
+import uk.gov.pay.api.model.ErrorResponse;
 import uk.gov.pay.api.service.ConnectorUriGenerator;
 import uk.gov.pay.api.service.DirectDebitEventService;
 import uk.gov.pay.api.validation.DirectDebitEventSearchValidator;
@@ -55,7 +55,7 @@ public class DirectDebitEventsResource {
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK", response = List.class),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class)})
+            @ApiResponse(code = 429, message = "Too many requests", response = ErrorResponse.class)})
     public Response getDirectDebitEvents(
             @ApiParam(value = "accountId", hidden = true) @Auth Account account,
             @QueryParam("to_date") String toDate,

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -19,12 +19,12 @@ import uk.gov.pay.api.exception.GetRefundException;
 import uk.gov.pay.api.exception.GetRefundsException;
 import uk.gov.pay.api.model.ChargeFromResponse;
 import uk.gov.pay.api.model.CreatePaymentRefundRequest;
+import uk.gov.pay.api.model.ErrorResponse;
 import uk.gov.pay.api.model.PaymentError;
 import uk.gov.pay.api.model.RefundFromConnector;
 import uk.gov.pay.api.model.RefundResponse;
 import uk.gov.pay.api.model.RefundsFromConnector;
 import uk.gov.pay.api.model.RefundsResponse;
-import uk.gov.pay.api.resources.error.ApiErrorResponse;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -92,7 +92,7 @@ public class PaymentRefundsResource {
             @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
+            @ApiResponse(code = 429, message = "Too many requests", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response getRefunds(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                @PathParam(PATH_PAYMENT_KEY) String paymentId) {
@@ -128,7 +128,7 @@ public class PaymentRefundsResource {
             @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
+            @ApiResponse(code = 429, message = "Too many requests", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response getRefundById(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                   @PathParam(PATH_PAYMENT_KEY) String paymentId,
@@ -164,7 +164,7 @@ public class PaymentRefundsResource {
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
             @ApiResponse(code = 412, message = "Refund amount available mismatch"),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
+            @ApiResponse(code = 429, message = "Too many requests", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response submitRefund(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                  @ApiParam(value = "paymentId", required = true) @PathParam(PATH_PAYMENT_KEY) String paymentId,

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -48,3 +48,4 @@ apiKeyHmacSecret: ${TOKEN_API_HMAC_SECRET}
 # Caching authenticator.
 authenticationCachePolicy: expireAfterWrite=1m
 
+config: inflector.yaml

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.resources;
 
+import io.swagger.inflector.models.ResponseContext;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +30,7 @@ import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.Collections;
 
+import static org.apache.http.HttpHeaders.LOCATION;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -88,10 +90,10 @@ public class PaymentsResourceCreatePaymentTest {
 
         when(createPaymentService.create(account, createPaymentRequest)).thenReturn(injectedResponse);
 
-        final Response newPayment = paymentsResource.createNewPayment(account, createPaymentRequest);
+        final ResponseContext newPayment = paymentsResource.createNewPayment(account, createPaymentRequest);
 
         assertThat(newPayment.getStatus(), is(201));
-        assertThat(newPayment.getLocation(), is(URI.create(paymentUri)));
+        assertThat(newPayment.getHeaders().getFirst(LOCATION), is(paymentUri));
         assertThat(newPayment.getEntity(), sameInstance(injectedResponse));
     }
 

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -45,3 +45,5 @@ apiKeyHmacSecret: qwer9yuhgf
 
 # Caching authenticator.
 authenticationCachePolicy: expireAfterWrite=3s
+
+config: inflector.yaml

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -15,8 +15,9 @@
     "/v1/payments" : {
       "get" : {
         "summary" : "Search payments",
+        "x-swagger-router-controller": "Payments",
+        "operationId": "searchPayments",
         "description" : "Search payments by reference, state, 'from' and 'to' date. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "searchPayments",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "reference",
@@ -118,8 +119,9 @@
       },
       "post" : {
         "summary" : "Create new payment",
+        "x-swagger-router-controller": "Payments",
+        "operationId": "createNewPayment",
         "description" : "Create a new payment for the account associated to the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "newPayment",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -171,6 +173,7 @@
     "/v1/payments/{paymentId}" : {
       "get" : {
         "summary" : "Find payment by ID",
+        "x-swagger-router-controller": "Payments",
         "description" : "Return information about the payment The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "getPayment",
         "produces" : [ "application/json" ],
@@ -214,6 +217,7 @@
     "/v1/payments/{paymentId}/cancel" : {
       "post" : {
         "summary" : "Cancel payment",
+        "x-swagger-router-controller": "Payments",
         "description" : "Cancel a payment based on the provided payment ID and the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be cancelled if it's in a state that isn't finished.",
         "operationId" : "cancelPayment",
         "produces" : [ "application/json" ],
@@ -266,6 +270,7 @@
     "/v1/payments/{paymentId}/capture" : {
       "post" : {
         "summary" : "Capture payment",
+        "x-swagger-router-controller": "Payments",
         "description" : "Capture a payment based on the provided payment ID and the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be captured if it's in 'submitted' state",
         "operationId" : "capturePayment",
         "produces" : [ "application/json" ],
@@ -318,6 +323,7 @@
     "/v1/payments/{paymentId}/events" : {
       "get" : {
         "summary" : "Return payment events by ID",
+        "x-swagger-router-controller": "Payments",
         "description" : "Return payment events information about a certain payment The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "getPaymentEvents",
         "produces" : [ "application/json" ],
@@ -362,6 +368,7 @@
       "get" : {
         "tags" : [ "refunds" ],
         "summary" : "Get all refunds for a payment.",
+        "x-swagger-router-controller": "PaymentRefundsResource",
         "description" : "Return refunds for a payment. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "getRefunds",
         "produces" : [ "application/json" ],
@@ -401,6 +408,7 @@
       "post" : {
         "tags" : [ "refunds" ],
         "summary" : "Submit a refund for a payment",
+        "x-swagger-router-controller": "PaymentRefundsResource",
         "description" : "Return issued refund information. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "submitRefund",
         "consumes" : [ "application/json" ],
@@ -455,6 +463,7 @@
       "get" : {
         "tags" : [ "refunds" ],
         "summary" : "Find payment refund by ID",
+        "x-swagger-router-controller": "PaymentRefundsResource",
         "description" : "Return payment refund information by Refund ID The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "getRefundById",
         "produces" : [ "application/json" ],


### PR DESCRIPTION
For purposes of show and tell. This PR uses https://github.com/swagger-api/swagger-inflector to get us from API -> Code and not the other way round.

Pros:
1. Got rid of @ApiModelProperty on model classes
2. Got rid of @POST, @Path("/v1/payments"), @Consumes, @Produces, @ApiOperation, @ApiResponses and @ApiResponse annotations.

That's a lot of lines of code that can be got rid of.

Cons:
1. Had to use a middleware to translate the inflector's `(RequestContext request, ValidCreatePaymentRequest validCreatePaymentRequest)` method to the PaymentResource's `createNewPayment(Account account, ValidCreatePaymentRequest validCreatePaymentRequest)` method.
1. We lost functionality of @Auth annotation. Couldn't see a way to wire this in properly, making use of its related auth filter classes. This means if authentication failed in Payments.class we have to manually map the response from that to the appropriate REST Response.
2. We lost functionality of dropwizard exception mapping. This means if an exception is thrown in the resource class the error message in that exception is lost to the external caller of the resource.

THESE ARE BIG CONS.

I think swagger-inflector is still too immature for adoption.