### PR TITLE
BAU: Run e2e tests sequentially

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,7 +112,7 @@ pipeline {
     }
     stage('Tests') {
       failFast true
-      parallel {
+      stages {
         stage('Card Payment End-to-End Tests') {
             when {
                 anyOf {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,17 +146,17 @@ pipeline {
                 runDirectDebitE2E("publicapi")
             }
         }
-         stage('ZAP Tests') {
-            when {
-                anyOf {
-                  branch 'master'
-                  environment name: 'RUN_ZAP_ON_PR', value: 'true'
-                }
-            }
-            steps {
-                runZap("publicapi")
-            }
-         }
+        stage('ZAP Tests') {
+           when {
+               anyOf {
+                 branch 'master'
+                 environment name: 'RUN_ZAP_ON_PR', value: 'true'
+               }
+           }
+           steps {
+               runZap("publicapi")
+           }
+        }
       }
     }
     stage('Docker Tag') {


### PR DESCRIPTION
I have a hunch that running these in parallel is causing flakiness due to
resource contention