### PR TITLE
PP-4886: Store metadata for charge

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -7,7 +7,9 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.commons.model.charge.ExternalMetadata;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
@@ -42,17 +44,20 @@ public class CardPayment extends Payment {
     @JsonProperty("provider_id")
     @ApiModelProperty(example = "reference-from-payment-gateway")
     private final String providerId;
+    
+    private final Map<String, Object> metadata;
 
     public CardPayment(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                        String reference, String email, String paymentProvider, String createdDate,
                        RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
-                       SupportedLanguage language, boolean delayedCapture, Long corporateCardSurcharge, Long totalAmount, 
-                       String providerId) {
+                       SupportedLanguage language, boolean delayedCapture, Long corporateCardSurcharge, Long totalAmount,
+                       String providerId, ExternalMetadata metadata) {
         super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate);
         this.refundSummary = refundSummary;
         this.settlementSummary = settlementSummary;
         this.cardDetails = cardDetails;
         this.providerId = providerId;
+        this.metadata = metadata == null ? Map.of() : metadata.getMetadata();
         this.paymentType = CARD.getFriendlyName();
         this.language = language;
         this.delayedCapture = delayedCapture;
@@ -71,6 +76,10 @@ public class CardPayment extends Payment {
     @Deprecated
     public String getCardBrand() {
         return cardDetails != null ? cardDetails.getCardBrand() : null;
+    }
+
+    public Map<String, Object> getMetadata() {
+        return metadata;
     }
 
     @ApiModelProperty(dataType = "uk.gov.pay.api.model.RefundSummary")

--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -6,10 +6,10 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import uk.gov.pay.commons.api.json.ExternalMetadataSerialiser;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 
-import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
@@ -44,8 +44,9 @@ public class CardPayment extends Payment {
     @JsonProperty("provider_id")
     @ApiModelProperty(example = "reference-from-payment-gateway")
     private final String providerId;
-    
-    private final Map<String, Object> metadata;
+
+    @JsonSerialize(using = ExternalMetadataSerialiser.class)
+    private final ExternalMetadata metadata;
 
     public CardPayment(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                        String reference, String email, String paymentProvider, String createdDate,
@@ -57,7 +58,7 @@ public class CardPayment extends Payment {
         this.settlementSummary = settlementSummary;
         this.cardDetails = cardDetails;
         this.providerId = providerId;
-        this.metadata = metadata == null ? Map.of() : metadata.getMetadata();
+        this.metadata = metadata;
         this.paymentType = CARD.getFriendlyName();
         this.language = language;
         this.delayedCapture = delayedCapture;
@@ -78,7 +79,7 @@ public class CardPayment extends Payment {
         return cardDetails != null ? cardDetails.getCardBrand() : null;
     }
 
-    public Map<String, Object> getMetadata() {
+    public ExternalMetadata getMetadata() {
         return metadata;
     }
 

--- a/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
@@ -5,10 +5,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import uk.gov.pay.api.utils.CustomSupportedLanguageDeserializer;
+import uk.gov.pay.commons.api.json.ExternalMetadataDeserialiser;
 import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.commons.model.charge.ExternalMetadata;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -62,6 +65,13 @@ public class ChargeFromResponse {
 
     @JsonProperty(value = "gateway_transaction_id")
     private String gatewayTransactionId;
+
+    @JsonDeserialize(using = ExternalMetadataDeserialiser.class)
+    private ExternalMetadata metadata;
+
+    public Optional<ExternalMetadata> getMetadata() {
+        return Optional.ofNullable(metadata);
+    }
 
     public String getChargeId() {
         return chargeId;

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.apache.commons.lang3.StringUtils;
+import uk.gov.pay.commons.model.charge.ExternalMetadata;
 
 import java.util.Optional;
 import java.util.StringJoiner;
@@ -26,8 +27,93 @@ public class CreatePaymentRequest {
     private final String agreementId;
     private final String language;
     private final Boolean delayedCapture;
+    private final ExternalMetadata metadata;
+    
+    private CreatePaymentRequest(CreatePaymentRequestBuilder createPaymentRequestBuilder) {
+        this.amount = createPaymentRequestBuilder.amount;
+        this.returnUrl = createPaymentRequestBuilder.returnUrl;
+        this.reference = createPaymentRequestBuilder.reference;
+        this.description = createPaymentRequestBuilder.description;
+        this.agreementId = createPaymentRequestBuilder.agreementId;
+        this.language = createPaymentRequestBuilder.language;
+        this.delayedCapture = createPaymentRequestBuilder.delayedCapture;
+        this.metadata = createPaymentRequestBuilder.metadata;
+    }
+
+    @ApiModelProperty(value = "amount in pence", required = true, allowableValues = "range[1, 10000000]", example = "12000")
+    public int getAmount() {
+        return amount;
+    }
+
+    @ApiModelProperty(value = "payment reference", required = true, example = "12345")
+    public String getReference() {
+        return reference;
+    }
+
+    @ApiModelProperty(value = "payment description", required = true, example = "New passport application")
+    public String getDescription() {
+        return description;
+    }
+
+    @ApiModelProperty(value = "service return url", required = false, example = "https://service-name.gov.uk/transactions/12345")
+    @JsonProperty("return_url")
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    @ApiModelProperty(value = "ID of the agreement being used to collect the payment", required = false, example = "33890b55-b9ea-4e2f-90fd-77ae0e9009e2")
+    @JsonProperty(AGREEMENT_ID_FIELD_NAME)
+    public String getAgreementId() {
+        return agreementId;
+    }
+
+    @ApiModelProperty(value = "ISO-639-1 Alpha-2 code of a supported language to use on the payment pages", required = false, example = "en")
+    @JsonProperty(LANGUAGE_FIELD_NAME)
+    public String getLanguage() {
+        return language;
+    }
+
+    @ApiModelProperty(value = "delayed capture flag", required = false, example = "false")
+    @JsonProperty(DELAYED_CAPTURE_FIELD_NAME)
+    public Boolean getDelayedCapture() {
+        return delayedCapture;
+    }
+
+    @JsonProperty("metadata")
+    public ExternalMetadata getMetadata() {
+        return metadata;
+    }
+
+    public boolean hasReturnUrl() {
+        return StringUtils.isNotBlank(returnUrl);
+    }
+
+    public boolean hasAgreementId() {
+        return StringUtils.isNotBlank(agreementId);
+    }
+
+    public boolean hasLanguage() {
+        return StringUtils.isNotBlank(language);
+    }
+
+    /**
+     * This looks JSONesque but is not identical to the received request
+     */
+    @Override
+    public String toString() {
+        // Some services put PII in the description, so don’t include it in the stringification
+        StringJoiner joiner = new StringJoiner(", ", "{", "}");
+        joiner.add("amount: ").add(String.valueOf(amount));
+        joiner.add("reference: ").add(reference);
+        Optional.ofNullable(returnUrl).ifPresent(value -> joiner.add("return_url: ").add(value));
+        Optional.ofNullable(agreementId).ifPresent(value -> joiner.add("agreement_id: ").add(value));
+        Optional.ofNullable(language).ifPresent(value -> joiner.add("language: ").add(value));
+        Optional.ofNullable(delayedCapture).ifPresent(value -> joiner.add("delayed_capture: ").add(value.toString()));
+        return joiner.toString();
+    }
 
     public static class CreatePaymentRequestBuilder {
+        private ExternalMetadata metadata;
         private int amount;
         private String returnUrl;
         private String reference;
@@ -71,6 +157,11 @@ public class CreatePaymentRequest {
             return this;
         }
 
+        public CreatePaymentRequestBuilder metadata(ExternalMetadata metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
         public CreatePaymentRequest build() {
             return new CreatePaymentRequest(this);
         }
@@ -79,82 +170,4 @@ public class CreatePaymentRequest {
     public static CreatePaymentRequestBuilder builder() {
         return new CreatePaymentRequestBuilder();
     }
-
-    private CreatePaymentRequest(CreatePaymentRequestBuilder createPaymentRequestBuilder) {
-        this.amount = createPaymentRequestBuilder.amount;
-        this.returnUrl = createPaymentRequestBuilder.returnUrl;
-        this.reference = createPaymentRequestBuilder.reference;
-        this.description = createPaymentRequestBuilder.description;
-        this.agreementId = createPaymentRequestBuilder.agreementId;
-        this.language = createPaymentRequestBuilder.language;
-        this.delayedCapture = createPaymentRequestBuilder.delayedCapture;
-    }
-
-    @ApiModelProperty(value = "amount in pence", required = true, allowableValues = "range[1, 10000000]", example = "12000")
-    public int getAmount() {
-        return amount;
-    }
-
-    @ApiModelProperty(value = "payment reference", required = true, example = "12345")
-    public String getReference() {
-        return reference;
-    }
-
-    @ApiModelProperty(value = "payment description", required = true, example = "New passport application")
-    public String getDescription() {
-        return description;
-    }
-
-    @ApiModelProperty(value = "service return url", required = false, example = "https://service-name.gov.uk/transactions/12345")
-    @JsonProperty("return_url")
-    public String getReturnUrl() {
-        return returnUrl;
-    }
-
-    @ApiModelProperty(value = "ID of the agreement being used to collect the payment", required = false, example = "33890b55-b9ea-4e2f-90fd-77ae0e9009e2")
-    @JsonProperty(AGREEMENT_ID_FIELD_NAME)
-    public String getAgreementId() {
-        return agreementId;
-    }
-
-    @ApiModelProperty(value = "ISO-639-1 Alpha-2 code of a supported language to use on the payment pages", required = false, example = "en")
-    @JsonProperty(LANGUAGE_FIELD_NAME)
-    public String getLanguage() {
-        return language;
-    }
-
-    @ApiModelProperty(value = "delayed capture flag", required = false, example = "false")
-    @JsonProperty(DELAYED_CAPTURE_FIELD_NAME)
-    public Boolean getDelayedCapture() {
-        return delayedCapture;
-    }
-
-    public boolean hasReturnUrl() {
-        return StringUtils.isNotBlank(returnUrl);
-    }
-
-    public boolean hasAgreementId() {
-        return StringUtils.isNotBlank(agreementId);
-    }
-
-    public boolean hasLanguage() {
-        return StringUtils.isNotBlank(language);
-    }
-
-    /**
-     * This looks JSONesque but is not identical to the received request
-     */
-    @Override
-    public String toString() {
-        // Some services put PII in the description, so don’t include it in the stringification
-        StringJoiner joiner = new StringJoiner(", ", "{", "}");
-        joiner.add("amount: ").add(String.valueOf(amount));
-        joiner.add("reference: ").add(reference);
-        Optional.ofNullable(returnUrl).ifPresent(value -> joiner.add("return_url: ").add(value));
-        Optional.ofNullable(agreementId).ifPresent(value -> joiner.add("agreement_id: ").add(value));
-        Optional.ofNullable(language).ifPresent(value -> joiner.add("language: ").add(value));
-        Optional.ofNullable(delayedCapture).ifPresent(value -> joiner.add("delayed_capture: ").add(value.toString()));
-        return joiner.toString();
-    }
-
 }

--- a/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.commons.model.charge.ExternalMetadata;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -30,8 +31,9 @@ public class ValidCreatePaymentRequest {
     @ApiModelProperty(name = "language", value = "ISO-639-1 Alpha-2 code of a supported language to use on the payment pages", required = false, example = "en", allowableValues = "en,cy")
     private SupportedLanguage language;
     @ApiModelProperty(name = "delayed_capture", value = "delayed capture flag", required = false, example = "false" )
-    @JsonProperty("delayed_capture")
     private Boolean delayedCapture;
+    
+    private ExternalMetadata metadata;
 
     public ValidCreatePaymentRequest(CreatePaymentRequest createPaymentRequest) {
         amount = createPaymentRequest.getAmount();
@@ -47,6 +49,7 @@ public class ValidCreatePaymentRequest {
         }
 
         delayedCapture = createPaymentRequest.getDelayedCapture();
+        metadata = createPaymentRequest.getMetadata();
     }
 
     public int getAmount() {
@@ -76,6 +79,10 @@ public class ValidCreatePaymentRequest {
 
     public Optional<Boolean> getDelayedCapture() {
         return Optional.ofNullable(delayedCapture);
+    }
+
+    public Optional<ExternalMetadata> getMetadata() {
+        return Optional.ofNullable(metadata);
     }
 
     /**

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -15,9 +15,11 @@ import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.model.SettlementSummary;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.commons.model.charge.ExternalMetadata;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 
 import static uk.gov.pay.api.model.Payment.LINKS_JSON_ATTRIBUTE;
 
@@ -44,9 +46,9 @@ public class PaymentWithAllLinks {
                                String reference, String email, String paymentProvider, String createdDate, SupportedLanguage language,
                                boolean delayedCapture, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
                                List<PaymentConnectorResponseLink> paymentConnectorResponseLinks, URI selfLink, URI paymentEventsUri, URI paymentCancelUri,
-                               URI paymentRefundsUri, URI paymentCaptureUri, Long corporateCardSurcharge, Long totalAmount, String providerId) {
+                               URI paymentRefundsUri, URI paymentCaptureUri, Long corporateCardSurcharge, Long totalAmount, String providerId, ExternalMetadata metadata) {
         this.payment = new CardPayment(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate,
-                refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount, providerId);
+                refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount, providerId, metadata);
         this.links.addSelf(selfLink.toString());
         this.links.addKnownLinksValueOf(paymentConnectorResponseLinks);
         this.links.addEvents(paymentEventsUri.toString());
@@ -115,7 +117,8 @@ public class PaymentWithAllLinks {
                 paymentsCaptureUri,
                 paymentConnector.getCorporateCardSurcharge(),
                 paymentConnector.getTotalAmount(),
-                paymentConnector.getGatewayTransactionId());
+                paymentConnector.getGatewayTransactionId(),
+                paymentConnector.getMetadata().orElse(null));
     }
 
     public static PaymentWithAllLinks getPaymentWithLinks(

--- a/src/main/java/uk/gov/pay/api/model/search/card/GetPaymentResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/GetPaymentResult.java
@@ -28,6 +28,6 @@ public class GetPaymentResult extends CardPayment {
                             Long totalAmount, String providerId) {
         super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate, 
                 refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, 
-                totalAmount, providerId);
+                totalAmount, providerId, null);
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
@@ -28,7 +28,7 @@ public class PaymentForSearchResult extends CardPayment {
                                   List<PaymentConnectorResponseLink> links, URI selfLink, URI paymentEventsLink, URI paymentCancelLink, URI paymentRefundsLink, URI paymentCaptureUri,
                                   Long corporateCardSurcharge, Long totalAmount, String providerId) {
         super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider,
-                createdDate, refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount, providerId);
+                createdDate, refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount, providerId, null);
         this.links.addSelf(selfLink.toString());
         this.links.addEvents(paymentEventsLink.toString());
         this.links.addRefunds(paymentRefundsLink.toString());

--- a/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
@@ -75,6 +75,7 @@ public class CreatePaymentService {
         requestPayload.getReturnUrl().ifPresent(returnUrl -> request.add("return_url", returnUrl));
         requestPayload.getAgreementId().ifPresent(agreementId -> request.add("agreement_id", agreementId));
         requestPayload.getDelayedCapture().ifPresent(delayedCapture -> request.add("delayed_capture", delayedCapture));
+        requestPayload.getMetadata().ifPresent(metadata -> request.add("metadata", metadata.getMetadata()));
         return json(request.build());
     }
 }

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentITest.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentITest.java
@@ -9,21 +9,25 @@ import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.utils.DateTimeUtils;
 import uk.gov.pay.api.utils.JsonStringBuilder;
+import uk.gov.pay.api.utils.mocks.CreateChargeRequestParams;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import javax.ws.rs.core.HttpHeaders;
 import java.io.InputStream;
 import java.time.ZonedDateTime;
+import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
 import static uk.gov.pay.api.utils.Urls.paymentLocationFor;
+import static uk.gov.pay.api.utils.mocks.CreateChargeRequestParams.CreateChargeRequestParamsBuilder.aCreateChargeRequestParams;
 import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
 public class CreatePaymentITest extends PaymentResourceITestBase {
@@ -43,8 +47,30 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
     private static final String CREATED_DATE = ISO_INSTANT_MILLISECOND_PRECISION.format(TIMESTAMP);
     private static final Address BILLING_ADDRESS = new Address("line1", "line2", "NR2 5 6EG", "city", "UK");
     private static final CardDetails CARD_DETAILS = new CardDetails("1234", "123456", "Mr. Payment", "12/19", BILLING_ADDRESS, CARD_BRAND_LABEL);
-    private static final String SUCCESS_PAYLOAD = paymentPayload(AMOUNT, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL);
+    private static final String SUCCESS_PAYLOAD = paymentPayload(AMOUNT, RETURN_URL, DESCRIPTION, REFERENCE);
     private static final String GATEWAY_TRANSACTION_ID = "gateway-tx-123456";
+
+    @Test
+    public void createCardPaymentWithMetadata() {
+        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, CARD);
+
+        CreateChargeRequestParams createChargeRequestParams = aCreateChargeRequestParams()
+                .withAmount(100)
+                .withDescription(DESCRIPTION)
+                .withReference(REFERENCE)
+                .withReturnUrl(RETURN_URL)
+                .withMetadata(Map.of("foo", "foo you", "fuh", "fuh you"))
+                .build();
+        connectorMock.respondOk_whenCreateCharge(GATEWAY_ACCOUNT_ID, createChargeRequestParams);
+
+        postPaymentResponse(API_KEY, paymentPayload(createChargeRequestParams))
+                .statusCode(201)
+                .contentType(JSON).log().body()
+                .body("metadata.foo", is("foo you"))
+                .body("metadata.fuh", is("fuh you"));
+
+        connectorMock.verifyCreateChargeConnectorRequest(GATEWAY_ACCOUNT_ID, createChargeRequestParams);
+    }
 
     @Test
     public void createCardPayment() {
@@ -57,7 +83,7 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
         String responseBody = postPaymentResponse(API_KEY, SUCCESS_PAYLOAD)
                 .statusCode(201)
                 .contentType(JSON)
-                .header(HttpHeaders.LOCATION, is(paymentLocationFor(configuration.getBaseUrl(), CHARGE_ID)))
+                .header(HttpHeaders.LOCATION, is(paymentLocationFor(configuration.getBaseUrl(), CHARGE_ID))).log().body()
                 .body("payment_id", is(CHARGE_ID))
                 .body("amount", is(9999999))
                 .body("reference", is(REFERENCE))
@@ -87,6 +113,7 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
                 .body("_links.cancel.method", is("POST"))
                 .body("_links.refunds.href", is(paymentRefundsLocationFor(CHARGE_ID)))
                 .body("_links.refunds.method", is("GET"))
+                .body("metadata", nullValue())
                 .extract().body().asString();
 
         JsonAssert.with(responseBody)
@@ -109,7 +136,7 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
                 CREATED, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, SupportedLanguage.ENGLISH,
                 false, REFUND_SUMMARY, null, CARD_DETAILS, GATEWAY_TRANSACTION_ID);
 
-        postPaymentResponse(API_KEY, paymentPayload(minimumAmount, RETURN_URL, DESCRIPTION, REFERENCE, EMAIL))
+        postPaymentResponse(API_KEY, paymentPayload(minimumAmount, RETURN_URL, DESCRIPTION, REFERENCE))
                 .statusCode(201)
                 .contentType(JSON)
                 .body("payment_id", is(CHARGE_ID))
@@ -214,14 +241,26 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
                 .statusCode(503);
     }
 
-    private static String paymentPayload(long amount, String returnUrl, String description, String reference, String email) {
+    @Deprecated
+    private static String paymentPayload(long amount, String returnUrl, String description, String reference) {
         return new JsonStringBuilder()
                 .add("amount", amount)
                 .add("reference", reference)
-                .add("email", email)
                 .add("description", description)
                 .add("return_url", returnUrl)
                 .build();
+    }
+
+    private static String paymentPayload(CreateChargeRequestParams params) {
+        JsonStringBuilder payload = new JsonStringBuilder()
+                .add("amount", params.getAmount())
+                .add("reference", params.getReference())
+                .add("description", params.getDescription())
+                .add("return_url", params.getReturnUrl());
+        
+        if (!params.getMetadata().isEmpty()) payload.add("metadata", params.getMetadata());
+        
+        return payload.build();
     }
 
 

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentITest.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentITest.java
@@ -22,7 +22,6 @@ import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
@@ -59,14 +58,15 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
                 .withDescription(DESCRIPTION)
                 .withReference(REFERENCE)
                 .withReturnUrl(RETURN_URL)
-                .withMetadata(Map.of("foo", "foo you", "fuh", "fuh you"))
+                .withMetadata(Map.of("reconciled", true, "ledger_code", 123, "fuh", "fuh you"))
                 .build();
         connectorMock.respondOk_whenCreateCharge(GATEWAY_ACCOUNT_ID, createChargeRequestParams);
 
         postPaymentResponse(API_KEY, paymentPayload(createChargeRequestParams))
                 .statusCode(201)
                 .contentType(JSON).log().body()
-                .body("metadata.foo", is("foo you"))
+                .body("metadata.reconciled", is(true))
+                .body("metadata.ledger_code", is(123))
                 .body("metadata.fuh", is("fuh you"));
 
         connectorMock.verifyCreateChargeConnectorRequest(GATEWAY_ACCOUNT_ID, createChargeRequestParams);

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentITest.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentITest.java
@@ -64,7 +64,7 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
 
         postPaymentResponse(API_KEY, paymentPayload(createChargeRequestParams))
                 .statusCode(201)
-                .contentType(JSON).log().body()
+                .contentType(JSON)
                 .body("metadata.reconciled", is(true))
                 .body("metadata.ledger_code", is(123))
                 .body("metadata.fuh", is("fuh you"));
@@ -83,7 +83,7 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
         String responseBody = postPaymentResponse(API_KEY, SUCCESS_PAYLOAD)
                 .statusCode(201)
                 .contentType(JSON)
-                .header(HttpHeaders.LOCATION, is(paymentLocationFor(configuration.getBaseUrl(), CHARGE_ID))).log().body()
+                .header(HttpHeaders.LOCATION, is(paymentLocationFor(configuration.getBaseUrl(), CHARGE_ID)))
                 .body("payment_id", is(CHARGE_ID))
                 .body("amount", is(9999999))
                 .body("reference", is(REFERENCE))

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentResultBuilder.java
@@ -166,7 +166,7 @@ public abstract class PaymentResultBuilder {
     protected RefundSummary refundSummary;
     protected SettlementSummary settlementSummary;
     protected String gatewayTransactionId;
-    protected Map<String, ?> metadata;
+    protected Map<String, Object> metadata;
 
     public abstract String build();
     

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentResultBuilder.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.api.it.fixtures;
 
-import com.google.common.collect.ImmutableMap;
 import uk.gov.pay.api.utils.DateTimeUtils;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
@@ -8,6 +7,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 
 import static java.util.UUID.randomUUID;
@@ -24,7 +24,7 @@ public abstract class PaymentResultBuilder {
     public static final int DEFAULT_AMOUNT = 10000;
     public static final String DEFAULT_PAYMENT_PROVIDER = "worldpay";
     public static final String DEFAULT_CARD_BRAND_LABEL = "Mastercard";
-
+    
     protected static class Address {
         public String line1;
         public String line2;
@@ -106,16 +106,16 @@ public abstract class PaymentResultBuilder {
 
     protected static class TestPayment {
         public TestPaymentState state;
-        public String charge_id, description, reference, email, created_date;
+        public String charge_id, description, reference, email, created_date, gateway_transaction_id, return_url, 
+                payment_provider, language;
         public long amount;
-        public String gateway_transaction_id, return_url, payment_provider;
-        public String language;
         public boolean delayed_capture;
         public RefundSummary refund_summary;
         public SettlementSummary settlement_summary;
         public CardDetails card_details = new CardDetails();
         public Long corporate_card_surcharge, total_amount;
-        public List<ImmutableMap<?,?>> links;
+        public List<Map<?,?>> links;
+        public Map<String, ?> metadata;
     }
 
     protected static class TestPaymentState {
@@ -134,18 +134,6 @@ public abstract class PaymentResultBuilder {
         protected TestPaymentSuccessState(String status) {
             super(status, true);
             this.success = true;
-        }
-    }
-
-    protected static class TestPaymentFailureState extends TestPaymentState {
-        private boolean success;
-        private String message, code;
-
-        protected TestPaymentFailureState(String status, String message, String code) {
-            super(status, true);
-            this.success = false;
-            this.message = message;
-            this.code = code;
         }
     }
 
@@ -174,10 +162,11 @@ public abstract class PaymentResultBuilder {
     protected String returnUrl;
     protected String paymentProvider;
     protected String createdDate;
-    protected List<ImmutableMap<?, ?>> links = new ArrayList<>();
+    protected List<Map<?, ?>> links = new ArrayList<>();
     protected RefundSummary refundSummary;
     protected SettlementSummary settlementSummary;
     protected String gatewayTransactionId;
+    protected Map<String, ?> metadata;
 
     public abstract String build();
     
@@ -215,6 +204,7 @@ public abstract class PaymentResultBuilder {
         payment.corporate_card_surcharge = corporateCardSurcharge;
         payment.total_amount = totalAmount;
         payment.links = links ;
+        payment.metadata = metadata;
 
         return payment;
     }

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSingleResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSingleResultBuilder.java
@@ -1,12 +1,12 @@
 package uk.gov.pay.api.it.fixtures;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.util.List;
+import java.util.Map;
 
 public class PaymentSingleResultBuilder extends PaymentResultBuilder {
     
@@ -87,7 +87,7 @@ public class PaymentSingleResultBuilder extends PaymentResultBuilder {
         return this;
     }
     
-    public PaymentSingleResultBuilder withLinks(List<ImmutableMap< ?,? >> links) {
+    public PaymentSingleResultBuilder withLinks(List<Map< ?,? >> links) {
         this.links = links;
         return this;
     }
@@ -107,12 +107,13 @@ public class PaymentSingleResultBuilder extends PaymentResultBuilder {
         return this;
     }
 
-    public TestPayment getResult() {
-        return getPayment();
+    public String build() {
+        TestPayment result = getPayment();
+        return new Gson().toJson(result, new TypeReference<TestPayment>() {}.getType()); 
     }
 
-    public String build() {
-        TestPayment result = getResult();
-        return new Gson().toJson(result, new TypeReference<TestPayment>() {}.getType()); 
+    public PaymentSingleResultBuilder withMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
+        return this;
     }
 }

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentResourceMetadataITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentResourceMetadataITest.java
@@ -1,0 +1,5 @@
+package uk.gov.pay.api.it.validation;
+
+//TODO placeholder for validations test
+public class PaymentResourceMetadataITest {
+}

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -126,6 +126,7 @@ public class PaymentsResourceCreatePaymentTest {
                 URI.create(paymentUri + "/capture"),
                 null,
                 null,
-                "providerId");
+                "providerId", 
+                null);
     }
 }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
@@ -86,11 +86,33 @@ public abstract class BaseConnectorMockClient {
                 .build();
     }
 
+    String createChargePayload(CreateChargeRequestParams createChargeRequestParams) {
+        JsonStringBuilder payload = new JsonStringBuilder()
+                .add("amount", createChargeRequestParams.getAmount())
+                .add("reference", createChargeRequestParams.getReference())
+                .add("description", createChargeRequestParams.getDescription())
+                .add("return_url", createChargeRequestParams.getReturnUrl());
+
+        if (!createChargeRequestParams.getMetadata().isEmpty())
+            payload.add("metadata", createChargeRequestParams.getMetadata());
+
+        return payload.build();
+    }
+
     public void verifyCreateChargeConnectorRequest(int amount, String gatewayAccountId, String returnUrl, String description, String reference) {
         mockClient.verify(request()
                         .withMethod(POST)
                         .withPath(format(CONNECTOR_MOCK_CHARGES_PATH, gatewayAccountId))
                         .withBody(createChargePayload(amount, returnUrl, description, reference)),
+                once()
+        );
+    }
+
+    public void verifyCreateChargeConnectorRequest(String gatewayAccountId, CreateChargeRequestParams createChargeRequestParams) {
+        mockClient.verify(request()
+                        .withMethod(POST)
+                        .withPath(format(CONNECTOR_MOCK_CHARGES_PATH, gatewayAccountId))
+                        .withBody(createChargePayload(createChargeRequestParams)),
                 once()
         );
     }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -90,10 +90,18 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                 .withSettlementSummary(responseFromConnector.settlementSummary)
                 .withCardDetails(responseFromConnector.cardDetails);
         
-        if (responseFromConnector.refundSummary != null) resultBuilder.withRefundSummary(responseFromConnector.refundSummary);
-        if (responseFromConnector.gatewayTransactionId != null) resultBuilder.withGatewayTransactionId(responseFromConnector.gatewayTransactionId);
-        if (responseFromConnector.corporateCardSurcharge != null) resultBuilder.withCorporateCardSurcharge(responseFromConnector.corporateCardSurcharge);
-        if (responseFromConnector.totalAmount != null) resultBuilder.withTotalAmount(responseFromConnector.totalAmount);
+        if (responseFromConnector.refundSummary != null) {
+            resultBuilder.withRefundSummary(responseFromConnector.refundSummary);
+        }
+        if (responseFromConnector.gatewayTransactionId != null) {
+            resultBuilder.withGatewayTransactionId(responseFromConnector.gatewayTransactionId);
+        }
+        if (responseFromConnector.corporateCardSurcharge != null) {
+            resultBuilder.withCorporateCardSurcharge(responseFromConnector.corporateCardSurcharge);
+        }
+        if (responseFromConnector.totalAmount != null) {
+            resultBuilder.withTotalAmount(responseFromConnector.totalAmount);
+        }
         responseFromConnector.metadata.ifPresent(m -> resultBuilder.withMetadata(m));
         
         return resultBuilder.build();

--- a/src/test/java/uk/gov/pay/api/utils/mocks/CreateChargeRequestParams.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/CreateChargeRequestParams.java
@@ -1,0 +1,89 @@
+package uk.gov.pay.api.utils.mocks;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class CreateChargeRequestParams {
+    
+    private final int amount;
+    private final String returnUrl, description, reference;
+    private final Map<String, Object> metadata;
+
+    private CreateChargeRequestParams(int amount, 
+                                      String returnUrl, 
+                                      String description, 
+                                      String reference, 
+                                      Map<String, Object> metadata) {
+        this.amount = amount;
+        this.returnUrl = returnUrl;
+        this.description = description;
+        this.reference = reference;
+        this.metadata = metadata;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    public static final class CreateChargeRequestParamsBuilder {
+        private Integer amount;
+        private String returnUrl;
+        private String description;
+        private String reference;
+        private Map<String, Object> metadata = Map.of();
+
+        private CreateChargeRequestParamsBuilder() {
+        }
+
+        public static CreateChargeRequestParamsBuilder aCreateChargeRequestParams() {
+            return new CreateChargeRequestParamsBuilder();
+        }
+
+        public CreateChargeRequestParamsBuilder withAmount(int amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        public CreateChargeRequestParamsBuilder withReturnUrl(String returnUrl) {
+            this.returnUrl = returnUrl;
+            return this;
+        }
+
+        public CreateChargeRequestParamsBuilder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public CreateChargeRequestParamsBuilder withReference(String reference) {
+            this.reference = reference;
+            return this;
+        }
+
+        public CreateChargeRequestParamsBuilder withMetadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        public CreateChargeRequestParams build() {
+            List.of(amount, reference, returnUrl, description).forEach(Objects::requireNonNull);
+            return new CreateChargeRequestParams(amount, returnUrl, description, reference, metadata);
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/api/utils/mocks/CreateChargeResponseFromConnector.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/CreateChargeResponseFromConnector.java
@@ -1,0 +1,176 @@
+package uk.gov.pay.api.utils.mocks;
+
+import uk.gov.pay.api.model.CardDetails;
+import uk.gov.pay.api.model.PaymentState;
+import uk.gov.pay.api.model.RefundSummary;
+import uk.gov.pay.api.model.SettlementSummary;
+import uk.gov.pay.commons.model.SupportedLanguage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class CreateChargeResponseFromConnector {
+    public final Long amount, corporateCardSurcharge, totalAmount; 
+    public final PaymentState state; 
+    public final String chargeId, returnUrl, description, reference, email, paymentProvider, gatewayTransactionId, createdDate;
+    public final SupportedLanguage language; 
+    public final boolean delayedCapture; 
+    public final RefundSummary refundSummary; 
+    public final SettlementSummary settlementSummary; 
+    public final CardDetails cardDetails;
+    public final List<Map<?, ?>> links;
+    public final Optional<Map<String, Object>> metadata;
+
+    private CreateChargeResponseFromConnector(long amount, String chargeId, PaymentState state, String returnUrl,
+                                              String description, String reference, String email, String paymentProvider,
+                                              String gatewayTransactionId, String createdDate, SupportedLanguage language,
+                                              boolean delayedCapture, Long corporateCardSurcharge, Long totalAmount,
+                                              RefundSummary refundSummary, SettlementSummary settlementSummary,
+                                              CardDetails cardDetails, List<Map<?, ?>> links, Map<String, Object> metadata) {
+        this.amount = amount;
+        this.chargeId = chargeId;
+        this.state = state;
+        this.returnUrl = returnUrl;
+        this.description = description;
+        this.reference = reference;
+        this.email = email;
+        this.paymentProvider = paymentProvider;
+        this.gatewayTransactionId = gatewayTransactionId;
+        this.createdDate = createdDate;
+        this.language = language;
+        this.delayedCapture = delayedCapture;
+        this.corporateCardSurcharge = corporateCardSurcharge;
+        this.totalAmount = totalAmount;
+        this.refundSummary = refundSummary;
+        this.settlementSummary = settlementSummary;
+        this.cardDetails = cardDetails;
+        this.links = links;
+        this.metadata = metadata == null || metadata.isEmpty() ? Optional.empty() : Optional.of(metadata);;
+    }
+
+    public static final class CreateChargeResponseFromConnectorBuilder {
+        private Long amount, corporateCardSurcharge, totalAmount;
+        private PaymentState state;
+        private String chargeId, returnUrl, description, reference, email, paymentProvider, gatewayTransactionId, createdDate;
+        private SupportedLanguage language;
+        private Boolean delayedCapture;
+        private RefundSummary refundSummary;
+        private SettlementSummary settlementSummary;
+        private CardDetails cardDetails;
+        private List<Map<?, ?>> links = new ArrayList<>();
+        private Map<String, Object> metadata = Map.of();
+
+        private CreateChargeResponseFromConnectorBuilder() {
+        }
+
+        public static CreateChargeResponseFromConnectorBuilder aCreateChargeResponseFromConnector() {
+            return new CreateChargeResponseFromConnectorBuilder();
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withAmount(long amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withChargeId(String chargeId) {
+            this.chargeId = chargeId;
+            return this;
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withState(PaymentState state) {
+            this.state = state;
+            return this;
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withReturnUrl(String returnUrl) {
+            this.returnUrl = returnUrl;
+            return this;
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withReference(String reference) {
+            this.reference = reference;
+            return this;
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withEmail(String email) {
+            this.email = email;
+            return this;
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withPaymentProvider(String paymentProvider) {
+            this.paymentProvider = paymentProvider;
+            return this;
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withGatewayTransactionId(String gatewayTransactionId) {
+            this.gatewayTransactionId = gatewayTransactionId;
+            return this;
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withCreatedDate(String createdDate) {
+            this.createdDate = createdDate;
+            return this;
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withLanguage(SupportedLanguage language) {
+            this.language = language;
+            return this;
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withDelayedCapture(boolean delayedCapture) {
+            this.delayedCapture = delayedCapture;
+            return this;
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withCorporateCardSurcharge(Long corporateCardSurcharge) {
+            this.corporateCardSurcharge = corporateCardSurcharge;
+            return this;
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withTotalAmount(Long totalAmount) {
+            this.totalAmount = totalAmount;
+            return this;
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withRefundSummary(RefundSummary refundSummary) {
+            this.refundSummary = refundSummary;
+            return this;
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withSettlementSummary(SettlementSummary settlementSummary) {
+            this.settlementSummary = settlementSummary;
+            return this;
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withCardDetails(CardDetails cardDetails) {
+            this.cardDetails = cardDetails;
+            return this;
+        }
+
+        public CreateChargeResponseFromConnector build() {
+            List.of(amount, chargeId, language, cardDetails, links).forEach(Objects::requireNonNull);
+            
+            return new CreateChargeResponseFromConnector(amount, chargeId, state, returnUrl, description, reference, email, 
+                    paymentProvider, gatewayTransactionId, createdDate, language, delayedCapture, corporateCardSurcharge, 
+                    totalAmount, refundSummary, settlementSummary, cardDetails, links, metadata);
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withLink(Map<String, ?> link) {
+            links.add(link);
+            return this;
+        }
+
+        public CreateChargeResponseFromConnectorBuilder withMetadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+    }
+}

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -714,8 +714,10 @@
         "delayed_capture" : {
           "type" : "boolean",
           "example" : false,
-          "description" : "delayed capture flag",
-          "readOnly" : true
+          "description" : "delayed capture flag"
+        },
+        "metadata" : {
+          "$ref" : "#/definitions/ExternalMetadata"
         }
       }
     },
@@ -802,6 +804,17 @@
       },
       "description" : "An error response"
     },
+    "ExternalMetadata" : {
+      "type" : "object",
+      "properties" : {
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
     "GetPaymentResult" : {
       "type" : "object",
       "properties" : {
@@ -829,6 +842,12 @@
           "type" : "string",
           "example" : "en",
           "enum" : [ "en", "cy" ]
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
         },
         "payment_id" : {
           "type" : "string",
@@ -939,6 +958,12 @@
           "type" : "string",
           "example" : "en",
           "enum" : [ "en", "cy" ]
+        },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
         },
         "payment_id" : {
           "type" : "string",


### PR DESCRIPTION
The test of significance is CreatePaymentITest.createCardPaymentWithMetadata,
which assumes connector returns the metadata when creating a payment. There
will be a pact test for this in another PR. I've also taken the opportunity to
create builders for some nasty methods which take too many parameters.
