### PR TITLE
PP-4610 Swagger - Fix API docs for `create & get` payment

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/Address.java
+++ b/src/main/java/uk/gov/pay/api/model/Address.java
@@ -51,7 +51,7 @@ public class Address {
         return city;
     }
 
-    @ApiModelProperty(example = "UK")
+    @ApiModelProperty(example = "GB")
     public String getCountry() {
         return country;
     }

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentResult.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentResult.java
@@ -1,0 +1,67 @@
+package uk.gov.pay.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import uk.gov.pay.api.model.links.PaymentLinks;
+import uk.gov.pay.commons.model.SupportedLanguage;
+
+import static uk.gov.pay.api.model.Payment.LINKS_JSON_ATTRIBUTE;
+
+/**
+ * Defines swagger specs for create payment
+ */
+@ApiModel
+public class CreatePaymentResult {
+
+    @JsonProperty
+    @ApiModelProperty(name = "amount", example = "1200")
+    private long amount;
+
+    @JsonProperty
+    @ApiModelProperty(dataType = "uk.gov.pay.api.model.PaymentState")
+    private PaymentState state;
+
+    @JsonProperty
+    @ApiModelProperty(example = "Your Service Description")
+    private String description;
+
+    @JsonProperty
+    @ApiModelProperty(example = "your-reference")
+    private String reference;
+
+    @JsonProperty
+    @ApiModelProperty(name = "language", access = "language", example = "en")
+    private SupportedLanguage language;
+
+    @JsonProperty
+    @ApiModelProperty(example = "hu20sqlact5260q2nanm0q8u93")
+    private String paymentId;
+
+    @JsonProperty
+    @ApiModelProperty(name = "payment_provider", example = "worldpay")
+    private String paymentProvider;
+
+    @JsonProperty
+    @ApiModelProperty(name = "return_url", example = "http://your.service.domain/your-reference")
+    private String returnUrl;
+
+    @JsonProperty
+    @ApiModelProperty(name = "created_date", example = "2016-01-21T17:15:00Z")
+    private String createdDate;
+
+    @JsonProperty
+    @ApiModelProperty(name = "delayed_capture", access = "delayed_capture")
+    private boolean delayedCapture;
+
+    @JsonProperty("refund_summary")
+    private RefundSummary refundSummary;
+
+    @JsonProperty("settlement_summary")
+    private SettlementSummary settlementSummary;
+
+    @JsonProperty
+    @ApiModelProperty(name = LINKS_JSON_ATTRIBUTE)
+    private PaymentLinks links;
+
+}

--- a/src/main/java/uk/gov/pay/api/model/Payment.java
+++ b/src/main/java/uk/gov/pay/api/model/Payment.java
@@ -50,7 +50,7 @@ public abstract class Payment {
         this.createdDate = createdDate;
     }
 
-    @ApiModelProperty(example = "2016-01-21T17:15:00Z")
+    @ApiModelProperty(example = "2016-01-21T17:15:000Z")
     public String getCreatedDate() {
         return createdDate;
     }

--- a/src/main/java/uk/gov/pay/api/model/RefundSummary.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundSummary.java
@@ -30,7 +30,7 @@ public class RefundSummary {
         return status;
     }
 
-    @ApiModelProperty(value = "Amount available for refund in pence")
+    @ApiModelProperty(value = "Amount available for refund in pence", example = "100")
     public long getAmountAvailable() {
         return amountAvailable;
     }

--- a/src/main/java/uk/gov/pay/api/model/SettlementSummary.java
+++ b/src/main/java/uk/gov/pay/api/model/SettlementSummary.java
@@ -22,7 +22,7 @@ public class SettlementSummary {
         this.capturedDate = capturedDate;
     }
 
-    @ApiModelProperty(value = "Date and time capture request has been submitted (may be null if capture request was not immediately acknowledged by payment gateway)", example = "2016-01-21T17:15:00Z")
+    @ApiModelProperty(value = "Date and time capture request has been submitted (may be null if capture request was not immediately acknowledged by payment gateway)", example = "2016-01-21T17:15:000Z")
     public String getCaptureSubmitTime() {
         return captureSubmitTime;
     }

--- a/src/main/java/uk/gov/pay/api/model/search/card/GetPaymentResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/GetPaymentResult.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.api.model.search.card;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import uk.gov.pay.api.model.CardDetails;
+import uk.gov.pay.api.model.CardPayment;
+import uk.gov.pay.api.model.PaymentState;
+import uk.gov.pay.api.model.RefundSummary;
+import uk.gov.pay.api.model.SettlementSummary;
+import uk.gov.pay.api.model.links.PaymentLinks;
+import uk.gov.pay.commons.model.SupportedLanguage;
+
+/**
+ * Defines swagger specs for Get payment
+ */
+@ApiModel
+public class GetPaymentResult extends CardPayment {
+
+    @JsonProperty(LINKS_JSON_ATTRIBUTE)
+    @ApiModelProperty(name = LINKS_JSON_ATTRIBUTE, dataType = "uk.gov.pay.api.model.links.PaymentLinks")
+    private PaymentLinks links;
+
+    public GetPaymentResult(String chargeId, long amount, PaymentState state, String returnUrl, String description, String reference, String email, String paymentProvider, String createdDate, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails, SupportedLanguage language, boolean delayedCapture, Long corporateCardSurcharge, Long totalAmount) {
+        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate, refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount);
+    }
+}

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -15,11 +15,12 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CaptureChargeException;
 import uk.gov.pay.api.exception.GetEventsException;
+import uk.gov.pay.api.model.CreatePaymentResult;
 import uk.gov.pay.api.model.PaymentError;
 import uk.gov.pay.api.model.PaymentEvents;
 import uk.gov.pay.api.model.ValidCreatePaymentRequest;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
-import uk.gov.pay.api.model.search.card.PaymentForSearchResult;
+import uk.gov.pay.api.model.search.card.GetPaymentResult;
 import uk.gov.pay.api.model.search.card.PaymentSearchResults;
 import uk.gov.pay.api.resources.error.ApiErrorResponse;
 import uk.gov.pay.api.service.CancelPaymentService;
@@ -95,13 +96,15 @@ public class PaymentsResource {
             code = 200,
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = PaymentForSearchResult.class),
+            @ApiResponse(code = 200, message = "OK", response = GetPaymentResult.class),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
             @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response getPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
-                               @PathParam("paymentId") String paymentId) {
+                               @PathParam("paymentId")
+                               @ApiParam(name = "paymentId", value = "Payment identifier", example = "hu20sqlact5260q2nanm0q8u93")
+                                       String paymentId) {
 
         logger.info("Payment request - paymentId={}", paymentId);
 
@@ -130,7 +133,9 @@ public class PaymentsResource {
             @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response getPaymentEvents(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
-                                     @PathParam("paymentId") String paymentId) {
+                                     @PathParam("paymentId")
+                                     @ApiParam(name = "paymentId", value = "Payment identifier", example = "hu20sqlact5260q2nanm0q8u93")
+                                             String paymentId) {
 
         logger.info("Payment events request - payment_id={}", paymentId);
 
@@ -229,7 +234,7 @@ public class PaymentsResource {
             nickname = "newPayment",
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "Created", response = PaymentWithAllLinks.class),
+            @ApiResponse(code = 201, message = "Created", response = CreatePaymentResult.class),
             @ApiResponse(code = 400, message = "Bad request", response = PaymentError.class),
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 422, message = "Invalid attribute value: description. Must be less than or equal to 255 characters length", response = PaymentError.class),
@@ -272,7 +277,9 @@ public class PaymentsResource {
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)
     })
     public Response cancelPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
-                                  @PathParam("paymentId") String paymentId) {
+                                  @PathParam("paymentId")
+                                  @ApiParam(name = "paymentId", value = "Payment identifier", example = "hu20sqlact5260q2nanm0q8u93")
+                                          String paymentId) {
 
         logger.info("Payment cancel request - payment_id=[{}]", paymentId);
 
@@ -301,7 +308,9 @@ public class PaymentsResource {
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)
     })
     public Response capturePayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
-                                   @PathParam("paymentId") String paymentId) {
+                                   @PathParam("paymentId")
+                                   @ApiParam(name = "paymentId", value = "Payment identifier", example = "hu20sqlact5260q2nanm0q8u93")
+                                           String paymentId) {
         logger.info("Payment capture request - payment_id=[{}]", paymentId);
 
         Response connectorResponse = capturePaymentService.capture(account, paymentId);

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -137,7 +137,7 @@
           "201" : {
             "description" : "Created",
             "schema" : {
-              "$ref" : "#/definitions/PaymentWithAllLinks"
+              "$ref" : "#/definitions/CreatePaymentResult"
             }
           },
           "400" : {
@@ -182,14 +182,16 @@
         "parameters" : [ {
           "name" : "paymentId",
           "in" : "path",
+          "description" : "Payment identifier",
           "required" : true,
-          "type" : "string"
+          "type" : "string",
+          "x-example" : "hu20sqlact5260q2nanm0q8u93"
         } ],
         "responses" : {
           "200" : {
             "description" : "OK",
             "schema" : {
-              "$ref" : "#/definitions/PaymentDetailForSearch"
+              "$ref" : "#/definitions/GetPaymentResult"
             }
           },
           "401" : {
@@ -228,8 +230,10 @@
         "parameters" : [ {
           "name" : "paymentId",
           "in" : "path",
+          "description" : "Payment identifier",
           "required" : true,
-          "type" : "string"
+          "type" : "string",
+          "x-example" : "hu20sqlact5260q2nanm0q8u93"
         } ],
         "responses" : {
           "204" : {
@@ -283,8 +287,10 @@
         "parameters" : [ {
           "name" : "paymentId",
           "in" : "path",
+          "description" : "Payment identifier",
           "required" : true,
-          "type" : "string"
+          "type" : "string",
+          "x-example" : "hu20sqlact5260q2nanm0q8u93"
         } ],
         "responses" : {
           "204" : {
@@ -338,8 +344,10 @@
         "parameters" : [ {
           "name" : "paymentId",
           "in" : "path",
+          "description" : "Payment identifier",
           "required" : true,
-          "type" : "string"
+          "type" : "string",
+          "x-example" : "hu20sqlact5260q2nanm0q8u93"
         } ],
         "responses" : {
           "200" : {
@@ -629,7 +637,7 @@
         },
         "country" : {
           "type" : "string",
-          "example" : "UK",
+          "example" : "GB",
           "readOnly" : true
         }
       },
@@ -669,56 +677,6 @@
         }
       },
       "description" : "A structure representing the payment card"
-    },
-    "CardPayment" : {
-      "allOf" : [ {
-        "$ref" : "#/definitions/Payment"
-      }, {
-        "type" : "object",
-        "properties" : {
-          "language" : {
-            "type" : "string",
-            "example" : "en",
-            "enum" : [ "en", "cy" ]
-          },
-          "refund_summary" : {
-            "readOnly" : true,
-            "$ref" : "#/definitions/RefundSummary"
-          },
-          "settlement_summary" : {
-            "readOnly" : true,
-            "$ref" : "#/definitions/SettlementSummary"
-          },
-          "card_details" : {
-            "readOnly" : true,
-            "$ref" : "#/definitions/CardDetails"
-          },
-          "delayed_capture" : {
-            "type" : "boolean",
-            "example" : false,
-            "description" : "delayed capture flag",
-            "readOnly" : true
-          },
-          "corporate_card_surcharge" : {
-            "type" : "integer",
-            "format" : "int64",
-            "example" : 250,
-            "readOnly" : true
-          },
-          "total_amount" : {
-            "type" : "integer",
-            "format" : "int64",
-            "example" : 1450,
-            "readOnly" : true
-          },
-          "card_brand" : {
-            "type" : "string",
-            "example" : "Visa",
-            "description" : "Card Brand",
-            "readOnly" : true
-          }
-        }
-      } ]
     },
     "CreatePaymentRequest" : {
       "type" : "object",
@@ -761,12 +719,59 @@
         }
       }
     },
-    "DirectDebitPayment" : {
-      "allOf" : [ {
-        "$ref" : "#/definitions/Payment"
-      }, {
-        "type" : "object"
-      } ]
+    "CreatePaymentResult" : {
+      "type" : "object",
+      "properties" : {
+        "amount" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 1200
+        },
+        "state" : {
+          "$ref" : "#/definitions/PaymentState"
+        },
+        "description" : {
+          "type" : "string",
+          "example" : "Your Service Description"
+        },
+        "reference" : {
+          "type" : "string",
+          "example" : "your-reference"
+        },
+        "language" : {
+          "type" : "string",
+          "example" : "en",
+          "enum" : [ "ENGLISH", "WELSH" ]
+        },
+        "paymentId" : {
+          "type" : "string",
+          "example" : "hu20sqlact5260q2nanm0q8u93"
+        },
+        "payment_provider" : {
+          "type" : "string",
+          "example" : "worldpay"
+        },
+        "return_url" : {
+          "type" : "string",
+          "example" : "http://your.service.domain/your-reference"
+        },
+        "created_date" : {
+          "type" : "string",
+          "example" : "2016-01-21T17:15:00Z"
+        },
+        "delayed_capture" : {
+          "type" : "boolean"
+        },
+        "_links" : {
+          "$ref" : "#/definitions/PaymentLinks"
+        },
+        "refund_summary" : {
+          "$ref" : "#/definitions/RefundSummary"
+        },
+        "settlement_summary" : {
+          "$ref" : "#/definitions/SettlementSummary"
+        }
+      }
     },
     "EmbeddedRefunds" : {
       "type" : "object",
@@ -793,25 +798,8 @@
       },
       "description" : "An error response"
     },
-    "Link" : {
+    "GetPaymentResult" : {
       "type" : "object",
-      "properties" : {
-        "href" : {
-          "type" : "string",
-          "example" : "https://an.example.link/from/payment/platform",
-          "readOnly" : true
-        },
-        "method" : {
-          "type" : "string",
-          "example" : "GET",
-          "readOnly" : true
-        }
-      },
-      "description" : "A link related to a payment"
-    },
-    "Payment" : {
-      "type" : "object",
-      "discriminator" : "paymentType",
       "properties" : {
         "amount" : {
           "type" : "integer",
@@ -833,6 +821,11 @@
           "type" : "string",
           "example" : "your email"
         },
+        "language" : {
+          "type" : "string",
+          "example" : "en",
+          "enum" : [ "en", "cy" ]
+        },
         "payment_id" : {
           "type" : "string",
           "example" : "hu20sqlact5260q2nanm0q8u93",
@@ -850,10 +843,65 @@
         },
         "created_date" : {
           "type" : "string",
-          "example" : "2016-01-21T17:15:00Z",
+          "example" : "2016-01-21T17:15:000Z",
+          "readOnly" : true
+        },
+        "refund_summary" : {
+          "readOnly" : true,
+          "$ref" : "#/definitions/RefundSummary"
+        },
+        "settlement_summary" : {
+          "readOnly" : true,
+          "$ref" : "#/definitions/SettlementSummary"
+        },
+        "card_details" : {
+          "readOnly" : true,
+          "$ref" : "#/definitions/CardDetails"
+        },
+        "delayed_capture" : {
+          "type" : "boolean",
+          "example" : false,
+          "description" : "delayed capture flag",
+          "readOnly" : true
+        },
+        "corporate_card_surcharge" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 250,
+          "readOnly" : true
+        },
+        "total_amount" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 1450,
+          "readOnly" : true
+        },
+        "_links" : {
+          "$ref" : "#/definitions/PaymentLinks"
+        },
+        "card_brand" : {
+          "type" : "string",
+          "example" : "Visa",
+          "description" : "Card Brand",
           "readOnly" : true
         }
       }
+    },
+    "Link" : {
+      "type" : "object",
+      "properties" : {
+        "href" : {
+          "type" : "string",
+          "example" : "https://an.example.link/from/payment/platform",
+          "readOnly" : true
+        },
+        "method" : {
+          "type" : "string",
+          "example" : "GET",
+          "readOnly" : true
+        }
+      },
+      "description" : "A link related to a payment"
     },
     "PaymentDetailForSearch" : {
       "type" : "object",
@@ -900,7 +948,7 @@
         },
         "created_date" : {
           "type" : "string",
-          "example" : "2016-01-21T17:15:00Z",
+          "example" : "2016-01-21T17:15:000Z",
           "readOnly" : true
         },
         "refund_summary" : {
@@ -1185,55 +1233,6 @@
       },
       "description" : "A structure representing the current state of the payment in its lifecycle."
     },
-    "PaymentWithAllLinks" : {
-      "type" : "object",
-      "properties" : {
-        "amount" : {
-          "type" : "integer",
-          "format" : "int64",
-          "example" : 1200
-        },
-        "state" : {
-          "$ref" : "#/definitions/PaymentState"
-        },
-        "description" : {
-          "type" : "string",
-          "example" : "Your Service Description"
-        },
-        "reference" : {
-          "type" : "string",
-          "example" : "your-reference"
-        },
-        "email" : {
-          "type" : "string",
-          "example" : "your email"
-        },
-        "payment_id" : {
-          "type" : "string",
-          "example" : "hu20sqlact5260q2nanm0q8u93",
-          "readOnly" : true
-        },
-        "payment_provider" : {
-          "type" : "string",
-          "example" : "worldpay",
-          "readOnly" : true
-        },
-        "return_url" : {
-          "type" : "string",
-          "example" : "http://your.service.domain/your-reference",
-          "readOnly" : true
-        },
-        "created_date" : {
-          "type" : "string",
-          "example" : "2016-01-21T17:15:00Z",
-          "readOnly" : true
-        },
-        "_links" : {
-          "readOnly" : true,
-          "$ref" : "#/definitions/PaymentLinks"
-        }
-      }
-    },
     "PostLink" : {
       "type" : "object",
       "properties" : {
@@ -1412,6 +1411,7 @@
         "amount_available" : {
           "type" : "integer",
           "format" : "int64",
+          "example" : 100,
           "description" : "Amount available for refund in pence",
           "readOnly" : true
         },
@@ -1455,7 +1455,7 @@
       "properties" : {
         "capture_submit_time" : {
           "type" : "string",
-          "example" : "2016-01-21T17:15:00Z",
+          "example" : "2016-01-21T17:15:000Z",
           "description" : "Date and time capture request has been submitted (may be null if capture request was not immediately acknowledged by payment gateway)",
           "readOnly" : true
         },


### PR DESCRIPTION
## WHAT YOU DID

- Includes fixes for Create payment and Get payment specs

_A brief description of the pull request:_

We currently use `PaymentWithAllLinks` & `PaymentDetailForSearch` to represent responses for `CreatePayment` & `GetPayment` API calls respectively. But these object doesn't represent actual responses from publicapi. 

Created new classes `CreatePaymentResult` & `GetPaymentResult` that represent actual responses from both endpoints and also included minor improvements to examples/descriptions


