### PR TITLE
PP-3437: Add no auth token test

### DIFF
--- a/src/test/java/uk/gov/pay/api/it/AuthorisationTest.java
+++ b/src/test/java/uk/gov/pay/api/it/AuthorisationTest.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.api.it;
+
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.apache.http.HttpStatus;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.pay.api.app.PublicApi;
+import uk.gov.pay.api.app.config.PublicApiConfig;
+
+import static com.jayway.restassured.RestAssured.given;
+import static com.jayway.restassured.http.ContentType.JSON;
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static uk.gov.pay.api.utils.Payloads.aSuccessfulPaymentPayload;
+
+public class AuthorisationTest {
+
+    @Rule
+    public DropwizardAppRule<PublicApiConfig> app = new DropwizardAppRule<>(
+            PublicApi.class,
+            resourceFilePath("config/test-config.yaml"),
+            config("connectorUrl", "http://localhost"),
+            config("connectorDDUrl", "http://localhost"),
+            config("publicAuthUrl", "http://localhost"));
+
+    @Test
+    public void shouldRefuseAuthorisationIfTokenIsNotPresent() {
+        given().port(app.getLocalPort())
+                .body(aSuccessfulPaymentPayload())
+                .accept(JSON)
+                .contentType(JSON)
+                .post("/v1/payments/")
+                .then()
+                .statusCode(HttpStatus.SC_UNAUTHORIZED);
+    }
+}

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentITest.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentITest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
+import static uk.gov.pay.api.utils.Urls.paymentLocationFor;
 
 public class CreatePaymentITest extends PaymentResourceITestBase {
 
@@ -54,7 +55,7 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
         String responseBody = postPaymentResponse(API_KEY, SUCCESS_PAYLOAD)
                 .statusCode(201)
                 .contentType(JSON)
-                .header(HttpHeaders.LOCATION, is(paymentLocationFor(CHARGE_ID)))
+                .header(HttpHeaders.LOCATION, is(paymentLocationFor(configuration.getBaseUrl(), CHARGE_ID)))
                 .body("payment_id", is(CHARGE_ID))
                 .body("amount", is(9999999))
                 .body("reference", is(REFERENCE))
@@ -69,7 +70,7 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
                 .body("refund_summary.status", is("pending"))
                 .body("refund_summary.amount_submitted", is(50))
                 .body("refund_summary.amount_available", is(100))
-                .body("_links.self.href", is(paymentLocationFor(CHARGE_ID)))
+                .body("_links.self.href", is(paymentLocationFor(configuration.getBaseUrl(), CHARGE_ID)))
                 .body("_links.self.method", is("GET"))
                 .body("_links.next_url.href", is(frontendUrlFor(CARD) + CHARGE_TOKEN_ID))
                 .body("_links.next_url.method", is("GET"))

--- a/src/test/java/uk/gov/pay/api/it/GetPaymentITest.java
+++ b/src/test/java/uk/gov/pay/api/it/GetPaymentITest.java
@@ -26,10 +26,11 @@ import static org.apache.http.HttpStatus.SC_NOT_ACCEPTABLE;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
 import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
+import static uk.gov.pay.api.utils.Urls.directDebitFrontendSecureUrl;
+import static uk.gov.pay.api.utils.Urls.paymentLocationFor;
 
 public class GetPaymentITest extends PaymentResourceITestBase {
 
@@ -93,7 +94,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
                 .body("card_details.billing_address.line2", is(CARD_DETAILS.getBillingAddress().get().getLine2()))
                 .body("card_details.billing_address.postcode", is(CARD_DETAILS.getBillingAddress().get().getPostcode()))
                 .body("card_details.billing_address.country", is(CARD_DETAILS.getBillingAddress().get().getCountry()))
-                .body("_links.self.href", is(paymentLocationFor(CHARGE_ID)))
+                .body("_links.self.href", is(paymentLocationFor(configuration.getBaseUrl(), CHARGE_ID)))
                 .body("_links.self.method", is("GET"))
                 .body("_links.events.href", is(paymentEventsLocationFor(CHARGE_ID)))
                 .body("_links.events.method", is("GET"))
@@ -132,7 +133,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
                 .body("return_url", is(RETURN_URL))
                 .body("payment_provider", is(PAYMENT_PROVIDER))
                 .body("created_date", is(CREATED_DATE))
-                .body("_links.self.href", is(paymentLocationFor(CHARGE_ID)))
+                .body("_links.self.href", is(paymentLocationFor(configuration.getBaseUrl(), CHARGE_ID)))
                 .body("_links.self.method", is("GET"))
                 .body("_links.next_url.href", is(directDebitFrontendSecureUrl() + CHARGE_ID))
                 .body("_links.next_url.method", is("GET"))
@@ -269,7 +270,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
                 .body("events[0].payment_id", is(CHARGE_ID))
                 .body("events[0].state.status", is(CREATED.getStatus()))
                 .body("events[0].updated", is("2016-01-01T12:00:00Z"))
-                .body("events[0]._links.payment_url.href", is(paymentLocationFor(CHARGE_ID)));
+                .body("events[0]._links.payment_url.href", is(paymentLocationFor(configuration.getBaseUrl(), CHARGE_ID)));
     }
 
     @Test
@@ -341,7 +342,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
         getPaymentResponse(API_KEY, CHARGE_ID)
                 .statusCode(200)
                 .contentType(JSON)
-                .body("_links.capture.href", is(paymentLocationFor(CHARGE_ID) + "/capture"))
+                .body("_links.capture.href", is(paymentLocationFor(configuration.getBaseUrl(), CHARGE_ID) + "/capture"))
                 .body("_links.capture.method", is("POST"));
     }
 

--- a/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
@@ -24,6 +24,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.ACCEPTED;
 import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.api.utils.Urls.paymentLocationFor;
 
 public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
@@ -49,7 +50,7 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
                 .body("status", is("available"))
                 .body("created_date", is(CREATED_DATE))
                 .body("_links.self.href", is(paymentRefundLocationFor(CHARGE_ID, REFUND_ID)))
-                .body("_links.payment.href", is(paymentLocationFor(CHARGE_ID)));
+                .body("_links.payment.href", is(paymentLocationFor(configuration.getBaseUrl(), CHARGE_ID)));
     }
 
     @Test
@@ -98,7 +99,7 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
                 .contentType(JSON)
                 .body("payment_id", is(CHARGE_ID))
                 .body("_links.self.href", is(paymentRefundsLocationFor(CHARGE_ID)))
-                .body("_links.payment.href", is(paymentLocationFor(CHARGE_ID)))
+                .body("_links.payment.href", is(paymentLocationFor(configuration.getBaseUrl(), CHARGE_ID)))
                 .body("_embedded.refunds.size()", is(2))
                 .body("_embedded.refunds[0].refund_id", is("100"))
                 .body("_embedded.refunds[0].created_date", is(CREATED_DATE))
@@ -106,14 +107,14 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
                 .body("_embedded.refunds[0].status", is("available"))
                 .body("_embedded.refunds[0]._links.size()", is(2))
                 .body("_embedded.refunds[0]._links.self.href", is(paymentRefundLocationFor(CHARGE_ID, "100")))
-                .body("_embedded.refunds[0]._links.payment.href", is(paymentLocationFor(CHARGE_ID)))
+                .body("_embedded.refunds[0]._links.payment.href", is(paymentLocationFor(configuration.getBaseUrl(), CHARGE_ID)))
                 .body("_embedded.refunds[1].refund_id", is("300"))
                 .body("_embedded.refunds[1].created_date", is(CREATED_DATE))
                 .body("_embedded.refunds[1].amount", is(300))
                 .body("_embedded.refunds[1].status", is("pending"))
                 .body("_embedded.refunds[1]._links.size()", is(2))
                 .body("_embedded.refunds[1]._links.self.href", is(paymentRefundLocationFor(CHARGE_ID, "300")))
-                .body("_embedded.refunds[1]._links.payment.href", is(paymentLocationFor(CHARGE_ID)));
+                .body("_embedded.refunds[1]._links.payment.href", is(paymentLocationFor(configuration.getBaseUrl(), CHARGE_ID)));
     }
 
     @Test
@@ -126,7 +127,7 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
                 .contentType(JSON)
                 .body("payment_id", is(CHARGE_ID))
                 .body("_links.self.href", is(paymentRefundsLocationFor(CHARGE_ID)))
-                .body("_links.payment.href", is(paymentLocationFor(CHARGE_ID)))
+                .body("_links.payment.href", is(paymentLocationFor(configuration.getBaseUrl(), CHARGE_ID)))
                 .body("_embedded.refunds.size()", is(0));
     }
 
@@ -197,7 +198,7 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
                 .body("status", is(refundStatus))
                 .body("created_date", is(CREATED_DATE))
                 .body("_links.self.href", is(paymentRefundLocationFor(CHARGE_ID, REFUND_ID)))
-                .body("_links.payment.href", is(paymentLocationFor(CHARGE_ID)));
+                .body("_links.payment.href", is(paymentLocationFor(configuration.getBaseUrl(), CHARGE_ID)));
     }
 
     private Response postRefunds(String payload) {

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
@@ -17,6 +17,7 @@ import uk.gov.pay.api.utils.mocks.ConnectorMockClient;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static uk.gov.pay.api.utils.Urls.paymentLocationFor;
 
 public abstract class PaymentResourceITestBase {
     //Must use same secret set int confiPaymentsResourceReferenceVgured test-config.xml
@@ -57,12 +58,14 @@ public abstract class PaymentResourceITestBase {
     protected ConnectorMockClient connectorMock;
     protected ConnectorDDMockClient connectorDDMock;
     protected PublicAuthMockClient publicAuthMock;
+    protected PublicApiConfig configuration;
 
     @Before
     public void setup() {
         connectorMock = new ConnectorMockClient(connectorMockRule.getPort(), connectorBaseUrl());
         connectorDDMock = new ConnectorDDMockClient(connectorDDMockRule.getPort(), connectorDDBaseUrl());
         publicAuthMock = new PublicAuthMockClient(publicAuthMockRule.getPort());
+        configuration = app.getConfiguration();
     }
 
     private String connectorBaseUrl() {
@@ -77,24 +80,16 @@ public abstract class PaymentResourceITestBase {
         return "http://localhost:" + publicAuthMockRule.getPort() + "/v1/auth";
     }
 
-    protected String paymentLocationFor(String chargeId) {
-        return "http://publicapi.url" + PAYMENTS_PATH + chargeId;
-    }
-
     String frontendUrlFor(TokenPaymentType paymentType) {
         return "http://frontend_" + paymentType.toString().toLowerCase() + "/charge/";
     }
-
-    protected String directDebitFrontendSecureUrl() {
-        return "http://frontend_direct_debit/secure/";
-    }
-
+    
     String paymentEventsLocationFor(String chargeId) {
-        return paymentLocationFor(chargeId) + "/events";
+        return paymentLocationFor(configuration.getBaseUrl(), chargeId) + "/events";
     }
 
     String paymentRefundsLocationFor(String chargeId) {
-        return paymentLocationFor(chargeId) + "/refunds";
+        return paymentLocationFor(configuration.getBaseUrl(), chargeId) + "/refunds";
     }
 
     String paymentRefundLocationFor(String chargeId, String refundId) {
@@ -102,7 +97,7 @@ public abstract class PaymentResourceITestBase {
     }
 
     String paymentCancelLocationFor(String chargeId) {
-        return paymentLocationFor(chargeId) + "/cancel";
+        return paymentLocationFor(configuration.getBaseUrl(), chargeId) + "/cancel";
     }
 
 }

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -41,6 +41,7 @@ import static uk.gov.pay.api.it.fixtures.PaymentSearchResultBuilder.DEFAULT_CREA
 import static uk.gov.pay.api.it.fixtures.PaymentSearchResultBuilder.DEFAULT_PAYMENT_PROVIDER;
 import static uk.gov.pay.api.it.fixtures.PaymentSearchResultBuilder.DEFAULT_RETURN_URL;
 import static uk.gov.pay.api.it.fixtures.PaymentSearchResultBuilder.aSuccessfulSearchPayment;
+import static uk.gov.pay.api.utils.Urls.paymentLocationFor;
 
 public class PaymentResourceSearchITest extends PaymentResourceITestBase {
 
@@ -97,7 +98,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                 .body("results[0].language", is("en"))
                 .body("results[0].delayed_capture", is(true))
                 .body("results[0]._links.self.method", is("GET"))
-                .body("results[0]._links.self.href", is(paymentLocationFor("0")))
+                .body("results[0]._links.self.href", is(paymentLocationFor(configuration.getBaseUrl(), "0")))
                 .body("results[0]._links.events.href", is(paymentEventsLocationFor("0")))
                 .body("results[0]._links.events.method", is("GET"))
                 .body("results[0]._links.cancel.href", is(paymentCancelLocationFor("0")))

--- a/src/test/java/uk/gov/pay/api/it/directdebit/AgreementsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/directdebit/AgreementsResourceITest.java
@@ -17,6 +17,7 @@ import static com.jayway.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
+import static uk.gov.pay.api.utils.Urls.directDebitFrontendSecureUrl;
 
 public class AgreementsResourceITest extends PaymentResourceITestBase {
 

--- a/src/test/java/uk/gov/pay/api/utils/Payloads.java
+++ b/src/test/java/uk/gov/pay/api/utils/Payloads.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.api.utils;
+
+public class Payloads {
+
+    public static String aSuccessfulPaymentPayload() {
+        int amount = 100;
+        String returnUrl = "https://somewhere.gov.uk/rainbow/1";
+        String reference = "a reference";
+        String email = "alice.111@mail.fake";
+        String description = "a description";
+        return aSuccessfulPaymentPayload(amount, returnUrl, description, reference, email);
+    }
+
+    public static String aSuccessfulPaymentPayload(int amount, String returnUrl, String description, String reference, String email) {
+        return new JsonStringBuilder()
+                .add("amount", amount)
+                .add("reference", reference)
+                .add("email", email)
+                .add("description", description)
+                .add("return_url", returnUrl)
+                .build();
+    }
+}

--- a/src/test/java/uk/gov/pay/api/utils/Urls.java
+++ b/src/test/java/uk/gov/pay/api/utils/Urls.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.api.utils;
+
+public class Urls {
+    
+    public static String directDebitFrontendSecureUrl() {
+        return "http://frontend_direct_debit/secure/";
+    }
+
+    public static String paymentLocationFor(String publicApiBaseUrl, String chargeId) {
+        return publicApiBaseUrl + "v1/payments/" + chargeId;
+    }
+}


### PR DESCRIPTION
This replaces this e2e test:
https://github.com/alphagov/pay-endtoend/blob/3b6bab09049c4c712d897d1834060f7d527da125/src/test/java/uk/gov/pay/endtoend/tests/publicapi/AuthorisationIT.java

I've also taken the opportunity to clean up some test code.

Please also approve https://github.com/alphagov/pay-endtoend/pull/701!

@oswaldquek

