### PR TITLE
PP-5142 Use error identifiers when handling microservice errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <jackson.version>2.9.8</jackson.version>
         <logback.version>1.2.3</logback.version>
         <docker-client.version>8.15.2</docker-client.version>
-        <pay-java-commons.version>1.0.20190425163321</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20190507101128</pay-java-commons.version>
         <pact.version>3.6.2</pact.version>
         <PACT_BROKER_URL/>
         <PACT_BROKER_USERNAME/>

--- a/src/main/java/uk/gov/pay/api/exception/ConnectorResponseErrorException.java
+++ b/src/main/java/uk/gov/pay/api/exception/ConnectorResponseErrorException.java
@@ -1,8 +1,10 @@
 package uk.gov.pay.api.exception;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.commons.model.ErrorIdentifier;
 
 import javax.ws.rs.core.Response;
 
@@ -26,6 +28,10 @@ public class ConnectorResponseErrorException extends RuntimeException {
 
     public int getErrorStatus() {
         return status;
+    }
+    
+    public ErrorIdentifier getErrorIdentifier() {
+        return error == null ? ErrorIdentifier.GENERIC : error.errorIdentifier;
     }
 
     public String getReason() {
@@ -68,13 +74,21 @@ public class ConnectorResponseErrorException extends RuntimeException {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ConnectorErrorResponse {
 
+        @JsonProperty("error_identifier")
+        private ErrorIdentifier errorIdentifier;
+        
         private String reason;
+        
         private Object message;
+
+        public ErrorIdentifier getErrorIdentifier() {
+            return errorIdentifier;
+        }
 
         public String getReason() {
             return reason;
         }
-
+        
         public Object getMessage() {
             return message;
         }
@@ -82,7 +96,8 @@ public class ConnectorResponseErrorException extends RuntimeException {
         @Override
         public String toString() {
             return "ConnectorErrorResponse{" +
-                    "reason='" + reason + '\'' +
+                    "error_identifier='" + errorIdentifier + '\'' +
+                    ", reason='" + reason + '\'' +
                     ", message='" + message + '\'' +
                     '}';
         }

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapper.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.exception.CreateAgreementException;
 import uk.gov.pay.api.model.directdebit.agreement.AgreementError;
 import uk.gov.pay.api.model.directdebit.agreement.AgreementError.Code;
+import uk.gov.pay.commons.model.ErrorIdentifier;
 
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
@@ -22,7 +23,7 @@ public class CreateAgreementExceptionMapper implements ExceptionMapper<CreateAgr
         AgreementError agreementError;
         if (exception.getErrorStatus() == NOT_FOUND.getStatusCode()) {
             agreementError = anAgreementError(AgreementError.Code.CREATE_AGREEMENT_ACCOUNT_ERROR);
-        } else if (exception.getErrorStatus() == PRECONDITION_FAILED.getStatusCode()) {
+        } else if (exception.getErrorIdentifier() == ErrorIdentifier.INVALID_MANDATE_TYPE) {
             agreementError = anAgreementError(Code.CREATE_AGREEMENT_TYPE_ERROR);
         } else {
             agreementError = anAgreementError(AgreementError.Code.CREATE_AGREEMENT_CONNECTOR_ERROR);

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.exception.CreateChargeException;
 import uk.gov.pay.api.model.PaymentError;
+import uk.gov.pay.commons.model.ErrorIdentifier;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -27,7 +28,7 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
 
         if (exception.getErrorStatus() == NOT_FOUND.getStatusCode()) {
             paymentError = aPaymentError(CREATE_PAYMENT_ACCOUNT_ERROR);
-        } else if (exception.getErrorStatus() == PRECONDITION_FAILED.getStatusCode()) {
+        } else if (exception.getErrorIdentifier() == ErrorIdentifier.INVALID_MANDATE_TYPE) {
             paymentError = aPaymentError(CREATE_PAYMENT_AGREEMENT_TYPE_ERROR);
         } else {
             paymentError = aPaymentError(CREATE_PAYMENT_CONNECTOR_ERROR);

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapper.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.exception.CreateRefundException;
 import uk.gov.pay.api.model.PaymentError;
+import uk.gov.pay.commons.model.ErrorIdentifier;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -26,10 +27,10 @@ public class CreateRefundExceptionMapper implements ExceptionMapper<CreateRefund
             paymentError = aPaymentError(CREATE_PAYMENT_REFUND_NOT_FOUND_ERROR);
             status = NOT_FOUND;
 
-        } else if (exception.getErrorStatus() == BAD_REQUEST.getStatusCode() && exception.hasReason()) {
+        } else if (exception.getErrorIdentifier() == ErrorIdentifier.REFUND_NOT_AVAILABLE && exception.hasReason()) {
             paymentError = aPaymentError(CREATE_PAYMENT_REFUND_NOT_AVAILABLE, exception.getReason());
             status = BAD_REQUEST;
-        } else if (exception.getErrorStatus() == PRECONDITION_FAILED.getStatusCode()) {
+        } else if (exception.getErrorIdentifier() == ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH) {
             paymentError = aPaymentError(CREATE_PAYMENT_REFUND_AMOUNT_AVAILABLE_MISMATCH);
             status = PRECONDITION_FAILED;
         } else {


### PR DESCRIPTION
Use error_identifier in error response body from Connector and Direct Debit Connector to decide the error that Public API should return for errors where we cannot infer this from the status code alone.

Currently these are just errors with identifier:
INVALID_MANDATE_TYPE
REFUND_NOT_AVAILABLE
REFUND_AMOUNT_AVAILABLE_MISMATCH