### PR TITLE
PP-4162 Make billing address Optional in CardDetails 

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CardDetails.java
+++ b/src/main/java/uk/gov/pay/api/model/CardDetails.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.Optional;
+
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.ALWAYS;
 
 @JsonInclude(ALWAYS)
@@ -16,7 +18,7 @@ public class CardDetails {
 
     @JsonProperty("first_digits_card_number")
     private final String firstDigitsCardNumber;
-    
+
     @JsonProperty("cardholder_name")
     private final String cardHolderName;
 
@@ -30,7 +32,7 @@ public class CardDetails {
     private final String cardBrand;
 
     public CardDetails(@JsonProperty("last_digits_card_number") String lastDigitsCardNumber,
-                       @JsonProperty("first_digits_card_number") String firstDigitsCardNumber, 
+                       @JsonProperty("first_digits_card_number") String firstDigitsCardNumber,
                        @JsonProperty("cardholder_name") String cardHolderName,
                        @JsonProperty("expiry_date") String expiryDate,
                        @JsonProperty("billing_address") Address billingAddress,
@@ -52,7 +54,7 @@ public class CardDetails {
     public String getFirstDigitsCardNumber() {
         return firstDigitsCardNumber;
     }
-    
+
     @ApiModelProperty(example = "Mr. Card holder")
     public String getCardHolderName() {
         return cardHolderName;
@@ -63,8 +65,8 @@ public class CardDetails {
         return expiryDate;
     }
 
-    public Address getBillingAddress() {
-        return billingAddress;
+    public Optional<Address> getBillingAddress() {
+        return Optional.ofNullable(billingAddress);
     }
 
     @ApiModelProperty(example = "Visa")

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentResultBuilder.java
@@ -61,7 +61,7 @@ public abstract class PaymentResultBuilder {
             this.cardholder_name = cardDetails.getCardHolderName();
             this.expiry_date = cardDetails.getExpiryDate();
             this.card_brand = cardDetails.getCardBrand();
-            this.billing_address = cardDetails.getBillingAddress() == null ? null : new Address( cardDetails.getBillingAddress());
+            this.billing_address = cardDetails.getBillingAddress().map(Address::new).orElse(null);
         }
     }
 

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -190,6 +190,15 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                 );
     }
 
+    public void respondOk_whenSearchCharges(String accountId, String expectedResponse) {
+        whenSearchCharges(accountId, null, null, null, null, null, null, null, null, null)
+                .respond(response()
+                        .withStatusCode(OK_200)
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                        .withBody(expectedResponse)
+                );
+    }
+
     public void respondOk_whenSearchChargesWithPageAndSize(String accountId, String reference, String email, String page, String displaySize, String expectedResponse) {
         whenSearchCharges(accountId, reference, email, null, null, null, null, null, null, null, page, displaySize)
                 .respond(response()


### PR DESCRIPTION
## WHAT YOU DID

- Made billing address optional on domain objects.
- Added tests for both the get payment and search payments endpoints that the billing_address property has a null value when no address is returned from connector.

with @stephencdaly