### PR TITLE
PP-5080 New API response fields `fee` and `net_amount`

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -287,6 +287,8 @@ Content-Type: application/json
     },
     "payment_id": "ab2341da231434",
     "amount": 50000,
+    "fee": 10,
+    "net_amount": 49995
     "description": "Payment description",
     "status": "CREATED",
     "return_url": "https://service.example.com/some-reference-to-this-payment",
@@ -1368,6 +1370,8 @@ GET /v1/refunds
 | `results[i].created_date`            | Yes            | The created date in ISO_8601 format (```yyyy-MM-ddTHH:mm:ssZ```)  |
 | `results[i].status`   | Yes            | The status of this refund                             |
 | `results[i].amount`| Yes     | The total amount for this refund                |
+| `results[i].fee`| No     |  processing fee taken by the GOV.UK Pay platform, in pence. Only available depending on payment service provider               |
+| `results[i].net_amount`| No     | amount including all surcharges and less all fees, in pence. Only available depending on payment service provider         |
 | `results[i]._links.self`             | Yes            | Link to the refund                                               |
 | `results[i]._links.payment`           | Yes            | Link to the original payment                                          |
 | `_links.self.href`                | Yes            | Href link of the current page                                     |

--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -41,6 +41,12 @@ public class CardPayment extends Payment {
     @JsonProperty("total_amount")
     private final Long totalAmount;
 
+    @JsonProperty("fee")
+    private final Long fee;
+
+    @JsonProperty("net_amount")
+    private final Long netAmount;
+
     @JsonProperty("provider_id")
     @ApiModelProperty(example = "reference-from-payment-gateway")
     private final String providerId;
@@ -52,7 +58,7 @@ public class CardPayment extends Payment {
                        String reference, String email, String paymentProvider, String createdDate,
                        RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
                        SupportedLanguage language, boolean delayedCapture, Long corporateCardSurcharge, Long totalAmount,
-                       String providerId, ExternalMetadata metadata) {
+                       String providerId, ExternalMetadata metadata, Long fee, Long netAmount) {
         super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate);
         this.refundSummary = refundSummary;
         this.settlementSummary = settlementSummary;
@@ -64,6 +70,8 @@ public class CardPayment extends Payment {
         this.delayedCapture = delayedCapture;
         this.corporateCardSurcharge = corporateCardSurcharge;
         this.totalAmount = totalAmount;
+        this.fee = fee;
+        this.netAmount = netAmount;
     }
 
     /**
@@ -113,11 +121,21 @@ public class CardPayment extends Payment {
         return Optional.ofNullable(corporateCardSurcharge);
     }
 
+    @ApiModelProperty(example = "5", value = "processing fee taken by the GOV.UK Pay platform, in pence. Only available depending on payment service provider")
+    public Optional<Long> getFee() {
+        return Optional.ofNullable(fee);
+    }
+
+    @ApiModelProperty(example = "1195", value = "amount including all surcharges and less all fees, in pence. Only available depending on payment service provider")
+    public Optional<Long> getNetAmount() {
+        return Optional.ofNullable(netAmount);
+    }
+
     @ApiModelProperty(example = "1450")
     public Optional<Long> getTotalAmount() {
         return Optional.ofNullable(totalAmount);
     }
-    
+
     public String getProviderId() {
         return providerId;
     }
@@ -130,6 +148,8 @@ public class CardPayment extends Payment {
                 ", paymentProvider='" + paymentProvider + '\'' +
                 ", cardBrandLabel='" + getCardBrand() + '\'' +
                 ", amount=" + amount +
+                ", fee=" + fee +
+                ", netAmount=" + netAmount +
                 ", corporateCardSurcharge='" + corporateCardSurcharge + '\'' +
                 ", state='" + state + '\'' +
                 ", returnUrl='" + returnUrl + '\'' +

--- a/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
@@ -60,6 +60,12 @@ public class ChargeFromResponse {
     @JsonProperty("total_amount")
     private Long totalAmount;
 
+    @JsonProperty("fee")
+    private Long fee;
+
+    @JsonProperty("net_amount")
+    private Long netAmount;
+
     @JsonProperty(value = "created_date")
     private String createdDate;
 
@@ -117,6 +123,14 @@ public class ChargeFromResponse {
         return totalAmount;
     }
     
+    public Long getFee() {
+        return fee;
+    }
+
+    public Long getNetAmount() {
+        return netAmount;
+    }
+
     public String getPaymentProvider() {
         return paymentProvider;
     }

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -46,9 +46,10 @@ public class PaymentWithAllLinks {
                                String reference, String email, String paymentProvider, String createdDate, SupportedLanguage language,
                                boolean delayedCapture, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
                                List<PaymentConnectorResponseLink> paymentConnectorResponseLinks, URI selfLink, URI paymentEventsUri, URI paymentCancelUri,
-                               URI paymentRefundsUri, URI paymentCaptureUri, Long corporateCardSurcharge, Long totalAmount, String providerId, ExternalMetadata metadata) {
+                               URI paymentRefundsUri, URI paymentCaptureUri, Long corporateCardSurcharge, Long totalAmount, String providerId, ExternalMetadata metadata,
+                               Long fee, Long netAmount) {
         this.payment = new CardPayment(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate,
-                refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount, providerId, metadata);
+                refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount, providerId, metadata, fee, netAmount);
         this.links.addSelf(selfLink.toString());
         this.links.addKnownLinksValueOf(paymentConnectorResponseLinks);
         this.links.addEvents(paymentEventsUri.toString());
@@ -118,7 +119,9 @@ public class PaymentWithAllLinks {
                 paymentConnector.getCorporateCardSurcharge(),
                 paymentConnector.getTotalAmount(),
                 paymentConnector.getGatewayTransactionId(),
-                paymentConnector.getMetadata().orElse(null));
+                paymentConnector.getMetadata().orElse(null),
+                paymentConnector.getFee(),
+                paymentConnector.getNetAmount());
     }
 
     public static PaymentWithAllLinks getPaymentWithLinks(

--- a/src/main/java/uk/gov/pay/api/model/search/card/GetPaymentResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/GetPaymentResult.java
@@ -21,13 +21,13 @@ public class GetPaymentResult extends CardPayment {
     @ApiModelProperty(name = LINKS_JSON_ATTRIBUTE, dataType = "uk.gov.pay.api.model.links.PaymentLinks")
     private PaymentLinks links;
 
-    public GetPaymentResult(String chargeId, long amount, PaymentState state, String returnUrl, String description, 
-                            String reference, String email, String paymentProvider, String createdDate, 
-                            RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails, 
-                            SupportedLanguage language, boolean delayedCapture, Long corporateCardSurcharge, 
-                            Long totalAmount, String providerId) {
-        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate, 
-                refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, 
-                totalAmount, providerId, null);
+    public GetPaymentResult(String chargeId, long amount, PaymentState state, String returnUrl, String description,
+                            String reference, String email, String paymentProvider, String createdDate,
+                            RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
+                            SupportedLanguage language, boolean delayedCapture, Long corporateCardSurcharge,
+                            Long totalAmount, String providerId, Long fee, Long netAmount) {
+        super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate,
+                refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge,
+                totalAmount, providerId, null, fee, netAmount);
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
@@ -27,9 +27,12 @@ public class PaymentForSearchResult extends CardPayment {
                                   String reference, String email, String paymentProvider, String createdDate, SupportedLanguage language,
                                   boolean delayedCapture, RefundSummary refundSummary, SettlementSummary settlementSummary, CardDetails cardDetails,
                                   List<PaymentConnectorResponseLink> links, URI selfLink, URI paymentEventsLink, URI paymentCancelLink, URI paymentRefundsLink, URI paymentCaptureUri,
-                                  Long corporateCardSurcharge, Long totalAmount, String providerId, ExternalMetadata externalMetadata) {
+                                  Long corporateCardSurcharge, Long totalAmount, String providerId, ExternalMetadata externalMetadata,
+                                  Long fee, Long netAmount) {
+        
         super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider,
-                createdDate, refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount, providerId, externalMetadata);
+                createdDate, refundSummary, settlementSummary, cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount, providerId, externalMetadata,
+                fee, netAmount);
         this.links.addSelf(selfLink.toString());
         this.links.addEvents(paymentEventsLink.toString());
         this.links.addRefunds(paymentRefundsLink.toString());
@@ -74,7 +77,9 @@ public class PaymentForSearchResult extends CardPayment {
                 paymentResult.getCorporateCardSurcharge(),
                 paymentResult.getTotalAmount(),
                 paymentResult.getGatewayTransactionId(),
-                paymentResult.getMetadata().orElse(null));
+                paymentResult.getMetadata().orElse(null),
+                paymentResult.getFee(),
+                paymentResult.getNetAmount());
     }
 
     @ApiModelProperty(name = LINKS_JSON_ATTRIBUTE, dataType = "uk.gov.pay.api.model.links.PaymentLinksForSearch")

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -107,6 +107,8 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                         .withDelayedCapture(true)
                         .withNumberOfResults(1)
                         .withEmail(TEST_EMAIL)
+                        .withFee(5L)
+                        .withNetAmount(9995L)
                         .withGatewayTransactionId("gateway-tx-123456")
                         .getResults())
                 .build();
@@ -123,6 +125,8 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
                 .body("results[0].description", is("description-0"))
                 .body("results[0].state.status", is(TEST_STATE))
                 .body("results[0].amount", is(DEFAULT_AMOUNT))
+                .body("results[0].fee", is(5))
+                .body("results[0].net_amount", is(9995))
                 .body("results[0].payment_provider", is(DEFAULT_PAYMENT_PROVIDER))
                 .body("results[0].payment_id", is("0"))
                 .body("results[0].language", is("en"))

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentResultBuilder.java
@@ -113,7 +113,7 @@ public abstract class PaymentResultBuilder {
         public RefundSummary refund_summary;
         public SettlementSummary settlement_summary;
         public CardDetails card_details = new CardDetails();
-        public Long corporate_card_surcharge, total_amount;
+        public Long corporate_card_surcharge, total_amount, fee, net_amount;
         public List<Map<?,?>> links;
         public Map<String, ?> metadata;
     }
@@ -157,6 +157,8 @@ public abstract class PaymentResultBuilder {
     protected CardDetails cardDetails;
     protected Long corporateCardSurcharge = null;
     protected Long totalAmount = null;
+    protected Long fee = null;
+    protected Long netAmount = null;
     protected String chargeId = null;
     protected String description;
     protected String returnUrl;
@@ -203,6 +205,8 @@ public abstract class PaymentResultBuilder {
                 new SettlementSummary(DEFAULT_CAPTURE_SUBMIT_TIME, DEFAULT_CAPTURED_DATE) : settlementSummary;
         payment.corporate_card_surcharge = corporateCardSurcharge;
         payment.total_amount = totalAmount;
+        payment.fee = fee;
+        payment.net_amount = netAmount;
         payment.links = links ;
         payment.metadata = metadata;
 

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
@@ -12,7 +12,7 @@ import static com.google.common.collect.Lists.newArrayList;
 public class PaymentSearchResultBuilder extends PaymentResultBuilder {
 
     private int noOfResults = DEFAULT_NUMBER_OF_RESULTS;
-    
+
 
     public static PaymentSearchResultBuilder aSuccessfulSearchPayment() {
         return new PaymentSearchResultBuilder();
@@ -30,7 +30,7 @@ public class PaymentSearchResultBuilder extends PaymentResultBuilder {
         this.chargeId = chargeId;
         return this;
     }
-    
+
     public PaymentSearchResultBuilder withCardDetails(uk.gov.pay.api.model.CardDetails cardDetails) {
         this.cardDetails = new CardDetails(cardDetails);
         return this;
@@ -38,6 +38,16 @@ public class PaymentSearchResultBuilder extends PaymentResultBuilder {
 
     public PaymentSearchResultBuilder withReference(String reference) {
         this.reference = reference;
+        return this;
+    }
+
+    public PaymentSearchResultBuilder withFee(Long fee) {
+        this.fee = fee;
+        return this;
+    }
+
+    public PaymentSearchResultBuilder withNetAmount(Long netAmount) {
+        this.netAmount = netAmount;
         return this;
     }
 
@@ -65,7 +75,7 @@ public class PaymentSearchResultBuilder extends PaymentResultBuilder {
         this.state = new TestPaymentSuccessState(status);
         return this;
     }
-    
+
     public PaymentSearchResultBuilder withDelayedCapture(boolean delayedCapture) {
         this.delayedCapture = delayedCapture;
         return this;
@@ -81,7 +91,7 @@ public class PaymentSearchResultBuilder extends PaymentResultBuilder {
         this.noOfResults = numberOfResults;
         return this;
     }
-    
+
     public List<TestPayment> getResults() {
         List<TestPayment> results = newArrayList();
         for (int i = 0; i < noOfResults; i++) {

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSingleResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSingleResultBuilder.java
@@ -49,6 +49,16 @@ public class PaymentSingleResultBuilder extends PaymentResultBuilder {
         this.totalAmount = totalAmount;
         return this;
     }
+
+    public PaymentSingleResultBuilder withFee(Long fee) {
+        this.fee = fee;
+        return this;
+    }
+
+    public PaymentSingleResultBuilder withNetAmount(Long netAmount) {
+        this.netAmount = netAmount;
+        return this;
+    }
     
     public PaymentSingleResultBuilder withAmount(long amount) {
         this.amount = amount;

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -127,6 +127,7 @@ public class PaymentsResourceCreatePaymentTest {
                 null,
                 null,
                 "providerId", 
-                null);
+                null,
+                null, null);
     }
 }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ChargeResponseFromConnector.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ChargeResponseFromConnector.java
@@ -23,6 +23,8 @@ public class ChargeResponseFromConnector {
     private final CardDetails cardDetails;
     private final List<Map<?, ?>> links;
     private final Optional<Map<String, Object>> metadata;
+    private final Long fee;
+    private final Long netAmount;
 
     public Long getAmount() {
         return amount;
@@ -100,6 +102,14 @@ public class ChargeResponseFromConnector {
         return metadata;
     }
 
+    public Long getFee() {
+        return fee;
+    }
+
+    public Long getNetAmount() {
+        return netAmount;
+    }
+
     private ChargeResponseFromConnector(ChargeResponseFromConnectorBuilder builder) {
         this.amount = builder.amount;
         this.chargeId = builder.chargeId;
@@ -119,7 +129,9 @@ public class ChargeResponseFromConnector {
         this.settlementSummary = builder.settlementSummary;
         this.cardDetails = builder.cardDetails;
         this.links = builder.links;
-        this.metadata = builder.metadata == null || builder.metadata.isEmpty() ? Optional.empty() : Optional.of(builder.metadata);;
+        this.metadata = builder.metadata == null || builder.metadata.isEmpty() ? Optional.empty() : Optional.of(builder.metadata);
+        this.fee = builder.fee;
+        this.netAmount = builder.netAmount;
     }
 
     public static final class ChargeResponseFromConnectorBuilder {
@@ -133,6 +145,8 @@ public class ChargeResponseFromConnector {
         private CardDetails cardDetails;
         private List<Map<?, ?>> links = new ArrayList<>();
         private Map<String, Object> metadata = Map.of();
+        private Long fee = null;
+        private Long netAmount = null;
 
         private ChargeResponseFromConnectorBuilder() {
         }
@@ -160,7 +174,9 @@ public class ChargeResponseFromConnector {
                     .withRefundSummary(responseFromConnector.refundSummary)
                     .withSettlementSummary(responseFromConnector.settlementSummary)
                     .withCardDetails(responseFromConnector.cardDetails)
-                    .withMetadata(responseFromConnector.metadata.orElse(null));
+                    .withMetadata(responseFromConnector.metadata.orElse(null))
+                    .withNetAmount(responseFromConnector.getNetAmount())
+                    .withFee(responseFromConnector.getFee());
         }
 
         public ChargeResponseFromConnectorBuilder withAmount(long amount) {
@@ -261,6 +277,16 @@ public class ChargeResponseFromConnector {
 
         public ChargeResponseFromConnectorBuilder withMetadata(Map<String, Object> metadata) {
             this.metadata = metadata;
+            return this;
+        }
+        
+        public ChargeResponseFromConnectorBuilder withFee(Long fee) {
+            this.fee = fee;
+            return this;
+        }
+        
+        public ChargeResponseFromConnectorBuilder withNetAmount(Long netAmount) {
+            this.netAmount = netAmount;
             return this;
         }
     }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -100,6 +100,14 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
         if (responseFromConnector.getTotalAmount() != null) {
             resultBuilder.withTotalAmount(responseFromConnector.getTotalAmount());
         }
+        if(responseFromConnector.getFee() != null){
+            resultBuilder.withFee(responseFromConnector.getFee());
+        }
+        if(responseFromConnector.getNetAmount() != null){
+            resultBuilder.withNetAmount(responseFromConnector.getNetAmount());
+        }
+        System.out.println("net amount : " + responseFromConnector.getNetAmount());
+        System.out.println(responseFromConnector.getFee());
         responseFromConnector.getMetadata().ifPresent(m -> resultBuilder.withMetadata(m));
 
         return resultBuilder.build();
@@ -174,7 +182,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                 .withLink(validGetLink(chargeLocation(gatewayAccountId, responseFromConnector.getChargeId()), "self"))
                 .withLink(validGetLink(nextUrl(chargeTokenId), "next_url"))
                 .withLink(validPostLink(nextUrlPost(), "next_url_post", "application/x-www-form-urlencoded", getChargeIdTokenMap(chargeTokenId))).build();
-        
+
         whenCreateCharge(responseFromConnector.getAmount(), gatewayAccountId, responseFromConnector.getReturnUrl(),
                 responseFromConnector.getDescription(), responseFromConnector.getReference())
                 .respond(response()

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -896,6 +896,20 @@
           "example" : 1450,
           "readOnly" : true
         },
+        "fee" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 5,
+          "description" : "processing fee taken by the GOV.UK Pay platform, in pence. Only available depending on payment service provider",
+          "readOnly" : true
+        },
+        "net_amount" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 1195,
+          "description" : "amount including all surcharges and less all fees, in pence. Only available depending on payment service provider",
+          "readOnly" : true
+        },
         "provider_id" : {
           "type" : "string",
           "example" : "reference-from-payment-gateway",
@@ -1007,6 +1021,20 @@
           "type" : "integer",
           "format" : "int64",
           "example" : 1450,
+          "readOnly" : true
+        },
+        "fee" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 5,
+          "description" : "processing fee taken by the GOV.UK Pay platform, in pence. Only available depending on payment service provider",
+          "readOnly" : true
+        },
+        "net_amount" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 1195,
+          "description" : "amount including all surcharges and less all fees, in pence. Only available depending on payment service provider",
           "readOnly" : true
         },
         "provider_id" : {


### PR DESCRIPTION
## WHAT YOU DID
- Added new fields `fee` and `net_amount` that are available from connector to get/search payments API
- Also updates swagger file with new fields
