### PR TITLE
Firebreak - Swagger validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,12 @@
             <artifactId>mockserver-netty</artifactId>
             <version>${mockserver.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.fge</groupId>
+                    <artifactId>json-schema-validator</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>
@@ -293,6 +299,26 @@
             <version>2.3.1</version>
             <scope>compile</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.atlassian.oai</groupId>
+            <artifactId>swagger-request-validator-restassured</artifactId>
+            <version>2.2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.atlassian.oai</groupId>
+            <artifactId>swagger-request-validator-pact</artifactId>
+            <version>2.2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>au.com.dius</groupId>
+            <artifactId>pact-jvm-provider_2.12</artifactId>
+            <version>3.5.24</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
@@ -80,15 +80,15 @@ public abstract class PaymentResourceITestBase {
         return "http://localhost:" + publicAuthMockRule.getPort() + "/v1/auth";
     }
 
-    String frontendUrlFor(TokenPaymentType paymentType) {
+    protected String frontendUrlFor(TokenPaymentType paymentType) {
         return "http://frontend_" + paymentType.toString().toLowerCase() + "/charge/";
     }
     
-    String paymentEventsLocationFor(String chargeId) {
+    protected String paymentEventsLocationFor(String chargeId) {
         return paymentLocationFor(configuration.getBaseUrl(), chargeId) + "/events";
     }
 
-    String paymentRefundsLocationFor(String chargeId) {
+    protected String paymentRefundsLocationFor(String chargeId) {
         return paymentLocationFor(configuration.getBaseUrl(), chargeId) + "/refunds";
     }
 
@@ -96,7 +96,7 @@ public abstract class PaymentResourceITestBase {
         return "http://publicapi.url" + PAYMENTS_PATH + chargeId + "/refunds/" + refundId;
     }
 
-    String paymentCancelLocationFor(String chargeId) {
+    protected String paymentCancelLocationFor(String chargeId) {
         return paymentLocationFor(configuration.getBaseUrl(), chargeId) + "/cancel";
     }
 

--- a/src/test/java/uk/gov/pay/api/swagger/SimpleRequestCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/swagger/SimpleRequestCreatePaymentTest.java
@@ -1,0 +1,64 @@
+package uk.gov.pay.api.swagger;
+
+import com.atlassian.oai.validator.OpenApiInteractionValidator;
+import com.atlassian.oai.validator.model.Request;
+import com.atlassian.oai.validator.model.Response;
+import com.atlassian.oai.validator.model.SimpleRequest;
+import com.atlassian.oai.validator.model.SimpleResponse;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static io.dropwizard.testing.FixtureHelpers.fixture;
+import static org.junit.Assert.assertEquals;
+
+public class SimpleRequestCreatePaymentTest {
+
+    private static Logger logger = LoggerFactory.getLogger(SimpleRequestCreatePaymentTest.class);
+
+    private final OpenApiInteractionValidator classUnderTest =
+            OpenApiInteractionValidator.createFor("swagger/swagger.json").build();
+    private final SimpleResponse okResponse = SimpleResponse.Builder.ok().build();
+
+    @Test
+    public void testSearchPayments() {
+
+        final Request request = SimpleRequest.Builder
+                .get("/v1/payments")
+                .withAuthorization("auth-key")
+                .withAccept("application/json")
+                .build();
+
+        final Response response = SimpleResponse.Builder
+                .ok()
+                .withContentType("application/json")
+                .withBody(load("responses/search-payments.json"))
+                .build();
+
+        assertEquals(0, classUnderTest.validate(request, okResponse).getMessages().size());
+
+        assertValidResponse(classUnderTest, response);
+        assertEquals(0,
+                classUnderTest.validateResponse("/v1/payments",
+                        Request.Method.GET, response).getMessages().size());
+    }
+
+    private void assertValidResponse(OpenApiInteractionValidator classUnderTest, Response response) {
+
+        List msg = classUnderTest.validateResponse("/v1/payments",
+                Request.Method.GET, response).getMessages();
+
+        if (!msg.isEmpty()) {
+            for (Object m : msg) {
+                System.out.println(m);
+            }
+        }
+        assertEquals(0, msg.size());
+    }
+
+    private static String load(String location) {
+        return fixture(location);
+    }
+}

--- a/src/test/java/uk/gov/pay/api/swagger/api/CreateNewPaymentITest.java
+++ b/src/test/java/uk/gov/pay/api/swagger/api/CreateNewPaymentITest.java
@@ -1,0 +1,119 @@
+package uk.gov.pay.api.swagger.api;
+
+import com.atlassian.oai.validator.model.Response;
+import com.atlassian.oai.validator.restassured.OpenApiValidationFilter;
+import com.atlassian.oai.validator.restassured.RestAssuredResponse;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.restassured.response.ValidatableResponse;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.pay.api.it.PaymentResourceITestBase;
+import uk.gov.pay.api.model.Address;
+import uk.gov.pay.api.model.CardDetails;
+import uk.gov.pay.api.model.PaymentState;
+import uk.gov.pay.api.model.RefundSummary;
+import uk.gov.pay.api.utils.DateTimeUtils;
+import uk.gov.pay.api.utils.JsonStringBuilder;
+import uk.gov.pay.commons.model.SupportedLanguage;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import static com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder.responseDefinition;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static uk.gov.pay.api.model.TokenPaymentType.CARD;
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
+
+public class CreateNewPaymentITest extends PaymentResourceITestBase {
+
+    private final OpenApiValidationFilter validationFilter = new OpenApiValidationFilter("swagger/swagger.json");
+
+    private static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
+    private static final int AMOUNT = 9999999;
+    private static final String CHARGE_ID = "ch_ab2341da231434l";
+    private static final String CHARGE_TOKEN_ID = "token_1234567asdf";
+    private static final PaymentState CREATED = new PaymentState("created", false, null, null);
+    private static final RefundSummary REFUND_SUMMARY = new RefundSummary("pending", 100L, 50L);
+    private static final String PAYMENT_PROVIDER = "Sandbox";
+    private static final String CARD_BRAND_LABEL = "Mastercard";
+    private static final String RETURN_URL = "https://somewhere.gov.uk/rainbow/1";
+    private static final String REFERENCE = "Some reference <script> alert('This is a ?{simple} XSS attack.')</script>";
+    private static final String EMAIL = "alice.111@mail.fake";
+    private static final String DESCRIPTION = "Some description <script> alert('This is a ?{simple} XSS attack.')</script>";
+    private static final String CREATED_DATE = ISO_INSTANT_MILLISECOND_PRECISION.format(TIMESTAMP);
+    private static final Address BILLING_ADDRESS = new Address("line1", "line2", "NR2 5 6EG", "city", "UK");
+    private static final CardDetails CARD_DETAILS = new CardDetails("1234", "123456", "Mr. Payment", "12/19", BILLING_ADDRESS, CARD_BRAND_LABEL);
+    private static final String SUCCESS_PAYLOAD = paymentPayload(AMOUNT, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL);
+    private static final String GATEWAY_TRANSACTION_ID = "gateway-tx-123456";
+
+    @Rule
+    public WireMockRule wireMock = new WireMockRule();
+
+    @Before
+    public void setup() {
+        super.setup();
+    }
+
+    @Test
+    public void createCardPayment() {
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, CARD);
+
+        connectorMock.respondOk_whenCreateCharge(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CHARGE_TOKEN_ID,
+                CREATED, RETURN_URL, DESCRIPTION, REFERENCE, null, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH, true, REFUND_SUMMARY,
+                null, null, GATEWAY_TRANSACTION_ID);
+
+        postPaymentResponse(API_KEY, SUCCESS_PAYLOAD)
+                .statusCode(201);
+
+    }
+
+
+    @Test
+    public void responseHeadersAreMappedCorrectly() {
+
+        wireMock.stubFor(any(anyUrl()).willReturn(responseDefinition().withHeader("custom-header", "0").withStatus(200)));
+
+        final Response response = RestAssuredResponse.of(given()
+                .port(wireMock.port())
+                .when()
+                .get("/path")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .extract()
+                .response());
+
+        assertThat("custom-header must be preserved", response.getHeaderValue("custom-header"), is(Optional.of("0")));
+        assertThat("ContentType must be empty", response.getContentType(), is(Optional.empty()));
+
+    }
+
+    private static String paymentPayload(long amount, String returnUrl, String description, String reference, String email) {
+        return new JsonStringBuilder()
+                .add("amount", amount)
+                .add("reference", reference)
+//                .add("email", email)
+                .add("description", description)
+                .add("return_url", returnUrl)
+                .build();
+    }
+
+    private ValidatableResponse postPaymentResponse(String bearerToken, String payload) {
+        return given().port(app.getLocalPort())
+                .filter(validationFilter)
+                .body(payload)
+                .accept(JSON)
+                .contentType(JSON)
+                .header(AUTHORIZATION, "Bearer " + bearerToken)
+                .post(PAYMENTS_PATH)
+                .then();
+    }
+
+}

--- a/src/test/java/uk/gov/pay/api/swagger/pact/CreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/swagger/pact/CreatePaymentTest.java
@@ -1,0 +1,47 @@
+package uk.gov.pay.api.swagger.pact;
+
+import com.atlassian.oai.validator.pact.PactProviderValidationResults;
+import com.atlassian.oai.validator.pact.PactProviderValidator;
+import org.junit.Test;
+
+import java.net.URL;
+
+import static org.junit.Assert.fail;
+
+/**
+ * An example Pact Provider test that uses the {@link PactProviderValidator} to validate consumer Pacts
+ * against a service Swagger API specification.
+ */
+public class CreatePaymentTest {
+
+    public static final String SWAGGER_JSON_URL = "swagger/swagger.json";
+
+    /**
+     * This test simulates running against a Consumer where all interactions in the Pact spec are valid according
+     * to the Swagger API spec.
+     */
+    @Test
+    public void validate_withLocalPact_withValidInteractions() {
+
+        final PactProviderValidator validator = PactProviderValidator
+                .createFor(SWAGGER_JSON_URL)
+                .withConsumer("ExampleConsumer", pactUrl("valid-create-payment.json"))
+                .build();
+
+        assertNoBreakingChanges(validator.validate());
+
+    }
+    private URL pactUrl(final String name) {
+        return getClass().getResource("/pacts/" + name);
+    }
+
+    private void assertNoBreakingChanges(final PactProviderValidationResults results) {
+
+        if (results != null && results.hasErrors()) {
+            final StringBuilder msg = new StringBuilder("Validation errors found.\n\t");
+            msg.append(results.getValidationFailureReport().replace("\n", "\n\t"));
+            fail(msg.toString());
+        }
+    }
+
+}

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -74,7 +74,6 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                 .withChargeId(chargeId)
                 .withAmount(amount)
                 .withMatchingReference(reference)
-                .withEmail(email)
                 .withDescription(description)
                 .withState(state)
                 .withReturnUrl(returnUrl)
@@ -84,8 +83,15 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                 .withDelayedCapture(delayedCapture)
                 .withLinks(asList(links))
                 .withRefundSummary(refundSummary)
-                .withSettlementSummary(settlementSummary)
-                .withCardDetails(cardDetails);
+                .withSettlementSummary(settlementSummary);
+
+        if (cardDetails != null) {
+            resultBuilder.withCardDetails(cardDetails);
+        }
+
+        if (email != null) {
+            resultBuilder.withEmail(email);
+        }
 
         if (gatewayTransactionId != null) {
             resultBuilder.withGatewayTransactionId(gatewayTransactionId);
@@ -130,7 +136,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
     String nextUrlPost() {
         return "http://frontend_card/charge/";
     }
-    
+
     String captureUrlPost() {
         return "http:///";
     }
@@ -239,7 +245,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                                        SupportedLanguage language, boolean delayedCapture, String chargeTokenId, RefundSummary refundSummary, SettlementSummary settlementSummary,
                                        CardDetails cardDetails, Long corporateCardSurcharge, Long totalAmount, String gatewayTransactionId) {
         String chargeResponseBody;
-        
+
         if (AWAITING_CAPTURE_REQUEST == state) {
             chargeResponseBody = buildChargeResponse(amount, chargeId, state, returnUrl,
                     description, reference, email, paymentProvider, gatewayTransactionId, createdDate, language, delayedCapture,
@@ -382,7 +388,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                 .withBody(createChargePayload(amount, returnUrl, description, reference))
         );
     }
-    
+
     private ForwardChainExpectation whenCreateRefund(int amount, int refundAmountAvailable, String gatewayAccountId, String chargeId) {
         String payload = new GsonBuilder().create().toJson(
                 ImmutableMap.of("amount", amount, "refund_amount_available", refundAmountAvailable));

--- a/src/test/resources/pacts/valid-create-payment.json
+++ b/src/test/resources/pacts/valid-create-payment.json
@@ -1,0 +1,117 @@
+{
+  "provider": {
+    "name": "Petstore"
+  },
+  "consumer": {
+    "name": "ExampleConsumer"
+  },
+  "interactions": [
+    {
+      "providerState": null,
+      "description": "GET pet",
+      "request": {
+        "method": "GET",
+        "headers": {
+          "Authorization": "apy_key"
+        },
+        "path": "/v1/payments/123",
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json; charset=UTF-8"
+        },
+        "body": {
+          "amount": 1200,
+          "state": {
+            "status": "created",
+            "finished": true,
+            "message": "User cancelled the payment",
+            "code": "P010"
+          },
+          "description": "Your Service Description",
+          "reference": "your-reference",
+          "email1": "your email",
+          "language": "en",
+          "payment_id": "hu20sqlact5260q2nanm0q8u93",
+          "payment_provider": "worldpay",
+          "return_url": "http://your.service.domain/your-reference",
+          "created_date": "2016-01-21T17:15:000Z",
+          "refund_summary": {
+            "status": "available",
+            "amount_available": 100,
+            "amount_submitted": 0
+          },
+          "settlement_summary": {
+            "capture_submit_time": "2016-01-21T17:15:000Z",
+            "captured_date": "2016-01-21"
+          },
+          "card_details": {
+            "last_digits_card_number": "1234",
+            "first_digits_card_number": "123456",
+            "cardholder_name": "Mr. Card holder",
+            "expiry_date": "12/20",
+            "billing_address": {
+              "line1": "address line 1",
+              "line2": "address line 2",
+              "postcode": "AB1 2CD",
+              "city": "address city",
+              "country": "GB"
+            },
+            "card_brand": "Visa"
+          },
+          "delayed_capture": false,
+          "corporate_card_surcharge": 250,
+          "total_amount": 1450,
+          "provider_id": "reference-from-payment-gateway",
+          "_links": {
+            "self": {
+              "href": "https://an.example.link/from/payment/platform",
+              "method": "GET"
+            },
+            "next_url": {
+              "href": "https://an.example.link/from/payment/platform",
+              "method": "GET"
+            },
+            "next_url_post": {
+              "type": "application/x-www-form-urlencoded",
+              "params": "\"description\":\"This is a value for a parameter called description\"",
+              "href": "https://an.example.link/from/payment/platform",
+              "method": "POST"
+            },
+            "events": {
+              "href": "https://an.example.link/from/payment/platform",
+              "method": "GET"
+            },
+            "refunds": {
+              "href": "https://an.example.link/from/payment/platform",
+              "method": "GET"
+            },
+            "cancel": {
+              "type": "application/x-www-form-urlencoded",
+              "params": "\"description\":\"This is a value for a parameter called description\"",
+              "href": "https://an.example.link/from/payment/platform",
+              "method": "POST"
+            },
+            "capture": {
+              "type": "application/x-www-form-urlencoded",
+              "params": "\"description\":\"This is a value for a parameter called description\"",
+              "href": "https://an.example.link/from/payment/platform",
+              "method": "POST"
+            }
+          },
+          "card_brand": "Visa"
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "2.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.2.6"
+    }
+  }
+}

--- a/src/test/resources/responses/search-payments.json
+++ b/src/test/resources/responses/search-payments.json
@@ -1,0 +1,98 @@
+{
+  "total": 100,
+  "count": 20,
+  "page": 1,
+  "_links": {
+    "self": {
+      "href": "https://an.example.link/from/payment/platform",
+      "method": "GET"
+    },
+    "first_page": {
+      "href": "https://an.example.link/from/payment/platform",
+      "method": "GET"
+    },
+    "last_page": {
+      "href": "https://an.example.link/from/payment/platform",
+      "method": "GET"
+    },
+    "prev_page": {
+      "href": "https://an.example.link/from/payment/platform",
+      "method": "GET"
+    },
+    "next_page": {
+      "href": "https://an.example.link/from/payment/platform",
+      "method": "GET"
+    }
+  },
+  "results": [
+    {
+      "amount": 1200,
+      "state": {
+        "status": "created",
+        "finished": true,
+        "message": "User cancelled the payment",
+        "code": "P010"
+      },
+      "description": "Your Service Description",
+      "reference": "your-reference",
+      "email": "your email",
+      "language": "en",
+      "payment_id": "hu20sqlact5260q2nanm0q8u93",
+      "payment_provider": "worldpay",
+      "return_url": "http://your.service.domain/your-reference",
+      "created_date": "2016-01-21T17:15:000Z",
+      "refund_summary": {
+        "status": "available",
+        "amount_available": 100,
+        "amount_submitted": 0
+      },
+      "settlement_summary": {
+        "capture_submit_time": "2016-01-21T17:15:000Z",
+        "captured_date": "2016-01-21"
+      },
+      "card_details": {
+        "last_digits_card_number": "1234",
+        "first_digits_card_number": "123456",
+        "cardholder_name": "Mr. Card holder",
+        "expiry_date": "12/20",
+        "billing_address": {
+          "line1": "address line 1",
+          "line2": "address line 2",
+          "postcode": "AB1 2CD",
+          "city": "address city",
+          "country": "GB"
+        },
+        "card_brand": "Visa"
+      },
+      "delayed_capture": false,
+      "corporate_card_surcharge": 250,
+      "total_amount": 1450,
+      "provider_id": "reference-from-payment-gateway",
+      "_links": {
+        "self": {
+          "href": "https://an.example.link/from/payment/platform",
+          "method": "GET"
+        },
+        "cancel": {
+          "type": "application/x-www-form-urlencoded",
+          "href": "https://an.example.link/from/payment/platform",
+          "method": "POST"
+        },
+        "events": {
+          "href": "https://an.example.link/from/payment/platform",
+          "method": "GET"
+        },
+        "refunds": {
+          "href": "https://an.example.link/from/payment/platform",
+          "method": "GET"
+        },
+        "capture": {
+          "type": "application/x-www-form-urlencoded",
+          "href": "https://an.example.link/from/payment/platform",
+          "method": "POST"
+        }
+      },
+      "card_brand": "Visa"
+    }
+  ]
+}


### PR DESCRIPTION
## What you did
Explorer Swagger request validator library to validate swagger.json file (generated through annotation) with expected/actual responses https://bitbucket.org/atlassian/swagger-request-validator

Swagger can be validated in multiple ways with the library. Below are the ones that are close to frameworks we use / independent of frameworks (also variants includes using springmvc, mockmvc, spring web client)

### **1. Simple request/response validation**
Validates swagger.json with expected responses (json)
 
 **Pros**
 - Quick feedback
 - Independent of framework

 **Cons**
 - Can't actually test if swagger file is incorrect. An incorrect swagger with an incorrect expected responses will still pass
### **2. Pact provider validation**

Validates swagger.json with a pact interaction (local file / from pact-broker)

**Pros**
- Quick feedback

**Cons**
- Only useful when am actual consumer generates pact interactions. Generating interactions ourselves is not useful
- Can't actually test if swagger file is incorrect. Am incorrect swagger with an incorrect expected responses will still pass

### **3. Rest assured**

Validates swagger.json with actual responses to publicapi application

**Pros**
- Invokes requests on application which can detect if swagger itself is invalid

**Cons**
- Takes longer to run but shouldn't be a deal break

## What can it detect

Validator can detect the following in both swagger.json / responses (mock / actual responses)

- Schema mismatches ( objects, fields, datatype, enumerate values..)
- Unexpected fields (additional fields in swagger but not in response and vice verse)
- Request/Response headers

_Can also whitelist any validation errors if it is persistent issue that can't be fixed / to be ignored_ 

## Any issues

- Encountered issues with dependencies especially com.github.fge.json-schema-validator as it conflicts with another to read JsonSchema. Excluding this library seems fine but may have impacted existing integration tests using mockserver 
- Seems to work fine on both Java 8 & Java 11, but pacts provider tests doesn't work the latest (3.6.2) pact library.

## Additional info

Swagger request validator is listed as open source tool for Java by Swagger.io https://swagger.io/tools/open-source/open-source-integrations/

