### PR TITLE
PP-5142 Remove message from error response in Pact

### DIFF
--- a/src/test/resources/pacts/publicapi-connector-cancel-already-canceled-payment.json
+++ b/src/test/resources/pacts/publicapi-connector-cancel-already-canceled-payment.json
@@ -22,10 +22,7 @@
         "path": "/v1/api/accounts/123456/charges/charge8133029783750964630/cancel"
       },
       "response": {
-        "status": 400,
-        "body": {
-          "message": "Charge not in correct state to be processed, charge8133029783750964630"
-        }
+        "status": 400
       }
     }
   ],


### PR DESCRIPTION
The structure of error responses is changing so the message field will be an array. We should remove the field from the pact entirely as we don't consume it, so shouldn't be asserting on it.