### PR TITLE
PP-5101: Swagger doc for a payment's metadata

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -52,6 +52,7 @@ public class CardPayment extends Payment {
     private final String providerId;
 
     @JsonSerialize(using = ExternalMetadataSerialiser.class)
+    @ApiModelProperty(name = "metadata", dataType = "Map[String,String]")
     private final ExternalMetadata metadata;
 
     public CardPayment(String chargeId, long amount, PaymentState state, String returnUrl, String description,

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentResult.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentResult.java
@@ -5,6 +5,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import uk.gov.pay.api.model.links.PaymentLinks;
 import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.commons.model.charge.ExternalMetadata;
 
 import static uk.gov.pay.api.model.Payment.LINKS_JSON_ATTRIBUTE;
 
@@ -67,4 +68,8 @@ public class CreatePaymentResult {
     @JsonProperty
     @ApiModelProperty(name = "provider_id", example = "null")
     private String providerId;
+
+    @JsonProperty
+    @ApiModelProperty(name = "metadata", dataType = "Map[String,String]")
+    private ExternalMetadata metadata;
 }

--- a/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/ValidCreatePaymentRequest.java
@@ -31,6 +31,7 @@ public class ValidCreatePaymentRequest {
     private SupportedLanguage language;
     @ApiModelProperty(name = "delayed_capture", value = "delayed capture flag", required = false, example = "false" )
     private Boolean delayedCapture;
+    @ApiModelProperty(name = "metadata", dataType = "Map[String,String]")
     private ExternalMetadata metadata;
     @ApiModelProperty(name = "email", value = "email of the card holder", required = false, example = "joe.bogs@example.org")
     private String email;

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -717,7 +717,10 @@
           "description" : "delayed capture flag"
         },
         "metadata" : {
-          "$ref" : "#/definitions/ExternalMetadata"
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
         },
         "email" : {
           "type" : "string",
@@ -725,7 +728,6 @@
           "description" : "email of the card holder"
         },
         "prefilled_cardholder_details" : {
-          "example" : "J. Bogs",
           "description" : "prefilled cardholder details",
           "$ref" : "#/definitions/PrefilledCardholderDetails"
         }
@@ -781,6 +783,12 @@
           "type" : "string",
           "example" : "null"
         },
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
         "refund_summary" : {
           "$ref" : "#/definitions/RefundSummary"
         },
@@ -814,17 +822,6 @@
       },
       "description" : "An error response"
     },
-    "ExternalMetadata" : {
-      "type" : "object",
-      "properties" : {
-        "metadata" : {
-          "type" : "object",
-          "additionalProperties" : {
-            "type" : "object"
-          }
-        }
-      }
-    },
     "GetPaymentResult" : {
       "type" : "object",
       "properties" : {
@@ -854,7 +851,10 @@
           "enum" : [ "en", "cy" ]
         },
         "metadata" : {
-          "$ref" : "#/definitions/ExternalMetadata"
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
         },
         "payment_id" : {
           "type" : "string",
@@ -981,7 +981,10 @@
           "enum" : [ "en", "cy" ]
         },
         "metadata" : {
-          "$ref" : "#/definitions/ExternalMetadata"
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
         },
         "payment_id" : {
           "type" : "string",


### PR DESCRIPTION
Previously, without any annotation, when generated, metadata looked like

      "metadata": {
        "metadata": {
          "property1": {},
          "property2": {}
        }
      }

This commit forces the `metadata` on the swagger doc to be a
`Map<String,String>` by setting the `dataType` of the `ApiModelProperty`
annotation, which makes metadata look like

      "metadata": {
        "property1": "string",
        "property2": "string"
      }
