### PR TITLE
Bau use wiremock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <dropwizard.version>1.3.10</dropwizard.version>
         <guice.version>4.2.2</guice.version>
         <guava.version>27.1-jre</guava.version>
-        <mockserver.version>5.1.0</mockserver.version>
+        <wiremock.version>2.23.2</wiremock.version>
         <swagger.jersey2.version>1.5.22</swagger.jersey2.version>
         <hamcrest.version>2.1</hamcrest.version>
         <jackson.version>2.9.8</jackson.version>
@@ -164,15 +164,31 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-netty</artifactId>
-            <version>${mockserver.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-client-java</artifactId>
-            <version>${mockserver.version}</version>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>${wiremock.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-servlet</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-servlets</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-webapp</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
@@ -54,7 +54,7 @@ public class RedisRateLimiter {
         try (Jedis jedis = getResource()) {
             Long count = jedis.incr(derivedKey);
             
-            if (count == 1) {   
+            if (count == 1) {
                 jedis.expire(derivedKey, perMillis / 1000);
             }
             return count;

--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
@@ -54,7 +54,7 @@ public class RedisRateLimiter {
         try (Jedis jedis = getResource()) {
             Long count = jedis.incr(derivedKey);
             
-            if (count == 1) {
+            if (count == 1) {   
                 jedis.expire(derivedKey, perMillis / 1000);
             }
             return count;

--- a/src/test/java/uk/gov/pay/api/it/GetPaymentITest.java
+++ b/src/test/java/uk/gov/pay/api/it/GetPaymentITest.java
@@ -10,6 +10,9 @@ import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.model.SettlementSummary;
 import uk.gov.pay.api.utils.ChargeEventBuilder;
 import uk.gov.pay.api.utils.DateTimeUtils;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
+import uk.gov.pay.api.utils.mocks.ConnectorDDMockClient;
+import uk.gov.pay.api.utils.mocks.ConnectorMockClient;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.io.IOException;
@@ -61,11 +64,15 @@ public class GetPaymentITest extends PaymentResourceITestBase {
     private static final Address BILLING_ADDRESS = new Address("line1", "line2", "NR2 5 6EG", "city", "UK");
     private static final CardDetails CARD_DETAILS = new CardDetails("1234", "123456", "Mr. Payment", "12/19", BILLING_ADDRESS, CARD_BRAND_LABEL);
 
+    private ConnectorMockClient connectorMockClient = new ConnectorMockClient(connectorMock);
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+    private ConnectorDDMockClient connectorDDMockClient = new ConnectorDDMockClient(connectorDDMock);
+
     @Test
     public void getPaymentWithMetadata() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
-        connectorMock.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
+        connectorMockClient.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
                 aCreateOrGetChargeResponseFromConnector()
                         .withAmount(AMOUNT)
                         .withChargeId(CHARGE_ID)
@@ -141,9 +148,9 @@ public class GetPaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void getPayment_ReturnsPayment() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
-        connectorMock.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
+        connectorMockClient.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
                 aCreateOrGetChargeResponseFromConnector()
                         .withAmount(AMOUNT)
                         .withChargeId(CHARGE_ID)
@@ -215,9 +222,9 @@ public class GetPaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void getPayment_ReturnsDirectDebitPayment() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, DIRECT_DEBIT);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, DIRECT_DEBIT);
 
-        connectorDDMock.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CREATED, RETURN_URL,
+        connectorDDMockClient.respondWithChargeFound(AMOUNT, GATEWAY_ACCOUNT_ID, CHARGE_ID, CREATED, RETURN_URL,
                 DESCRIPTION, REFERENCE, EMAIL, PAYMENT_PROVIDER, CREATED_DATE, CHARGE_TOKEN_ID);
 
         getPaymentResponse(API_KEY, CHARGE_ID)
@@ -249,9 +256,9 @@ public class GetPaymentITest extends PaymentResourceITestBase {
     public void getPayment_DoesNotReturnCardDigits_IfNotPresentInCardDetails() {
         CardDetails cardDetails = new CardDetails(null, null, "Mr. Payment", "12/19", BILLING_ADDRESS, CARD_BRAND_LABEL);
 
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
-        connectorMock.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
+        connectorMockClient.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
                 aCreateOrGetChargeResponseFromConnector()
                         .withAmount(AMOUNT)
                         .withChargeId(CHARGE_ID)
@@ -280,9 +287,9 @@ public class GetPaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void getPayment_ShouldNotIncludeCancelLinkIfPaymentCannotBeCancelled() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
-        connectorMock.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
+        connectorMockClient.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
                 aCreateOrGetChargeResponseFromConnector()
                         .withAmount(AMOUNT)
                         .withChargeId(CHARGE_ID)
@@ -308,9 +315,9 @@ public class GetPaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void getPayment_ShouldNotIncludeSettlementFieldsIfNull() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
-        connectorMock.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
+        connectorMockClient.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
                 aCreateOrGetChargeResponseFromConnector()
                         .withAmount(AMOUNT)
                         .withChargeId(CHARGE_ID)
@@ -345,9 +352,9 @@ public class GetPaymentITest extends PaymentResourceITestBase {
                 "12/19",
                 null,
                 CARD_BRAND_LABEL);
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
-        connectorMock.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
+        connectorMockClient.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
                 aCreateOrGetChargeResponseFromConnector()
                         .withAmount(AMOUNT)
                         .withChargeId(CHARGE_ID)
@@ -376,7 +383,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void getPayment_Returns401_WhenUnauthorised() {
-        publicAuthMock.respondUnauthorised();
+        publicAuthMockClient.respondUnauthorised();
 
         getPaymentResponse(API_KEY, CHARGE_ID)
                 .statusCode(401);
@@ -386,8 +393,8 @@ public class GetPaymentITest extends PaymentResourceITestBase {
     public void getPayment_returns404_whenConnectorRespondsWith404() throws IOException {
         String paymentId = "ds2af2afd3df112";
         String errorMessage = "backend-error-message";
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respondChargeNotFound(GATEWAY_ACCOUNT_ID, paymentId, errorMessage);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respondChargeNotFound(GATEWAY_ACCOUNT_ID, paymentId, errorMessage);
 
         InputStream body = getPaymentResponse(API_KEY, paymentId)
                 .statusCode(404)
@@ -404,8 +411,8 @@ public class GetPaymentITest extends PaymentResourceITestBase {
     public void getPayment_returns500_whenConnectorRespondsWithResponseOtherThan200Or404() throws IOException {
         String paymentId = "ds2af2afd3df112";
         String errorMessage = "backend-error-message";
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respondWhenGetCharge(GATEWAY_ACCOUNT_ID, paymentId, errorMessage, SC_NOT_ACCEPTABLE);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respondWhenGetCharge(GATEWAY_ACCOUNT_ID, paymentId, errorMessage, SC_NOT_ACCEPTABLE);
 
         InputStream body = getPaymentResponse(API_KEY, paymentId)
                 .statusCode(500)
@@ -420,8 +427,8 @@ public class GetPaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void getPaymentEvents_ReturnsPaymentEvents() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respondWithChargeEventsFound(GATEWAY_ACCOUNT_ID, CHARGE_ID, EVENTS);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respondWithChargeEventsFound(GATEWAY_ACCOUNT_ID, CHARGE_ID, EVENTS);
 
         getPaymentEventsResponse(API_KEY, CHARGE_ID)
                 .statusCode(200)
@@ -437,7 +444,7 @@ public class GetPaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void getPaymentEvents_Returns401_WhenUnauthorised() {
-        publicAuthMock.respondUnauthorised();
+        publicAuthMockClient.respondUnauthorised();
 
         getPaymentEventsResponse(API_KEY, CHARGE_ID)
                 .statusCode(401);
@@ -447,8 +454,8 @@ public class GetPaymentITest extends PaymentResourceITestBase {
     public void getPaymentEvents_returns404_whenConnectorRespondsWith404() throws IOException {
         String paymentId = "ds2af2afd3df112";
         String errorMessage = "backend-error-message";
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respondChargeEventsNotFound(GATEWAY_ACCOUNT_ID, paymentId, errorMessage);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respondChargeEventsNotFound(GATEWAY_ACCOUNT_ID, paymentId, errorMessage);
 
         InputStream body = getPaymentEventsResponse(API_KEY, paymentId)
                 .statusCode(404)
@@ -465,8 +472,8 @@ public class GetPaymentITest extends PaymentResourceITestBase {
     public void getPaymentEvents_returns500_whenConnectorRespondsWithResponseOtherThan200Or404() throws IOException {
         String paymentId = "ds2af2afd3df112";
         String errorMessage = "backend-error-message";
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respondWhenGetChargeEvents(GATEWAY_ACCOUNT_ID, paymentId, errorMessage, SC_NOT_ACCEPTABLE);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respondWhenGetChargeEvents(GATEWAY_ACCOUNT_ID, paymentId, errorMessage, SC_NOT_ACCEPTABLE);
 
         InputStream body = getPaymentEventsResponse(API_KEY, paymentId)
                 .statusCode(500)
@@ -481,9 +488,9 @@ public class GetPaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void getPayment_ReturnsPaymentWithCorporateCardSurcharge() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
-        connectorMock.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
+        connectorMockClient.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
                 aCreateOrGetChargeResponseFromConnector()
                         .withAmount(AMOUNT)
                         .withChargeId(CHARGE_ID)
@@ -514,9 +521,9 @@ public class GetPaymentITest extends PaymentResourceITestBase {
     @Test
     public void getPayment_ReturnsPaymentWithFeeAndNetAmount() {
 
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
-        connectorMock.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
+        connectorMockClient.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
                 aCreateOrGetChargeResponseFromConnector()
                         .withAmount(AMOUNT)
                         .withChargeId(CHARGE_ID)
@@ -548,9 +555,9 @@ public class GetPaymentITest extends PaymentResourceITestBase {
     @Test
     public void getPayment_ReturnsPaymentWithOutFeeAndNetAmount_IfNotAvailableFromConnector() {
 
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
-        connectorMock.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
+        connectorMockClient.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
                 aCreateOrGetChargeResponseFromConnector()
                         .withAmount(AMOUNT)
                         .withChargeId(CHARGE_ID)
@@ -579,9 +586,9 @@ public class GetPaymentITest extends PaymentResourceITestBase {
 
     @Test
     public void getPayment_ReturnsPaymentWithCaptureUrl() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
-        connectorMock.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
+        connectorMockClient.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
                 aCreateOrGetChargeResponseFromConnector()
                         .withAmount(AMOUNT)
                         .withChargeId(CHARGE_ID)

--- a/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
@@ -10,6 +10,8 @@ import uk.gov.pay.api.model.Address;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.utils.DateTimeUtils;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
+import uk.gov.pay.api.utils.mocks.ConnectorMockClient;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.time.ZonedDateTime;
@@ -39,10 +41,13 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
     private static final Address BILLING_ADDRESS = new Address("line1", "line2", "NR2 5 6EG", "city", "UK");
     private static final CardDetails CARD_DETAILS = new CardDetails("1234", "123456", "Mr. Payment", "12/19", BILLING_ADDRESS, "Visa");
 
+    private ConnectorMockClient connectorMockClient = new ConnectorMockClient(connectorMock);
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+    
     @Test
     public void getRefundById_shouldGetValidResponse() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respondWithGetRefundById(GATEWAY_ACCOUNT_ID, CHARGE_ID, REFUND_ID, AMOUNT, REFUND_AMOUNT_AVAILABLE, "available", CREATED_DATE);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respondWithGetRefundById(GATEWAY_ACCOUNT_ID, CHARGE_ID, REFUND_ID, AMOUNT, REFUND_AMOUNT_AVAILABLE, "available", CREATED_DATE);
 
         getPaymentRefundByIdResponse(API_KEY, CHARGE_ID, REFUND_ID)
                 .statusCode(200)
@@ -57,7 +62,7 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void getRefundById_shouldGetNonAuthorized_whenPublicAuthRespondsUnauthorised() {
-        publicAuthMock.respondUnauthorised();
+        publicAuthMockClient.respondUnauthorised();
 
         getPaymentRefundByIdResponse(API_KEY, CHARGE_ID, REFUND_ID)
                 .statusCode(401);
@@ -65,8 +70,8 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void getRefundById_shouldReturnNotFound_whenRefundDoesNotExist() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respondRefundNotFound(GATEWAY_ACCOUNT_ID, CHARGE_ID, "unknown-refund-id");
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respondRefundNotFound(GATEWAY_ACCOUNT_ID, CHARGE_ID, "unknown-refund-id");
 
         getPaymentRefundByIdResponse(API_KEY, CHARGE_ID, REFUND_ID)
                 .statusCode(404)
@@ -77,8 +82,8 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void getRefundById_returns500_whenConnectorRespondsWithResponseOtherThan200Or404() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respondRefundWithError(GATEWAY_ACCOUNT_ID, CHARGE_ID, REFUND_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respondRefundWithError(GATEWAY_ACCOUNT_ID, CHARGE_ID, REFUND_ID);
 
         getPaymentRefundByIdResponse(API_KEY, CHARGE_ID, REFUND_ID)
                 .statusCode(500)
@@ -89,12 +94,12 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void getRefunds_shouldGetValidResponse() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
         PaymentRefundJsonFixture refund_1 = new PaymentRefundJsonFixture(100L, CREATED_DATE, "100", "available", new ArrayList<>());
         PaymentRefundJsonFixture refund_2 = new PaymentRefundJsonFixture(300L, CREATED_DATE, "300", "pending", new ArrayList<>());
 
-        connectorMock.respondWithGetAllRefunds(GATEWAY_ACCOUNT_ID, CHARGE_ID, refund_1, refund_2);
+        connectorMockClient.respondWithGetAllRefunds(GATEWAY_ACCOUNT_ID, CHARGE_ID, refund_1, refund_2);
 
         getPaymentRefundsResponse(API_KEY, CHARGE_ID)
                 .statusCode(200)
@@ -121,8 +126,8 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void getRefunds_shouldGetValidResponse_whenListReturnedIsEmpty() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respondWithGetAllRefunds(GATEWAY_ACCOUNT_ID, CHARGE_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respondWithGetAllRefunds(GATEWAY_ACCOUNT_ID, CHARGE_ID);
 
         getPaymentRefundsResponse(API_KEY, CHARGE_ID)
                 .statusCode(200)
@@ -135,7 +140,7 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void getRefunds_shouldGetNonAuthorized_whenPublicAuthRespondsUnauthorised() {
-        publicAuthMock.respondUnauthorised();
+        publicAuthMockClient.respondUnauthorised();
 
         getPaymentRefundsResponse(API_KEY, CHARGE_ID)
                 .statusCode(401);
@@ -154,7 +159,7 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
         String payload = new GsonBuilder().create().toJson(
                 ImmutableMap.of("amount", AMOUNT));
 
-        connectorMock.respondWithChargeFound(null, GATEWAY_ACCOUNT_ID,
+        connectorMockClient.respondWithChargeFound(null, GATEWAY_ACCOUNT_ID,
                 aCreateOrGetChargeResponseFromConnector()
                         .withAmount(AMOUNT)
                         .withChargeId(CHARGE_ID)
@@ -172,10 +177,10 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
     public void createRefundWhenRefundAmountAvailableMismatch_shouldReturn412Response() {
         String payload = new GsonBuilder().create().toJson(
                 ImmutableMap.of("amount", AMOUNT, "refund_amount_available", REFUND_AMOUNT_AVAILABLE));
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         String errorMessage = new GsonBuilder().create().toJson(
                 ImmutableMap.of("code", "P0604", "description", "Refund amount available mismatch."));
-        connectorMock.respondPreconditionFailed_whenCreateRefund(AMOUNT, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, errorMessage, CHARGE_ID);
+        connectorMockClient.respondPreconditionFailed_whenCreateRefund(GATEWAY_ACCOUNT_ID, errorMessage, CHARGE_ID);
 
         postRefunds(payload)
                 .then()
@@ -187,7 +192,7 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void createRefund_shouldGetNonAuthorized_whenPublicAuthRespondsUnauthorised() {
-        publicAuthMock.respondUnauthorised();
+        publicAuthMockClient.respondUnauthorised();
 
         postRefunds("{\"amount\": 1000}")
                 .then()
@@ -195,9 +200,9 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
     }
 
     private void postRefundRequest(String payload) {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         String refundStatus = "available";
-        connectorMock.respondAccepted_whenCreateARefund(AMOUNT, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, CHARGE_ID, REFUND_ID, refundStatus, CREATED_DATE);
+        connectorMockClient.respondAccepted_whenCreateARefund(AMOUNT, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, CHARGE_ID, REFUND_ID, refundStatus, CREATED_DATE);
 
         postRefunds(payload)
                 .then()

--- a/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.api.it;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
@@ -16,6 +15,7 @@ import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
@@ -148,16 +148,13 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void createRefund_shouldGetAcceptedResponse() {
-        String payload = new GsonBuilder().create().toJson(
-                ImmutableMap.of("amount", AMOUNT, "refund_amount_available", REFUND_AMOUNT_AVAILABLE));
-
+        String payload = new GsonBuilder().create().toJson(Map.of("amount", AMOUNT, "refund_amount_available", REFUND_AMOUNT_AVAILABLE));
         postRefundRequest(payload);
     }
 
     @Test
     public void createRefundWithNoRefundAmountAvailable_shouldGetAcceptedResponse() {
-        String payload = new GsonBuilder().create().toJson(
-                ImmutableMap.of("amount", AMOUNT));
+        String payload = new GsonBuilder().create().toJson(Map.of("amount", AMOUNT));
 
         connectorMockClient.respondWithChargeFound(null, GATEWAY_ACCOUNT_ID,
                 aCreateOrGetChargeResponseFromConnector()
@@ -176,10 +173,10 @@ public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
     @Test
     public void createRefundWhenRefundAmountAvailableMismatch_shouldReturn412Response() {
         String payload = new GsonBuilder().create().toJson(
-                ImmutableMap.of("amount", AMOUNT, "refund_amount_available", REFUND_AMOUNT_AVAILABLE));
+                Map.of("amount", AMOUNT, "refund_amount_available", REFUND_AMOUNT_AVAILABLE));
         publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         String errorMessage = new GsonBuilder().create().toJson(
-                ImmutableMap.of("code", "P0604", "description", "Refund amount available mismatch."));
+                Map.of("code", "P0604", "description", "Refund amount available mismatch."));
         connectorMockClient.respondPreconditionFailed_whenCreateRefund(GATEWAY_ACCOUNT_ID, errorMessage, CHARGE_ID);
 
         postRefunds(payload)

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
@@ -1,22 +1,20 @@
 package uk.gov.pay.api.it;
 
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.spotify.docker.client.exceptions.DockerException;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
-import org.mockserver.junit.MockServerRule;
 import uk.gov.pay.api.app.PublicApi;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.it.rule.RedisDockerRule;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.utils.ApiKeyGenerator;
-import uk.gov.pay.api.utils.PublicAuthMockClient;
-import uk.gov.pay.api.utils.mocks.ConnectorDDMockClient;
-import uk.gov.pay.api.utils.mocks.ConnectorMockClient;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.mockserver.socket.PortFactory.findFreePort;
 import static uk.gov.pay.api.utils.Urls.paymentLocationFor;
 
 public abstract class PaymentResourceITestBase {
@@ -36,48 +34,34 @@ public abstract class PaymentResourceITestBase {
         }
     }
 
+    private static final int CONNECTOR_PORT = findFreePort();
+    private static final int CONNECTOR_DD_PORT = findFreePort();
+    private static final int PUBLIC_AUTH_PORT = findFreePort();
+    
     @Rule
-    public MockServerRule connectorMockRule = new MockServerRule(this);
+    public WireMockClassRule connectorMock = new WireMockClassRule(CONNECTOR_PORT);
 
     @Rule
-    public MockServerRule connectorDDMockRule = new MockServerRule(this);
+    public WireMockClassRule connectorDDMock = new WireMockClassRule(CONNECTOR_DD_PORT);
 
     @Rule
-    public MockServerRule publicAuthMockRule = new MockServerRule(this);
-
+    public WireMockClassRule publicAuthMock = new WireMockClassRule(PUBLIC_AUTH_PORT);
+    
     @Rule
     public DropwizardAppRule<PublicApiConfig> app = new DropwizardAppRule<>(
             PublicApi.class
             , resourceFilePath("config/test-config.yaml")
-            , config("connectorUrl", connectorBaseUrl())
-            , config("connectorDDUrl", connectorDDBaseUrl())
-            , config("publicAuthUrl", publicAuthBaseUrl())
+            , config("connectorUrl", "http://localhost:" + CONNECTOR_PORT)
+            , config("connectorDDUrl", "http://localhost:" + CONNECTOR_DD_PORT)
+            , config("publicAuthUrl", "http://localhost:" + PUBLIC_AUTH_PORT + "/v1/auth")
             , config("redis.endpoint", redisDockerRule.getRedisUrl())
     );
 
-    protected ConnectorMockClient connectorMock;
-    protected ConnectorDDMockClient connectorDDMock;
-    protected PublicAuthMockClient publicAuthMock;
     protected PublicApiConfig configuration;
 
     @Before
     public void setup() {
-        connectorMock = new ConnectorMockClient(connectorMockRule.getPort(), connectorBaseUrl());
-        connectorDDMock = new ConnectorDDMockClient(connectorDDMockRule.getPort(), connectorDDBaseUrl());
-        publicAuthMock = new PublicAuthMockClient(publicAuthMockRule.getPort());
         configuration = app.getConfiguration();
-    }
-
-    private String connectorBaseUrl() {
-        return "http://localhost:" + connectorMockRule.getPort();
-    }
-
-    private String connectorDDBaseUrl() {
-        return "http://localhost:" + connectorDDMockRule.getPort();
-    }
-
-    private String publicAuthBaseUrl() {
-        return "http://localhost:" + publicAuthMockRule.getPort() + "/v1/auth";
     }
 
     String frontendUrlFor(TokenPaymentType paymentType) {

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
@@ -38,30 +38,33 @@ public abstract class PaymentResourceITestBase {
     private static final int CONNECTOR_DD_PORT = findFreePort();
     private static final int PUBLIC_AUTH_PORT = findFreePort();
     
-    @Rule
-    public WireMockClassRule connectorMock = new WireMockClassRule(CONNECTOR_PORT);
+    @ClassRule
+    public static WireMockClassRule connectorMock = new WireMockClassRule(CONNECTOR_PORT);
 
-    @Rule
-    public WireMockClassRule connectorDDMock = new WireMockClassRule(CONNECTOR_DD_PORT);
+    @ClassRule
+    public static WireMockClassRule connectorDDMock = new WireMockClassRule(CONNECTOR_DD_PORT);
 
-    @Rule
-    public WireMockClassRule publicAuthMock = new WireMockClassRule(PUBLIC_AUTH_PORT);
+    @ClassRule
+    public static WireMockClassRule publicAuthMock = new WireMockClassRule(PUBLIC_AUTH_PORT);
     
     @Rule
     public DropwizardAppRule<PublicApiConfig> app = new DropwizardAppRule<>(
-            PublicApi.class
-            , resourceFilePath("config/test-config.yaml")
-            , config("connectorUrl", "http://localhost:" + CONNECTOR_PORT)
-            , config("connectorDDUrl", "http://localhost:" + CONNECTOR_DD_PORT)
-            , config("publicAuthUrl", "http://localhost:" + PUBLIC_AUTH_PORT + "/v1/auth")
-            , config("redis.endpoint", redisDockerRule.getRedisUrl())
+            PublicApi.class,
+            resourceFilePath("config/test-config.yaml"),
+            config("connectorUrl", "http://localhost:" + CONNECTOR_PORT),
+            config("connectorDDUrl", "http://localhost:" + CONNECTOR_DD_PORT),
+            config("publicAuthUrl", "http://localhost:" + PUBLIC_AUTH_PORT + "/v1/auth"),
+            config("redis.endpoint", redisDockerRule.getRedisUrl())
     );
 
-    protected PublicApiConfig configuration;
+    PublicApiConfig configuration;
 
     @Before
     public void setup() {
         configuration = app.getConfiguration();
+        connectorMock.resetAll();
+        connectorDDMock.resetAll();
+        publicAuthMock.resetAll();
     }
 
     String frontendUrlFor(TokenPaymentType paymentType) {

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
@@ -18,7 +18,7 @@ import static org.mockserver.socket.PortFactory.findFreePort;
 import static uk.gov.pay.api.utils.Urls.paymentLocationFor;
 
 public abstract class PaymentResourceITestBase {
-    //Must use same secret set int confiPaymentsResourceReferenceVgured test-config.xml
+    //Must use same secret set in test-config.xml's apiKeyHmacSecret
     protected static final String API_KEY = ApiKeyGenerator.apiKeyValueOf("TEST_BEARER_TOKEN", "qwer9yuhgf");
     protected static final String GATEWAY_ACCOUNT_ID = "GATEWAY_ACCOUNT_ID";
     protected static final String PAYMENTS_PATH = "/v1/payments/";

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchITest.java
@@ -175,14 +175,12 @@ public class PaymentResourceSearchITest extends PaymentResourceITestBase {
 
     @Test
     public void searchPayments_ShouldNotIncludeCancelLinkIfThePaymentCannotBeCancelled() {
-        String SUCCEEDED_STATE = "success";
-
         String payments = aPaginatedPaymentSearchResult()
                 .withCount(10)
                 .withPage(2)
                 .withTotal(20)
                 .withPayments(aSuccessfulSearchPayment()
-                        .withSuccessState(SUCCEEDED_STATE)
+                        .withSuccessState("success")
                         .withReference(TEST_REFERENCE)
                         .withNumberOfResults(1)
                         .getResults())

--- a/src/test/java/uk/gov/pay/api/it/PaymentsCancelResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsCancelResourceITest.java
@@ -28,19 +28,14 @@ public class PaymentsCancelResourceITest extends PaymentResourceITestBase {
     @Test
     public void cancelPayment_Returns401_WhenUnauthorised() {
         publicAuthMockClient.respondUnauthorised();
-
-        postCancelPaymentResponse(TEST_CHARGE_ID)
-                .statusCode(401);
+        postCancelPaymentResponse(TEST_CHARGE_ID).statusCode(401);
     }
 
     @Test
     public void successful_whenConnector_AllowsCancellation() {
         publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMockClient.respondOk_whenCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID);
-
-        postCancelPaymentResponse(TEST_CHARGE_ID)
-                .statusCode(204);
-
+        postCancelPaymentResponse(TEST_CHARGE_ID).statusCode(204);
         connectorMockClient.verifyCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID);
     }
 

--- a/src/test/java/uk/gov/pay/api/it/PaymentsCancelResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsCancelResourceITest.java
@@ -3,6 +3,8 @@ package uk.gov.pay.api.it;
 import com.jayway.jsonassert.JsonAssert;
 import io.restassured.response.ValidatableResponse;
 import org.junit.Test;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
+import uk.gov.pay.api.utils.mocks.ConnectorMockClient;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,9 +22,12 @@ public class PaymentsCancelResourceITest extends PaymentResourceITestBase {
     private static final String TEST_CHARGE_ID = "ch_ab2341da231434";
     private static final String CANCEL_PAYMENTS_PATH = PAYMENTS_PATH + "%s/cancel";
 
+    private ConnectorMockClient connectorMockClient = new ConnectorMockClient(connectorMock);
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+    
     @Test
     public void cancelPayment_Returns401_WhenUnauthorised() {
-        publicAuthMock.respondUnauthorised();
+        publicAuthMockClient.respondUnauthorised();
 
         postCancelPaymentResponse(TEST_CHARGE_ID)
                 .statusCode(401);
@@ -30,19 +35,19 @@ public class PaymentsCancelResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void successful_whenConnector_AllowsCancellation() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respondOk_whenCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respondOk_whenCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID);
 
         postCancelPaymentResponse(TEST_CHARGE_ID)
                 .statusCode(204);
 
-        connectorMock.verifyCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.verifyCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID);
     }
 
     @Test
     public void cancelPayment_returns404_whenPaymentNotFound() throws IOException {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respondChargeNotFound_WhenCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "some backend error message");
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respondChargeNotFound_WhenCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "some backend error message");
 
         InputStream body = postCancelPaymentResponse(TEST_CHARGE_ID)
                 .statusCode(404)
@@ -57,8 +62,8 @@ public class PaymentsCancelResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void cancelPayment_returns409_whenConnectorReturns409() throws IOException {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respond_WhenCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "some backend error message", CONFLICT_409);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respond_WhenCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "some backend error message", CONFLICT_409);
 
         InputStream body = postCancelPaymentResponse(TEST_CHARGE_ID)
                 .statusCode(409)
@@ -73,8 +78,8 @@ public class PaymentsCancelResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void cancelPayment_returns500_whenConnectorResponseIsUnexpected() throws IOException {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respond_WhenCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "some backend error message", LENGTH_REQUIRED_411);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respond_WhenCancelCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "some backend error message", LENGTH_REQUIRED_411);
 
         InputStream body = postCancelPaymentResponse(TEST_CHARGE_ID)
                 .statusCode(500)

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceCaptureITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceCaptureITest.java
@@ -3,6 +3,8 @@ package uk.gov.pay.api.it;
 import com.jayway.jsonassert.JsonAssert;
 import io.restassured.response.ValidatableResponse;
 import org.junit.Test;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
+import uk.gov.pay.api.utils.mocks.ConnectorMockClient;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,9 +22,12 @@ public class PaymentsResourceCaptureITest extends PaymentResourceITestBase {
     private static final String TEST_CHARGE_ID = "ch_e36c168c41a0";
     private static final String CAPTURE_PAYMENTS_PATH = PAYMENTS_PATH + "%s/capture";
 
+    private ConnectorMockClient connectorMockClient = new ConnectorMockClient(connectorMock);
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+
     @Test
     public void capturePayment_Returns401_WhenUnauthorised() {
-        publicAuthMock.respondUnauthorised();
+        publicAuthMockClient.respondUnauthorised();
 
         postCapturePaymentResponse(TEST_CHARGE_ID)
                 .statusCode(401);
@@ -30,19 +35,19 @@ public class PaymentsResourceCaptureITest extends PaymentResourceITestBase {
 
     @Test
     public void successful_whenConnector_AllowsCapture() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respondOk_whenCaptureCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respondOk_whenCaptureCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID);
 
         postCapturePaymentResponse(TEST_CHARGE_ID)
                 .statusCode(204);
 
-        connectorMock.verifyCaptureCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.verifyCaptureCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID);
     }
 
     @Test
     public void capturePayment_returns400_whenConnectorRespondsWithA400() throws IOException {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respondBadRequest_WhenCaptureCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "Invalid account Id");
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respondBadRequest_WhenCaptureCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "Invalid account Id");
 
         InputStream body = postCapturePaymentResponse(TEST_CHARGE_ID)
                 .statusCode(400)
@@ -57,8 +62,8 @@ public class PaymentsResourceCaptureITest extends PaymentResourceITestBase {
 
     @Test
     public void capturePayment_returns404_whenPaymentNotFound() throws IOException {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respondChargeNotFound_WhenCaptureCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "some backend error message");
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respondChargeNotFound_WhenCaptureCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "some backend error message");
 
         InputStream body = postCapturePaymentResponse(TEST_CHARGE_ID)
                 .statusCode(404)
@@ -73,8 +78,8 @@ public class PaymentsResourceCaptureITest extends PaymentResourceITestBase {
 
     @Test
     public void capturePayment_returns409_whenConnectorReturns409() throws IOException {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respond_WhenCaptureCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "some backend error message", CONFLICT_409);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respond_WhenCaptureCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "some backend error message", CONFLICT_409);
 
         InputStream body = postCapturePaymentResponse(TEST_CHARGE_ID)
                 .statusCode(409)
@@ -89,8 +94,8 @@ public class PaymentsResourceCaptureITest extends PaymentResourceITestBase {
 
     @Test
     public void capturePayment_returns500_whenConnectorResponseIsUnexpected() throws IOException {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-        connectorMock.respond_WhenCaptureCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "some backend error message", LENGTH_REQUIRED_411);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respond_WhenCaptureCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID, "some backend error message", LENGTH_REQUIRED_411);
 
         InputStream body = postCapturePaymentResponse(TEST_CHARGE_ID)
                 .statusCode(500)

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceCaptureITest.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceCaptureITest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.api.it;
 
 import com.jayway.jsonassert.JsonAssert;
 import io.restassured.response.ValidatableResponse;
+import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.api.utils.PublicAuthMockClient;
 import uk.gov.pay.api.utils.mocks.ConnectorMockClient;
@@ -28,19 +29,14 @@ public class PaymentsResourceCaptureITest extends PaymentResourceITestBase {
     @Test
     public void capturePayment_Returns401_WhenUnauthorised() {
         publicAuthMockClient.respondUnauthorised();
-
-        postCapturePaymentResponse(TEST_CHARGE_ID)
-                .statusCode(401);
+        postCapturePaymentResponse(TEST_CHARGE_ID).statusCode(401);
     }
 
     @Test
     public void successful_whenConnector_AllowsCapture() {
         publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
         connectorMockClient.respondOk_whenCaptureCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID);
-
-        postCapturePaymentResponse(TEST_CHARGE_ID)
-                .statusCode(204);
-
+        postCapturePaymentResponse(TEST_CHARGE_ID).statusCode(204);
         connectorMockClient.verifyCaptureCharge(TEST_CHARGE_ID, GATEWAY_ACCOUNT_ID);
     }
 

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterAuthorisationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterAuthorisationITest.java
@@ -28,8 +28,8 @@ public class ResourcesFilterAuthorisationITest extends ResourcesFilterITestBase 
     public void getPayment_whenInvalidAuthorizationHeader_shouldReturn401Response() throws Exception {
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
-                () -> getPaymentResponse("InvalidToken2", CHARGE_ID),
-                () -> getPaymentResponse("InvalidToken2", CHARGE_ID)
+                () -> getPaymentResponse("InvalidToken2"),
+                () -> getPaymentResponse("InvalidToken2")
         );
 
         List<ValidatableResponse> finishedTasks = invokeAll(tasks);
@@ -42,8 +42,8 @@ public class ResourcesFilterAuthorisationITest extends ResourcesFilterITestBase 
     public void getPaymentEvents_whenInvalidAuthorizationHeader_shouldReturn401Response() throws Exception {
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
-                () -> getPaymentEventsResponse("InvalidToken3", CHARGE_ID),
-                () -> getPaymentEventsResponse("InvalidToken3", CHARGE_ID)
+                () -> getPaymentEventsResponse("InvalidToken3"),
+                () -> getPaymentEventsResponse("InvalidToken3")
         );
 
         List<ValidatableResponse> finishedTasks = invokeAll(tasks);
@@ -70,8 +70,8 @@ public class ResourcesFilterAuthorisationITest extends ResourcesFilterITestBase 
     public void cancelPayment_whenInvalidAuthorizationHeader_shouldReturn401Response() throws Exception {
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
-                () -> postCancelPaymentResponse("InvalidToken6", CHARGE_ID),
-                () -> postCancelPaymentResponse("InvalidToken6", CHARGE_ID)
+                () -> postCancelPaymentResponse("InvalidToken6"),
+                () -> postCancelPaymentResponse("InvalidToken6")
         );
 
         List<ValidatableResponse> finishedTasks = invokeAll(tasks);

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterITestBase.java
@@ -1,23 +1,28 @@
 package uk.gov.pay.api.it;
 
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.google.common.collect.ImmutableMap;
+import com.spotify.docker.client.exceptions.DockerException;
+import io.dropwizard.testing.junit.DropwizardAppRule;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
-import uk.gov.pay.api.model.Address;
-import uk.gov.pay.api.model.CardDetails;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import uk.gov.pay.api.app.PublicApi;
+import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.it.rule.RedisDockerRule;
 import uk.gov.pay.api.model.PaymentState;
-import uk.gov.pay.api.model.RefundSummary;
+import uk.gov.pay.api.utils.ApiKeyGenerator;
 import uk.gov.pay.api.utils.ChargeEventBuilder;
 import uk.gov.pay.api.utils.DateTimeUtils;
 import uk.gov.pay.api.utils.JsonStringBuilder;
 import uk.gov.pay.api.utils.PublicAuthMockClient;
 
 import java.time.ZonedDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -25,44 +30,75 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.eclipse.jetty.http.HttpStatus.TOO_MANY_REQUESTS_429;
 import static org.junit.Assert.fail;
+import static org.mockserver.socket.PortFactory.findFreePort;
 import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
-abstract public class ResourcesFilterITestBase extends PaymentResourceITestBase {
+abstract public class ResourcesFilterITestBase {
 
-    protected static final int AMOUNT = 9999999;
-    protected static final String CHARGE_ID = "ch_ab2341da231434l";
-    protected static final String CHARGE_TOKEN_ID = "token_1234567asdf";
-    protected static final PaymentState CREATED = new PaymentState("created", false, null, null);
-    protected static final RefundSummary REFUND_SUMMARY = new RefundSummary("pending", 100L, 50L);
-    protected static final String PAYMENT_PROVIDER = "Sandbox";
-    protected static final String CARD_BRAND = "master-card";
-    protected static final String CARD_BRAND_LABEL = "Mastercard";
-    protected static final String RETURN_URL = "https://somewhere.gov.uk/rainbow/1";
-    protected static final String REFERENCE = "Some reference";
-    protected static final String EMAIL = "alice.111@mail.fake";
-    protected static final String DESCRIPTION = "Some description";
-    protected static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
-    protected static final String CREATED_DATE = ISO_INSTANT_MILLISECOND_PRECISION.format(TIMESTAMP);
-    protected static final Map<String, String> PAYMENT_CREATED = new ChargeEventBuilder(CREATED, CREATED_DATE).build();
-    protected static final List<Map<String, String>> EVENTS = Collections.singletonList(PAYMENT_CREATED);
-    protected static final Address BILLING_ADDRESS = new Address("line1", "line2", "NR2 5 6EG", "city", "UK");
-    protected static final CardDetails CARD_DETAILS = new CardDetails("1234", "123456", "Mr. Payment", "12/19", BILLING_ADDRESS, "Visa");
+    static final String API_KEY = ApiKeyGenerator.apiKeyValueOf("TEST_BEARER_TOKEN", "qwer9yuhgf"); //Must use same secret set in test-config.xml's apiKeyHmacSecret
+    static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
+    static final String PAYMENTS_PATH = "/v1/payments/";
+    static final int AMOUNT = 9999999;
+    static final String CHARGE_ID = "ch_ab2341da231434l";
+    static final PaymentState CREATED = new PaymentState("created", false, null, null);
+    static final String RETURN_URL = "https://somewhere.gov.uk/rainbow/1";
+    static final String REFERENCE = "Some reference";
+    static final String DESCRIPTION = "Some description";
+    static final String CREATED_DATE = ISO_INSTANT_MILLISECOND_PRECISION.format(TIMESTAMP);
+    static final List<Map<String, String>> EVENTS = List.of(new ChargeEventBuilder(CREATED, CREATED_DATE).build());
+    static final String GATEWAY_ACCOUNT_ID = "GATEWAY_ACCOUNT_ID";
+    static final String PAYLOAD = paymentPayload();
+    
+    private static final int CONNECTOR_PORT = findFreePort();
+    private static final int PUBLIC_AUTH_PORT = findFreePort();
 
-    protected static final String PAYLOAD = paymentPayload(AMOUNT, RETURN_URL, DESCRIPTION, REFERENCE);
-    protected ExecutorService executor = Executors.newFixedThreadPool(2);
+    private ExecutorService executor = Executors.newFixedThreadPool(2);
+    
+    @ClassRule
+    public static RedisDockerRule redisDockerRule;
+
+    static {
+        try {
+            redisDockerRule = new RedisDockerRule();
+        } catch (DockerException e) {
+            e.printStackTrace();
+        }
+    }
+    
+    @ClassRule
+    public static WireMockClassRule connectorMock = new WireMockClassRule(CONNECTOR_PORT);
+
+    @ClassRule
+    public static WireMockClassRule publicAuthMock = new WireMockClassRule(PUBLIC_AUTH_PORT);
+
+    @Rule
+    public DropwizardAppRule<PublicApiConfig> app = new DropwizardAppRule<>(
+            PublicApi.class, 
+            resourceFilePath("config/test-config.yaml"), 
+            config("connectorUrl", "http://localhost:" + CONNECTOR_PORT), 
+            config("connectorDDUrl", "http://localhost"), 
+            config("publicAuthUrl", "http://localhost:" + PUBLIC_AUTH_PORT + "/v1/auth"), 
+            config("redis.endpoint", redisDockerRule.getRedisUrl()),
+            config("rateLimiter.noOfReq", "1"),
+            config("rateLimiter.noOfReqForPost", "1")
+    );
 
     private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
 
     @Before
     public void setupApiKey() {
+        redisDockerRule.clearCache();
         publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
     }
 
-    protected List<ValidatableResponse> invokeAll(List<Callable<ValidatableResponse>> tasks) throws InterruptedException {
+    List<ValidatableResponse> invokeAll(List<Callable<ValidatableResponse>> tasks) throws InterruptedException {
         return executor.invokeAll(tasks)
                 .stream()
                 .map(future -> {
@@ -76,8 +112,8 @@ abstract public class ResourcesFilterITestBase extends PaymentResourceITestBase 
                 .collect(Collectors.toList());
     }
 
-    protected TypeSafeMatcher<ValidatableResponse> aResponse(final int statusCode) {
-        return new TypeSafeMatcher<ValidatableResponse>() {
+    TypeSafeMatcher<ValidatableResponse> aResponse(final int statusCode) {
+        return new TypeSafeMatcher<>() {
             @Override
             protected boolean matchesSafely(ValidatableResponse validatableResponse) {
                 return validatableResponse.extract().statusCode() == statusCode;
@@ -91,49 +127,49 @@ abstract public class ResourcesFilterITestBase extends PaymentResourceITestBase 
         };
     }
 
-    protected TypeSafeMatcher<ValidatableResponse> anErrorResponse(int statusCode, String publicApiErrorCode, String expectedDescription) {
-        return new TypeSafeMatcher<ValidatableResponse>() {
+    TypeSafeMatcher<ValidatableResponse> anErrorResponse() {
+        return new TypeSafeMatcher<>() {
             @Override
             protected boolean matchesSafely(ValidatableResponse validatableResponse) {
                 ExtractableResponse<Response> extract = validatableResponse.extract();
-                return extract.statusCode() == statusCode
-                        && publicApiErrorCode.equals(extract.body().<String>path("code"))
-                        && expectedDescription.equals(extract.body().<String>path("description"));
+                return extract.statusCode() == TOO_MANY_REQUESTS_429
+                        && "P0900".equals(extract.body().<String>path("code"))
+                        && "Too many requests".equals(extract.body().<String>path("description"));
             }
 
             @Override
             public void describeTo(Description description) {
                 description.appendText(" Status code: ")
-                        .appendValue(statusCode)
+                        .appendValue(TOO_MANY_REQUESTS_429)
                         .appendText(", error code: ")
-                        .appendValue(publicApiErrorCode)
+                        .appendValue("P0900")
                         .appendText(", message: ")
-                        .appendValue(expectedDescription)
+                        .appendValue("Too many requests")
                 ;
             }
         };
     }
 
-    protected static String paymentPayload(long amount, String returnUrl, String description, String reference) {
+    private static String paymentPayload() {
         return new JsonStringBuilder()
-                .add("amount", amount)
-                .add("reference", reference)
-                .add("description", description)
-                .add("return_url", returnUrl)
+                .add("amount", (long) ResourcesFilterITestBase.AMOUNT)
+                .add("reference", ResourcesFilterITestBase.REFERENCE)
+                .add("description", ResourcesFilterITestBase.DESCRIPTION)
+                .add("return_url", ResourcesFilterITestBase.RETURN_URL)
                 .build();
     }
 
-    protected ValidatableResponse getPaymentResponse(String bearerToken, String paymentId) {
+    ValidatableResponse getPaymentResponse(String bearerToken) {
         return given().port(app.getLocalPort())
                 .header(AUTHORIZATION, "Bearer " + bearerToken)
-                .get(PAYMENTS_PATH + paymentId)
+                .get(PAYMENTS_PATH + CHARGE_ID)
                 .then();
     }
 
-    protected ValidatableResponse getPaymentEventsResponse(String bearerToken, String paymentId) {
+    ValidatableResponse getPaymentEventsResponse(String bearerToken) {
         return given().port(app.getLocalPort())
                 .header(AUTHORIZATION, "Bearer " + bearerToken)
-                .get(String.format("/v1/payments/%s/events", paymentId))
+                .get(String.format("/v1/payments/%s/events", CHARGE_ID))
                 .then();
     }
 
@@ -147,7 +183,7 @@ abstract public class ResourcesFilterITestBase extends PaymentResourceITestBase 
                 .then();
     }
 
-    protected ValidatableResponse searchPayments(String bearerToken, ImmutableMap<String, String> queryParams) {
+    ValidatableResponse searchPayments(String bearerToken, ImmutableMap<String, String> queryParams) {
         return given().port(app.getLocalPort())
                 .accept(JSON)
                 .contentType(JSON)
@@ -157,10 +193,10 @@ abstract public class ResourcesFilterITestBase extends PaymentResourceITestBase 
                 .then();
     }
 
-    protected ValidatableResponse postCancelPaymentResponse(String bearerToken, String paymentId) {
+    ValidatableResponse postCancelPaymentResponse(String bearerToken) {
         return given().port(app.getLocalPort())
                 .header(AUTHORIZATION, "Bearer " + bearerToken)
-                .post(String.format("/v1/payments/%s/cancel", paymentId))
+                .post(String.format("/v1/payments/%s/cancel", CHARGE_ID))
                 .then();
     }
 }

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterITestBase.java
@@ -14,6 +14,7 @@ import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.utils.ChargeEventBuilder;
 import uk.gov.pay.api.utils.DateTimeUtils;
 import uk.gov.pay.api.utils.JsonStringBuilder;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
 
 import java.time.ZonedDateTime;
 import java.util.Collections;
@@ -54,9 +55,11 @@ abstract public class ResourcesFilterITestBase extends PaymentResourceITestBase 
     protected static final String PAYLOAD = paymentPayload(AMOUNT, RETURN_URL, DESCRIPTION, REFERENCE);
     protected ExecutorService executor = Executors.newFixedThreadPool(2);
 
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+
     @Before
     public void setupApiKey() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
     }
 
     protected List<ValidatableResponse> invokeAll(List<Callable<ValidatableResponse>> tasks) throws InterruptedException {

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterLocalRateLimiterITest.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterLocalRateLimiterITest.java
@@ -8,6 +8,7 @@ import io.restassured.response.ValidatableResponse;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.api.app.PublicApi;
@@ -68,14 +69,14 @@ public class ResourcesFilterLocalRateLimiterITest {
     private static final String PAYLOAD = paymentPayload(AMOUNT, RETURN_URL, DESCRIPTION, REFERENCE);
     private ExecutorService executor = Executors.newFixedThreadPool(2);
 
-    @Rule
-    public WireMockClassRule connectorMock = new WireMockClassRule(CONNECTOR_PORT);
+    @ClassRule
+    public static WireMockClassRule connectorMock = new WireMockClassRule(CONNECTOR_PORT);
 
-    @Rule
-    public WireMockClassRule publicAuthMock = new WireMockClassRule(PUBLIC_AUTH_PORT);
+    @ClassRule
+    public static WireMockClassRule publicAuthMock = new WireMockClassRule(PUBLIC_AUTH_PORT);
     
-    @Rule
-    public DropwizardAppRule<PublicApiConfig> app = new DropwizardAppRule<>(
+    @ClassRule
+    public static DropwizardAppRule<PublicApiConfig> app = new DropwizardAppRule<>(
             PublicApi.class
             , resourceFilePath("config/test-config.yaml")
             , config("connectorUrl", "http://localhost:" + CONNECTOR_PORT)

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterITest.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterITest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.restassured.response.ValidatableResponse;
 import org.junit.Test;
 import uk.gov.pay.api.it.fixtures.PaymentNavigationLinksFixture;
+import uk.gov.pay.api.utils.mocks.ConnectorMockClient;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.util.Arrays;
@@ -18,10 +19,12 @@ import static uk.gov.pay.api.utils.mocks.ChargeResponseFromConnector.ChargeRespo
 
 public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
 
+    private ConnectorMockClient connectorMockClient = new ConnectorMockClient(connectorMock);
+    
     @Test
     public void createPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
 
-        connectorMock.respondOk_whenCreateCharge(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
+        connectorMockClient.respondOk_whenCreateCharge(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
                 .withAmount(AMOUNT)
                 .withChargeId(CHARGE_ID)
                 .withState(CREATED)
@@ -52,7 +55,7 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
     @Test
     public void getPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
 
-        connectorMock.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
+        connectorMockClient.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
                 aCreateOrGetChargeResponseFromConnector()
                         .withAmount(AMOUNT)
                         .withChargeId(CHARGE_ID)
@@ -84,7 +87,7 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
     @Test
     public void getPaymentEvents_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
 
-        connectorMock.respondWithChargeEventsFound(GATEWAY_ACCOUNT_ID, CHARGE_ID, EVENTS);
+        connectorMockClient.respondWithChargeEventsFound(GATEWAY_ACCOUNT_ID, CHARGE_ID, EVENTS);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> getPaymentEventsResponse(API_KEY, CHARGE_ID),
@@ -112,7 +115,7 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
                         .withNumberOfResults(1).getResults())
                 .build();
 
-        connectorMock.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, REFERENCE, null, null, null, null, null, null, null, null, payments);
+        connectorMockClient.respondOk_whenSearchCharges(null, payments);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> searchPayments(API_KEY, ImmutableMap.of("reference", REFERENCE)),
@@ -129,7 +132,7 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
     @Test
     public void cancelPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
 
-        connectorMock.respondOk_whenCancelCharge(CHARGE_ID, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respondOk_whenCancelCharge(CHARGE_ID, GATEWAY_ACCOUNT_ID);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> postCancelPaymentResponse(API_KEY, CHARGE_ID),

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterITest.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterITest.java
@@ -24,19 +24,17 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
     @Test
     public void createPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
 
-        connectorMockClient.respondOk_whenCreateCharge(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
+        connectorMockClient.respondOk_whenCreateCharge("token_1234567asdf", GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
                 .withAmount(AMOUNT)
                 .withChargeId(CHARGE_ID)
                 .withState(CREATED)
                 .withReturnUrl(RETURN_URL)
                 .withDescription(DESCRIPTION)
                 .withReference(REFERENCE)
-                .withPaymentProvider(PAYMENT_PROVIDER)
+                .withPaymentProvider("Sandbox")
                 .withCreatedDate(CREATED_DATE)
                 .withLanguage(SupportedLanguage.ENGLISH)
                 .withDelayedCapture(false)
-                .withRefundSummary(REFUND_SUMMARY)
-                .withCardDetails(CARD_DETAILS)
                 .withGatewayTransactionId("gatewayTxId")
                 .build());
 
@@ -49,13 +47,13 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
         List<ValidatableResponse> finishedTasks = invokeAll(tasks);
 
         assertThat(finishedTasks, hasItem(aResponse(201)));
-        assertThat(finishedTasks, hasItem(anErrorResponse(429, "P0900", "Too many requests")));
+        assertThat(finishedTasks, hasItem(anErrorResponse()));
     }
 
     @Test
     public void getPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
 
-        connectorMockClient.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID,
+        connectorMockClient.respondWithChargeFound("token_1234567asdf", GATEWAY_ACCOUNT_ID,
                 aCreateOrGetChargeResponseFromConnector()
                         .withAmount(AMOUNT)
                         .withChargeId(CHARGE_ID)
@@ -63,25 +61,23 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
                         .withReturnUrl(RETURN_URL)
                         .withDescription(DESCRIPTION)
                         .withReference(REFERENCE)
-                        .withPaymentProvider(PAYMENT_PROVIDER)
+                        .withPaymentProvider("Sandbox")
                         .withCreatedDate(CREATED_DATE)
                         .withLanguage(SupportedLanguage.ENGLISH)
                         .withDelayedCapture(false)
-                        .withRefundSummary(REFUND_SUMMARY)
-                        .withCardDetails(CARD_DETAILS)
                         .build());
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
-                () -> getPaymentResponse(API_KEY, CHARGE_ID),
-                () -> getPaymentResponse(API_KEY, CHARGE_ID),
-                () -> getPaymentResponse(API_KEY, CHARGE_ID),
-                () -> getPaymentResponse(API_KEY, CHARGE_ID)
+                () -> getPaymentResponse(API_KEY),
+                () -> getPaymentResponse(API_KEY),
+                () -> getPaymentResponse(API_KEY),
+                () -> getPaymentResponse(API_KEY)
         );
 
         List<ValidatableResponse> finishedTasks = invokeAll(tasks);
 
         assertThat(finishedTasks, hasItem(aResponse(200)));
-        assertThat(finishedTasks, hasItem(anErrorResponse(429, "P0900", "Too many requests")));
+        assertThat(finishedTasks, hasItem(anErrorResponse()));
     }
 
     @Test
@@ -90,16 +86,16 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
         connectorMockClient.respondWithChargeEventsFound(GATEWAY_ACCOUNT_ID, CHARGE_ID, EVENTS);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
-                () -> getPaymentEventsResponse(API_KEY, CHARGE_ID),
-                () -> getPaymentEventsResponse(API_KEY, CHARGE_ID),
-                () -> getPaymentEventsResponse(API_KEY, CHARGE_ID),
-                () -> getPaymentEventsResponse(API_KEY, CHARGE_ID)
+                () -> getPaymentEventsResponse(API_KEY),
+                () -> getPaymentEventsResponse(API_KEY),
+                () -> getPaymentEventsResponse(API_KEY),
+                () -> getPaymentEventsResponse(API_KEY)
         );
 
         List<ValidatableResponse> finishedTasks = invokeAll(tasks);
 
         assertThat(finishedTasks, hasItem(aResponse(200)));
-        assertThat(finishedTasks, hasItem(anErrorResponse(429, "P0900", "Too many requests")));
+        assertThat(finishedTasks, hasItem(anErrorResponse()));
     }
 
     @Test
@@ -115,7 +111,7 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
                         .withNumberOfResults(1).getResults())
                 .build();
 
-        connectorMockClient.respondOk_whenSearchCharges(null, payments);
+        connectorMockClient.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, payments);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> searchPayments(API_KEY, ImmutableMap.of("reference", REFERENCE)),
@@ -126,7 +122,7 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
         List<ValidatableResponse> finishedTasks = invokeAll(tasks);
 
         assertThat(finishedTasks, hasItem(aResponse(200)));
-        assertThat(finishedTasks, hasItem(anErrorResponse(429, "P0900", "Too many requests")));
+        assertThat(finishedTasks, hasItem(anErrorResponse()));
     }
 
     @Test
@@ -135,14 +131,14 @@ public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
         connectorMockClient.respondOk_whenCancelCharge(CHARGE_ID, GATEWAY_ACCOUNT_ID);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
-                () -> postCancelPaymentResponse(API_KEY, CHARGE_ID),
-                () -> postCancelPaymentResponse(API_KEY, CHARGE_ID),
-                () -> postCancelPaymentResponse(API_KEY, CHARGE_ID)
+                () -> postCancelPaymentResponse(API_KEY),
+                () -> postCancelPaymentResponse(API_KEY),
+                () -> postCancelPaymentResponse(API_KEY)
         );
 
         List<ValidatableResponse> finishedTasks = invokeAll(tasks);
 
         assertThat(finishedTasks, hasItem(aResponse(204)));
-        assertThat(finishedTasks, hasItem(anErrorResponse(429, "P0900", "Too many requests")));
+        assertThat(finishedTasks, hasItem(anErrorResponse()));
     }
 }

--- a/src/test/java/uk/gov/pay/api/it/directdebit/AgreementsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/directdebit/AgreementsResourceITest.java
@@ -109,11 +109,9 @@ public class AgreementsResourceITest extends PaymentResourceITestBase {
 
         String errorMessage = "something went wrong";
 
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, DIRECT_DEBIT);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, DIRECT_DEBIT);
 
-        connectorDDMock.respondWithMandateTypeInvalid_whenCreateAgreementRequest(
-                MandateType.ONE_OFF,
-                "https://service-name.gov.uk/transactions/12345",
+        connectorDDMockClient.respondWithMandateTypeInvalid_whenCreateAgreementRequest(
                 GATEWAY_ACCOUNT_ID,
                 errorMessage
         );

--- a/src/test/java/uk/gov/pay/api/it/directdebit/AgreementsResourceITest.java
+++ b/src/test/java/uk/gov/pay/api/it/directdebit/AgreementsResourceITest.java
@@ -8,6 +8,8 @@ import uk.gov.pay.api.model.directdebit.agreement.MandateState;
 import uk.gov.pay.api.model.directdebit.agreement.MandateType;
 import uk.gov.pay.api.utils.DateTimeUtils;
 import uk.gov.pay.api.utils.JsonStringBuilder;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
+import uk.gov.pay.api.utils.mocks.ConnectorDDMockClient;
 
 import javax.ws.rs.core.HttpHeaders;
 import java.time.ZonedDateTime;
@@ -22,6 +24,9 @@ import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_
 
 public class AgreementsResourceITest extends PaymentResourceITestBase {
 
+    private ConnectorDDMockClient connectorDDMockClient = new ConnectorDDMockClient(connectorDDMock);
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+    
     private static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
     private static final String CREATED_DATE = ISO_INSTANT_MILLISECOND_PRECISION.format(TIMESTAMP);
     private static final String CHARGE_TOKEN_ID = "token_1234567asdf";
@@ -32,9 +37,9 @@ public class AgreementsResourceITest extends PaymentResourceITestBase {
 
     @Test
     public void createDirectDebitAgreement_withReference() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, DIRECT_DEBIT);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, DIRECT_DEBIT);
         
-        connectorDDMock.respondOk_whenCreateAgreementRequest(
+        connectorDDMockClient.respondOk_whenCreateAgreementRequest(
                 MANDATE_ID,
                 MandateType.ON_DEMAND,
                 MANDATE_REFERENCE,
@@ -80,14 +85,9 @@ public class AgreementsResourceITest extends PaymentResourceITestBase {
 
         String errorMessage = "something went wrong";
 
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, DIRECT_DEBIT);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, DIRECT_DEBIT);
 
-        connectorDDMock.respondBadRequest_whenCreateAgreementRequest(
-                MandateType.ON_DEMAND,
-                "https://service-name.gov.uk/transactions/12345",
-                GATEWAY_ACCOUNT_ID,
-                errorMessage
-        );
+        connectorDDMockClient.respondBadRequest_whenCreateAgreementRequest(GATEWAY_ACCOUNT_ID, errorMessage);
 
         String payload = agreementPayload("https://service-name.gov.uk/transactions/12345", AgreementType.ON_DEMAND);
         given().port(app.getLocalPort())
@@ -136,9 +136,9 @@ public class AgreementsResourceITest extends PaymentResourceITestBase {
     @Test
     public void shouldGetADirectDebitAgreement_withReference() {
 
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, DIRECT_DEBIT);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, DIRECT_DEBIT);
 
-        connectorDDMock.respondOk_whenGetAgreementRequest(
+        connectorDDMockClient.respondOk_whenGetAgreementRequest(
                 MANDATE_ID,
                 MandateType.ON_DEMAND,
                 MANDATE_REFERENCE,

--- a/src/test/java/uk/gov/pay/api/it/rule/RedisContainer.java
+++ b/src/test/java/uk/gov/pay/api/it/rule/RedisContainer.java
@@ -6,6 +6,7 @@ import com.spotify.docker.client.LogStream;
 import com.spotify.docker.client.exceptions.DockerException;
 import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.ContainerInfo;
+import com.spotify.docker.client.messages.ExecCreation;
 import com.spotify.docker.client.messages.HostConfig;
 import com.spotify.docker.client.messages.LogConfig;
 import com.spotify.docker.client.messages.PortBinding;
@@ -14,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -122,6 +124,16 @@ class RedisContainer {
         } catch (DockerException | InterruptedException | IOException e) {
             System.err.println("Could not shutdown " + containerId);
             e.printStackTrace();
+        }
+    }
+
+    public void clearRedisCache() {
+        try {
+            String[] command = {"redis-cli", "FLUSHALL"};
+            String id = docker.execCreate(containerId, command).id();
+            docker.execStart(id);
+        } catch (DockerException | InterruptedException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/test/java/uk/gov/pay/api/it/rule/RedisDockerRule.java
+++ b/src/test/java/uk/gov/pay/api/it/rule/RedisDockerRule.java
@@ -61,4 +61,7 @@ public class RedisDockerRule implements TestRule {
         return container.getConnectionUrl();
     }
 
+    public void clearCache() {
+        container.clearRedisCache();
+    }
 }

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentResourceMetadataValidationFailuresITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentResourceMetadataValidationFailuresITest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.api.it.PaymentResourceITestBase;
 import uk.gov.pay.api.utils.JsonStringBuilder;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
 import uk.gov.pay.api.utils.mocks.CreateChargeRequestParams;
 import uk.gov.pay.api.utils.mocks.CreateChargeRequestParams.CreateChargeRequestParamsBuilder;
 
@@ -36,10 +37,12 @@ public class PaymentResourceMetadataValidationFailuresITest extends PaymentResou
                 .withDescription("DESCRIPTION")
                 .withReference("REFERENCE")
                 .withReturnUrl("https://somewhere.gov.uk/rainbow/1");
+
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
     
     @Before
     public void before() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, CARD);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, CARD);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentResourceSearchValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentResourceSearchValidationITest.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.api.it.PaymentResourceITestBase;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
 
 import java.io.InputStream;
 
@@ -30,9 +31,11 @@ public class PaymentResourceSearchValidationITest extends PaymentResourceITestBa
 
     private static final String SEARCH_PATH = "/v1/payments";
 
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+
     @Before
     public void mapBearerTokenToAccountId() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsRefundsResourceAmountValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsRefundsResourceAmountValidationITest.java
@@ -8,6 +8,8 @@ import uk.gov.pay.api.it.PaymentResourceITestBase;
 import uk.gov.pay.api.model.Address;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.RefundSummary;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
+import uk.gov.pay.api.utils.mocks.ConnectorMockClient;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.io.IOException;
@@ -26,9 +28,12 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
     private static final Address BILLING_ADDRESS = new Address("line1", "line2", "NR2 5 6EG", "city", "UK");
     private static final CardDetails CARD_DETAILS = new CardDetails("1234", "123456", "Mr. Payment", "12/19", BILLING_ADDRESS, "Visa");
 
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+    private ConnectorMockClient connectorMockClient = new ConnectorMockClient(connectorMock);
+    
     @Before
     public void setUpBearerToken() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
     }
 
     @Test
@@ -273,7 +278,7 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
         int amount = 1000;
         String externalChargeId = "charge_12345";
 
-        connectorMock.respondWithChargeFound(null, GATEWAY_ACCOUNT_ID,
+        connectorMockClient.respondWithChargeFound(null, GATEWAY_ACCOUNT_ID,
                 aCreateOrGetChargeResponseFromConnector()
                         .withAmount(amount)
                         .withChargeId(externalChargeId)
@@ -284,7 +289,7 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
                         .withGatewayTransactionId("gatewayTransactionId")
                         .build());
         
-        connectorMock.respondBadRequest_whenCreateARefund("full", amount, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, externalChargeId);
+        connectorMockClient.respondBadRequest_whenCreateARefund("full", GATEWAY_ACCOUNT_ID, externalChargeId);
 
         String refundRequest = "{\"amount\":" + amount + "}";
 
@@ -305,7 +310,7 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
         int amount = 1000;
         String externalChargeId = "charge_12345";
 
-        connectorMock.respondWithChargeFound(null, GATEWAY_ACCOUNT_ID,
+        connectorMockClient.respondWithChargeFound(null, GATEWAY_ACCOUNT_ID,
                 aCreateOrGetChargeResponseFromConnector()
                         .withAmount(amount)
                         .withChargeId(externalChargeId)
@@ -316,7 +321,7 @@ public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourc
                         .withGatewayTransactionId("gatewayTransactionId")
                         .build());
         
-        connectorMock.respondBadRequest_whenCreateARefund("pending", amount, REFUND_AMOUNT_AVAILABLE, GATEWAY_ACCOUNT_ID, externalChargeId);
+        connectorMockClient.respondBadRequest_whenCreateARefund("pending", GATEWAY_ACCOUNT_ID, externalChargeId);
 
         String refundRequest = "{\"amount\":" + amount + "}";
 

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceAgreementIdValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceAgreementIdValidationITest.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.api.it.PaymentResourceITestBase;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,9 +19,11 @@ import static org.hamcrest.core.Is.is;
 
 public class PaymentsResourceAgreementIdValidationITest extends PaymentResourceITestBase {
 
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+    
     @Before
     public void setUpBearerToken() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceAmountValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceAmountValidationITest.java
@@ -5,6 +5,7 @@ import io.restassured.response.ValidatableResponse;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.api.it.PaymentResourceITestBase;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,9 +18,11 @@ import static org.hamcrest.core.Is.is;
 
 public class PaymentsResourceAmountValidationITest extends PaymentResourceITestBase {
 
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+    
     @Before
     public void setUpBearerToken() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceDescriptionValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceDescriptionValidationITest.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.api.it.PaymentResourceITestBase;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,9 +19,11 @@ import static org.hamcrest.core.Is.is;
 
 public class PaymentsResourceDescriptionValidationITest extends PaymentResourceITestBase {
 
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+    
     @Before
     public void setUpBearerToken() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceLanguageValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceLanguageValidationITest.java
@@ -5,6 +5,7 @@ import io.restassured.response.ValidatableResponse;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.api.it.PaymentResourceITestBase;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,9 +18,11 @@ import static org.hamcrest.core.Is.is;
 
 public class PaymentsResourceLanguageValidationITest extends PaymentResourceITestBase {
 
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+    
     @Before
     public void setUpBearerToken() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceReferenceValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceReferenceValidationITest.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.api.it.PaymentResourceITestBase;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,9 +19,11 @@ import static org.hamcrest.core.Is.is;
 
 public class PaymentsResourceReferenceValidationITest extends PaymentResourceITestBase {
 
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+    
     @Before
     public void setUpBearerToken() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceReturnUrlValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceReturnUrlValidationITest.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.api.it.PaymentResourceITestBase;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,9 +19,11 @@ import static org.hamcrest.core.Is.is;
 
 public class PaymentsResourceReturnUrlValidationITest extends PaymentResourceITestBase {
 
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+    
     @Before
     public void setUpBearerToken() {
-        publicAuthMock.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
@@ -8,6 +8,7 @@ import uk.gov.pay.api.utils.JsonStringBuilder;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -99,6 +100,6 @@ public abstract class BaseConnectorMockClient {
     public void verifyCreateChargeConnectorRequest(String gatewayAccountId, CreateChargeRequestParams createChargeRequestParams) {
         wireMockClassRule.verify(1,
                 postRequestedFor(urlEqualTo(format(CONNECTOR_MOCK_CHARGES_PATH, gatewayAccountId)))
-                        .withRequestBody(equalTo(createChargePayload(createChargeRequestParams))));
+                        .withRequestBody(equalToJson(createChargePayload(createChargeRequestParams))));
     }
 }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ChargeResponseFromConnector.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ChargeResponseFromConnector.java
@@ -265,7 +265,7 @@ public class ChargeResponseFromConnector {
         }
 
         public ChargeResponseFromConnector build() {
-            List.of(amount, chargeId, language, cardDetails, links).forEach(Objects::requireNonNull);
+            List.of(amount, chargeId, language, links).forEach(Objects::requireNonNull);
             
             return new ChargeResponseFromConnector(this);
         }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -34,6 +34,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static java.util.Optional.ofNullable;
 import static javax.ws.rs.core.HttpHeaders.ACCEPT;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.HttpHeaders.LOCATION;
@@ -47,7 +48,6 @@ import static org.eclipse.jetty.http.HttpStatus.NOT_FOUND_404;
 import static org.eclipse.jetty.http.HttpStatus.NO_CONTENT_204;
 import static org.eclipse.jetty.http.HttpStatus.OK_200;
 import static org.eclipse.jetty.http.HttpStatus.PRECONDITION_FAILED_412;
-import static org.mockserver.model.HttpResponse.response;
 import static uk.gov.pay.api.it.GetPaymentITest.AWAITING_CAPTURE_REQUEST;
 import static uk.gov.pay.api.it.fixtures.PaymentSingleResultBuilder.aSuccessfulSinglePayment;
 import static uk.gov.pay.api.utils.JsonStringBuilder.jsonString;
@@ -89,29 +89,15 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                 .withPaymentProvider(responseFromConnector.getPaymentProvider())
                 .withDelayedCapture(responseFromConnector.isDelayedCapture())
                 .withLinks(responseFromConnector.getLinks())
-                .withSettlementSummary(responseFromConnector.getSettlementSummary())
-                .withCardDetails(responseFromConnector.getCardDetails());
+                .withSettlementSummary(responseFromConnector.getSettlementSummary());
 
-        if (responseFromConnector.getRefundSummary() != null) {
-            resultBuilder.withRefundSummary(responseFromConnector.getRefundSummary());
-        }
-        if (responseFromConnector.getGatewayTransactionId() != null) {
-            resultBuilder.withGatewayTransactionId(responseFromConnector.getGatewayTransactionId());
-        }
-        if (responseFromConnector.getCorporateCardSurcharge() != null) {
-            resultBuilder.withCorporateCardSurcharge(responseFromConnector.getCorporateCardSurcharge());
-        }
-        if (responseFromConnector.getTotalAmount() != null) {
-            resultBuilder.withTotalAmount(responseFromConnector.getTotalAmount());
-        }
-        if (responseFromConnector.getFee() != null) {
-            resultBuilder.withFee(responseFromConnector.getFee());
-        }
-        if (responseFromConnector.getNetAmount() != null) {
-            resultBuilder.withNetAmount(responseFromConnector.getNetAmount());
-        }
-        System.out.println("net amount : " + responseFromConnector.getNetAmount());
-        System.out.println(responseFromConnector.getFee());
+        ofNullable(responseFromConnector.getCardDetails()).ifPresent(x -> resultBuilder.withCardDetails(x));
+        ofNullable(responseFromConnector.getRefundSummary()).ifPresent(x -> resultBuilder.withRefundSummary(x));
+        ofNullable(responseFromConnector.getGatewayTransactionId()).ifPresent(x -> resultBuilder.withGatewayTransactionId(x));
+        ofNullable(responseFromConnector.getCorporateCardSurcharge()).ifPresent(x -> resultBuilder.withCorporateCardSurcharge(x));
+        ofNullable(responseFromConnector.getTotalAmount()).ifPresent(x -> resultBuilder.withTotalAmount(x));
+        ofNullable(responseFromConnector.getFee()).ifPresent(x -> resultBuilder.withFee(x));
+        ofNullable(responseFromConnector.getNetAmount()).ifPresent(x -> resultBuilder.withNetAmount(x));
         responseFromConnector.getMetadata().ifPresent(m -> resultBuilder.withMetadata(m));
 
         return resultBuilder.build();

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -28,9 +28,9 @@ jerseyClientConfig:
   disabledSecureConnection: "true"
 
 rateLimiter:
-  noOfReq: 1
+  noOfReq: 1000
   perMillis: 1000
-  noOfReqForPost: 1
+  noOfReqForPost: 1000
   noOfReqPerNode: 1
   noOfReqForPostPerNode: 1
 

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -725,6 +725,7 @@
           "description" : "email of the card holder"
         },
         "prefilled_cardholder_details" : {
+          "example" : "J. Bogs",
           "description" : "prefilled cardholder details",
           "$ref" : "#/definitions/PrefilledCardholderDetails"
         }


### PR DESCRIPTION
This PR makes https://github.com/alphagov/pay-publicapi/pull/435 irrelevant. I find the API for wiremock is much easier to use/understand than the mockserver ones. 

A major change in this PR is that previously, when mocking calls to an external service (publicAuth, connector, ddConnector) the exact request and response was set on the mockServer class. I've removed the "exact request" bit in this PR so when writing tests, only the expected Url and responses are specified. This is ok because we already verify the wiremock server is called with certain json bodies.

Using wiremock causes the test run to reduce from 5 minutes to 2 minutes. This caused many test failures due to the redis rate limiting in integration tests. To rectify this I've created a method to clear the redis cache which can be called before a test run.

Also some miscellaneous code cleanups flagged by intellij.

Unfortunately I couldn't make this a smaller commit, sorry!