### PR TITLE
PP-4765 Allow double slashes in "return_url"

### DIFF
--- a/src/main/java/uk/gov/pay/api/validation/URLValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/URLValidator.java
@@ -1,15 +1,15 @@
 package uk.gov.pay.api.validation;
 
-
-import static org.apache.commons.validator.routines.UrlValidator.ALLOW_LOCAL_URLS;
-
 import org.apache.commons.validator.routines.DomainValidator;
 import org.apache.commons.validator.routines.DomainValidator.ArrayType;
 import org.apache.commons.validator.routines.UrlValidator;
 
-public enum URLValidator  {
+import static org.apache.commons.validator.routines.UrlValidator.ALLOW_2_SLASHES;
+import static org.apache.commons.validator.routines.UrlValidator.ALLOW_LOCAL_URLS;
+
+public enum URLValidator {
     SECURITY_ENABLED {
-        private final UrlValidator URL_VALIDATOR = new UrlValidator(new String[]{"https"}, ALLOW_LOCAL_URLS);
+        private final UrlValidator URL_VALIDATOR = new UrlValidator(new String[]{"https"}, ALLOW_LOCAL_URLS + ALLOW_2_SLASHES);
 
         @Override
         public boolean isValid(String value) {
@@ -17,7 +17,7 @@ public enum URLValidator  {
         }
 
     }, SECURITY_DISABLED {
-        private final UrlValidator URL_VALIDATOR = new UrlValidator(new String[]{"http", "https"}, ALLOW_LOCAL_URLS);
+        private final UrlValidator URL_VALIDATOR = new UrlValidator(new String[]{"http", "https"}, ALLOW_LOCAL_URLS + ALLOW_2_SLASHES);
 
         @Override
         public boolean isValid(String value) {

--- a/src/test/java/uk/gov/pay/api/validation/URLValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/URLValidatorTest.java
@@ -34,42 +34,42 @@ public class URLValidatorTest {
     }
 
     @Test
-    public void whenIsDisabledSecureConnection_httpUrlAreValid() throws Exception {
+    public void whenIsDisabledSecureConnection_httpUrlAreValid() {
         assertThat(SECURITY_DISABLED.isValid("http://my-valid-url.com"), is(true));
     }
 
     @Test
-    public void whenIsDisabledSecureConnection_allowingLocalUrl() throws Exception {
+    public void whenIsDisabledSecureConnection_allowingLocalUrl() {
         assertThat(SECURITY_DISABLED.isValid("http://localhost:8080/pay"), is(true));
     }
 
     @Test
-    public void whenIsDisabledSecureConnection_httpsUrlsAreValid() throws Exception {
+    public void whenIsDisabledSecureConnection_httpsUrlsAreValid() {
         assertThat(SECURITY_DISABLED.isValid("https://my-valid-url.com"), is(true));
     }
 
     @Test
-    public void whenIsDisabledSecureConnection_doubleSlashUrlsAreValid() throws Exception {
+    public void whenIsDisabledSecureConnection_doubleSlashUrlsAreValid() {
         assertThat(SECURITY_DISABLED.isValid("https://www.example.com/path-here//path-there"), is(true));
     }
 
     @Test
-    public void whenIsEnabledSecureConnection_httpUrlsAreNotValid() throws Exception {
+    public void whenIsEnabledSecureConnection_httpUrlsAreNotValid() {
         assertThat(SECURITY_ENABLED.isValid("http://my-valid-url.com"), is(false));
     }
 
     @Test
-    public void whenIsEnabledSecureConnection_httpsUrlsAreValid() throws Exception {
+    public void whenIsEnabledSecureConnection_httpsUrlsAreValid() {
         assertThat(SECURITY_ENABLED.isValid("https://my-valid-url.com"), is(true));
     }
 
     @Test
-    public void whenIsEnabledSecureConnection_allowingLocalUrl() throws Exception {
+    public void whenIsEnabledSecureConnection_allowingLocalUrl() {
         assertThat(SECURITY_ENABLED.isValid("https://localhost:8080/pay"), is(true));
     }
 
     @Test
-    public void whenIsEnabledSecureConnection_allowingLocalUrl_shouldFailForHttp() throws Exception {
+    public void whenIsEnabledSecureConnection_allowingLocalUrl_shouldFailForHttp() {
         assertThat(SECURITY_ENABLED.isValid("http://localhost:8080/pay"), is(false));
     }
 
@@ -84,7 +84,7 @@ public class URLValidatorTest {
     }
 
     @Test
-    public void whenIsEnabledSecureConnection_doubleSlashUrlsAreValid() throws Exception {
+    public void whenIsEnabledSecureConnection_doubleSlashUrlsAreValid() {
         assertThat(SECURITY_ENABLED.isValid("https://www.example.com/path-here//path-there"), is(true));
     }
 

--- a/src/test/java/uk/gov/pay/api/validation/URLValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/URLValidatorTest.java
@@ -7,7 +7,9 @@ import java.util.List;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static uk.gov.pay.api.validation.URLValidator.*;
+import static uk.gov.pay.api.validation.URLValidator.SECURITY_DISABLED;
+import static uk.gov.pay.api.validation.URLValidator.SECURITY_ENABLED;
+import static uk.gov.pay.api.validation.URLValidator.urlValidatorValueOf;
 
 public class URLValidatorTest {
 
@@ -47,6 +49,11 @@ public class URLValidatorTest {
     }
 
     @Test
+    public void whenIsDisabledSecureConnection_doubleSlashUrlsAreValid() throws Exception {
+        assertThat(SECURITY_DISABLED.isValid("https://www.example.com/path-here//path-there"), is(true));
+    }
+
+    @Test
     public void whenIsEnabledSecureConnection_httpUrlsAreNotValid() throws Exception {
         assertThat(SECURITY_ENABLED.isValid("http://my-valid-url.com"), is(false));
     }
@@ -74,6 +81,11 @@ public class URLValidatorTest {
     @Test
     public void whenIsEnabledSecureConnection_disallowingEvilDomains() {
         assertThat(SECURITY_ENABLED.isValid("https://an.evil/claim/pay/id/receiver"), is(false));
+    }
+
+    @Test
+    public void whenIsEnabledSecureConnection_doubleSlashUrlsAreValid() throws Exception {
+        assertThat(SECURITY_ENABLED.isValid("https://www.example.com/path-here//path-there"), is(true));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID

Allow double slashes in `return_url` by configuring `UrlValidator` to allow 2 slashes using `ALLOW_2_SLASHES` flag.

Related Zendesk ticket: https://govuk.zendesk.com/agent/tickets/3583119