### PR TITLE
PP-5100 Remove validation from CreatePaymentRequestDeserialiser

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
@@ -14,6 +14,7 @@ import uk.gov.pay.api.filter.ratelimit.RedisRateLimiter;
 import uk.gov.pay.api.json.CreatePaymentRefundRequestDeserializer;
 import uk.gov.pay.api.json.CreatePaymentRequestDeserializer;
 import uk.gov.pay.api.model.CreatePaymentRefundRequest;
+import uk.gov.pay.api.model.CreatePaymentRequest;
 import uk.gov.pay.api.model.ValidCreatePaymentRequest;
 import uk.gov.pay.api.validation.PaymentRefundRequestValidator;
 import uk.gov.pay.api.validation.PaymentRequestValidator;
@@ -37,6 +38,7 @@ public class PublicApiModule extends AbstractModule {
     protected void configure() {
         bind(PublicApiConfig.class).toInstance(configuration);
         bind(Environment.class).toInstance(environment);
+        bind(URLValidator.class).toInstance(urlValidatorValueOf(configuration.getAllowHttpForReturnUrl()));
     }
 
     @Provides
@@ -50,12 +52,11 @@ public class PublicApiModule extends AbstractModule {
     public ObjectMapper provideObjectMapper() {
         ObjectMapper objectMapper = environment.getObjectMapper();
 
-        URLValidator urlValidator = urlValidatorValueOf(configuration.getAllowHttpForReturnUrl());
-        CreatePaymentRequestDeserializer paymentRequestDeserializer = new CreatePaymentRequestDeserializer(new PaymentRequestValidator(urlValidator));
+        CreatePaymentRequestDeserializer paymentRequestDeserializer = new CreatePaymentRequestDeserializer();
         CreatePaymentRefundRequestDeserializer paymentRefundRequestDeserializer = new CreatePaymentRefundRequestDeserializer(new PaymentRefundRequestValidator());
 
         SimpleModule publicApiDeserializationModule = new SimpleModule("publicApiDeserializationModule");
-        publicApiDeserializationModule.addDeserializer(ValidCreatePaymentRequest.class, paymentRequestDeserializer);
+        publicApiDeserializationModule.addDeserializer(CreatePaymentRequest.class, paymentRequestDeserializer);
         publicApiDeserializationModule.addDeserializer(CreatePaymentRefundRequest.class, paymentRefundRequestDeserializer);
 
         objectMapper.configure(DeserializationFeature.ACCEPT_FLOAT_AS_INT, false);

--- a/src/main/java/uk/gov/pay/api/json/CreatePaymentRequestDeserializer.java
+++ b/src/main/java/uk/gov/pay/api/json/CreatePaymentRequestDeserializer.java
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import uk.gov.pay.api.exception.BadRequestException;
 import uk.gov.pay.api.model.CreatePaymentRequest;
-import uk.gov.pay.api.model.ValidCreatePaymentRequest;
-import uk.gov.pay.api.validation.PaymentRequestValidator;
 
 import java.io.IOException;
 
@@ -15,27 +13,19 @@ import static uk.gov.pay.api.json.RequestJsonParser.parsePaymentRequest;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_PARSING_ERROR;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 
-public class CreatePaymentRequestDeserializer extends StdDeserializer<ValidCreatePaymentRequest> {
+public class CreatePaymentRequestDeserializer extends StdDeserializer<CreatePaymentRequest> {
 
-    private PaymentRequestValidator validator;
-
-    public CreatePaymentRequestDeserializer(PaymentRequestValidator validator) {
+    public CreatePaymentRequestDeserializer() {
         super(CreatePaymentRequest.class);
-        this.validator = validator;
     }
 
     @Override
-    public ValidCreatePaymentRequest deserialize(JsonParser parser, DeserializationContext context) {
-        CreatePaymentRequest paymentRequest;
+    public CreatePaymentRequest deserialize(JsonParser parser, DeserializationContext context) {
         try {
             JsonNode json = parser.readValueAsTree();
-            paymentRequest = parsePaymentRequest(json);
+            return parsePaymentRequest(json);
         } catch (IOException e) {
             throw new BadRequestException(aPaymentError(CREATE_PAYMENT_PARSING_ERROR));
         }
-
-        validator.validate(paymentRequest);
-
-        return new ValidCreatePaymentRequest(paymentRequest);
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/Address.java
+++ b/src/main/java/uk/gov/pay/api/model/Address.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.Objects;
+
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -54,5 +56,22 @@ public class Address {
     @ApiModelProperty(example = "GB")
     public String getCountry() {
         return country;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Address address = (Address) o;
+        return Objects.equals(line1, address.line1) &&
+                Objects.equals(line2, address.line2) &&
+                Objects.equals(postcode, address.postcode) &&
+                Objects.equals(city, address.city) &&
+                Objects.equals(country, address.country);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(line1, line2, postcode, city, country);
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/PrefilledCardholderDetails.java
+++ b/src/main/java/uk/gov/pay/api/model/PrefilledCardholderDetails.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.Objects;
 import java.util.Optional;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -31,5 +32,19 @@ public class PrefilledCardholderDetails {
     
     public void setAddress(String addressLine1, String addressLine2, String postcode, String city, String country) {
         this.billingAddress = new Address(addressLine1, addressLine2, postcode, city, country);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PrefilledCardholderDetails that = (PrefilledCardholderDetails) o;
+        return Objects.equals(cardholderName, that.cardholderName) &&
+                Objects.equals(billingAddress, that.billingAddress);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cardholderName, billingAddress);
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
@@ -114,4 +114,25 @@ public class ValidCreatePaymentRequest {
         return joiner.toString();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ValidCreatePaymentRequest that = (ValidCreatePaymentRequest) o;
+        return amount == that.amount &&
+                Objects.equals(reference, that.reference) &&
+                Objects.equals(returnUrl, that.returnUrl) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(agreementId, that.agreementId) &&
+                language == that.language &&
+                Objects.equals(delayedCapture, that.delayedCapture) &&
+                Objects.equals(metadata, that.metadata) &&
+                Objects.equals(email, that.email) &&
+                Objects.equals(prefilledCardholderDetails, that.prefilledCardholderDetails);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, reference, returnUrl, description, agreementId, language, delayedCapture, metadata, email, prefilledCardholderDetails);
+    }
 }

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -67,7 +67,7 @@ public class PaymentsResource {
     private final GetPaymentService getPaymentService;
     private final CapturePaymentService capturePaymentService;
     private final CancelPaymentService cancelPaymentService;
-    private PaymentRequestValidator paymentRequestValidator;
+    private final PaymentRequestValidator paymentRequestValidator;
 
     @Inject
     public PaymentsResource(Client client,

--- a/src/main/java/uk/gov/pay/api/validation/PaymentRequestValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/PaymentRequestValidator.java
@@ -6,6 +6,8 @@ import uk.gov.pay.api.model.CreatePaymentRequest;
 import uk.gov.pay.api.model.PaymentError;
 import uk.gov.pay.api.model.PrefilledCardholderDetails;
 
+import javax.inject.Inject;
+
 import static java.lang.String.format;
 import static uk.gov.pay.api.model.CreatePaymentRequest.AGREEMENT_ID_FIELD_NAME;
 import static uk.gov.pay.api.model.CreatePaymentRequest.AMOUNT_FIELD_NAME;
@@ -40,15 +42,16 @@ public class PaymentRequestValidator {
     static final int EMAIL_MAX_LENGTH = 254;
     static final int CARD_BRAND_MAX_LENGTH = 20;
     static final int AGREEMENT_ID_MAX_LENGTH = 26;
-    private static final int CARDHOLDER_NAME_MAX_LENGTH = 255;
-    private static final int ADDRESS_LINE1_MAX_LENGTH = 255;
-    private static final int ADDRESS_LINE2_MAX_LENGTH = 255;
-    private static final int POSTCODE_MAX_LENGTH = 25;
-    private static final int CITY_MAX_LENGTH = 255;
-    private static final int COUNTRY_EXACT_LENGTH = 2;
+    static final int CARDHOLDER_NAME_MAX_LENGTH = 255;
+    static final int ADDRESS_LINE1_MAX_LENGTH = 255;
+    static final int ADDRESS_LINE2_MAX_LENGTH = 255;
+    static final int POSTCODE_MAX_LENGTH = 25;
+    static final int CITY_MAX_LENGTH = 255;
+    static final int COUNTRY_EXACT_LENGTH = 2;
 
     private URLValidator urlValidator;
 
+    @Inject
     public PaymentRequestValidator(URLValidator urlValidator) {
         this.urlValidator = urlValidator;
     }

--- a/src/test/java/uk/gov/pay/api/json/CreatePaymentRequestDeserializerTest.java
+++ b/src/test/java/uk/gov/pay/api/json/CreatePaymentRequestDeserializerTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.api.exception.BadRequestException;
 import uk.gov.pay.api.model.Address;
+import uk.gov.pay.api.model.CreatePaymentRequest;
 import uk.gov.pay.api.model.ValidCreatePaymentRequest;
 import uk.gov.pay.api.validation.PaymentRequestValidator;
 import uk.gov.pay.api.validation.URLValidator;
@@ -43,7 +44,7 @@ public class CreatePaymentRequestDeserializerTest {
     @Before
     public void setup() {
         URLValidator urlValidator = URLValidator.urlValidatorValueOf(true);
-        deserializer = new CreatePaymentRequestDeserializer(new PaymentRequestValidator(urlValidator));
+        deserializer = new CreatePaymentRequestDeserializer();
     }
 
     @Test
@@ -56,16 +57,16 @@ public class CreatePaymentRequestDeserializerTest {
                 "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
                 "}";
 
-        ValidCreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
+        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
 
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl().get(), is("https://somewhere.gov.uk/rainbow/1"));
-        assertThat(paymentRequest.getLanguage(), is(Optional.empty()));
-        assertThat(paymentRequest.getDelayedCapture(), is(Optional.empty()));
-        assertThat(paymentRequest.getEmail(), is(Optional.empty()));
-        assertThat(paymentRequest.getPrefilledCardholderDetails(), is(Optional.empty()));
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
+        assertThat(paymentRequest.getLanguage(), is(nullValue()));
+        assertThat(paymentRequest.getDelayedCapture(), is(nullValue()));
+        assertThat(paymentRequest.getEmail(), is(nullValue()));
+        assertThat(paymentRequest.getPrefilledCardholderDetails(), is(nullValue()));
     }
 
     @Test
@@ -79,13 +80,13 @@ public class CreatePaymentRequestDeserializerTest {
                 "  \"language\": \"en\"\n" +
                 "}";
 
-        ValidCreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
+        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
 
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl().get(), is("https://somewhere.gov.uk/rainbow/1"));
-        assertThat(paymentRequest.getLanguage().get(), is(SupportedLanguage.ENGLISH));
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
+        assertThat(paymentRequest.getLanguage(), is(SupportedLanguage.ENGLISH.toString()));
     }
 
     @Test
@@ -99,13 +100,13 @@ public class CreatePaymentRequestDeserializerTest {
                 "  \"language\": \"cy\"\n" +
                 "}";
 
-        ValidCreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
+        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
 
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl().get(), is("https://somewhere.gov.uk/rainbow/1"));
-        assertThat(paymentRequest.getLanguage().get(), is(SupportedLanguage.WELSH));
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
+        assertThat(paymentRequest.getLanguage(), is(SupportedLanguage.WELSH.toString()));
     }
 
     @Test
@@ -119,13 +120,13 @@ public class CreatePaymentRequestDeserializerTest {
                 "  \"delayed_capture\": true\n" +
                 "}";
 
-        ValidCreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
+        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
 
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl().get(), is("https://somewhere.gov.uk/rainbow/1"));
-        assertThat(paymentRequest.getDelayedCapture().get(), is(Boolean.TRUE));
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
+        assertThat(paymentRequest.getDelayedCapture(), is(Boolean.TRUE));
     }
 
     @Test
@@ -139,13 +140,13 @@ public class CreatePaymentRequestDeserializerTest {
                 "  \"delayed_capture\": false\n" +
                 "}";
 
-        ValidCreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
+        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
 
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl().get(), is("https://somewhere.gov.uk/rainbow/1"));
-        assertThat(paymentRequest.getDelayedCapture().get(), is(Boolean.FALSE));
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
+        assertThat(paymentRequest.getDelayedCapture(), is(Boolean.FALSE));
     }
 
     @Test
@@ -158,13 +159,13 @@ public class CreatePaymentRequestDeserializerTest {
                 "  \"description\": \"Some description\"\n" +
                 "}";
 
-        ValidCreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
+        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
 
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl(), is(Optional.empty()));
-        assertThat(paymentRequest.getAgreementId().get(), is("abc123"));
+        assertThat(paymentRequest.getReturnUrl(), is(nullValue()));
+        assertThat(paymentRequest.getAgreementId(), is("abc123"));
     }
 
     @Test
@@ -227,36 +228,6 @@ public class CreatePaymentRequestDeserializerTest {
     }
 
     @Test
-    public void deserialize_shouldThrowValidationException_whenAmountIsLessThanMinimum() throws Exception {
-        // language=JSON
-        String json = "{\n" +
-                "  \"amount\": 0,\n" +
-                "  \"reference\": \"Some reference\",\n" +
-                "  \"description\": \"Some description\",\n" +
-                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
-                "}";
-
-        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: amount. Must be greater than or equal to 1"));
-
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
-    }
-
-    @Test
-    public void deserialize_shouldThrowValidationException_whenAmountIsMoreThanMaximum() throws Exception {
-        // language=JSON
-        String json = "{\n" +
-                "  \"amount\": 10000001,\n" +
-                "  \"reference\": \"Some reference\",\n" +
-                "  \"description\": \"Some description\",\n" +
-                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
-                "}";
-
-        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: amount. Must be less than or equal to 10000000"));
-
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
-    }
-
-    @Test
     public void deserialize_shouldThrowValidationException_whenReturnUrlIsNotAStringValue() throws Exception {
         // language=JSON
         String json = "{\n" +
@@ -267,36 +238,6 @@ public class CreatePaymentRequestDeserializerTest {
                 "}";
 
         expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: return_url. Must be a valid URL format"));
-
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
-    }
-
-    @Test
-    public void deserialize_shouldThrowValidationException_whenReturnUrlLengthIsMoreThan2000CharactersLength() throws Exception {
-        // language=JSON
-        String json = "{\n" +
-                "  \"amount\": 1000000,\n" +
-                "  \"reference\": \"Some reference\",\n" +
-                "  \"description\": \"Some description\",\n" +
-                "  \"return_url\": \"" + RandomStringUtils.randomAlphanumeric(2001) + "\"\n" +
-                "}";
-
-        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: return_url. Must be less than or equal to 2000 characters length"));
-
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
-    }
-
-    @Test
-    public void deserialize_shouldThrowValidationException_whenReturnUrlIsAMalformedUrl() throws Exception {
-        // language=JSON
-        String json = "{\n" +
-                "  \"amount\": 666,\n" +
-                "  \"reference\": \"Some reference\",\n" +
-                "  \"description\": \"Some description\",\n" +
-                "  \"return_url\": \"" + RandomStringUtils.randomAlphanumeric(50) + "\"\n" +
-                "}";
-
-        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: return_url. Must be a valid URL format"));
 
         deserializer.deserialize(jsonFactory.createParser(json), ctx);
     }
@@ -375,21 +316,6 @@ public class CreatePaymentRequestDeserializerTest {
     }
 
     @Test
-    public void deserialize_shouldThrowValidationException_whenReferenceIsMoreThan255CharactersLength() throws Exception {
-        // language=JSON
-        String json = "{\n" +
-                "  \"amount\": 666,\n" +
-                "  \"reference\": \"" + RandomStringUtils.randomAlphanumeric(256) + "\",\n" +
-                "  \"description\": \"Some description\",\n" +
-                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
-                "}";
-
-        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: reference. Must be less than or equal to 255 characters length"));
-
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
-    }
-
-    @Test
     public void deserialize_shouldThrowValidationException_whenDescriptionIsMissing() throws Exception {
         // language=JSON
         String json = "{\n" +
@@ -434,21 +360,6 @@ public class CreatePaymentRequestDeserializerTest {
     }
 
     @Test
-    public void deserialize_shouldThrowValidationException_whenDescriptionIsMoreThan255CharactersLength() throws Exception {
-        // language=JSON
-        String json = "{\n" +
-                "  \"amount\": 666,\n" +
-                "  \"reference\": \"Some reference\",\n" +
-                "  \"description\": \"" + RandomStringUtils.randomAlphanumeric(256) + "\",\n" +
-                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
-                "}";
-
-        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: description. Must be less than or equal to 255 characters length"));
-
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
-    }
-
-    @Test
     public void deserialize_shouldThrowValidationException_AsAgreementIdIsMissing_whenAgreementIdIsNullValue() throws Exception {
         // language=JSON
         String json = "{\n" +
@@ -474,37 +385,6 @@ public class CreatePaymentRequestDeserializerTest {
                 "}";
 
         expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: agreement_id. Must be a valid agreement ID"));
-
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
-    }
-
-    @Test
-    public void deserialize_shouldThrowValidationException_whenAgreementIdIsMoreThan26CharactersLength() throws Exception {
-        // language=JSON
-        String json = "{\n" +
-                "  \"amount\": 666,\n" +
-                "  \"reference\": \"Some reference\",\n" +
-                "  \"description\": \"Some description\",\n" +
-                "  \"agreement_id\": \"" + RandomStringUtils.randomAlphanumeric(27) + "\"\n" +
-                "}";
-
-        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: agreement_id. Must be less than or equal to 26 characters length"));
-
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
-    }
-
-    @Test
-    public void deserialize_shouldThrowValidationException_whenLanguageIsNotSupported() throws Exception {
-        // language=JSON
-        String json = "{\n" +
-                "  \"amount\": 1337,\n" +
-                "  \"reference\": \"Some reference\",\n" +
-                "  \"description\": \"Some description\",\n" +
-                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\",\n" +
-                "  \"language\": \"fr\"\n" +
-                "}";
-
-        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: language. Must be \"en\" or \"cy\""));
 
         deserializer.deserialize(jsonFactory.createParser(json), ctx);
     }
@@ -624,19 +504,18 @@ public class CreatePaymentRequestDeserializerTest {
                 "\"country\": \"GB\"\n" +
                 "}" + "}" + "}";
 
-        ValidCreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(payload), ctx);
+        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(payload), ctx);
         assertThat(paymentRequest.getAmount(), is(1000));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl().get(), is("https://somewhere.gov.uk/rainbow/1"));
-        assertThat(paymentRequest.getLanguage(), is(Optional.empty()));
-        assertThat(paymentRequest.getDelayedCapture(), is(Optional.empty()));
-        assertThat(paymentRequest.getEmail().get(), is("j.bogs@example.org"));
-        assertThat(paymentRequest.getPrefilledCardholderDetails().isPresent(), is(true));
-        assertThat(paymentRequest.getPrefilledCardholderDetails().get().getCardholderName().isPresent(), is(true));
-        assertThat(paymentRequest.getPrefilledCardholderDetails().get().getCardholderName().get(), is("J Bogs"));
-        assertThat(paymentRequest.getPrefilledCardholderDetails().get().getBillingAddress().isPresent(), is(true));
-        Address billingAddress = paymentRequest.getPrefilledCardholderDetails().get().getBillingAddress().get();
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
+        assertThat(paymentRequest.getLanguage(), is(nullValue()));
+        assertThat(paymentRequest.getDelayedCapture(), is(nullValue()));
+        assertThat(paymentRequest.getEmail(), is("j.bogs@example.org"));
+        assertThat(paymentRequest.getPrefilledCardholderDetails().getCardholderName().isPresent(), is(true));
+        assertThat(paymentRequest.getPrefilledCardholderDetails().getCardholderName().get(), is("J Bogs"));
+        assertThat(paymentRequest.getPrefilledCardholderDetails().getBillingAddress().isPresent(), is(true));
+        Address billingAddress = paymentRequest.getPrefilledCardholderDetails().getBillingAddress().get();
         assertThat(billingAddress.getLine1(), is("address line 1"));
         assertThat(billingAddress.getLine2(), is(nullValue()));
         assertThat(billingAddress.getPostcode(), is("AB1 CD2"));
@@ -657,18 +536,14 @@ public class CreatePaymentRequestDeserializerTest {
                 "\"cardholder_name\": \"J Bogs\"\n" +
                 "}" + "}";
 
-        ValidCreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(payload), ctx);
+        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(payload), ctx);
         assertThat(paymentRequest.getAmount(), is(1000));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl().get(), is("https://somewhere.gov.uk/rainbow/1"));
-        assertThat(paymentRequest.getLanguage(), is(Optional.empty()));
-        assertThat(paymentRequest.getDelayedCapture(), is(Optional.empty()));
-        assertThat(paymentRequest.getEmail().get(), is("j.bogs@example.org"));
-        assertThat(paymentRequest.getPrefilledCardholderDetails().isPresent(), is(true));
-        assertThat(paymentRequest.getPrefilledCardholderDetails().get().getCardholderName().isPresent(), is(true));
-        assertThat(paymentRequest.getPrefilledCardholderDetails().get().getCardholderName().get(), is("J Bogs"));
-        assertThat(paymentRequest.getPrefilledCardholderDetails().get().getBillingAddress().isPresent(), is(false));
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
+        assertThat(paymentRequest.getEmail(), is("j.bogs@example.org"));
+        assertThat(paymentRequest.getPrefilledCardholderDetails().getCardholderName().get(), is("J Bogs"));
+        assertThat(paymentRequest.getPrefilledCardholderDetails().getBillingAddress().isPresent(), is(false));
     }
 
     @Test
@@ -689,17 +564,16 @@ public class CreatePaymentRequestDeserializerTest {
                 "\"country\": null\n" +
                 "}" + "}" + "}";
 
-        ValidCreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(payload), ctx);
+        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(payload), ctx);
         assertThat(paymentRequest.getAmount(), is(1000));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl().get(), is("https://somewhere.gov.uk/rainbow/1"));
-        assertThat(paymentRequest.getLanguage(), is(Optional.empty()));
-        assertThat(paymentRequest.getDelayedCapture(), is(Optional.empty()));
-        assertThat(paymentRequest.getPrefilledCardholderDetails().isPresent(), is(true));
-        assertThat(paymentRequest.getPrefilledCardholderDetails().get().getCardholderName().isPresent(), is(false));
-        assertThat(paymentRequest.getPrefilledCardholderDetails().get().getBillingAddress().isPresent(), is(true));
-        Address billingAddress = paymentRequest.getPrefilledCardholderDetails().get().getBillingAddress().get();
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
+        assertThat(paymentRequest.getLanguage(), is(nullValue()));
+        assertThat(paymentRequest.getDelayedCapture(), is(nullValue()));
+        assertThat(paymentRequest.getPrefilledCardholderDetails().getCardholderName(), is(Optional.empty()));
+        assertThat(paymentRequest.getPrefilledCardholderDetails().getBillingAddress().isPresent(), is(true));
+        Address billingAddress = paymentRequest.getPrefilledCardholderDetails().getBillingAddress().get();
         assertThat(billingAddress.getLine1(), is("address line 1"));
         assertThat(billingAddress.getLine2(), is("address line 2"));
         assertThat(billingAddress.getPostcode(), is("AB1 CD2"));
@@ -725,17 +599,16 @@ public class CreatePaymentRequestDeserializerTest {
                 "\"country\": \"\"\n" +
                 "}" + "}" + "}";
 
-        ValidCreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(payload), ctx);
+        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(payload), ctx);
         assertThat(paymentRequest.getAmount(), is(1000));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl().get(), is("https://somewhere.gov.uk/rainbow/1"));
-        assertThat(paymentRequest.getLanguage(), is(Optional.empty()));
-        assertThat(paymentRequest.getDelayedCapture(), is(Optional.empty()));
-        assertThat(paymentRequest.getPrefilledCardholderDetails().isPresent(), is(true));
-        assertThat(paymentRequest.getPrefilledCardholderDetails().get().getCardholderName().isPresent(), is(false));
-        assertThat(paymentRequest.getPrefilledCardholderDetails().get().getBillingAddress().isPresent(), is(true));
-        Address billingAddress = paymentRequest.getPrefilledCardholderDetails().get().getBillingAddress().get();
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
+        assertThat(paymentRequest.getLanguage(), is(nullValue()));
+        assertThat(paymentRequest.getDelayedCapture(), is(nullValue()));
+        assertThat(paymentRequest.getPrefilledCardholderDetails().getCardholderName().isPresent(), is(false));
+        assertThat(paymentRequest.getPrefilledCardholderDetails().getBillingAddress().isPresent(), is(true));
+        Address billingAddress = paymentRequest.getPrefilledCardholderDetails().getBillingAddress().get();
         assertThat(billingAddress.getLine1(), is("address line 1"));
         assertThat(billingAddress.getLine2(), is("address line 2"));
         assertThat(billingAddress.getPostcode(), is("AB1 CD2"));
@@ -762,147 +635,6 @@ public class CreatePaymentRequestDeserializerTest {
                 "}" + "}" + "}";
 
         expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: line1. Field must be a string"));
-
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
-    }
-
-    @Test
-    public void deserialize_shouldThrowValidationException_whenEmailIs255Character() throws Exception {
-        // language=JSON
-        String json = "{\n" +
-                "  \"amount\": 1000,\n" +
-                "  \"reference\": \"Some reference\",\n" +
-                "  \"description\": \"Some description\",\n" +
-                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\",\n" +
-                "  \"email\": \"" + RandomStringUtils.randomAlphanumeric(255) + "\"\n" +
-                "}";
-
-        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: email. Must be less than or equal to 254 characters length"));
-
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
-    }
-
-    @Test
-    public void deserialize_shouldThrowValidationException_whenCardholderNameIs256Character() throws Exception {
-        // language=JSON
-        String json = "{\n" +
-                "  \"amount\": 1000,\n" +
-                "  \"reference\": \"Some reference\",\n" +
-                "  \"description\": \"Some description\",\n" +
-                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\",\n" +
-                "\"prefilled_cardholder_details\": {\n" +
-                "\"cardholder_name\": \"" + RandomStringUtils.randomAlphanumeric(256) + "\"\n" +
-                "}" + "}";
-
-        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: cardholder_name. Must be less than or equal to 255 characters length"));
-
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
-    }
-
-    @Test
-    public void deserialize_shouldThrowValidationException_whenLine1Is256Character() throws Exception {
-        // language=JSON
-        String json = "{\n" +
-                "  \"amount\": 1000,\n" +
-                "  \"reference\": \"Some reference\",\n" +
-                "  \"description\": \"Some description\",\n" +
-                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\",\n" +
-                "\"prefilled_cardholder_details\": {\n" +
-                "\"billing_address\": {\n" +
-                "\"line1\": \"" + RandomStringUtils.randomAlphanumeric(256) + "\"\n" +
-                "}" + "}" + "}";
-
-        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: line1. Must be less than or equal to 255 characters length"));
-
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
-    }
-
-    @Test
-    public void deserialize_shouldThrowValidationException_whenLine2Is256Character() throws Exception {
-        // language=JSON
-        String json = "{\n" +
-                "  \"amount\": 1000,\n" +
-                "  \"reference\": \"Some reference\",\n" +
-                "  \"description\": \"Some description\",\n" +
-                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\",\n" +
-                "\"prefilled_cardholder_details\": {\n" +
-                "\"billing_address\": {\n" +
-                "\"line2\": \"" + RandomStringUtils.randomAlphanumeric(256) + "\"\n" +
-                "}" + "}" + "}";
-
-        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: line2. Must be less than or equal to 255 characters length"));
-
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
-    }
-
-    @Test
-    public void deserialize_shouldThrowValidationException_whenPostcodeIs26Character() throws Exception {
-        // language=JSON
-        String json = "{\n" +
-                "  \"amount\": 1000,\n" +
-                "  \"reference\": \"Some reference\",\n" +
-                "  \"description\": \"Some description\",\n" +
-                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\",\n" +
-                "\"prefilled_cardholder_details\": {\n" +
-                "\"billing_address\": {\n" +
-                "\"postcode\": \"" + RandomStringUtils.randomAlphanumeric(26) + "\"\n" +
-                "}" + "}" + "}";
-
-        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: postcode. Must be less than or equal to 25 characters length"));
-
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
-    }
-
-    @Test
-    public void deserialize_shouldThrowValidationException_whenCityIs256Character() throws Exception {
-        // language=JSON
-        String json = "{\n" +
-                "  \"amount\": 1000,\n" +
-                "  \"reference\": \"Some reference\",\n" +
-                "  \"description\": \"Some description\",\n" +
-                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\",\n" +
-                "\"prefilled_cardholder_details\": {\n" +
-                "\"billing_address\": {\n" +
-                "\"city\": \"" + RandomStringUtils.randomAlphanumeric(256) + "\"\n" +
-                "}" + "}" + "}";
-
-        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: city. Must be less than or equal to 255 characters length"));
-
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
-    }
-
-    @Test
-    public void deserialize_shouldThrowValidationException_whenCountryIsMoreThan2Character() throws Exception {
-        // language=JSON
-        String json = "{\n" +
-                "  \"amount\": 1000,\n" +
-                "  \"reference\": \"Some reference\",\n" +
-                "  \"description\": \"Some description\",\n" +
-                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\",\n" +
-                "\"prefilled_cardholder_details\": {\n" +
-                "\"billing_address\": {\n" +
-                "\"country\": \"" + RandomStringUtils.randomAlphanumeric(3) + "\"\n" +
-                "}" + "}" + "}";
-
-        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: country. Must be exactly 2 characters length"));
-
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
-    }
-
-    @Test
-    public void deserialize_shouldThrowValidationException_whenCountryIsLessThan2Character() throws Exception {
-        // language=JSON
-        String json = "{\n" +
-                "  \"amount\": 1000,\n" +
-                "  \"reference\": \"Some reference\",\n" +
-                "  \"description\": \"Some description\",\n" +
-                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\",\n" +
-                "\"prefilled_cardholder_details\": {\n" +
-                "\"billing_address\": {\n" +
-                "\"country\": \"" + RandomStringUtils.randomAlphanumeric(1) + "\"\n" +
-                "}" + "}" + "}";
-
-        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: country. Must be exactly 2 characters length"));
 
         deserializer.deserialize(jsonFactory.createParser(json), ctx);
     }

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -99,9 +99,11 @@ public class PaymentsResourceCreatePaymentTest {
                 .description("New Passport")
                 .build();
 
+        final ValidCreatePaymentRequest validCreatePaymentRequest = new ValidCreatePaymentRequest(createPaymentRequest);
+
         PaymentWithAllLinks injectedResponse = aSuccessfullyCreatedPayment();
 
-        when(createPaymentService.create(eq(account), ArgumentMatchers.any())).thenReturn(injectedResponse);
+        when(createPaymentService.create(account, validCreatePaymentRequest)).thenReturn(injectedResponse);
 
         final Response newPayment = paymentsResource.createNewPayment(account, createPaymentRequest);
 

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.api.resources;
 
+import org.hamcrest.Matchers;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.api.auth.Account;
@@ -23,6 +25,7 @@ import uk.gov.pay.api.service.CreatePaymentService;
 import uk.gov.pay.api.service.GetPaymentService;
 import uk.gov.pay.api.service.PaymentSearchService;
 import uk.gov.pay.api.service.PublicApiUriGenerator;
+import uk.gov.pay.api.validation.PaymentRequestValidator;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import javax.ws.rs.client.Client;
@@ -30,10 +33,12 @@ import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.Collections;
 
+import static org.hamcrest.CoreMatchers.any;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -65,6 +70,9 @@ public class PaymentsResourceCreatePaymentTest {
     @Mock
     private CancelPaymentService cancelPaymentService;
 
+    @Mock
+    private PaymentRequestValidator paymentRequestValidator;
+
     private final String paymentUri = "https://my.link/v1/payments/abc123";
 
     @Before
@@ -76,22 +84,24 @@ public class PaymentsResourceCreatePaymentTest {
                 connectorUriGenerator,
                 getPaymentService,
                 capturePaymentService,
-                cancelPaymentService);
+                cancelPaymentService,
+                paymentRequestValidator);
         when(publicApiUriGenerator.getPaymentURI(anyString())).thenReturn(URI.create(paymentUri));
     }
 
     @Test
     public void createNewPayment_withCardPayment_invokesCreatePaymentService() {
         final Account account = new Account("foo", TokenPaymentType.CARD);
-        final ValidCreatePaymentRequest createPaymentRequest = new ValidCreatePaymentRequest(CreatePaymentRequest.builder()
+        final CreatePaymentRequest createPaymentRequest = CreatePaymentRequest.builder()
                 .amount(100)
                 .returnUrl("https://somewhere.test")
                 .reference("my_ref")
                 .description("New Passport")
-                .build());
+                .build();
+
         PaymentWithAllLinks injectedResponse = aSuccessfullyCreatedPayment();
 
-        when(createPaymentService.create(account, createPaymentRequest)).thenReturn(injectedResponse);
+        when(createPaymentService.create(eq(account), ArgumentMatchers.any())).thenReturn(injectedResponse);
 
         final Response newPayment = paymentsResource.createNewPayment(account, createPaymentRequest);
 

--- a/src/test/java/uk/gov/pay/api/validation/PaymentRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/PaymentRequestValidatorTest.java
@@ -8,6 +8,7 @@ import uk.gov.pay.api.model.CreatePaymentRequest;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static uk.gov.pay.api.matcher.PaymentValidationExceptionMatcher.aValidationExceptionContaining;
 
 public class PaymentRequestValidatorTest {
 
@@ -49,7 +50,10 @@ public class PaymentRequestValidatorTest {
     @Test
     public void validateUnsupportedLanguage_shouldFailValue() {
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().language("unsupported language").build();
+
         expectedException.expect(PaymentValidationException.class);
+        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: language. Must be \"en\" or \"cy\""));
+
         paymentRequestValidator.validate(createPaymentRequest);
     }
 
@@ -62,7 +66,10 @@ public class PaymentRequestValidatorTest {
     @Test
     public void validateMinimumAmount_shouldFailValue() {
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().amount(PaymentRequestValidator.AMOUNT_MIN_VALUE - 1).build();
+
         expectedException.expect(PaymentValidationException.class);
+        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: amount. Must be greater than or equal to 1"));
+
         paymentRequestValidator.validate(createPaymentRequest);
     }
 
@@ -75,7 +82,10 @@ public class PaymentRequestValidatorTest {
     @Test
     public void validateMaximumAmount_shouldFailValue() {
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().amount(PaymentRequestValidator.AMOUNT_MAX_VALUE + 1).build();
+
         expectedException.expect(PaymentValidationException.class);
+        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: amount. Must be less than or equal to 10000000"));
+
         paymentRequestValidator.validate(createPaymentRequest);
     }
 
@@ -83,7 +93,10 @@ public class PaymentRequestValidatorTest {
     public void validateReturnUrlMaxLength_shouldFailValue() {
         String invalidMaxLengthReturnUrl = "https://" + randomAlphanumeric(PaymentRequestValidator.URL_MAX_LENGTH) + ".com/";
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().returnUrl(invalidMaxLengthReturnUrl).build();
+
         expectedException.expect(PaymentValidationException.class);
+        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: return_url. Must be less than or equal to 2000 characters length"));
+
         paymentRequestValidator.validate(createPaymentRequest);
     }
 
@@ -91,7 +104,10 @@ public class PaymentRequestValidatorTest {
     public void validateReturnUrlNotHttps_shouldFailValue() {
         String validHttpOnlyUrl = "http://www.example.com/";
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().returnUrl(validHttpOnlyUrl).build();
+
         expectedException.expect(PaymentValidationException.class);
+        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: return_url. Must be a valid URL format"));
+
         paymentRequestValidator.validate(createPaymentRequest);
     }
 
@@ -99,7 +115,10 @@ public class PaymentRequestValidatorTest {
     public void validateReferenceMaxLength_shouldFailValue() {
         String invalidMaxLengthReference = randomAlphanumeric(PaymentRequestValidator.REFERENCE_MAX_LENGTH + 1);
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().reference(invalidMaxLengthReference).build();
+
         expectedException.expect(PaymentValidationException.class);
+        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: reference. Must be less than or equal to 255 characters length"));
+
         paymentRequestValidator.validate(createPaymentRequest);
     }
 
@@ -107,7 +126,10 @@ public class PaymentRequestValidatorTest {
     public void validateDescriptionMaxLength_shouldFailValue() {
         String invalidMaxLengthDescription = randomAlphanumeric(PaymentRequestValidator.DESCRIPTION_MAX_LENGTH + 1);
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().description(invalidMaxLengthDescription).build();
+
         expectedException.expect(PaymentValidationException.class);
+        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: description. Must be less than or equal to 255 characters length"));
+
         paymentRequestValidator.validate(createPaymentRequest);
     }
 
@@ -115,7 +137,105 @@ public class PaymentRequestValidatorTest {
     public void validateAgreementIdMaxLength_shouldFailValue() {
         String invalidMaxLengthAgreementId = randomAlphanumeric(PaymentRequestValidator.AGREEMENT_ID_MAX_LENGTH + 1);
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().agreementId(invalidMaxLengthAgreementId).build();
+
         expectedException.expect(PaymentValidationException.class);
+        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: agreement_id. Must be less than or equal to 26 characters length"));
+
+        paymentRequestValidator.validate(createPaymentRequest);
+    }
+
+    @Test
+    public void validateEmailMaxLength_shouldFailValue() {
+        String invalidMaxLengthEmail = randomAlphanumeric(PaymentRequestValidator.EMAIL_MAX_LENGTH + 1);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().email(invalidMaxLengthEmail).build();
+
+        expectedException.expect(PaymentValidationException.class);
+        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: email. Must be less than or equal to 254 characters length"));
+
+        paymentRequestValidator.validate(createPaymentRequest);
+    }
+
+    @Test
+    public void validateCardHolderNameMaxLength_shouldFailValue() {
+        String invalidMaxLengthEmail = randomAlphanumeric(PaymentRequestValidator.CARDHOLDER_NAME_MAX_LENGTH + 1);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().cardholderName(invalidMaxLengthEmail).build();
+
+        expectedException.expect(PaymentValidationException.class);
+        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: cardholder_name. Must be less than or equal to 255 characters length"));
+
+        paymentRequestValidator.validate(createPaymentRequest);
+    }
+
+    @Test
+    public void validateLine1MaxLength_shouldFailValue() {
+        String invalidMaxLengthEmail = randomAlphanumeric(PaymentRequestValidator.ADDRESS_LINE1_MAX_LENGTH+ 1);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().addressLine1(invalidMaxLengthEmail).build();
+
+        expectedException.expect(PaymentValidationException.class);
+        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: line1. Must be less than or equal to 255 characters length"));
+
+        paymentRequestValidator.validate(createPaymentRequest);
+    }
+
+    @Test
+    public void validateLine2MaxLength_shouldFailValue() {
+        String invalidMaxLengthEmail = randomAlphanumeric(PaymentRequestValidator.ADDRESS_LINE2_MAX_LENGTH+ 1);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().addressLine2(invalidMaxLengthEmail).build();
+
+        expectedException.expect(PaymentValidationException.class);
+        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: line2. Must be less than or equal to 255 characters length"));
+
+        paymentRequestValidator.validate(createPaymentRequest);
+    }
+
+    @Test
+    public void validatePostCodeMaxLength_shouldFailValue() {
+        String invalidMaxLengthEmail = randomAlphanumeric(PaymentRequestValidator.POSTCODE_MAX_LENGTH+ 1);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().postcode(invalidMaxLengthEmail).build();
+
+        expectedException.expect(PaymentValidationException.class);
+        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: postcode. Must be less than or equal to 25 characters length"));
+
+        paymentRequestValidator.validate(createPaymentRequest);
+    }
+
+    @Test
+    public void validateCityMaxLength_shouldFailValue() {
+        String invalidMaxLengthEmail = randomAlphanumeric(PaymentRequestValidator.CITY_MAX_LENGTH+ 1);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().city(invalidMaxLengthEmail).build();
+
+        expectedException.expect(PaymentValidationException.class);
+        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: city. Must be less than or equal to 255 characters length"));
+
+        paymentRequestValidator.validate(createPaymentRequest);
+    }
+
+    @Test
+    public void validateCountryMaxLength_shouldFailValue() {
+        String invalidMaxLengthEmail = randomAlphanumeric(PaymentRequestValidator.COUNTRY_EXACT_LENGTH+ 1);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().country(invalidMaxLengthEmail).build();
+
+        expectedException.expect(PaymentValidationException.class);
+        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: country. Must be exactly 2 characters length"));
+
+        paymentRequestValidator.validate(createPaymentRequest);
+    }
+
+    @Test
+    public void validateCountryMinLength_shouldFailValue() {
+        String invalidMaxLengthEmail = randomAlphanumeric(1);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().country(invalidMaxLengthEmail).build();
+
+        expectedException.expect(PaymentValidationException.class);
+        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: country. Must be exactly 2 characters length"));
+
+        paymentRequestValidator.validate(createPaymentRequest);
+    }
+    
+    @Test
+    public void validateCountryEmpty_shouldPass() {
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().country("").build();
+
         paymentRequestValidator.validate(createPaymentRequest);
     }
 

--- a/src/test/java/uk/gov/pay/api/validation/PaymentRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/PaymentRequestValidatorTest.java
@@ -51,7 +51,6 @@ public class PaymentRequestValidatorTest {
     public void validateUnsupportedLanguage_shouldFailValue() {
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().language("unsupported language").build();
 
-        expectedException.expect(PaymentValidationException.class);
         expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: language. Must be \"en\" or \"cy\""));
 
         paymentRequestValidator.validate(createPaymentRequest);
@@ -67,7 +66,6 @@ public class PaymentRequestValidatorTest {
     public void validateMinimumAmount_shouldFailValue() {
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().amount(PaymentRequestValidator.AMOUNT_MIN_VALUE - 1).build();
 
-        expectedException.expect(PaymentValidationException.class);
         expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: amount. Must be greater than or equal to 1"));
 
         paymentRequestValidator.validate(createPaymentRequest);
@@ -83,7 +81,6 @@ public class PaymentRequestValidatorTest {
     public void validateMaximumAmount_shouldFailValue() {
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().amount(PaymentRequestValidator.AMOUNT_MAX_VALUE + 1).build();
 
-        expectedException.expect(PaymentValidationException.class);
         expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: amount. Must be less than or equal to 10000000"));
 
         paymentRequestValidator.validate(createPaymentRequest);
@@ -94,7 +91,6 @@ public class PaymentRequestValidatorTest {
         String invalidMaxLengthReturnUrl = "https://" + randomAlphanumeric(PaymentRequestValidator.URL_MAX_LENGTH) + ".com/";
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().returnUrl(invalidMaxLengthReturnUrl).build();
 
-        expectedException.expect(PaymentValidationException.class);
         expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: return_url. Must be less than or equal to 2000 characters length"));
 
         paymentRequestValidator.validate(createPaymentRequest);
@@ -105,7 +101,16 @@ public class PaymentRequestValidatorTest {
         String validHttpOnlyUrl = "http://www.example.com/";
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().returnUrl(validHttpOnlyUrl).build();
 
-        expectedException.expect(PaymentValidationException.class);
+        expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: return_url. Must be a valid URL format"));
+
+        paymentRequestValidator.validate(createPaymentRequest);
+    }
+
+    @Test
+    public void validateReturnUrlInvalidFormat_shouldFailValue() {
+        String invalidUrlFormat = randomAlphanumeric(50);
+        CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().returnUrl(invalidUrlFormat).build();
+
         expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: return_url. Must be a valid URL format"));
 
         paymentRequestValidator.validate(createPaymentRequest);
@@ -116,7 +121,6 @@ public class PaymentRequestValidatorTest {
         String invalidMaxLengthReference = randomAlphanumeric(PaymentRequestValidator.REFERENCE_MAX_LENGTH + 1);
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().reference(invalidMaxLengthReference).build();
 
-        expectedException.expect(PaymentValidationException.class);
         expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: reference. Must be less than or equal to 255 characters length"));
 
         paymentRequestValidator.validate(createPaymentRequest);
@@ -127,7 +131,6 @@ public class PaymentRequestValidatorTest {
         String invalidMaxLengthDescription = randomAlphanumeric(PaymentRequestValidator.DESCRIPTION_MAX_LENGTH + 1);
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithReturnUrl().description(invalidMaxLengthDescription).build();
 
-        expectedException.expect(PaymentValidationException.class);
         expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: description. Must be less than or equal to 255 characters length"));
 
         paymentRequestValidator.validate(createPaymentRequest);
@@ -138,7 +141,6 @@ public class PaymentRequestValidatorTest {
         String invalidMaxLengthAgreementId = randomAlphanumeric(PaymentRequestValidator.AGREEMENT_ID_MAX_LENGTH + 1);
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().agreementId(invalidMaxLengthAgreementId).build();
 
-        expectedException.expect(PaymentValidationException.class);
         expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: agreement_id. Must be less than or equal to 26 characters length"));
 
         paymentRequestValidator.validate(createPaymentRequest);
@@ -149,7 +151,6 @@ public class PaymentRequestValidatorTest {
         String invalidMaxLengthEmail = randomAlphanumeric(PaymentRequestValidator.EMAIL_MAX_LENGTH + 1);
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().email(invalidMaxLengthEmail).build();
 
-        expectedException.expect(PaymentValidationException.class);
         expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: email. Must be less than or equal to 254 characters length"));
 
         paymentRequestValidator.validate(createPaymentRequest);
@@ -160,7 +161,6 @@ public class PaymentRequestValidatorTest {
         String invalidMaxLengthEmail = randomAlphanumeric(PaymentRequestValidator.CARDHOLDER_NAME_MAX_LENGTH + 1);
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().cardholderName(invalidMaxLengthEmail).build();
 
-        expectedException.expect(PaymentValidationException.class);
         expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: cardholder_name. Must be less than or equal to 255 characters length"));
 
         paymentRequestValidator.validate(createPaymentRequest);
@@ -171,7 +171,6 @@ public class PaymentRequestValidatorTest {
         String invalidMaxLengthEmail = randomAlphanumeric(PaymentRequestValidator.ADDRESS_LINE1_MAX_LENGTH+ 1);
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().addressLine1(invalidMaxLengthEmail).build();
 
-        expectedException.expect(PaymentValidationException.class);
         expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: line1. Must be less than or equal to 255 characters length"));
 
         paymentRequestValidator.validate(createPaymentRequest);
@@ -182,7 +181,6 @@ public class PaymentRequestValidatorTest {
         String invalidMaxLengthEmail = randomAlphanumeric(PaymentRequestValidator.ADDRESS_LINE2_MAX_LENGTH+ 1);
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().addressLine2(invalidMaxLengthEmail).build();
 
-        expectedException.expect(PaymentValidationException.class);
         expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: line2. Must be less than or equal to 255 characters length"));
 
         paymentRequestValidator.validate(createPaymentRequest);
@@ -193,7 +191,6 @@ public class PaymentRequestValidatorTest {
         String invalidMaxLengthEmail = randomAlphanumeric(PaymentRequestValidator.POSTCODE_MAX_LENGTH+ 1);
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().postcode(invalidMaxLengthEmail).build();
 
-        expectedException.expect(PaymentValidationException.class);
         expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: postcode. Must be less than or equal to 25 characters length"));
 
         paymentRequestValidator.validate(createPaymentRequest);
@@ -204,7 +201,6 @@ public class PaymentRequestValidatorTest {
         String invalidMaxLengthEmail = randomAlphanumeric(PaymentRequestValidator.CITY_MAX_LENGTH+ 1);
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().city(invalidMaxLengthEmail).build();
 
-        expectedException.expect(PaymentValidationException.class);
         expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: city. Must be less than or equal to 255 characters length"));
 
         paymentRequestValidator.validate(createPaymentRequest);
@@ -215,7 +211,6 @@ public class PaymentRequestValidatorTest {
         String invalidMaxLengthEmail = randomAlphanumeric(PaymentRequestValidator.COUNTRY_EXACT_LENGTH+ 1);
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().country(invalidMaxLengthEmail).build();
 
-        expectedException.expect(PaymentValidationException.class);
         expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: country. Must be exactly 2 characters length"));
 
         paymentRequestValidator.validate(createPaymentRequest);
@@ -226,7 +221,6 @@ public class PaymentRequestValidatorTest {
         String invalidMaxLengthEmail = randomAlphanumeric(1);
         CreatePaymentRequest createPaymentRequest = createPaymentRequestBuilderWithAgreementId().country(invalidMaxLengthEmail).build();
 
-        expectedException.expect(PaymentValidationException.class);
         expectedException.expect(aValidationExceptionContaining("P0102", "Invalid attribute value: country. Must be exactly 2 characters length"));
 
         paymentRequestValidator.validate(createPaymentRequest);


### PR DESCRIPTION
- As step towards refactoring to use Java Bean Validation rather than custom validation
methods this moves the validation of the CreatePaymentRequest outside of the
deserialisation and temporarily into the Resource. The important part is the removal of `validator.validate(paymentRequest);` from within `CreatePaymentRequestDeserializer`
- When refactoring is complete the validation will be invoked via the `@Valid`
annotation on the method parameter and the `PaymentRequestValidator` can be removed
entirely.
- Removed validation related tests from `CreatePaymentRequestDeserializerTest`
which are covered by validation tests within `PaymentRequestValidatorTest`
```
deserialize_shouldThrowValidationException_whenAmountIsLessThanMinimum = validateMinimumAmount_shouldFailValue
deserialize_shouldThrowValidationException_whenAmountIsMoreThanMaximum = validateMaximumAmount_shouldFailValue
deserialize_shouldThrowValidationException_whenReturnUrlLengthIsMoreThan2000CharactersLength = validateReturnUrlMaxLength_shouldFailValue
deserialize_shouldThrowValidationException_whenReturnUrlIsAMalformedUrl = validateReturnUrlNotHttps_shouldFailValue
deserialize_shouldThrowValidationException_whenReferenceIsMoreThan255CharactersLength = validateReferenceMaxLength_shouldFailValue
deserialize_shouldThrowValidationException_whenDescriptionIsMoreThan255CharactersLength = validateDescriptionMaxLength_shouldFailValue
deserialize_shouldThrowValidationException_whenAgreementIdIsMoreThan26CharactersLength = validateAgreementIdMaxLength_shouldFailValue
deserialize_shouldThrowValidationException_whenLanguageIsNotSupported = validateUnsupportedLanguage_shouldFailValue
deserialize_shouldThrowValidationException_whenEmailIs255Character = validateEmailMaxLength_shouldFailValue
deserialize_shouldThrowValidationException_whenCardholderNameIs256Character = validateCardHolderNameMaxLength_shouldFailValue
deserialize_shouldThrowValidationException_whenLine1Is256Character = validateLine1MaxLength_shouldFailValue
deserialize_shouldThrowValidationException_whenPostcodeIs26Character = validatePostCodeMaxLength_shouldFailValue
deserialize_shouldThrowValidationException_whenCityIs256Character = validateCityMaxLength_shouldFailValue
deserialize_shouldThrowValidationException_whenCountryIsLessThan2Character = validateCountryMinLength_shouldFailValue
deserialize_shouldNotThrowValidationException_whenCountryIsEmptyString = validateCountryEmpty_shouldPass

```
## WHAT YOU DID
Please see commit notes. Essentially separate the deserialization from the validation as a prerequisite to refactoring the validation to use java validation spec. There should be no change to any responses.