### PR TITLE
PP-4610 Swagger - Remove payment_id from refund details

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
@@ -56,7 +56,7 @@ public class RefundForSearchRefundsResult {
     }
 
     @JsonProperty("payment_id")
-    @ApiModelProperty(example = "2q1r18djndhsrm3closjqr81fx")
+    @ApiModelProperty(example = "2q1r18djndhsrm3closjqr81fx", hidden = true)
     public String getChargeId() {
         return chargeId;
     }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1274,11 +1274,6 @@
           "example" : "2017-01-10T16:52:07.855Z",
           "readOnly" : true
         },
-        "payment_id" : {
-          "type" : "string",
-          "example" : "2q1r18djndhsrm3closjqr81fx",
-          "readOnly" : true
-        },
         "amount" : {
           "type" : "integer",
           "format" : "int64",
@@ -1307,11 +1302,6 @@
         "created_date" : {
           "type" : "string",
           "example" : "2017-01-10T16:52:07.855Z",
-          "readOnly" : true
-        },
-        "payment_id" : {
-          "type" : "string",
-          "example" : "2q1r18djndhsrm3closjqr81fx",
           "readOnly" : true
         },
         "amount" : {


### PR DESCRIPTION
## WHAT YOU DID
- Removed `payment_id` from Refund detail as it is not currently included in actual refund API responses
