### PR TITLE
BAU: Don't log at error level for not found errors

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CancelChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CancelChargeExceptionMapper.java
@@ -37,7 +37,9 @@ public class CancelChargeExceptionMapper implements ExceptionMapper<CancelCharge
             status = INTERNAL_SERVER_ERROR;
         }
 
-        LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, paymentError);
+        if (status != NOT_FOUND) {
+            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, paymentError);
+        }
         return Response
                 .status(status)
                 .entity(paymentError)

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CaptureChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CaptureChargeExceptionMapper.java
@@ -42,7 +42,9 @@ public class CaptureChargeExceptionMapper implements ExceptionMapper<CaptureChar
             status = INTERNAL_SERVER_ERROR;
         }
 
-        LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, paymentError);
+        if (status != NOT_FOUND) {
+            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, paymentError);
+        }
         return Response
                 .status(status)
                 .entity(paymentError)

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapper.java
@@ -38,7 +38,9 @@ public class CreateRefundExceptionMapper implements ExceptionMapper<CreateRefund
             status = INTERNAL_SERVER_ERROR;
         }
 
-        LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {} {}", exception.getMessage(), status, paymentError);
+        if (status != NOT_FOUND) {
+            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {} {}", exception.getMessage(), status, paymentError);
+        }
 
         return Response
                 .status(status)

--- a/src/main/java/uk/gov/pay/api/exception/mapper/GetAgreementExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/GetAgreementExceptionMapper.java
@@ -29,9 +29,9 @@ public class GetAgreementExceptionMapper implements ExceptionMapper<GetAgreement
         } else {
             paymentError = anAgreementError(GET_AGREEMENT_CONNECTOR_ERROR);
             status = INTERNAL_SERVER_ERROR;
+            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, paymentError);
         }
 
-        LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, paymentError);
         return Response
                 .status(status)
                 .entity(paymentError)

--- a/src/main/java/uk/gov/pay/api/exception/mapper/GetChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/GetChargeExceptionMapper.java
@@ -30,9 +30,9 @@ public class GetChargeExceptionMapper implements ExceptionMapper<GetChargeExcept
         } else {
             paymentError = aPaymentError(GET_PAYMENT_CONNECTOR_ERROR);
             status = INTERNAL_SERVER_ERROR;
+            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, paymentError);
         }
 
-        LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, paymentError);
         return Response
                 .status(status)
                 .entity(paymentError)

--- a/src/main/java/uk/gov/pay/api/exception/mapper/GetEventsExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/GetEventsExceptionMapper.java
@@ -30,9 +30,9 @@ public class GetEventsExceptionMapper implements ExceptionMapper<GetEventsExcept
         } else {
             paymentError = aPaymentError(GET_PAYMENT_EVENTS_CONNECTOR_ERROR);
             status = INTERNAL_SERVER_ERROR;
+            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {} {}", exception.getMessage(), status, paymentError);
         }
 
-        LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {} {}", exception.getMessage(), status, paymentError);
         return Response
                 .status(status)
                 .entity(paymentError)

--- a/src/main/java/uk/gov/pay/api/exception/mapper/GetRefundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/GetRefundExceptionMapper.java
@@ -30,9 +30,8 @@ public class GetRefundExceptionMapper implements ExceptionMapper<GetRefundExcept
         } else {
             paymentError = aPaymentError(GET_PAYMENT_REFUND_CONNECTOR_ERROR);
             status = INTERNAL_SERVER_ERROR;
+            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {} {}", exception.getMessage(), status, paymentError);
         }
-
-        LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {} {}", exception.getMessage(), status, paymentError);
 
         return Response
                 .status(status)

--- a/src/main/java/uk/gov/pay/api/exception/mapper/GetRefundsExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/GetRefundsExceptionMapper.java
@@ -30,9 +30,8 @@ public class GetRefundsExceptionMapper implements ExceptionMapper<GetRefundsExce
         } else {
             paymentError = aPaymentError(GET_PAYMENT_REFUNDS_CONNECTOR_ERROR);
             status = INTERNAL_SERVER_ERROR;
+            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {} {}", exception.getMessage(), status, paymentError);
         }
-
-        LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {} {}", exception.getMessage(), status, paymentError);
 
         return Response
                 .status(status)

--- a/src/main/java/uk/gov/pay/api/exception/mapper/SearchChargesExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/SearchChargesExceptionMapper.java
@@ -20,17 +20,20 @@ public class SearchChargesExceptionMapper implements ExceptionMapper<SearchPayme
     @Override
     public Response toResponse(SearchPaymentsException exception) {
         if (exception.getErrorStatus() == NOT_FOUND.getStatusCode()) {
-            return buildResponse(exception, SEARCH_PAYMENTS_NOT_FOUND, NOT_FOUND);
+            return Response
+                    .status(NOT_FOUND)
+                    .entity(aPaymentError(SEARCH_PAYMENTS_NOT_FOUND))
+                    .build();
         }
-        return buildResponse(exception, SEARCH_PAYMENTS_CONNECTOR_ERROR, INTERNAL_SERVER_ERROR);
+        else {
+            PaymentError paymentError = aPaymentError(SEARCH_PAYMENTS_CONNECTOR_ERROR);
+            final Response.Status status = INTERNAL_SERVER_ERROR;
+            LOGGER.error("Connector response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, paymentError);
+            return Response
+                    .status(status)
+                    .entity(paymentError)
+                    .build();
+        }
     }
 
-    private Response buildResponse(SearchPaymentsException exception, PaymentError.Code searchPaymentsConnectorError, Response.Status status) {
-        PaymentError paymentError = aPaymentError(searchPaymentsConnectorError);
-        LOGGER.error("Connector response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, paymentError);
-        return Response
-                .status(status)
-                .entity(paymentError)
-                .build();
-    }
 }


### PR DESCRIPTION
Not found errors are user errors in the use of the API. They should not be
logged at ERROR level (and don't really need to be logged at all)

## Reviewers

please merge on approval