### PR TITLE
PP-4131 Change refund_summary.amount_available field in Pact interaction

### DIFF
--- a/src/test/resources/pacts/publicapi-connector-get-payment-with-corporate-surcharge.json
+++ b/src/test/resources/pacts/publicapi-connector-get-payment-with-corporate-surcharge.json
@@ -56,7 +56,7 @@
           "refund_summary": {
             "status": "available",
             "user_external_id": null,
-            "amount_available": 2000,
+            "amount_available": 2250,
             "amount_submitted": 0
           },
           "settlement_summary": {
@@ -111,6 +111,9 @@
             },
             "$.created_date": {
               "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
+            },
+            "$.refund_summary.amount_available": {
+              "matchers": [{"match": "type"}]
             }
           }
         }


### PR DESCRIPTION
## WHAT YOU DID

- Changed `refund_summary.amount_available` field in Pact interaction
  because we will have corporate card surcharge fee included in the amount.
- Added `refund_summary.amount_available` matcher because we want the value
  to be ignored as connector has tests for that and it is out of the scope
  of the contract testing.

with @stephencdaly and @oswaldquek
