### PR TITLE
BAU: Specify UTF-8 as the encoding of java source files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
     <artifactId>pay-publicapi</artifactId>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dropwizard.version>1.3.7</dropwizard.version>
         <guice.version>4.2.2</guice.version>
         <guava.version>27.0.1-jre</guava.version>


### PR DESCRIPTION
This removes the following warning from the build:

[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!