### PR TITLE
PP-3437: Replace test with pact test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
       }
       steps {
         script {
-          def long stepBuildTime = System.currentTimeMillis()
+          def stepBuildTime = System.currentTimeMillis()
           def commit = gitCommit()
           def branchName = 'master'
 
@@ -58,7 +58,7 @@ pipeline {
       }
       steps {
         script {
-          def long stepBuildTime = System.currentTimeMillis()
+          def stepBuildTime = System.currentTimeMillis()
           def commit = gitCommit()
           def branchName = gitBranchName()
 

--- a/src/main/java/uk/gov/pay/api/service/CancelPaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CancelPaymentService.java
@@ -24,7 +24,7 @@ public class CancelPaymentService {
         Response connectorResponse = client
                 .target(connectorUriGenerator.cancelURI(account, chargeId))
                 .request()
-                .post(Entity.json("{}"));
+                .post(null);
 
         if (connectorResponse.getStatus() == HttpStatus.SC_NO_CONTENT) {
             connectorResponse.close();

--- a/src/test/java/uk/gov/pay/api/it/PaymentsCancelResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsCancelResourceITest.java
@@ -40,22 +40,6 @@ public class PaymentsCancelResourceITest extends PaymentResourceITestBase {
     }
 
     @Test
-    public void cancelPayment_returns400_whenConnectorRespondsWithA400() throws IOException {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respondBadRequest_WhenCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "Invalid account Id");
-
-        InputStream body = postCancelPaymentResponse(TEST_CHARGE_ID)
-                .statusCode(400)
-                .contentType(JSON).extract()
-                .body().asInputStream();
-
-        JsonAssert.with(body)
-                .assertThat("$.*", hasSize(2))
-                .assertThat("$.code", Is.is("P0501"))
-                .assertThat("$.description", Is.is("Cancellation of payment failed"));
-    }
-
-    @Test
     public void cancelPayment_returns404_whenPaymentNotFound() throws IOException {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondChargeNotFound_WhenCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "some backend error message");

--- a/src/test/java/uk/gov/pay/api/it/directdebit/pact/CancelPaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/it/directdebit/pact/CancelPaymentTest.java
@@ -1,0 +1,63 @@
+package uk.gov.pay.api.it.directdebit.pact;
+
+import au.com.dius.pact.consumer.PactVerification;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.pay.api.app.PublicApi;
+import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.utils.ApiKeyGenerator;
+import uk.gov.pay.commons.testing.pact.consumers.PactProviderRule;
+import uk.gov.pay.commons.testing.pact.consumers.Pacts;
+
+import static com.jayway.restassured.RestAssured.given;
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.hamcrest.Matchers.is;
+import static org.mockserver.socket.PortFactory.findFreePort;
+import static uk.gov.pay.api.model.TokenPaymentType.CARD;
+import static uk.gov.pay.api.utils.WiremockStubbing.stubPublicAuthV1ApiAuth;
+
+public class CancelPaymentTest {
+
+    private static final String API_KEY = ApiKeyGenerator.apiKeyValueOf("TEST_BEARER_TOKEN", "qwer9yuhgf");
+
+    private final int publicAuthPort = findFreePort();
+    
+    @Rule
+    public WireMockRule publicAuth = new WireMockRule(publicAuthPort);
+
+    @Rule
+    public PactProviderRule connector = new PactProviderRule("connector", this);
+
+    @Rule
+    public DropwizardAppRule<PublicApiConfig> app = new DropwizardAppRule<>(
+            PublicApi.class,
+            resourceFilePath("config/test-config.yaml"),
+            config("connectorUrl", "http://localhost:" + connector.getConfig().getPort()),
+            config("connectorDDUrl", "http://localhost"),
+            config("publicAuthUrl", "http://localhost:" + publicAuthPort + "/v1/api/auth"));
+
+    @Before
+    public void setup() throws Exception {
+        stubPublicAuthV1ApiAuth(publicAuth, new Account("123456", CARD), API_KEY);
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector-cancel-already-canceled-payment"})
+    public void cancelAPaymentThatIsAlreadyCanceled() {
+        given().port(app.getLocalPort())
+                .header(AUTHORIZATION, "Bearer " + API_KEY)
+                .post(String.format("/v1/payments/%s/cancel", "charge8133029783750964630"))
+                .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("code", is("P0501"))
+                .body("description", is("Cancellation of payment failed"));
+    }
+}

--- a/src/test/java/uk/gov/pay/api/service/CancelPaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CancelPaymentServiceTest.java
@@ -24,8 +24,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CancelPaymentServiceTest {
-    
-    private final String CHARGE_ID = "charge8133029783750964639";
+
     private final Account ACCOUNT = new Account("123456", TokenPaymentType.CARD);
     
     private CancelPaymentService cancelPaymentService;
@@ -39,7 +38,6 @@ public class CancelPaymentServiceTest {
     @Before
     public void setUp() {
         when(mockConfiguration.getConnectorUrl()).thenReturn(connectorRule.getUrl());
-
         ConnectorUriGenerator connectorUriGenerator = new ConnectorUriGenerator(mockConfiguration);
         Client client = RestClientFactory.buildClient(new RestClientConfig(false));
         cancelPaymentService = new CancelPaymentService(client, connectorUriGenerator);
@@ -49,9 +47,7 @@ public class CancelPaymentServiceTest {
     @PactVerification({"connector"})
     @Pacts(pacts = {"publicapi-connector-cancel-payment-with-created-state"})
     public void cancelAPaymentWithCreatedState() {
-        
-        Response cancelPaymentResponse = cancelPaymentService.cancel(ACCOUNT, CHARGE_ID);
-
+        Response cancelPaymentResponse = cancelPaymentService.cancel(ACCOUNT, "charge8133029783750964639");
         assertThat(cancelPaymentResponse.getStatus(), is(204));
     }
 }

--- a/src/test/java/uk/gov/pay/api/utils/WiremockStubbing.java
+++ b/src/test/java/uk/gov/pay/api/utils/WiremockStubbing.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.api.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.common.collect.ImmutableMap;
+import uk.gov.pay.api.auth.Account;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+public class WiremockStubbing {
+    
+    public static void stubPublicAuthV1ApiAuth(WireMockRule wireMockRule, Account account, String token) throws JsonProcessingException {
+        Map<String, String> entity = ImmutableMap.of("account_id", account.getAccountId(), "token_type", account.getPaymentType().name());
+        String json = new ObjectMapper().writeValueAsString(entity);
+        wireMockRule.stubFor(get(urlEqualTo("/v1/api/auth"))
+                .withHeader(AUTHORIZATION, equalTo("Bearer " + token))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", APPLICATION_JSON)
+                        .withBody(json)));
+    }
+}

--- a/src/test/resources/pacts/publicapi-connector-cancel-already-canceled-payment.json
+++ b/src/test/resources/pacts/publicapi-connector-cancel-already-canceled-payment.json
@@ -1,0 +1,40 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "cancel an already canceled charge",
+      "providerStates": [
+        {
+          "name": "a canceled charge exists",
+          "params": {
+            "gateway_account_id": "123456",
+            "charge_id": "charge8133029783750964630"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/v1/api/accounts/123456/charges/charge8133029783750964630/cancel"
+      },
+      "response": {
+        "status": 400,
+        "body": {
+          "message": "Charge not in correct state to be processed, charge8133029783750964630"
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/alphagov/pay-endtoend/blob/3b6bab09049c4c712d897d1834060f7d527da125/src/test/java/uk/gov/pay/endtoend/tests/publicapi/CancelPaymentIT.java#L24
can be deleted. Refactoring the relevant test to a one pact one so we can have
confidence in deleting said e2e test.

Also did some minor refactoring.

@oswaldquek
