### PR TITLE
Intellij fixups

### DIFF
--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
@@ -33,7 +33,7 @@ public class RedisRateLimiter {
     synchronized void checkRateOf(String key, String method)
             throws RedisException, RateLimitException {
 
-        Long count = null;
+        Long count;
 
         try {
             count = updateAllowance(key);

--- a/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
@@ -34,7 +34,7 @@ public class ValidCreatePaymentRequest {
     private Boolean delayedCapture;
 
     public ValidCreatePaymentRequest(CreatePaymentRequest createPaymentRequest) {
-        amount = Objects.requireNonNull(createPaymentRequest.getAmount());
+        amount = createPaymentRequest.getAmount();
         reference = Objects.requireNonNull(createPaymentRequest.getReference());
         description = Objects.requireNonNull(createPaymentRequest.getDescription());
 

--- a/src/test/java/uk/gov/pay/api/it/rule/RedisDockerRule.java
+++ b/src/test/java/uk/gov/pay/api/it/rule/RedisDockerRule.java
@@ -8,7 +8,6 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -48,7 +47,7 @@ public class RedisDockerRule implements TestRule {
                 DockerClient docker = DefaultDockerClient.fromEnv().build();
                 container = new RedisContainer(docker, host);
             }
-        } catch (DockerCertificateException | InterruptedException | IOException e) {
+        } catch (DockerCertificateException | InterruptedException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -305,7 +305,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
 
     public void respondRefundWithError(String gatewayAccountId, String chargeId, String refundId) {
         whenGetRefundById(gatewayAccountId, chargeId, refundId)
-                .respond(withStatusAndErrorMessage(INTERNAL_SERVER_ERROR_500, String.format("server error", refundId)));
+                .respond(withStatusAndErrorMessage(INTERNAL_SERVER_ERROR_500, "server error"));
 
     }
 


### PR DESCRIPTION
Address some things IntelliJ didn't like the look of.

Most of the attention was on `RedisContainer` where the `get()` from the `Map` of port mappings could throw a null. Add some guard code around that.

Remove some copypasta in `ConnectorMockClient` when constructing exceptions - we don't need `String.format()` here because we're passing a fixed string.