### PR TITLE
PP-5142 Make parsing connector error compatible with message array

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/ConnectorResponseErrorException.java
+++ b/src/main/java/uk/gov/pay/api/exception/ConnectorResponseErrorException.java
@@ -69,13 +69,13 @@ public class ConnectorResponseErrorException extends RuntimeException {
     public static class ConnectorErrorResponse {
 
         private String reason;
-        private String message;
+        private Object message;
 
         public String getReason() {
             return reason;
         }
 
-        public String getMessage() {
+        public Object getMessage() {
             return message;
         }
 

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -509,7 +509,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
         return response()
                 .withStatusCode(statusCode)
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON)
-                .withBody(jsonString("message", errorMsg));
+                .withBody(jsonString("message", List.of(errorMsg)));
     }
 
     //"Gson can not automatically deserialize the pure inner classes since their no-args constructor"
@@ -540,6 +540,6 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                         .withHeader(CONTENT_TYPE, APPLICATION_JSON)
                         .withBody(new JsonStringBuilder()
                                 .add("reason", reason)
-                                .add("message", "A message that should be completely ignored (only log)").build()));
+                                .add("message", List.of("A message that should be completely ignored (only log)")).build()));
     }
 }


### PR DESCRIPTION
- The error response body cannot be parsed if the message field is an array of strings, which is what Connector will return in the future. We need to be able to parse the response body to get the "reason" field for refund error responses. This change will make public api compatible with the upcoming connector change.
- Currently we only log the error message so changing the type of the message field to "Object" will mean we will continue to log it.