### PR TITLE
PP-4128 Add corporate surcharge and total amount to payment response

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -8,9 +8,11 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
+import java.util.Optional;
+
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
 
-@JsonInclude(value = JsonInclude.Include.NON_NULL)
+@JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 @ApiModel(value = "CardPayment")
 public class CardPayment extends Payment {
 
@@ -31,10 +33,16 @@ public class CardPayment extends Payment {
     @ApiModelProperty(name = "delayed_capture", access = "delayed_capture")
     private final boolean delayedCapture;
 
+    @JsonProperty("corporate_card_surcharge")
+    private final Long corporateCardSurcharge;
+
+    @JsonProperty("total_amount")
+    private final Long totalAmount;
+
     public CardPayment(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                        String reference, String email, String paymentProvider, String createdDate,
                        RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
-                       SupportedLanguage language, boolean delayedCapture) {
+                       SupportedLanguage language, boolean delayedCapture, Long corporateCardSurcharge, Long totalAmount) {
         super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate);
         this.refundSummary = refundSummary;
         this.settlementSummary = settlementSummary;
@@ -42,6 +50,8 @@ public class CardPayment extends Payment {
         this.paymentType = CARD.getFriendlyName();
         this.language = language;
         this.delayedCapture = delayedCapture;
+        this.corporateCardSurcharge = corporateCardSurcharge;
+        this.totalAmount = totalAmount;
     }
 
     /**
@@ -82,6 +92,16 @@ public class CardPayment extends Payment {
         return delayedCapture;
     }
 
+    @ApiModelProperty(example = "250")
+    public Optional<Long> getCorporateCardSurcharge() {
+        return Optional.ofNullable(corporateCardSurcharge);
+    }
+
+    @ApiModelProperty(example = "1450")
+    public Optional<Long> getTotalAmount() {
+        return Optional.ofNullable(totalAmount);
+    }
+
     @Override
     public String toString() {
         // Some services put PII in the description, so don’t include it in the stringification
@@ -90,6 +110,7 @@ public class CardPayment extends Payment {
                 ", paymentProvider='" + paymentProvider + '\'' +
                 ", cardBrandLabel='" + getCardBrand() + '\'' +
                 ", amount=" + amount +
+                ", corporateCardSurcharge='" + corporateCardSurcharge + '\'' +
                 ", state='" + state + '\'' +
                 ", returnUrl='" + returnUrl + '\'' +
                 ", reference='" + reference + '\'' +

--- a/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
@@ -51,6 +51,12 @@ public class ChargeFromResponse {
     @JsonProperty(value = "delayed_capture")
     private boolean delayedCapture;
 
+    @JsonProperty("corporate_card_surcharge")
+    private Long corporateCardSurcharge;
+
+    @JsonProperty("total_amount")
+    private Long totalAmount;
+
     @JsonProperty(value = "created_date")
     private String createdDate;
 
@@ -90,6 +96,14 @@ public class ChargeFromResponse {
         return delayedCapture;
     }
 
+    public Long getCorporateCardSurcharge() {
+        return corporateCardSurcharge;
+    }
+
+    public Long getTotalAmount() {
+        return totalAmount;
+    }
+    
     public String getPaymentProvider() {
         return paymentProvider;
     }

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -42,9 +42,9 @@ public class PaymentWithAllLinks {
                                String reference, String email, String paymentProvider, String createdDate, SupportedLanguage language,
                                boolean delayedCapture, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
                                List<PaymentConnectorResponseLink> paymentConnectorResponseLinks, URI selfLink, URI paymentEventsUri, URI paymentCancelUri,
-                               URI paymentRefundsUri) {
+                               URI paymentRefundsUri, Long corporateCardSurcharge, Long totalAmount) {
         this.payment = new CardPayment(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate,
-                refundSummary, settlementSummary, cardDetails, language, delayedCapture);
+                refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount);
         this.links.addSelf(selfLink.toString());
         this.links.addKnownLinksValueOf(paymentConnectorResponseLinks);
         this.links.addEvents(paymentEventsUri.toString());
@@ -104,7 +104,9 @@ public class PaymentWithAllLinks {
                 selfLink,
                 paymentEventsUri,
                 paymentCancelUri,
-                paymentRefundsUri
+                paymentRefundsUri,
+                paymentConnector.getCorporateCardSurcharge(), 
+                paymentConnector.getTotalAmount()
         );
     }
 

--- a/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
@@ -21,9 +21,10 @@ public class PaymentForSearchResult extends CardPayment {
     public PaymentForSearchResult(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                                   String reference, String email, String paymentProvider, String createdDate, SupportedLanguage language,
                                   boolean delayedCapture, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
-                                  URI selfLink, URI paymentEventsLink, URI paymentCancelLink, URI paymentRefundsLink) {
+                                  URI selfLink, URI paymentEventsLink, URI paymentCancelLink, URI paymentRefundsLink,
+                                  Long corporateCardSurcharge, Long totalAmount) {
         super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider,
-                createdDate, refundSummary, settlementSummary, cardDetails, language, delayedCapture);
+                createdDate, refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount);
         this.links.addSelf(selfLink.toString());
         this.links.addEvents(paymentEventsLink.toString());
         this.links.addRefunds(paymentRefundsLink.toString());
@@ -58,7 +59,9 @@ public class PaymentForSearchResult extends CardPayment {
                 selfLink,
                 paymentEventsLink,
                 paymentCancelLink,
-                paymentRefundsLink);
+                paymentRefundsLink, 
+                paymentResult.getCorporateCardSurcharge(), 
+                paymentResult.getTotalAmount());
     }
 
     @ApiModelProperty(dataType = "uk.gov.pay.api.model.links.PaymentLinksForSearch")

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
@@ -92,6 +92,7 @@ public class PaymentSearchResultBuilder {
         public RefundSummary refund_summary = new RefundSummary();
         public SettlementSummary settlement_summary = new SettlementSummary();
         public CardDetails card_details = new CardDetails();
+        public Long corporate_card_surcharge, total_amount;
     }
 
     private static class TestPaymentState {
@@ -144,6 +145,8 @@ public class PaymentSearchResultBuilder {
     private String fromDate = null;
     private String toDate = null;
     private CardDetails cardDetails = new CardDetails();
+    private Long corporateCardSurcharge = null;
+    private Long totalAmount = null;
 
     public static PaymentSearchResultBuilder aSuccessfulSearchPayment() {
         return new PaymentSearchResultBuilder();
@@ -203,6 +206,16 @@ public class PaymentSearchResultBuilder {
 
     public PaymentSearchResultBuilder withNumberOfResults(int numberOfResults) {
         this.noOfResults = numberOfResults;
+        return this;
+    }
+    
+    public PaymentSearchResultBuilder withCorporateCardSurcharge(Long surcharge) {
+        this.corporateCardSurcharge = surcharge;
+        return this;
+    }
+    
+    public PaymentSearchResultBuilder withTotalAmount(Long totalAmount) {
+        this.totalAmount = totalAmount;
         return this;
     }
 
@@ -275,6 +288,8 @@ public class PaymentSearchResultBuilder {
         payment.refund_summary.amount_submitted = 300;
         payment.settlement_summary.capture_submit_time = DEFAULT_CAPTURE_SUBMIT_TIME;
         payment.settlement_summary.captured_date = DEFAULT_CAPTURED_DATE;
+        payment.corporate_card_surcharge = corporateCardSurcharge;
+        payment.total_amount = totalAmount;
 
         return payment;
     }

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -122,7 +122,9 @@ public class PaymentsResourceCreatePaymentTest {
                 URI.create(paymentUri),
                 URI.create(paymentUri + "/events"),
                 URI.create(paymentUri + "/cancel"),
-                URI.create(paymentUri + "/refunds")
+                URI.create(paymentUri + "/refunds"),
+                null,
+                null
         );
     }
 }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -66,7 +66,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
 
     private String buildChargeResponse(long amount, String chargeId, PaymentState state, String returnUrl, String description,
                                        String reference, String email, String paymentProvider, String gatewayTransactionId, String createdDate,
-                                       SupportedLanguage language, boolean delayedCapture, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
+                                       SupportedLanguage language, boolean delayedCapture, Long corporateCardSurcharge, Long totalAmount, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
                                        ImmutableMap<?, ?>... links) {
         JsonStringBuilder jsonStringBuilder = new JsonStringBuilder()
                 .add("charge_id", chargeId)
@@ -88,6 +88,14 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
 
         if (gatewayTransactionId != null) {
             jsonStringBuilder.add("gateway_transaction_id", gatewayTransactionId);
+        }
+        
+        if (corporateCardSurcharge != null) {
+            jsonStringBuilder.add("corporate_card_surcharge", corporateCardSurcharge);
+        }
+        
+        if (totalAmount != null) {
+            jsonStringBuilder.add("total_amount", totalAmount);
         }
 
         return jsonStringBuilder.build();
@@ -149,6 +157,8 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                                 createdDate,
                                 language,
                                 delayedCapture,
+                                null,
+                                null,
                                 refundSummary,
                                 settlementSummary,
                                 cardDetails,
@@ -208,8 +218,19 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                                        String description, String reference, String email, String paymentProvider, String createdDate,
                                        SupportedLanguage language, boolean delayedCapture, String chargeTokenId, RefundSummary refundSummary, SettlementSummary settlementSummary,
                                        CardDetails cardDetails) {
+        respondWithChargeFound(amount, gatewayAccountId, chargeId, state, returnUrl,
+                description, reference, email, paymentProvider, createdDate,
+                language, delayedCapture, chargeTokenId, refundSummary, settlementSummary,
+                cardDetails, null, null);
+    }
+
+    public void respondWithChargeFound(long amount, String gatewayAccountId, String chargeId, PaymentState state, String returnUrl,
+                                       String description, String reference, String email, String paymentProvider, String createdDate,
+                                       SupportedLanguage language, boolean delayedCapture, String chargeTokenId, RefundSummary refundSummary, SettlementSummary settlementSummary,
+                                       CardDetails cardDetails, Long corporateCardurcharge, Long totalAmount) {
         String chargeResponseBody = buildChargeResponse(amount, chargeId, state, returnUrl,
-                description, reference, email, paymentProvider, gatewayAccountId, createdDate, language, delayedCapture, refundSummary, settlementSummary, cardDetails,
+                description, reference, email, paymentProvider, gatewayAccountId, createdDate, language, delayedCapture,
+                corporateCardurcharge, totalAmount, refundSummary, settlementSummary, cardDetails,
                 validGetLink(chargeLocation(gatewayAccountId, chargeId), "self"),
                 validGetLink(chargeLocation(gatewayAccountId, chargeId) + "/refunds", "refunds"),
                 validGetLink(nextUrl(chargeId), "next_url"), validPostLink(nextUrlPost(), "next_url_post", "application/x-www-form-urlencoded",

--- a/src/test/resources/pacts/publicapi-connector-get-payment-with-corporate-surcharge.json
+++ b/src/test/resources/pacts/publicapi-connector-get-payment-with-corporate-surcharge.json
@@ -1,0 +1,128 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "get a charge request with corporate surcharge",
+      "providerStates": [
+        {
+          "name": "a charge with corporate surcharge exists",
+          "params": {
+            "account_id": "123456",
+            "charge_id": "ch_123abc456def"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/api/accounts/123456/charges/ch_123abc456def"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "amount": 2000,
+          "state": {
+            "finished": true,
+            "status": "success"
+          },
+          "description": "Test description",
+          "reference": "aReference",
+          "language": "en",
+          "links": [
+            {
+              "rel": "self",
+              "method": "GET",
+              "href": "https://connector/v1/api/accounts/123456/charges/ch_123abc456def"
+            },
+            {
+              "rel": "refunds",
+              "method": "GET",
+              "href": "https://connector/v1/api/accounts/123456/charges/ch_123abc456def/refunds"
+            }
+          ],
+          "charge_id": "ch_123abc456def",
+          "return_url": "https://somewhere.gov.uk/rainbow/1",
+          "payment_provider": "sandbox",
+          "created_date": "2018-10-16T10:46:02.121Z",
+          "corporate_card_surcharge": 250,
+          "total_amount": 2250,
+          "refund_summary": {
+            "status": "available",
+            "user_external_id": null,
+            "amount_available": 2000,
+            "amount_submitted": 0
+          },
+          "settlement_summary": {
+            "capture_submit_time": null,
+            "captured_date": null
+          },
+          "delayed_capture": false
+        },
+        "matchingRules": {
+          "body": {
+            "$.reference": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.description": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.links[0].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/ch_123abc456def"
+                }
+              ]
+            },
+            "$.links[1].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/ch_123abc456def\/refunds"
+                }
+              ]
+            },
+            "$.links[2].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/secure\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.links[3].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/secure"
+                }
+              ]
+            },
+            "$.links[3].params.chargeTokenId": {
+              "matchers": [
+                {"match": "type"}
+              ]
+            },
+            "$.return_url": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.created_date": {
+              "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
## WHAT YOU DID
- Add pact test for payment with corporate surcharge to confirm
`corporate_card_surchage` and `total_amount` are in the get charge response.
- Add `corporate_card_surcharge` and `total_amount` to the get charge response.

with @danworth
