### PR TITLE
PP-4610 Swagger - Add authentication information to API docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -438,6 +438,14 @@
                             </info>
                             <swaggerDirectory>${basedir}/swagger</swaggerDirectory>
                             <outputFormats>json</outputFormats>
+                            <securityDefinitions>
+                                <securityDefinition>
+                                    <name>Authorisation</name>
+                                    <type>apiKey</type>
+                                    <in>header</in>
+                                    <description>The Authorisation token needs to be specified in the 'authorization' header as 'Authorization: Bearer YOUR_API_KEY_HERE'</description>
+                                </securityDefinition>
+                            </securityDefinitions>
                         </apiSource>
                     </apiSources>
                 </configuration>

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -9,6 +9,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,8 +25,8 @@ import uk.gov.pay.api.model.RefundFromConnector;
 import uk.gov.pay.api.model.RefundResponse;
 import uk.gov.pay.api.model.RefundsFromConnector;
 import uk.gov.pay.api.model.RefundsResponse;
-import uk.gov.pay.api.model.search.card.RefundResult;
 import uk.gov.pay.api.model.search.card.RefundForSearchResult;
+import uk.gov.pay.api.model.search.card.RefundResult;
 import uk.gov.pay.api.resources.error.ApiErrorResponse;
 
 import javax.inject.Inject;
@@ -90,7 +91,8 @@ public class PaymentRefundsResource {
             value = "Get all refunds for a payment",
             notes = "Return refunds for a payment. " +
                     "The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
-            code = 200)
+            code = 200,
+            authorizations = {@Authorization("Authorisation")})
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
@@ -127,7 +129,8 @@ public class PaymentRefundsResource {
             notes = "Return payment refund information by Refund ID " +
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
-            code = 200)
+            code = 200,
+            authorizations = {@Authorization("Authorisation")})
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
@@ -163,7 +166,9 @@ public class PaymentRefundsResource {
             value = "Submit a refund for a payment",
             notes = "Return issued refund information. " +
                     "The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
-            code = 202)
+            code = 202,
+            authorizations = {@Authorization("Authorisation")}
+    )
     @ApiResponses(value = {
             @ApiResponse(code = 202, message = "ACCEPTED"),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,7 +92,8 @@ public class PaymentsResource {
             notes = "Return information about the payment " +
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
-            code = 200)
+            code = 200,
+            authorizations = {@Authorization("Authorisation")})
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK", response = PaymentForSearchResult.class),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
@@ -119,7 +121,8 @@ public class PaymentsResource {
             notes = "Return payment events information about a certain payment " +
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
-            code = 200)
+            code = 200,
+            authorizations = {@Authorization("Authorisation")})
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK", response = PaymentEvents.class),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
@@ -165,7 +168,8 @@ public class PaymentsResource {
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             responseContainer = "List",
-            code = 200)
+            code = 200,
+            authorizations = {@Authorization("Authorisation")})
 
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK", response = PaymentSearchResults.class),
@@ -222,7 +226,8 @@ public class PaymentsResource {
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             code = 201,
-            nickname = "newPayment")
+            nickname = "newPayment",
+            authorizations = {@Authorization("Authorisation")})
     @ApiResponses(value = {
             @ApiResponse(code = 201, message = "Created", response = PaymentWithAllLinks.class),
             @ApiResponse(code = 400, message = "Bad request", response = PaymentError.class),
@@ -255,7 +260,8 @@ public class PaymentsResource {
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be cancelled if it's in " +
                     "a state that isn't finished.",
-            code = 204)
+            code = 204,
+            authorizations = {@Authorization("Authorisation")})
     @ApiResponses(value = {
             @ApiResponse(code = 204, message = "No Content"),
             @ApiResponse(code = 400, message = "Cancellation of payment failed", response = PaymentError.class),
@@ -283,7 +289,8 @@ public class PaymentsResource {
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be captured if it's in " +
                     "'submitted' state",
-            code = 204)
+            code = 204,
+            authorizations = {@Authorization("Authorisation")})
     @ApiResponses(value = {
             @ApiResponse(code = 204, message = "No Content"),
             @ApiResponse(code = 400, message = "Capture of payment failed", response = PaymentError.class),

--- a/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.auth.Account;
@@ -49,6 +50,7 @@ public class SearchRefundsResource {
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             responseContainer = "List",
+            authorizations = {@Authorization("Authorisation")},
             code = 200)
 
     @ApiResponses(value = {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -114,7 +114,10 @@
               "$ref" : "#/definitions/PaymentError"
             }
           }
-        }
+        },
+        "security" : [ {
+          "Authorisation" : [ ]
+        } ]
       },
       "post" : {
         "summary" : "Create new payment",
@@ -165,7 +168,10 @@
               "$ref" : "#/definitions/PaymentError"
             }
           }
-        }
+        },
+        "security" : [ {
+          "Authorisation" : [ ]
+        } ]
       }
     },
     "/v1/payments/{paymentId}" : {
@@ -208,7 +214,10 @@
               "$ref" : "#/definitions/PaymentError"
             }
           }
-        }
+        },
+        "security" : [ {
+          "Authorisation" : [ ]
+        } ]
       }
     },
     "/v1/payments/{paymentId}/cancel" : {
@@ -260,7 +269,10 @@
               "$ref" : "#/definitions/PaymentError"
             }
           }
-        }
+        },
+        "security" : [ {
+          "Authorisation" : [ ]
+        } ]
       }
     },
     "/v1/payments/{paymentId}/capture" : {
@@ -312,7 +324,10 @@
               "$ref" : "#/definitions/PaymentError"
             }
           }
-        }
+        },
+        "security" : [ {
+          "Authorisation" : [ ]
+        } ]
       }
     },
     "/v1/payments/{paymentId}/events" : {
@@ -355,7 +370,10 @@
               "$ref" : "#/definitions/PaymentError"
             }
           }
-        }
+        },
+        "security" : [ {
+          "Authorisation" : [ ]
+        } ]
       }
     },
     "/v1/payments/{paymentId}/refunds" : {
@@ -399,7 +417,10 @@
               "$ref" : "#/definitions/PaymentError"
             }
           }
-        }
+        },
+        "security" : [ {
+          "Authorisation" : [ ]
+        } ]
       },
       "post" : {
         "tags" : [ "refunds" ],
@@ -457,7 +478,10 @@
               "$ref" : "#/definitions/PaymentError"
             }
           }
-        }
+        },
+        "security" : [ {
+          "Authorisation" : [ ]
+        } ]
       }
     },
     "/v1/payments/{paymentId}/refunds/{refundId}" : {
@@ -506,7 +530,10 @@
               "$ref" : "#/definitions/PaymentError"
             }
           }
-        }
+        },
+        "security" : [ {
+          "Authorisation" : [ ]
+        } ]
       }
     },
     "/v1/refunds" : {
@@ -562,8 +589,18 @@
               "$ref" : "#/definitions/RefundError"
             }
           }
-        }
+        },
+        "security" : [ {
+          "Authorisation" : [ ]
+        } ]
       }
+    }
+  },
+  "securityDefinitions" : {
+    "Authorisation" : {
+      "type" : "apiKey",
+      "name" : "Authorisation",
+      "in" : "header"
     }
   },
   "definitions" : {


### PR DESCRIPTION
## WHAT YOU DID

- Adds authentication information to all API calls
- Can't represent the authentication information precisely ( `Authentication : Bearer [API_KEY]` ) as it is not supported in Swagger v2.0.0.
  (Migrating to open api v3.0.0 supports header with `Bearer` info, but we are not there)

