### PR TITLE
Pp 4862 Return the provider id

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -40,6 +40,7 @@ public class CardPayment extends Payment {
     private final Long totalAmount;
 
     @JsonProperty("provider_id")
+    @ApiModelProperty(example = "reference-from-payment-gateway")
     private final String providerId;
 
     public CardPayment(String chargeId, long amount, PaymentState state, String returnUrl, String description,

--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -39,14 +39,19 @@ public class CardPayment extends Payment {
     @JsonProperty("total_amount")
     private final Long totalAmount;
 
+    @JsonProperty("provider_id")
+    private final String providerId;
+
     public CardPayment(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                        String reference, String email, String paymentProvider, String createdDate,
                        RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
-                       SupportedLanguage language, boolean delayedCapture, Long corporateCardSurcharge, Long totalAmount) {
+                       SupportedLanguage language, boolean delayedCapture, Long corporateCardSurcharge, Long totalAmount, 
+                       String providerId) {
         super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate);
         this.refundSummary = refundSummary;
         this.settlementSummary = settlementSummary;
         this.cardDetails = cardDetails;
+        this.providerId = providerId;
         this.paymentType = CARD.getFriendlyName();
         this.language = language;
         this.delayedCapture = delayedCapture;
@@ -101,6 +106,10 @@ public class CardPayment extends Payment {
     public Optional<Long> getTotalAmount() {
         return Optional.ofNullable(totalAmount);
     }
+    
+    public String getProviderId() {
+        return providerId;
+    }
 
     @Override
     public String toString() {
@@ -119,5 +128,4 @@ public class CardPayment extends Payment {
                 ", createdDate='" + createdDate + '\'' +
                 '}';
     }
-
 }

--- a/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
@@ -60,6 +60,9 @@ public class ChargeFromResponse {
     @JsonProperty(value = "created_date")
     private String createdDate;
 
+    @JsonProperty(value = "gateway_transaction_id")
+    private String gatewayTransactionId;
+
     public String getChargeId() {
         return chargeId;
     }
@@ -137,5 +140,9 @@ public class ChargeFromResponse {
 
     public CardDetails getCardDetails() {
         return cardDetails;
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentResult.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentResult.java
@@ -64,4 +64,7 @@ public class CreatePaymentResult {
     @ApiModelProperty(name = LINKS_JSON_ATTRIBUTE)
     private PaymentLinks links;
 
+    @JsonProperty
+    @ApiModelProperty(example = "null")
+    private String providerId;
 }

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -44,9 +44,9 @@ public class PaymentWithAllLinks {
                                String reference, String email, String paymentProvider, String createdDate, SupportedLanguage language,
                                boolean delayedCapture, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
                                List<PaymentConnectorResponseLink> paymentConnectorResponseLinks, URI selfLink, URI paymentEventsUri, URI paymentCancelUri,
-                               URI paymentRefundsUri, URI paymentCaptureUri, Long corporateCardSurcharge, Long totalAmount) {
+                               URI paymentRefundsUri, URI paymentCaptureUri, Long corporateCardSurcharge, Long totalAmount, String providerId) {
         this.payment = new CardPayment(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate,
-                refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount);
+                refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount, providerId);
         this.links.addSelf(selfLink.toString());
         this.links.addKnownLinksValueOf(paymentConnectorResponseLinks);
         this.links.addEvents(paymentEventsUri.toString());
@@ -114,8 +114,8 @@ public class PaymentWithAllLinks {
                 paymentRefundsUri,
                 paymentsCaptureUri,
                 paymentConnector.getCorporateCardSurcharge(),
-                paymentConnector.getTotalAmount()
-        );
+                paymentConnector.getTotalAmount(),
+                paymentConnector.getGatewayTransactionId());
     }
 
     public static PaymentWithAllLinks getPaymentWithLinks(

--- a/src/main/java/uk/gov/pay/api/model/search/card/GetPaymentResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/GetPaymentResult.java
@@ -21,7 +21,13 @@ public class GetPaymentResult extends CardPayment {
     @ApiModelProperty(name = LINKS_JSON_ATTRIBUTE, dataType = "uk.gov.pay.api.model.links.PaymentLinks")
     private PaymentLinks links;
 
-    public GetPaymentResult(String chargeId, long amount, PaymentState state, String returnUrl, String description, String reference, String email, String paymentProvider, String createdDate, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails, SupportedLanguage language, boolean delayedCapture, Long corporateCardSurcharge, Long totalAmount) {
-        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate, refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount);
+    public GetPaymentResult(String chargeId, long amount, PaymentState state, String returnUrl, String description, 
+                            String reference, String email, String paymentProvider, String createdDate, 
+                            RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails, 
+                            SupportedLanguage language, boolean delayedCapture, Long corporateCardSurcharge, 
+                            Long totalAmount, String providerId) {
+        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate, 
+                refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, 
+                totalAmount, providerId);
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
@@ -26,9 +26,9 @@ public class PaymentForSearchResult extends CardPayment {
                                   String reference, String email, String paymentProvider, String createdDate, SupportedLanguage language,
                                   boolean delayedCapture, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
                                   List<PaymentConnectorResponseLink> links, URI selfLink, URI paymentEventsLink, URI paymentCancelLink, URI paymentRefundsLink, URI paymentCaptureUri,
-                                  Long corporateCardSurcharge, Long totalAmount) {
+                                  Long corporateCardSurcharge, Long totalAmount, String providerId) {
         super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider,
-                createdDate, refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount);
+                createdDate, refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount, providerId);
         this.links.addSelf(selfLink.toString());
         this.links.addEvents(paymentEventsLink.toString());
         this.links.addRefunds(paymentRefundsLink.toString());
@@ -71,7 +71,8 @@ public class PaymentForSearchResult extends CardPayment {
                 paymentRefundsLink,
                 paymentCaptureUri,
                 paymentResult.getCorporateCardSurcharge(),
-                paymentResult.getTotalAmount());
+                paymentResult.getTotalAmount(),
+                paymentResult.getGatewayTransactionId());
     }
 
     @ApiModelProperty(name = LINKS_JSON_ATTRIBUTE, dataType = "uk.gov.pay.api.model.links.PaymentLinksForSearch")

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentITest.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentITest.java
@@ -44,6 +44,7 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
     private static final Address BILLING_ADDRESS = new Address("line1", "line2", "NR2 5 6EG", "city", "UK");
     private static final CardDetails CARD_DETAILS = new CardDetails("1234", "123456", "Mr. Payment", "12/19", BILLING_ADDRESS, CARD_BRAND_LABEL);
     private static final String SUCCESS_PAYLOAD = paymentPayload(AMOUNT, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL);
+    private static final String GATEWAY_TRANSACTION_ID = "gateway-tx-123456";
 
     @Test
     public void createCardPayment() {
@@ -51,7 +52,7 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
 
         connectorMock.respondOk_whenCreateCharge(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID,
                 CREATED, RETURN_URL, DESCRIPTION, REFERENCE, null, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, true, REFUND_SUMMARY,
-                null, CARD_DETAILS);
+                null, CARD_DETAILS, GATEWAY_TRANSACTION_ID);
 
         String responseBody = postPaymentResponse(API_KEY, SUCCESS_PAYLOAD)
                 .statusCode(201)
@@ -68,6 +69,7 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
                 .body("card_brand", is(CARD_BRAND_LABEL))
                 .body("created_date", is(CREATED_DATE))
                 .body("delayed_capture", is(true))
+                .body("provider_id", is(GATEWAY_TRANSACTION_ID))
                 .body("refund_summary.status", is("pending"))
                 .body("refund_summary.amount_submitted", is(50))
                 .body("refund_summary.amount_available", is(100))
@@ -105,7 +107,7 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondOk_whenCreateCharge(minimumAmount, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID,
                 CREATED, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH,
-                false, REFUND_SUMMARY, null, CARD_DETAILS);
+                false, REFUND_SUMMARY, null, CARD_DETAILS, GATEWAY_TRANSACTION_ID);
 
         postPaymentResponse(API_KEY, paymentPayload(minimumAmount, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL))
                 .statusCode(201)
@@ -133,7 +135,7 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondOk_whenCreateCharge(amount, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID,
                 CREATED, return_url, description, reference, email, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH,
-                false, REFUND_SUMMARY, null, CARD_DETAILS);
+                false, REFUND_SUMMARY, null, CARD_DETAILS, GATEWAY_TRANSACTION_ID);
 
         String body = new JsonStringBuilder()
                 .add("amount", amount)

--- a/src/test/java/uk/gov/pay/api/it/GetPaymentITest.java
+++ b/src/test/java/uk/gov/pay/api/it/GetPaymentITest.java
@@ -50,6 +50,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
     private static final String RETURN_URL = "https://somewhere.gov.uk/rainbow/1";
     private static final String REFERENCE = "Some reference <script> alert('This is a ?{simple} XSS attack.')</script>";
     private static final String EMAIL = "alice.111@mail.fake";
+    private static final String GATEWAY_TRANSACTION_ID = "gateway-tx-123456";
     private static final String DESCRIPTION = "Some description <script> alert('This is a ?{simple} XSS attack.')</script>";
     private static final String CREATED_DATE = ISO_INSTANT_MILLISECOND_PRECISION.format(ZonedDateTime.parse("2010-12-31T22:59:59.132012345Z"));
     private static final Map<String, String> PAYMENT_CREATED = new ChargeEventBuilder(CREATED, CREATED_DATE).build();
@@ -62,8 +63,9 @@ public class GetPaymentITest extends PaymentResourceITestBase {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CAPTURED, RETURN_URL,
-                DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, true, CHARGE_TOKEN_ID, REFUND_SUMMARY, SETTLEMENT_SUMMARY,
-                CARD_DETAILS);
+                DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, 
+                true, CHARGE_TOKEN_ID, REFUND_SUMMARY, SETTLEMENT_SUMMARY,
+                CARD_DETAILS, GATEWAY_TRANSACTION_ID);
 
         getPaymentResponse(API_KEY, CHARGE_ID)
                 .statusCode(200)
@@ -80,6 +82,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
                 .body("created_date", is(CREATED_DATE))
                 .body("language", is("en"))
                 .body("delayed_capture", is(true))
+                .body("provider_id", is(GATEWAY_TRANSACTION_ID))
                 .body("refund_summary.status", is("pending"))
                 .body("refund_summary.amount_submitted", is(50))
                 .body("refund_summary.amount_available", is(100))
@@ -152,7 +155,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
 
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CAPTURED, RETURN_URL,
-                DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, true, CHARGE_TOKEN_ID, REFUND_SUMMARY, SETTLEMENT_SUMMARY, cardDetails);
+                DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, true, CHARGE_TOKEN_ID, REFUND_SUMMARY, SETTLEMENT_SUMMARY, cardDetails, GATEWAY_TRANSACTION_ID);
 
         getPaymentResponse(API_KEY, CHARGE_ID)
                 .statusCode(200)
@@ -168,7 +171,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID,
                 new PaymentState("success", true, null, null),
                 RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, false, CHARGE_TOKEN_ID, REFUND_SUMMARY,
-                null, CARD_DETAILS);
+                null, CARD_DETAILS, GATEWAY_TRANSACTION_ID);
 
         getPaymentResponse(API_KEY, CHARGE_ID)
                 .statusCode(200)
@@ -181,7 +184,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID,
                 CREATED, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, false, CHARGE_TOKEN_ID, REFUND_SUMMARY,
-                new SettlementSummary(null, null), CARD_DETAILS);
+                new SettlementSummary(null, null), CARD_DETAILS, GATEWAY_TRANSACTION_ID);
 
         getPaymentResponse(API_KEY, CHARGE_ID)
                 .statusCode(200)
@@ -202,7 +205,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CAPTURED, RETURN_URL,
                 DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH,
-                true, CHARGE_TOKEN_ID, REFUND_SUMMARY, SETTLEMENT_SUMMARY, cardDetails);
+                true, CHARGE_TOKEN_ID, REFUND_SUMMARY, SETTLEMENT_SUMMARY, cardDetails, GATEWAY_TRANSACTION_ID);
 
         getPaymentResponse(API_KEY, CHARGE_ID)
                 .statusCode(200)
@@ -322,7 +325,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
         publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CAPTURED, RETURN_URL,
                 DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH,
-                true, CHARGE_TOKEN_ID, REFUND_SUMMARY, SETTLEMENT_SUMMARY, CARD_DETAILS, 250L, AMOUNT + 250L);
+                true, CHARGE_TOKEN_ID, REFUND_SUMMARY, SETTLEMENT_SUMMARY, CARD_DETAILS, 250L, AMOUNT + 250L, GATEWAY_TRANSACTION_ID);
 
         getPaymentResponse(API_KEY, CHARGE_ID)
                 .statusCode(200)
@@ -337,7 +340,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, AWAITING_CAPTURE_REQUEST, RETURN_URL,
                 DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH,
                 true, CHARGE_TOKEN_ID, REFUND_SUMMARY, SETTLEMENT_SUMMARY, CARD_DETAILS,
-                0L, 0L);
+                0L, 0L, GATEWAY_TRANSACTION_ID);
 
         getPaymentResponse(API_KEY, CHARGE_ID)
                 .statusCode(200)

--- a/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
@@ -154,7 +154,7 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
                 ImmutableMap.of("amount", AMOUNT));
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, null, null, null, null, null,
                 null, null, SupportedLanguage.ENGLISH, false, null,
-                new RefundSummary("available", 9000, 1000), null, CARD_DETAILS);
+                new RefundSummary("available", 9000, 1000), null, CARD_DETAILS, "gatewayTransactionId");
 
         postRefundRequest(payload);
     }

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -77,6 +77,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .withDelayedCapture(true)
                         .withNumberOfResults(1)
                         .withEmail(TEST_EMAIL)
+                        .withGatewayTransactionId("gateway-tx-123456")
                         .getResults())
                 .build();
 
@@ -96,6 +97,7 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                 .body("results[0].payment_id", is("0"))
                 .body("results[0].language", is("en"))
                 .body("results[0].delayed_capture", is(true))
+                .body("results[0].provider_id", is("gateway-tx-123456"))
                 .body("results[0]._links.self.method", is("GET"))
                 .body("results[0]._links.self.href", is(paymentLocationFor(configuration.getBaseUrl(), "0")))
                 .body("results[0]._links.events.href", is(paymentEventsLocationFor("0")))

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterLocalRateLimiterITest.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterLocalRateLimiterITest.java
@@ -88,7 +88,7 @@ public class ResourcesFilterLocalRateLimiterITest {
 
         connectorMock.respondOk_whenCreateCharge(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID, CREATED,
                 RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH,
-                false, REFUND_SUMMARY, null, CARD_DETAILS);
+                false, REFUND_SUMMARY, null, CARD_DETAILS, null);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterITest.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterITest.java
@@ -22,7 +22,7 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
 
         connectorMock.respondOk_whenCreateCharge(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID, CREATED,
                 RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH,
-                false, REFUND_SUMMARY, null, CARD_DETAILS);
+                false, REFUND_SUMMARY, null, CARD_DETAILS, "gatewayTxId");
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> postPaymentResponse(API_KEY, PAYLOAD),
@@ -41,7 +41,7 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
 
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CREATED,
                 RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH,
-                false, CHARGE_TOKEN_ID, REFUND_SUMMARY, null, CARD_DETAILS, "gatewayTransactionId");
+                false, CHARGE_TOKEN_ID, REFUND_SUMMARY, null, CARD_DETAILS, null);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> getPaymentResponse(API_KEY, CHARGE_ID),

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterITest.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterITest.java
@@ -41,7 +41,7 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
 
         connectorMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CREATED,
                 RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH,
-                false, CHARGE_TOKEN_ID, REFUND_SUMMARY, null, CARD_DETAILS);
+                false, CHARGE_TOKEN_ID, REFUND_SUMMARY, null, CARD_DETAILS, "gatewayTransactionId");
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> getPaymentResponse(API_KEY, CHARGE_ID),

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
@@ -46,6 +46,11 @@ public class PaymentSearchResultBuilder extends PaymentResultBuilder {
         return this;
     }
 
+    public PaymentSearchResultBuilder withGatewayTransactionId(String gatewayTransactionId) {
+        this.gatewayTransactionId = gatewayTransactionId;
+        return this;
+    }
+
     public PaymentSearchResultBuilder withInProgressState(String status) {
         this.state = new TestPaymentState(status, false);
         return this;

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsRefundsResourceAmountValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsRefundsResourceAmountValidationITest.java
@@ -274,7 +274,7 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
 
         connectorMock.respondWithChargeFound(amount, GATEWAY_ACCOUNT_ID, externalChargeId, null, null, null, null,
                 null, null, null, SupportedLanguage.ENGLISH, false, null,
-                new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000), null, CARD_DETAILS);
+                new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000), null, CARD_DETAILS, "gatewayTransactionId");
         connectorMock.respondBadRequest_whenCreateARefund("full", amount, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, externalChargeId);
 
         String refundRequest = "{\"amount\":" + amount + "}";
@@ -298,7 +298,7 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
 
         connectorMock.respondWithChargeFound(amount, GATEWAY_ACCOUNT_ID, externalChargeId, null, null, null, null,
                 null, null, null, SupportedLanguage.ENGLISH, false, null,
-                new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000), null, CARD_DETAILS);
+                new RefundSummary("available", REFUND_AMOUNT_AVAILABLE, 1000), null, CARD_DETAILS, "gatewayTransactionId");
         connectorMock.respondBadRequest_whenCreateARefund("pending", amount, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, externalChargeId);
 
         String refundRequest = "{\"amount\":" + amount + "}";

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -125,7 +125,7 @@ public class PaymentsResourceCreatePaymentTest {
                 URI.create(paymentUri + "/refunds"),
                 URI.create(paymentUri + "/capture"),
                 null,
-                null
-        );
+                null,
+                "providerId");
     }
 }

--- a/src/test/java/uk/gov/pay/api/service/GetPaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentServiceTest.java
@@ -58,6 +58,16 @@ public class GetPaymentServiceTest {
 
     @Test
     @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector-get-payment-with-gateway-transaction-id"})
+    public void providerIdIsAvailableWhenPaymentIsSubmitted() {
+        Account account = new Account(ACCOUNT_ID, TokenPaymentType.CARD);
+        PaymentWithAllLinks paymentResponse = getPaymentService.getPayment(account, "ch_999abc456def");
+        CardPayment payment = (CardPayment) paymentResponse.getPayment();
+        assertThat(payment.getProviderId(), is("gateway-tx-123456"));
+    }
+
+    @Test
+    @PactVerification({"connector"})
     @Pacts(pacts = {"publicapi-connector-get-payment-with-delayed-capture-true"})
     public void testGetPayment() {
         Account account = new Account(ACCOUNT_ID, TokenPaymentType.CARD);

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -142,7 +142,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
     public void respondOk_whenCreateCharge(int amount, String gatewayAccountId, String chargeId, String chargeTokenId, PaymentState state, String returnUrl,
                                            String description, String reference, String email, String paymentProvider, String createdDate,
                                            SupportedLanguage language, boolean delayedCapture, RefundSummary refundSummary, SettlementSummary settlementSummary,
-                                           CardDetails cardDetails) {
+                                           CardDetails cardDetails, String gatewayTransactionId) {
 
         whenCreateCharge(amount, gatewayAccountId, returnUrl, description, reference)
                 .respond(response()
@@ -158,7 +158,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                                 reference,
                                 email,
                                 paymentProvider,
-                                null,
+                                gatewayTransactionId,
                                 createdDate,
                                 language,
                                 delayedCapture,

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -227,22 +227,22 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
     public void respondWithChargeFound(long amount, String gatewayAccountId, String chargeId, PaymentState state, String returnUrl,
                                        String description, String reference, String email, String paymentProvider, String createdDate,
                                        SupportedLanguage language, boolean delayedCapture, String chargeTokenId, RefundSummary refundSummary, SettlementSummary settlementSummary,
-                                       CardDetails cardDetails) {
+                                       CardDetails cardDetails, String gatewayTransactionId) {
         respondWithChargeFound(amount, gatewayAccountId, chargeId, state, returnUrl,
                 description, reference, email, paymentProvider, createdDate,
                 language, delayedCapture, chargeTokenId, refundSummary, settlementSummary,
-                cardDetails, null, null);
+                cardDetails, null, null, gatewayTransactionId);
     }
 
     public void respondWithChargeFound(long amount, String gatewayAccountId, String chargeId, PaymentState state, String returnUrl,
                                        String description, String reference, String email, String paymentProvider, String createdDate,
                                        SupportedLanguage language, boolean delayedCapture, String chargeTokenId, RefundSummary refundSummary, SettlementSummary settlementSummary,
-                                       CardDetails cardDetails, Long corporateCardSurcharge, Long totalAmount) {
+                                       CardDetails cardDetails, Long corporateCardSurcharge, Long totalAmount, String gatewayTransactionId) {
         String chargeResponseBody;
         
         if (AWAITING_CAPTURE_REQUEST == state) {
             chargeResponseBody = buildChargeResponse(amount, chargeId, state, returnUrl,
-                    description, reference, email, paymentProvider, gatewayAccountId, createdDate, language, delayedCapture,
+                    description, reference, email, paymentProvider, gatewayTransactionId, createdDate, language, delayedCapture,
                     corporateCardSurcharge, totalAmount, refundSummary, settlementSummary, cardDetails,
                     validGetLink(chargeLocation(gatewayAccountId, chargeId), "self"),
                     validGetLink(chargeLocation(gatewayAccountId, chargeId) + "/refunds", "refunds"),
@@ -250,7 +250,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                             new HashMap<>()));
         } else {
             chargeResponseBody = buildChargeResponse(amount, chargeId, state, returnUrl,
-                    description, reference, email, paymentProvider, gatewayAccountId, createdDate, language, delayedCapture,
+                    description, reference, email, paymentProvider, gatewayTransactionId, createdDate, language, delayedCapture,
                     corporateCardSurcharge, totalAmount, refundSummary, settlementSummary, cardDetails,
                     validGetLink(chargeLocation(gatewayAccountId, chargeId), "self"),
                     validGetLink(chargeLocation(gatewayAccountId, chargeId) + "/refunds", "refunds"),

--- a/src/test/resources/pacts/publicapi-connector-get-payment-with-gateway-transaction-id.json
+++ b/src/test/resources/pacts/publicapi-connector-get-payment-with-gateway-transaction-id.json
@@ -30,8 +30,8 @@
         "body": {
           "amount": 100,
           "state": {
-            "finished": false,
-            "status": "submitted"
+            "finished": true,
+            "status": "success"
           },
           "description": "Test description",
           "reference": "aReference",
@@ -46,11 +46,6 @@
               "rel": "refunds",
               "method": "GET",
               "href": "https://connector/v1/api/accounts/123456/charges/ch_999abc456def/refunds"
-            },
-            {
-              "rel": "capture",
-              "method": "POST",
-              "href": "https://connector/v1/api/accounts/123456/charges/ch_999abc456def/capture"
             }
           ],
           "charge_id": "ch_999abc456def",
@@ -59,7 +54,7 @@
           "payment_provider": "sandbox",
           "created_date": "2018-10-16T10:46:02.121Z",
           "refund_summary": {
-            "status": "unavailable",
+            "status": "available",
             "user_external_id": null,
             "amount_available": 100,
             "amount_submitted": 0
@@ -68,7 +63,7 @@
             "capture_submit_time": null,
             "captured_date": null
           },
-          "delayed_capture": true
+          "delayed_capture": false
         },
         "matchingRules": {
           "body": {

--- a/src/test/resources/pacts/publicapi-connector-get-payment-with-gateway-transaction-id.json
+++ b/src/test/resources/pacts/publicapi-connector-get-payment-with-gateway-transaction-id.json
@@ -1,0 +1,124 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "get a charge request with authorisation success state",
+      "providerStates": [
+        {
+          "name": "a charge with a gateway transaction id exists",
+          "params": {
+            "gateway_account_id": "123456",
+            "charge_id": "ch_999abc456def",
+            "gateway_transaction_id": "gateway-tx-123456"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/api/accounts/123456/charges/ch_999abc456def"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "amount": 100,
+          "state": {
+            "finished": false,
+            "status": "submitted"
+          },
+          "description": "Test description",
+          "reference": "aReference",
+          "language": "en",
+          "links": [
+            {
+              "rel": "self",
+              "method": "GET",
+              "href": "https://connector/v1/api/accounts/123456/charges/ch_999abc456def"
+            },
+            {
+              "rel": "refunds",
+              "method": "GET",
+              "href": "https://connector/v1/api/accounts/123456/charges/ch_999abc456def/refunds"
+            },
+            {
+              "rel": "capture",
+              "method": "POST",
+              "href": "https://connector/v1/api/accounts/123456/charges/ch_999abc456def/capture"
+            }
+          ],
+          "charge_id": "ch_999abc456def",
+          "gateway_transaction_id": "gateway-tx-123456",
+          "return_url": "https://somewhere.gov.uk/rainbow/1",
+          "payment_provider": "sandbox",
+          "created_date": "2018-10-16T10:46:02.121Z",
+          "refund_summary": {
+            "status": "unavailable",
+            "user_external_id": null,
+            "amount_available": 100,
+            "amount_submitted": 0
+          },
+          "settlement_summary": {
+            "capture_submit_time": null,
+            "captured_date": null
+          },
+          "delayed_capture": true
+        },
+        "matchingRules": {
+          "body": {
+            "$.reference": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.description": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.links[0].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/ch_999abc456def"
+                }
+              ]
+            },
+            "$.links[1].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/ch_999abc456def\/refunds"
+                }
+              ]
+            },
+            "$.links[2].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/ch_999abc456def\/capture"
+                }
+              ]
+            },
+            "$.return_url": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.created_date": {
+              "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
+            },
+            "$.refund_summary.amount_available": {
+              "matchers": [{"match": "type"}]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-cardholder-name.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-cardholder-name.json
@@ -7,7 +7,7 @@
   },
   "interactions": [
     {
-      "description": "a search payment request",
+      "description": "search payment by cardholder name",
       "providerStates": [
         {
           "name": "a charge with card details exists",

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-first-digits-card-number.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-first-digits-card-number.json
@@ -7,7 +7,7 @@
   },
   "interactions": [
     {
-      "description": "a search payment request",
+      "description": "search payment by first digits card number",
       "providerStates": [
         {
           "name": "a charge with card details exists",

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-first-digits-card-number.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-first-digits-card-number.json
@@ -16,7 +16,8 @@
             "gateway_account_id": "123456",
             "cardholder_name": "Mr Payment",
             "first_digits_card_number": "123456",
-            "last_digits_card_number": "1234"
+            "last_digits_card_number": "1234",
+            "gateway_transaction_id": "txId-1234"
           }
         }
       ],
@@ -74,6 +75,7 @@
                 }
               ],
               "charge_id": "charge8133029783750964639",
+              "gateway_transaction_id": "txId-1234",
               "return_url": "aReturnUrl",
               "email": "test@test.com",
               "payment_provider": "sandbox",

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-last-digits-card-number.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-last-digits-card-number.json
@@ -16,7 +16,8 @@
             "gateway_account_id": "123456",
             "cardholder_name": "Mr Payment",
             "first_digits_card_number": "123456",
-            "last_digits_card_number": "1234"
+            "last_digits_card_number": "1234",
+            "gateway_transaction_id": "txId-1234"
           }
         }
       ],
@@ -74,6 +75,7 @@
                 }
               ],
               "charge_id": "charge8133029783750964639",
+              "gateway_transaction_id": "txId-1234",
               "return_url": "aReturnUrl",
               "email": "test@test.com",
               "payment_provider": "sandbox",

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-last-digits-card-number.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-last-digits-card-number.json
@@ -7,7 +7,7 @@
   },
   "interactions": [
     {
-      "description": "a search payment request",
+      "description": "search payment by last digits card number",
       "providerStates": [
         {
           "name": "a charge with card details exists",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -876,6 +876,10 @@
           "example" : 1450,
           "readOnly" : true
         },
+        "provider_id" : {
+          "type" : "string",
+          "readOnly" : true
+        },
         "_links" : {
           "$ref" : "#/definitions/PaymentLinks"
         },
@@ -979,6 +983,10 @@
           "type" : "integer",
           "format" : "int64",
           "example" : 1450,
+          "readOnly" : true
+        },
+        "provider_id" : {
+          "type" : "string",
           "readOnly" : true
         },
         "_links" : {


### PR DESCRIPTION
Return the provider id (also known as the gateway transaction id in connector) when getting / searching payment(s).

Depends on https://github.com/alphagov/pay-connector/pull/1107