### PR TITLE
Document environment variables and remove certificate deduplication logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM govukpay/openjdk:alpine-3.9-jre-base-8.201.08
 
 RUN apk --no-cache upgrade
 
-# openssl is only here temporarily whilst docker-startup.sh needs it
-RUN apk --no-cache add bash openssl
+RUN apk --no-cache add bash
 
 ENV PORT 8080
 ENV ADMIN_PORT 8081

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -6,15 +6,10 @@ if [ -n "${CERTS_PATH:-}" ]; then
   i=0
   truststore=/etc/ssl/certs/java/cacerts
   truststore_pass=changeit
-  existing_fingerprints=$(keytool -list -keystore "$truststore" -storepass "$truststore_pass"| sed -ne 's/^Certificate fingerprint (SHA1): //p')
   for cert in "$CERTS_PATH"/*; do
     [ -f "$cert" ] || continue
-    if grep -qFx "$(openssl x509 -in "$cert" -fingerprint -noout | sed -ne 's/^SHA1 Fingerprint=//p')" <<<"$existing_fingerprints"; then
-      echo "$cert already in truststore $truststore"
-    else
-      echo "Adding $cert to $truststore"
-      keytool -importcert -noprompt -keystore "$truststore" -storepass "$truststore_pass" -file "$cert" -alias custom$((i++))
-    fi
+    echo "Adding $cert to $truststore"
+    keytool -importcert -noprompt -keystore "$truststore" -storepass "$truststore_pass" -file "$cert" -alias custom$((i++))
   done
 fi
 

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -1,10 +1,10 @@
 server:
   applicationConnectors:
     - type: http
-      port: ${PORT}
+      port: ${PORT:-8080}
   adminConnectors:
     - type: http
-      port: ${ADMIN_PORT}
+      port: ${ADMIN_PORT:-8081}
 
 logging:
   level: INFO
@@ -24,7 +24,7 @@ graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 
 jerseyClientConfig:
-  disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS}
+  disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS:-false}
 
 rateLimiter:  # rate = noOfReq per perMillis
   noOfReq: ${RATE_LIMITER_VALUE:-75}  # for requests except POST and across all publicapi instances.


### PR DESCRIPTION
## WHAT YOU DID
Improve documentation of the environment variables in use by publicapi

Also, remove logic to avoid adding duplicate certificates to the default Java truststore; this is no longer necessary.
