### PR TITLE
PP-4297 Add capture URI to search results

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/links/PaymentLinksForSearch.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentLinksForSearch.java
@@ -14,6 +14,7 @@ public class PaymentLinksForSearch {
     private static final String EVENTS = "events";
     private static final String CANCEL = "cancel";
     private static final String REFUNDS = "refunds";
+    private static final String CAPTURE = "capture";
 
     @JsonProperty(value = SELF)
     private Link self;
@@ -26,6 +27,9 @@ public class PaymentLinksForSearch {
 
     @JsonProperty(value = REFUNDS)
     private Link refunds;
+    
+    @JsonProperty(value = CAPTURE)
+    private PostLink capture;
 
     @ApiModelProperty(value = SELF, dataType = "uk.gov.pay.api.model.links.Link")
     public Link getSelf() {
@@ -47,6 +51,11 @@ public class PaymentLinksForSearch {
         return refunds;
     }
 
+    @ApiModelProperty(value = CAPTURE, dataType = "uk.gov.pay.api.model.links.PostLink")
+    public Link getCapture() {
+        return capture;
+    }
+
     public void addSelf(String href) {
         this.self = new Link(href, GET);
     }
@@ -61,5 +70,9 @@ public class PaymentLinksForSearch {
 
     public void addRefunds(String href) {
         this.refunds = new Link(href, GET);
+    }
+
+    public void addCapture(String href) {
+        this.capture = new PostLink(href, POST);
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -42,7 +42,7 @@ public class PaymentWithAllLinks {
                                String reference, String email, String paymentProvider, String createdDate, SupportedLanguage language,
                                boolean delayedCapture, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
                                List<PaymentConnectorResponseLink> paymentConnectorResponseLinks, URI selfLink, URI paymentEventsUri, URI paymentCancelUri,
-                               URI paymentRefundsUri, URI captureUri, Long corporateCardSurcharge, Long totalAmount) {
+                               URI paymentRefundsUri, URI paymentCaptureUri, Long corporateCardSurcharge, Long totalAmount) {
         this.payment = new CardPayment(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate,
                 refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount);
         this.links.addSelf(selfLink.toString());
@@ -55,7 +55,7 @@ public class PaymentWithAllLinks {
         }
         
         if (paymentConnectorResponseLinks.stream().anyMatch(link -> "capture".equals(link.getRel()))) {
-            this.links.addCapture(captureUri.toString());
+            this.links.addCapture(paymentCaptureUri.toString());
         }
     }
 

--- a/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
@@ -5,6 +5,7 @@ import io.swagger.annotations.ApiModelProperty;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.CardPayment;
 import uk.gov.pay.api.model.ChargeFromResponse;
+import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.model.SettlementSummary;
@@ -12,6 +13,7 @@ import uk.gov.pay.api.model.links.PaymentLinksForSearch;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.net.URI;
+import java.util.List;
 
 public class PaymentForSearchResult extends CardPayment {
 
@@ -21,7 +23,7 @@ public class PaymentForSearchResult extends CardPayment {
     public PaymentForSearchResult(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                                   String reference, String email, String paymentProvider, String createdDate, SupportedLanguage language,
                                   boolean delayedCapture, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
-                                  URI selfLink, URI paymentEventsLink, URI paymentCancelLink, URI paymentRefundsLink,
+                                  List<PaymentConnectorResponseLink> links, URI selfLink, URI paymentEventsLink, URI paymentCancelLink, URI paymentRefundsLink, URI paymentCaptureUri,
                                   Long corporateCardSurcharge, Long totalAmount) {
         super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider,
                 createdDate, refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount);
@@ -32,6 +34,9 @@ public class PaymentForSearchResult extends CardPayment {
         if (!state.isFinished()) {
             this.links.addCancel(paymentCancelLink.toString());
         }
+        if (links.stream().anyMatch(link -> "capture".equals(link.getRel()))) {
+            this.links.addCapture(paymentCaptureUri.toString());
+        }
     }
 
     public static PaymentForSearchResult valueOf(
@@ -39,7 +44,8 @@ public class PaymentForSearchResult extends CardPayment {
             URI selfLink,
             URI paymentEventsLink,
             URI paymentCancelLink,
-            URI paymentRefundsLink) {
+            URI paymentRefundsLink,
+            URI paymentCaptureUri) {
 
         return new PaymentForSearchResult(
                 paymentResult.getChargeId(),
@@ -56,10 +62,12 @@ public class PaymentForSearchResult extends CardPayment {
                 paymentResult.getRefundSummary(),
                 paymentResult.getSettlementSummary(),
                 paymentResult.getCardDetails(),
+                paymentResult.getLinks(),
                 selfLink,
                 paymentEventsLink,
                 paymentCancelLink,
-                paymentRefundsLink, 
+                paymentRefundsLink,
+                paymentCaptureUri,
                 paymentResult.getCorporateCardSurcharge(), 
                 paymentResult.getTotalAmount());
     }

--- a/src/main/java/uk/gov/pay/api/model/search/card/SearchCardPayments.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/SearchCardPayments.java
@@ -88,7 +88,8 @@ public class SearchCardPayments extends SearchPaymentsBase {
                             paymentUriGenerator.getPaymentURI(baseUrl, charge.getChargeId()),
                             paymentUriGenerator.getPaymentEventsURI(baseUrl, charge.getChargeId()),
                             paymentUriGenerator.getPaymentCancelURI(baseUrl, charge.getChargeId()),
-                            paymentUriGenerator.getPaymentRefundsURI(baseUrl, charge.getChargeId())))
+                            paymentUriGenerator.getPaymentRefundsURI(baseUrl, charge.getChargeId()),
+                            paymentUriGenerator.getPaymentCaptureURI(baseUrl, charge.getChargeId())))
                     .collect(Collectors.toList());
             HalRepresentation.HalRepresentationBuilder halRepresentation = HalRepresentation
                     .builder()

--- a/src/main/java/uk/gov/pay/api/service/PaymentUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/PaymentUriGenerator.java
@@ -28,4 +28,10 @@ public class PaymentUriGenerator {
                 .build(chargeId);
     }
 
+    public URI getPaymentCaptureURI(String baseUrl, String chargeId) {
+        return UriBuilder.fromUri(baseUrl)
+                .path("/v1/payments/{paymentId}/capture")
+                .build(chargeId);
+    }
+
 }

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
@@ -3,10 +3,13 @@ package uk.gov.pay.api.it.fixtures;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import uk.gov.pay.api.model.PaymentConnectorResponseLink;
+import uk.gov.pay.api.model.links.PaymentLinksForSearch;
 import uk.gov.pay.api.utils.DateTimeUtils;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -93,6 +96,7 @@ public class PaymentSearchResultBuilder {
         public SettlementSummary settlement_summary = new SettlementSummary();
         public CardDetails card_details = new CardDetails();
         public Long corporate_card_surcharge, total_amount;
+        public List<PaymentConnectorResponseLink> links = new ArrayList<>();
     }
 
     private static class TestPaymentState {
@@ -147,6 +151,8 @@ public class PaymentSearchResultBuilder {
     private CardDetails cardDetails = new CardDetails();
     private Long corporateCardSurcharge = null;
     private Long totalAmount = null;
+    private List<PaymentConnectorResponseLink> links = new ArrayList<>();
+    private String chargeId;
 
     public static PaymentSearchResultBuilder aSuccessfulSearchPayment() {
         return new PaymentSearchResultBuilder();
@@ -219,6 +225,16 @@ public class PaymentSearchResultBuilder {
         return this;
     }
 
+    public PaymentSearchResultBuilder withCaptureLink() {
+        this.links.add(new PaymentConnectorResponseLink("capture", "https://connector.pymnt.localdomain/v1/api/accounts/1/charges/chargeid/capture", "POST", null, null));
+        return this;
+    }
+    
+    public PaymentSearchResultBuilder withChargeId(String chargeId) {
+        this.chargeId = chargeId;
+        return this;
+    }
+
     public List<TestPayment> getResults() {
         List<TestPayment> results = newArrayList();
         for (int i = 0; i < noOfResults; i++) {
@@ -261,7 +277,8 @@ public class PaymentSearchResultBuilder {
         }
 
         defaultPaymentResult.delayed_capture = delayedCapture;
-
+        defaultPaymentResult.links.addAll(this.links);
+        
         return defaultPaymentResult;
     }
 
@@ -269,7 +286,7 @@ public class PaymentSearchResultBuilder {
         TestPayment payment = new TestPayment();
         TestPaymentState state = states.get(new Random().nextInt(states.size()));
 
-        payment.charge_id = "" + i;
+        payment.charge_id = chargeId == null ? "" + i : chargeId;
         payment.description = "description-" + i;
         payment.reference = randomUUID().toString();
         payment.email = DEFAULT_EMAIL;

--- a/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServiceTest.java
@@ -24,6 +24,7 @@ import static com.jayway.jsonassert.JsonAssert.collectionWithSize;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -146,7 +147,23 @@ public class CardPaymentSearchServiceTest {
                 .assertThat("_links", hasKey("self"))
                 .assertThat("_links", hasKey("first_page"))
                 .assertThat("_links", hasKey("last_page"))
+                .assertThat("results[0]._links.capture", is(nullValue()))
                 .assertNotDefined("_links.next_page")
                 .assertNotDefined("_links.prev_page");
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector-search-payment-with-charge-in-awaiting-capture-state"})
+    public void searchShouldReturnAResponseWithCaptureLinkPresent() {
+        Account account = new Account("123456", TokenPaymentType.CARD);
+        Response response =
+                paymentSearchService.doSearch(account, null, null,
+                        null, null, null,
+                        null, null, null,
+                        null, null, null, null);
+        JsonAssert.with(response.getEntity().toString())
+                .assertThat("results[0]._links", hasKey("capture"))
+                .assertThat("results[0]._links.capture.method", is("POST"));
     }
 }

--- a/src/test/resources/pacts/publicapi-connector-search-payment-with-charge-in-awaiting-capture-state.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-with-charge-in-awaiting-capture-state.json
@@ -1,0 +1,185 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "search a charge request with awaiting charge request state",
+      "providerStates": [
+        {
+          "name": "a charge with delayed capture true and awaiting capture request status exists",
+          "params": {
+            "gateway_account_id": "123456",
+            "charge_id": "ch_123abc456def"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/api/accounts/123456/charges",
+        "query": {
+          "transactionType": ["charge"]
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "page": 1,
+          "total": 1,
+          "count": 1,
+          "results": [
+            {
+              "amount": 100,
+              "state": {
+                "finished": false,
+                "status": "submitted"
+              },
+              "description": "Test description",
+              "reference": "aReference",
+              "language": "en",
+              "links": [
+                {
+                  "rel": "self",
+                  "method": "GET",
+                  "href": "https://connector.service.backend/v1/api/accounts/123456/charges/ch_123abc456def"
+                },
+                {
+                  "rel": "refunds",
+                  "method": "GET",
+                  "href": "https://connector.service.backend/v1/api/accounts/123456/charges/ch_123abc456def/refunds"
+                },
+                {
+                  "rel": "capture",
+                  "method": "POST",
+                  "href": "https://connector.service.backend/v1/api/accounts/123456/charges/ch_123abc456def/capture"
+                }
+              ],
+              "charge_id": "ch_123abc456def",
+              "return_url": "https://somewhere.gov.uk/rainbow/1",
+              "payment_provider": "sandbox",
+              "created_date": "2018-10-16T10:46:02.121Z",
+              "refund_summary": {
+                "status": "unavailable",
+                "user_external_id": null,
+                "amount_available": 100,
+                "amount_submitted": 0
+              },
+              "settlement_summary": {
+                "capture_submit_time": null,
+                "captured_date": null
+              },
+              "delayed_capture": true
+            }
+          ],
+          "_links": {
+            "self": {
+              "href": "http://connector.service.backend/v1/api/accounts/123456/charges?page=1&display_size=500"
+            },
+            "last_page": {
+              "href": "http://connector.service.backend/v1/api/accounts/123456/charges?page=1&display_size=500"
+            },
+            "first_page": {
+              "href": "http://connector.service.backend/v1/api/accounts/123456/charges?page=1&display_size=500"
+            }
+          }
+        },
+        "matchingRules": {
+          "body": {
+            "$.results[0].links[0].href": {
+              "matchers": [
+                {
+                  "regex": "https.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/ch_123abc456def"
+                }
+              ]
+            },
+            "$.results[0].links[1].href": {
+              "matchers": [
+                {
+                  "regex": "https.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/ch_123abc456def\/refunds"
+                }
+              ]
+            },
+            "$.results[0].links[2].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/ch_123abc456def\/capture"
+                }
+              ]
+            },
+            "$._links.self.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\\?page=1&display_size=500"
+                }
+              ]
+            },
+            "$._links.last_page.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\\?page=1&display_size=500"
+                }
+              ]
+            },
+            "$._links.first_page.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\\?page=1&display_size=500"
+                }
+              ]
+            },
+            "$.results[*].card_details.cardholder_name": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].card_details.first_digits_card_number": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].card_details.last_digits_card_number": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].charge_id": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].amount": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].reference": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].email": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].description": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].state.status": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].return_url": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].payment_provider": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.results[*].created_date": {
+              "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -855,6 +855,11 @@
           "description" : "refunds",
           "readOnly" : true,
           "$ref" : "#/definitions/Link"
+        },
+        "capture" : {
+          "description" : "capture",
+          "readOnly" : true,
+          "$ref" : "#/definitions/PostLink"
         }
       },
       "description" : "links for search payment resource"


### PR DESCRIPTION
## WHAT YOU DID
- add capture URI to search results
- add pact test

## How to test

When a charge is on AWAITING_CAPTURE_REQUEST state in connector, calling the endpoint /v1/payments should include

"results":[
....
  "_links":
    "capture": {
             "href": "xxxx/v1/payments/xxxxx/capture",
             "method": "POST"
         }
...]
in the response payload.
Any other states should include

"results":
  "_links":
    "capture": null