### PR TITLE
PP-4862 Fix API specs for paymentId, providerId

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentResult.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentResult.java
@@ -35,7 +35,7 @@ public class CreatePaymentResult {
     private SupportedLanguage language;
 
     @JsonProperty
-    @ApiModelProperty(example = "hu20sqlact5260q2nanm0q8u93")
+    @ApiModelProperty(name = "payment_id", example = "hu20sqlact5260q2nanm0q8u93")
     private String paymentId;
 
     @JsonProperty
@@ -65,6 +65,6 @@ public class CreatePaymentResult {
     private PaymentLinks links;
 
     @JsonProperty
-    @ApiModelProperty(example = "null")
+    @ApiModelProperty(name = "provider_id", example = "null")
     private String providerId;
 }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -743,7 +743,7 @@
           "example" : "en",
           "enum" : [ "ENGLISH", "WELSH" ]
         },
-        "paymentId" : {
+        "payment_id" : {
           "type" : "string",
           "example" : "hu20sqlact5260q2nanm0q8u93"
         },
@@ -764,6 +764,10 @@
         },
         "_links" : {
           "$ref" : "#/definitions/PaymentLinks"
+        },
+        "provider_id" : {
+          "type" : "string",
+          "example" : "null"
         },
         "refund_summary" : {
           "$ref" : "#/definitions/RefundSummary"
@@ -878,6 +882,7 @@
         },
         "provider_id" : {
           "type" : "string",
+          "example" : "reference-from-payment-gateway",
           "readOnly" : true
         },
         "_links" : {
@@ -987,6 +992,7 @@
         },
         "provider_id" : {
           "type" : "string",
+          "example" : "reference-from-payment-gateway",
           "readOnly" : true
         },
         "_links" : {


### PR DESCRIPTION
## WHAT YOU DID
- paymentId, providerId are currently generated as-is as @JsonPropery/@ApiModelProperty doesn't name the fields explicitly.

