### PR TITLE
PP-4297 Add capture url to `/v1/payments/{payment_external_id}` response

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/links/PaymentLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentLinks.java
@@ -10,7 +10,7 @@ import java.util.List;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 
-@ApiModel(value = "PaymentLinks", description = "self,events and next links of a Payment")
+@ApiModel(value = "PaymentLinks", description = "links for payment")
 public class PaymentLinks {
 
     private static final String SELF = "self";
@@ -19,6 +19,7 @@ public class PaymentLinks {
     private static final String EVENTS = "events";
     private static final String CANCEL = "cancel";
     private static final String REFUNDS = "refunds";
+    private static final String CAPTURE = "capture";
 
     @JsonProperty(value = SELF)
     private Link self;
@@ -37,6 +38,9 @@ public class PaymentLinks {
 
     @JsonProperty(value = CANCEL)
     private PostLink cancel;
+    
+    @JsonProperty(value = CAPTURE)
+    private PostLink capture;
 
     @ApiModelProperty(value = SELF, dataType = "uk.gov.pay.api.model.links.Link")
     public Link getSelf() {
@@ -68,9 +72,15 @@ public class PaymentLinks {
         return cancel;
     }
 
+    @ApiModelProperty(value = CAPTURE, dataType = "uk.gov.pay.api.model.links.PostLink")
+    public PostLink getCapture() {
+        return capture;
+    }
+
     public void addKnownLinksValueOf(List<PaymentConnectorResponseLink> chargeLinks) {
         addNextUrlIfPresent(chargeLinks);
         addNextUrlPostIfPresent(chargeLinks);
+        addCaptureUrlIfPresent(chargeLinks);
     }
 
     public void addSelf(String href) {
@@ -88,6 +98,10 @@ public class PaymentLinks {
     public void addCancel(String href) {
         this.cancel = new PostLink(href, POST);
     }
+    
+    public void addCapture(String href) {
+        this.capture = new PostLink(href, POST);
+    }
 
     private void addNextUrlPostIfPresent(List<PaymentConnectorResponseLink> chargeLinks) {
         chargeLinks.stream()
@@ -101,5 +115,12 @@ public class PaymentLinks {
                 .filter(chargeLink -> NEXT_URL.equals(chargeLink.getRel()))
                 .findFirst()
                 .ifPresent(chargeLink -> this.nextUrl = new Link(chargeLink.getHref(), chargeLink.getMethod()));
+    }
+
+    private void addCaptureUrlIfPresent(List<PaymentConnectorResponseLink> chargeLinks) {
+        chargeLinks.stream()
+                .filter(chargeLink -> CAPTURE.equals(chargeLink.getRel()))
+                .findFirst()
+                .ifPresent(chargeLink -> this.capture = new PostLink(chargeLink.getHref(), chargeLink.getMethod()));
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -42,7 +42,7 @@ public class PaymentWithAllLinks {
                                String reference, String email, String paymentProvider, String createdDate, SupportedLanguage language,
                                boolean delayedCapture, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
                                List<PaymentConnectorResponseLink> paymentConnectorResponseLinks, URI selfLink, URI paymentEventsUri, URI paymentCancelUri,
-                               URI paymentRefundsUri, Long corporateCardSurcharge, Long totalAmount) {
+                               URI paymentRefundsUri, URI captureUri, Long corporateCardSurcharge, Long totalAmount) {
         this.payment = new CardPayment(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate,
                 refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount);
         this.links.addSelf(selfLink.toString());
@@ -52,6 +52,10 @@ public class PaymentWithAllLinks {
 
         if (!state.isFinished()) {
             this.links.addCancel(paymentCancelUri.toString());
+        }
+        
+        if (paymentConnectorResponseLinks.stream().anyMatch(link -> "capture".equals(link.getRel()))) {
+            this.links.addCapture(captureUri.toString());
         }
     }
 
@@ -84,7 +88,8 @@ public class PaymentWithAllLinks {
                                               URI selfLink,
                                               URI paymentEventsUri,
                                               URI paymentCancelUri,
-                                              URI paymentRefundsUri) {
+                                              URI paymentRefundsUri,
+                                              URI paymentsCaptureUri) {
         return new PaymentWithAllLinks(
                 paymentConnector.getChargeId(),
                 paymentConnector.getAmount(),
@@ -105,6 +110,7 @@ public class PaymentWithAllLinks {
                 paymentEventsUri,
                 paymentCancelUri,
                 paymentRefundsUri,
+                paymentsCaptureUri,
                 paymentConnector.getCorporateCardSurcharge(), 
                 paymentConnector.getTotalAmount()
         );
@@ -116,12 +122,13 @@ public class PaymentWithAllLinks {
             URI selfLink,
             URI paymentEventsUri,
             URI paymentCancelUri,
-            URI paymentRefundsUri) {
+            URI paymentRefundsUri,
+            URI paymentsCaptureUri) {
         switch (paymentType) {
             case DIRECT_DEBIT:
                 return PaymentWithAllLinks.valueOf(paymentConnector, selfLink);
             default:
-                return PaymentWithAllLinks.valueOf(paymentConnector, selfLink, paymentEventsUri, paymentCancelUri, paymentRefundsUri);
+                return PaymentWithAllLinks.valueOf(paymentConnector, selfLink, paymentEventsUri, paymentCancelUri, paymentRefundsUri, paymentsCaptureUri);
         }
     }
 

--- a/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
@@ -47,7 +47,8 @@ public class CreatePaymentService {
                 publicApiUriGenerator.getPaymentURI(chargeFromResponse.getChargeId()),
                 publicApiUriGenerator.getPaymentEventsURI(chargeFromResponse.getChargeId()),
                 publicApiUriGenerator.getPaymentCancelURI(chargeFromResponse.getChargeId()),
-                publicApiUriGenerator.getPaymentRefundsURI(chargeFromResponse.getChargeId()));
+                publicApiUriGenerator.getPaymentRefundsURI(chargeFromResponse.getChargeId()),
+                publicApiUriGenerator.getPaymentCaptureURI(chargeFromResponse.getChargeId()));
     }
 
     private boolean createdSuccessfully(Response connectorResponse) {

--- a/src/main/java/uk/gov/pay/api/service/GetPaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/GetPaymentService.java
@@ -41,7 +41,8 @@ public class GetPaymentService {
                     paymentURI,
                     publicApiUriGenerator.getPaymentEventsURI(chargeFromResponse.getChargeId()),
                     publicApiUriGenerator.getPaymentCancelURI(chargeFromResponse.getChargeId()),
-                    publicApiUriGenerator.getPaymentRefundsURI(chargeFromResponse.getChargeId()));
+                    publicApiUriGenerator.getPaymentRefundsURI(chargeFromResponse.getChargeId()),
+                    publicApiUriGenerator.getPaymentCaptureURI(chargeFromResponse.getChargeId()));
             return payment;
         }
         throw new GetChargeException(connectorResponse);

--- a/src/main/java/uk/gov/pay/api/service/PublicApiUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/PublicApiUriGenerator.java
@@ -51,6 +51,12 @@ public class PublicApiUriGenerator {
                 .path("/v1/agreements/{agreementId}")
                 .build(agreementId);
     }
+    
+    public URI getPaymentCaptureURI(String chargeId) {
+        return UriBuilder.fromUri(baseUrl)
+                .path("/v1/payments/{paymentId}/capture")
+                .build(chargeId);
+    }
 
     public String convertHostToPublicAPI(String link) {
         URI originalUri = UriBuilder.fromUri(link).build();

--- a/src/test/java/uk/gov/pay/api/model/PaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/model/PaymentTest.java
@@ -22,6 +22,7 @@ public class PaymentTest {
         URI eventsUri = URI.create("http://self.link.com/events");
         URI cancelUri = URI.create("http://self.link.com/cancel");
         URI refundsUri = URI.create("http://self.link.com/cancel");
+        URI captureUri = URI.create("self.link.com/capture");
 
         // language=JSON
         ChargeFromResponse paymentFromConnector = objectMapper.readValue("{\n" +
@@ -46,7 +47,7 @@ public class PaymentTest {
                 "  }\n" +
                 "}", ChargeFromResponse.class);
 
-        PaymentWithAllLinks payment = PaymentWithAllLinks.valueOf(paymentFromConnector, selfUri, eventsUri, cancelUri, refundsUri);
+        PaymentWithAllLinks payment = PaymentWithAllLinks.valueOf(paymentFromConnector, selfUri, eventsUri, cancelUri, refundsUri, captureUri);
 
         assertThat(payment.toString(), not(containsString("user@example.com")));
         assertThat(payment.toString(), not(containsString("last_digits_card_number")));

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -123,6 +123,7 @@ public class PaymentsResourceCreatePaymentTest {
                 URI.create(paymentUri + "/events"),
                 URI.create(paymentUri + "/cancel"),
                 URI.create(paymentUri + "/refunds"),
+                URI.create(paymentUri + "/capture"),
                 null,
                 null
         );

--- a/src/test/resources/pacts/publicapi-connector-get-payment-with-awaiting-capture-request-state.json
+++ b/src/test/resources/pacts/publicapi-connector-get-payment-with-awaiting-capture-request-state.json
@@ -10,7 +10,7 @@
       "description": "get a charge request with awaiting charge request state",
       "providerStates": [
         {
-          "name": "a charge in awaiting charge request state exists",
+          "name": "a charge with delayed capture true and awaiting capture request status exists",
           "params": {
             "gateway_account_id": "123456",
             "charge_id": "ch_123abc456def"
@@ -27,10 +27,14 @@
           "Content-Type": "application/json"
         },
         "body": {
+          "amount": 100,
           "state": {
             "finished": false,
             "status": "submitted"
           },
+          "description": "Test description",
+          "reference": "aReference",
+          "language": "en",
           "links": [
             {
               "rel": "self",
@@ -45,13 +49,33 @@
             {
               "rel": "capture",
               "method": "POST",
-              "href": "https://card_frontend/secure/ae749781-6562-4e0e-8f56-32d9639079dc/capture"
+              "href": "https://connector/v1/api/accounts/123456/charges/ch_123abc456def/capture"
             }
           ],
-          "charge_id": "ch_123abc456def"
+          "charge_id": "ch_123abc456def",
+          "return_url": "https://somewhere.gov.uk/rainbow/1",
+          "payment_provider": "sandbox",
+          "created_date": "2018-10-16T10:46:02.121Z",
+          "refund_summary": {
+            "status": "unavailable",
+            "user_external_id": null,
+            "amount_available": 100,
+            "amount_submitted": 0
+          },
+          "settlement_summary": {
+            "capture_submit_time": null,
+            "captured_date": null
+          },
+          "delayed_capture": true
         },
         "matchingRules": {
           "body": {
+            "$.reference": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.description": {
+              "matchers": [{"match": "type"}]
+            },
             "$.links[0].href": {
               "matchers": [
                 {
@@ -72,6 +96,15 @@
                   "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/ch_123abc456def\/capture"
                 }
               ]
+            },
+            "$.return_url": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.created_date": {
+              "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
+            },
+            "$.refund_summary.amount_available": {
+              "matchers": [{"match": "type"}]
             }
           }
         }

--- a/src/test/resources/pacts/publicapi-connector-get-payment-with-awaiting_capture_request_state.json
+++ b/src/test/resources/pacts/publicapi-connector-get-payment-with-awaiting_capture_request_state.json
@@ -1,0 +1,89 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "get a charge request with awaiting charge request state",
+      "providerStates": [
+        {
+          "name": "a charge in awaiting charge request state exists",
+          "params": {
+            "gateway_account_id": "123456",
+            "charge_id": "ch_123abc456def"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/api/accounts/123456/charges/ch_123abc456def"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "state": {
+            "finished": false,
+            "status": "submitted"
+          },
+          "links": [
+            {
+              "rel": "self",
+              "method": "GET",
+              "href": "https://connector/v1/api/accounts/123456/charges/ch_123abc456def"
+            },
+            {
+              "rel": "refunds",
+              "method": "GET",
+              "href": "https://connector/v1/api/accounts/123456/charges/ch_123abc456def/refunds"
+            },
+            {
+              "rel": "capture",
+              "method": "POST",
+              "href": "https://card_frontend/secure/ae749781-6562-4e0e-8f56-32d9639079dc/capture"
+            }
+          ],
+          "charge_id": "ch_123abc456def"
+        },
+        "matchingRules": {
+          "body": {
+            "$.links[0].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/ch_123abc456def"
+                }
+              ]
+            },
+            "$.links[1].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/ch_123abc456def\/refunds"
+                }
+              ]
+            },
+            "$.links[2].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/ch_123abc456def\/capture"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -799,9 +799,39 @@
           "description" : "self",
           "readOnly" : true,
           "$ref" : "#/definitions/Link"
+        },
+        "next_url" : {
+          "description" : "next_url",
+          "readOnly" : true,
+          "$ref" : "#/definitions/Link"
+        },
+        "next_url_post" : {
+          "description" : "next_url_post",
+          "readOnly" : true,
+          "$ref" : "#/definitions/PostLink"
+        },
+        "events" : {
+          "description" : "events",
+          "readOnly" : true,
+          "$ref" : "#/definitions/Link"
+        },
+        "refunds" : {
+          "description" : "refunds",
+          "readOnly" : true,
+          "$ref" : "#/definitions/Link"
+        },
+        "cancel" : {
+          "description" : "cancel",
+          "readOnly" : true,
+          "$ref" : "#/definitions/PostLink"
+        },
+        "capture" : {
+          "description" : "capture",
+          "readOnly" : true,
+          "$ref" : "#/definitions/PostLink"
         }
       },
-      "description" : "links for events resource"
+      "description" : "links for payment"
     },
     "PaymentLinksForSearch" : {
       "type" : "object",


### PR DESCRIPTION
## WHAT YOU DID
Return capture url in the response object when received from connector
Add/refactor process to handle capture uri

## How to test
When a charge is on AWAITING_CAPTURE_REQUEST state in connector, calling the endpoint `/v1/payments/{payment_external_id}` should include 
```
"_links":
   "capture": {
            "href": "xxxx/v1/payments/xxxxx/capture",
            "method": "POST"
        }
```
in the response payload. 
Any other states should include
```
"_links":
   "capture": null
```
