### PR TITLE
Stylistic improvements to tests

### DIFF
--- a/src/test/java/uk/gov/pay/api/it/PaymentsCancelResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsCancelResourceITest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.api.it;
 
 import com.jayway.jsonassert.JsonAssert;
 import com.jayway.restassured.response.ValidatableResponse;
-import org.hamcrest.core.Is;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -13,6 +12,7 @@ import static com.jayway.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.eclipse.jetty.http.HttpStatus.CONFLICT_409;
 import static org.eclipse.jetty.http.HttpStatus.LENGTH_REQUIRED_411;
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.Matchers.hasSize;
 
 public class PaymentsCancelResourceITest extends PaymentResourceITestBase {
@@ -51,8 +51,8 @@ public class PaymentsCancelResourceITest extends PaymentResourceITestBase {
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(2))
-                .assertThat("$.code", Is.is("P0500"))
-                .assertThat("$.description", Is.is("Not found"));
+                .assertThat("$.code", is("P0500"))
+                .assertThat("$.description", is("Not found"));
     }
 
     @Test
@@ -67,8 +67,8 @@ public class PaymentsCancelResourceITest extends PaymentResourceITestBase {
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(2))
-                .assertThat("$.code", Is.is("P0502"))
-                .assertThat("$.description", Is.is("Cancellation of payment failed"));
+                .assertThat("$.code", is("P0502"))
+                .assertThat("$.description", is("Cancellation of payment failed"));
     }
 
     @Test
@@ -83,8 +83,8 @@ public class PaymentsCancelResourceITest extends PaymentResourceITestBase {
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(2))
-                .assertThat("$.code", Is.is("P0598"))
-                .assertThat("$.description", Is.is("Downstream system error"));
+                .assertThat("$.code", is("P0598"))
+                .assertThat("$.description", is("Downstream system error"));
     }
 
     private ValidatableResponse postCancelPaymentResponse(String paymentId) {

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceCaptureITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceCaptureITest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.api.it;
 
 import com.jayway.jsonassert.JsonAssert;
 import com.jayway.restassured.response.ValidatableResponse;
-import org.hamcrest.core.Is;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -13,6 +12,7 @@ import static com.jayway.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.eclipse.jetty.http.HttpStatus.CONFLICT_409;
 import static org.eclipse.jetty.http.HttpStatus.LENGTH_REQUIRED_411;
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.Matchers.hasSize;
 
 public class PaymentsResourceCaptureITest extends PaymentResourceITestBase {
@@ -51,8 +51,8 @@ public class PaymentsResourceCaptureITest extends PaymentResourceITestBase {
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(2))
-                .assertThat("$.code", Is.is("P1001"))
-                .assertThat("$.description", Is.is("Capture of payment failed"));
+                .assertThat("$.code", is("P1001"))
+                .assertThat("$.description", is("Capture of payment failed"));
     }
 
     @Test
@@ -67,8 +67,8 @@ public class PaymentsResourceCaptureITest extends PaymentResourceITestBase {
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(2))
-                .assertThat("$.code", Is.is("P1000"))
-                .assertThat("$.description", Is.is("Not found"));
+                .assertThat("$.code", is("P1000"))
+                .assertThat("$.description", is("Not found"));
     }
 
     @Test
@@ -83,8 +83,8 @@ public class PaymentsResourceCaptureITest extends PaymentResourceITestBase {
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(2))
-                .assertThat("$.code", Is.is("P1003"))
-                .assertThat("$.description", Is.is("Payment cannot be captured"));
+                .assertThat("$.code", is("P1003"))
+                .assertThat("$.description", is("Payment cannot be captured"));
     }
 
     @Test
@@ -99,8 +99,8 @@ public class PaymentsResourceCaptureITest extends PaymentResourceITestBase {
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(2))
-                .assertThat("$.code", Is.is("P1098"))
-                .assertThat("$.description", Is.is("Downstream system error"));
+                .assertThat("$.code", is("P1098"))
+                .assertThat("$.description", is("Downstream system error"));
     }
 
     private ValidatableResponse postCapturePaymentResponse(String paymentId) {

--- a/src/test/java/uk/gov/pay/api/resources/HealthCheckResourceTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/HealthCheckResourceTest.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.jayway.jsonassert.JsonAssert;
 import io.dropwizard.setup.Environment;
-import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,16 +43,19 @@ public class HealthCheckResourceTest {
         SortedMap<String,HealthCheck.Result> map = new TreeMap<>();
         map.put("ping", HealthCheck.Result.unhealthy("application is unavailable"));
         map.put("deadlocks", HealthCheck.Result.unhealthy("no new threads available"));
+
         when(healthCheckRegistry.runHealthChecks()).thenReturn(map);
+
         Response response = resource.healthCheck();
+
         assertThat(response.getStatus(), is(503));
+
         ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
         String body = ow.writeValueAsString(response.getEntity());
-
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(2))
-                .assertThat("$.ping.healthy", Is.is(false))
-                .assertThat("$.deadlocks.healthy", Is.is(false));
+                .assertThat("$.ping.healthy", is(false))
+                .assertThat("$.deadlocks.healthy", is(false));
     }
 
     @Test
@@ -61,33 +63,41 @@ public class HealthCheckResourceTest {
         SortedMap<String,HealthCheck.Result> map = new TreeMap<>();
         map.put("ping", HealthCheck.Result.healthy());
         map.put("deadlocks", HealthCheck.Result.healthy());
+
         when(healthCheckRegistry.runHealthChecks()).thenReturn(map);
+
         Response response = resource.healthCheck();
+
         assertThat(response.getStatus(), is(200));
+
         ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
         String body = ow.writeValueAsString(response.getEntity());
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(2))
-                .assertThat("$.ping.healthy", Is.is(true))
-                .assertThat("$.deadlocks.healthy", Is.is(true));
+                .assertThat("$.ping.healthy", is(true))
+                .assertThat("$.deadlocks.healthy", is(true));
     }
 
     @Test
-    public void checkHealthCheck_pingIsHealthy_deadlocksIsUnhealthy() throws JsonProcessingException {
+    public void checkHealthCheck_isUnhealthyIfPartiallyHealthy() throws JsonProcessingException {
         SortedMap<String,HealthCheck.Result> map = new TreeMap<>();
         map.put("ping", HealthCheck.Result.healthy());
         map.put("deadlocks", HealthCheck.Result.unhealthy("no new threads available"));
+
         when(healthCheckRegistry.runHealthChecks()).thenReturn(map);
+
         Response response = resource.healthCheck();
+
         assertThat(response.getStatus(), is(503));
+
         ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
         String body = ow.writeValueAsString(response.getEntity());
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(2))
-                .assertThat("$.ping.healthy", Is.is(true))
-                .assertThat("$.deadlocks.healthy", Is.is(false));
+                .assertThat("$.ping.healthy", is(true))
+                .assertThat("$.deadlocks.healthy", is(false));
     }
 
 }


### PR DESCRIPTION
HealthCheckResourceTest was taken across to pay-cardid and some improvements
were made there. Bring those improvements home.

Also, statically import hamcrest's `Is.is` in the two other tests which didn't.