### PR TITLE
Separate integration tests from unit tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
                   string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
           ) {
               sh 'mvn -version'
-              sh "mvn clean package pact:publish -DPACT_BROKER_URL=https://pact-broker-test.cloudapps.digital -DPACT_CONSUMER_VERSION=${commit}" +
+              sh "mvn clean verify pact:publish -DPACT_BROKER_URL=https://pact-broker-test.cloudapps.digital -DPACT_CONSUMER_VERSION=${commit}" +
                       " -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${branchName}"
           }
           postSuccessfulMetrics("publicapi.maven-build", stepBuildTime)
@@ -69,7 +69,7 @@ pipeline {
                   string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
           ) {
               sh 'mvn -version'
-              sh "mvn clean package pact:publish -DPACT_BROKER_URL=https://pact-broker-test.cloudapps.digital -DPACT_CONSUMER_VERSION=${commit}" +
+              sh "mvn clean verify pact:publish -DPACT_BROKER_URL=https://pact-broker-test.cloudapps.digital -DPACT_CONSUMER_VERSION=${commit}" +
                       " -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${branchName}"
           }
           postSuccessfulMetrics("publicapi.maven-build", stepBuildTime)

--- a/build-local.sh
+++ b/build-local.sh
@@ -4,5 +4,5 @@ set -e
 
 cd "$(dirname "$0")"
 
-mvn -DskipTests clean package
+mvn -DskipITs clean verify
 docker build -t govukpay/publicapi:local .

--- a/pom.xml
+++ b/pom.xml
@@ -431,6 +431,26 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>failsafe-integration-tests</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.6.0</version>

--- a/src/test/java/uk/gov/pay/api/it/AuthorisationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/AuthorisationIT.java
@@ -13,7 +13,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static uk.gov.pay.api.utils.Payloads.aSuccessfulPaymentPayload;
 
-public class AuthorisationTest {
+public class AuthorisationIT {
 
     @Rule
     public DropwizardAppRule<PublicApiConfig> app = new DropwizardAppRule<>(

--- a/src/test/java/uk/gov/pay/api/it/CachingAuthenticatorIT.java
+++ b/src/test/java/uk/gov/pay/api/it/CachingAuthenticatorIT.java
@@ -28,7 +28,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
 import static uk.gov.pay.api.utils.WiremockStubbing.stubPublicAuthV1ApiAuth;
 
-public class CachingAuthenticatorTest {
+public class CachingAuthenticatorIT {
     
     private String accountId = "123";
     private String bearerToken = ApiKeyGenerator.apiKeyValueOf("TEST_BEARER_TOKEN", "qwer9yuhgf");

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
@@ -35,7 +35,7 @@ import static uk.gov.pay.api.utils.mocks.ChargeResponseFromConnector.ChargeRespo
 import static uk.gov.pay.api.utils.mocks.CreateChargeRequestParams.CreateChargeRequestParamsBuilder.aCreateChargeRequestParams;
 import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
-public class CreatePaymentITest extends PaymentResourceITestBase {
+public class CreatePaymentIT extends PaymentResourceITestBase {
 
     private static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
     private static final int AMOUNT = 9999999;

--- a/src/test/java/uk/gov/pay/api/it/GetDirectDebitEventsIT.java
+++ b/src/test/java/uk/gov/pay/api/it/GetDirectDebitEventsIT.java
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-public class GetDirectDebitEventsTest {
+public class GetDirectDebitEventsIT {
 
     static final String API_KEY = ApiKeyGenerator.apiKeyValueOf("TEST_BEARER_TOKEN", "qwer9yuhgf");
 

--- a/src/test/java/uk/gov/pay/api/it/GetPaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/GetPaymentIT.java
@@ -37,7 +37,7 @@ import static uk.gov.pay.api.utils.Urls.paymentLocationFor;
 import static uk.gov.pay.api.utils.mocks.ChargeResponseFromConnector.ChargeResponseFromConnectorBuilder.aCreateOrGetChargeResponseFromConnector;
 import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
-public class GetPaymentITest extends PaymentResourceITestBase {
+public class GetPaymentIT extends PaymentResourceITestBase {
 
     private static final ZonedDateTime CAPTURED_DATE = ZonedDateTime.parse("2016-01-02T14:03:00Z");
     private static final ZonedDateTime CAPTURE_SUBMIT_TIME = ZonedDateTime.parse("2016-01-02T15:02:00Z");

--- a/src/test/java/uk/gov/pay/api/it/HealthCheckResourceIT.java
+++ b/src/test/java/uk/gov/pay/api/it/HealthCheckResourceIT.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.api.resources.HealthCheckResource.HEALTHCHECK;
 
-public class HealthCheckResourceITest extends PaymentResourceITestBase {
+public class HealthCheckResourceIT extends PaymentResourceITestBase {
 
     @Test
     public void getAccountShouldReturn404IfAccountIdIsUnknown() {

--- a/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceIT.java
@@ -30,7 +30,7 @@ import static uk.gov.pay.api.utils.Urls.paymentLocationFor;
 import static uk.gov.pay.api.utils.mocks.ChargeResponseFromConnector.ChargeResponseFromConnectorBuilder.aCreateOrGetChargeResponseFromConnector;
 import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
-public class PaymentRefundsResourceITest extends PaymentResourceITestBase {
+public class PaymentRefundsResourceIT extends PaymentResourceITestBase {
 
     private static final int AMOUNT = 1000;
     private static final int REFUND_AMOUNT_AVAILABLE = 9000;

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchIT.java
@@ -44,7 +44,7 @@ import static uk.gov.pay.api.it.fixtures.PaymentSearchResultBuilder.DEFAULT_RETU
 import static uk.gov.pay.api.it.fixtures.PaymentSearchResultBuilder.aSuccessfulSearchPayment;
 import static uk.gov.pay.api.utils.Urls.paymentLocationFor;
 
-public class PaymentResourceSearchITest extends PaymentResourceITestBase {
+public class PaymentResourceSearchIT extends PaymentResourceITestBase {
 
     private static final String TEST_REFERENCE = "test_reference";
     private static final String TEST_EMAIL = "alice.111@mail.fake";

--- a/src/test/java/uk/gov/pay/api/it/PaymentsCancelResourceIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsCancelResourceIT.java
@@ -17,7 +17,7 @@ import static org.eclipse.jetty.http.HttpStatus.LENGTH_REQUIRED_411;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 
-public class PaymentsCancelResourceITest extends PaymentResourceITestBase {
+public class PaymentsCancelResourceIT extends PaymentResourceITestBase {
 
     private static final String TEST_CHARGE_ID = "ch_ab2341da231434";
     private static final String CANCEL_PAYMENTS_PATH = PAYMENTS_PATH + "%s/cancel";

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceCaptureIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceCaptureIT.java
@@ -18,7 +18,7 @@ import static org.eclipse.jetty.http.HttpStatus.LENGTH_REQUIRED_411;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 
-public class PaymentsResourceCaptureITest extends PaymentResourceITestBase {
+public class PaymentsResourceCaptureIT extends PaymentResourceITestBase {
 
     private static final String TEST_CHARGE_ID = "ch_e36c168c41a0";
     private static final String CAPTURE_PAYMENTS_PATH = PAYMENTS_PATH + "%s/capture";

--- a/src/test/java/uk/gov/pay/api/it/PingIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PingIT.java
@@ -10,7 +10,7 @@ import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
-public class PingTest {
+public class PingIT {
 
     @Rule
     public DropwizardAppRule<PublicApiConfig> app = new DropwizardAppRule<>(PublicApi.class, resourceFilePath("config/test-config.yaml"));

--- a/src/test/java/uk/gov/pay/api/it/RequestDeniedResourceIT.java
+++ b/src/test/java/uk/gov/pay/api/it/RequestDeniedResourceIT.java
@@ -11,7 +11,7 @@ import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 
-public class RequestDeniedResourceITest extends PaymentResourceITestBase {
+public class RequestDeniedResourceIT extends PaymentResourceITestBase {
 
     @Test
     public void requestDeniedPost() throws IOException {

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterAuthorisationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterAuthorisationIT.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-public class ResourcesFilterAuthorisationITest extends ResourcesFilterITestBase {
+public class ResourcesFilterAuthorisationIT extends ResourcesFilterITestBase {
 
     @Test
     public void createPayment_whenInvalidAuthorizationHeader_shouldReturn401Response() throws Exception {

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterLocalRateLimiterIT.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterLocalRateLimiterIT.java
@@ -43,7 +43,7 @@ import static org.mockserver.socket.PortFactory.findFreePort;
 import static uk.gov.pay.api.utils.mocks.ChargeResponseFromConnector.ChargeResponseFromConnectorBuilder.aCreateOrGetChargeResponseFromConnector;
 import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
-public class ResourcesFilterLocalRateLimiterITest {
+public class ResourcesFilterLocalRateLimiterIT {
 
     private static final int CONNECTOR_PORT = findFreePort();
     private static final int PUBLIC_AUTH_PORT = findFreePort();

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterIT.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterIT.java
@@ -17,7 +17,7 @@ import static uk.gov.pay.api.it.fixtures.PaginatedPaymentSearchResultFixture.aPa
 import static uk.gov.pay.api.it.fixtures.PaymentSearchResultBuilder.aSuccessfulSearchPayment;
 import static uk.gov.pay.api.utils.mocks.ChargeResponseFromConnector.ChargeResponseFromConnectorBuilder.aCreateOrGetChargeResponseFromConnector;
 
-public class ResourcesFilterRateLimiterITest extends ResourcesFilterITestBase {
+public class ResourcesFilterRateLimiterIT extends ResourcesFilterITestBase {
 
     private ConnectorMockClient connectorMockClient = new ConnectorMockClient(connectorMock);
     

--- a/src/test/java/uk/gov/pay/api/it/directdebit/AgreementsResourceIT.java
+++ b/src/test/java/uk/gov/pay/api/it/directdebit/AgreementsResourceIT.java
@@ -22,7 +22,7 @@ import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
 import static uk.gov.pay.api.utils.Urls.directDebitFrontendSecureUrl;
 import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
-public class AgreementsResourceITest extends PaymentResourceITestBase {
+public class AgreementsResourceIT extends PaymentResourceITestBase {
 
     private ConnectorDDMockClient connectorDDMockClient = new ConnectorDDMockClient(connectorDDMock);
     private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);

--- a/src/test/java/uk/gov/pay/api/it/directdebit/pact/CancelPaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/directdebit/pact/CancelPaymentIT.java
@@ -23,7 +23,7 @@ import static org.mockserver.socket.PortFactory.findFreePort;
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
 import static uk.gov.pay.api.utils.WiremockStubbing.stubPublicAuthV1ApiAuth;
 
-public class CancelPaymentTest {
+public class CancelPaymentIT {
 
     private static final String API_KEY = ApiKeyGenerator.apiKeyValueOf("TEST_BEARER_TOKEN", "qwer9yuhgf");
 

--- a/src/test/java/uk/gov/pay/api/it/directdebit/pact/DirectDebitPaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/directdebit/pact/DirectDebitPaymentIT.java
@@ -30,7 +30,7 @@ import static uk.gov.pay.api.utils.Urls.directDebitFrontendSecureUrl;
 import static uk.gov.pay.api.utils.Urls.paymentLocationFor;
 import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
-public class DirectDebitPaymentTest {
+public class DirectDebitPaymentIT {
 
     private static final int AMOUNT = 100;
     private static final String CHARGE_ID = "ch_ab2341da231434l";

--- a/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentReturnUrlValidationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentReturnUrlValidationIT.java
@@ -15,7 +15,7 @@ import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 
-public class CreatePaymentReturnUrlValidationITest extends PaymentResourceITestBase {
+public class CreatePaymentReturnUrlValidationIT extends PaymentResourceITestBase {
 
     private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
     

--- a/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentWithHttpReturnUrlIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentWithHttpReturnUrlIT.java
@@ -28,7 +28,7 @@ import static org.mockserver.socket.PortFactory.findFreePort;
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
 import static uk.gov.pay.api.utils.mocks.CreateChargeRequestParams.CreateChargeRequestParamsBuilder.aCreateChargeRequestParams;
 
-public class CreatePaymentWithHttpReturnUrlTest {
+public class CreatePaymentWithHttpReturnUrlIT {
 
     private static final String API_KEY = ApiKeyGenerator.apiKeyValueOf("TEST_BEARER_TOKEN", "qwer9yuhgf");
     private static final String GATEWAY_ACCOUNT_ID = "GATEWAY_ACCOUNT_ID";

--- a/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentWithPrefilledCardholderDetailsValidationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentWithPrefilledCardholderDetailsValidationIT.java
@@ -19,7 +19,7 @@ import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.api.utils.mocks.CreateChargeRequestParams.CreateChargeRequestParamsBuilder.aCreateChargeRequestParams;
 
 @RunWith(JUnitParamsRunner.class)
-public class CreatePaymentWithPrefilledCardholderDetailsValidationITest extends PaymentResourceITestBase {
+public class CreatePaymentWithPrefilledCardholderDetailsValidationIT extends PaymentResourceITestBase {
 
     private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
     private ConnectorMockClient connectorMockClient = new ConnectorMockClient(connectorMock);

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentResourceMetadataValidationFailuresIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentResourceMetadataValidationFailuresIT.java
@@ -22,12 +22,12 @@ import static io.restassured.http.ContentType.JSON;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.Is.is;
-import static uk.gov.pay.api.it.CreatePaymentITest.paymentPayload;
+import static uk.gov.pay.api.it.CreatePaymentIT.paymentPayload;
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
 import static uk.gov.pay.api.utils.mocks.CreateChargeRequestParams.CreateChargeRequestParamsBuilder.aCreateChargeRequestParams;
 
 @RunWith(JUnitParamsRunner.class)
-public class PaymentResourceMetadataValidationFailuresITest extends PaymentResourceITestBase {
+public class PaymentResourceMetadataValidationFailuresIT extends PaymentResourceITestBase {
 
     private static CreateChargeRequestParamsBuilder createChargeRequestParamsBuilder = aCreateChargeRequestParams()
                 .withAmount(100)

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentResourceSearchValidationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentResourceSearchValidationIT.java
@@ -18,7 +18,7 @@ import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 
-public class PaymentResourceSearchValidationITest extends PaymentResourceITestBase {
+public class PaymentResourceSearchValidationIT extends PaymentResourceITestBase {
 
     private static final String VALID_REFERENCE = "test_reference";
     private static final String VALID_LAST_DIGITS_CARD_NUMBER = "4242";

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsRefundsResourceAmountValidationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsRefundsResourceAmountValidationIT.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.api.utils.mocks.ChargeResponseFromConnector.ChargeResponseFromConnectorBuilder.aCreateOrGetChargeResponseFromConnector;
 
-public class PaymentsRefundsResourceAmountValidationITest extends PaymentResourceITestBase {
+public class PaymentsRefundsResourceAmountValidationIT extends PaymentResourceITestBase {
 
     private static final int REFUND_AMOUNT_AVAILABLE = 9000;
     private static final Address BILLING_ADDRESS = new Address("line1", "line2", "NR2 5 6EG", "city", "UK");

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceAgreementIdValidationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceAgreementIdValidationIT.java
@@ -19,7 +19,7 @@ import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 
-public class PaymentsResourceAgreementIdValidationITest extends PaymentResourceITestBase {
+public class PaymentsResourceAgreementIdValidationIT extends PaymentResourceITestBase {
 
     private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
     

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceAmountValidationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceAmountValidationIT.java
@@ -16,7 +16,7 @@ import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 
-public class PaymentsResourceAmountValidationITest extends PaymentResourceITestBase {
+public class PaymentsResourceAmountValidationIT extends PaymentResourceITestBase {
 
     private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
     

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceDescriptionValidationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceDescriptionValidationIT.java
@@ -17,7 +17,7 @@ import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 
-public class PaymentsResourceReferenceValidationITest extends PaymentResourceITestBase {
+public class PaymentsResourceDescriptionValidationIT extends PaymentResourceITestBase {
 
     private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
     
@@ -27,12 +27,12 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
     }
 
     @Test
-    public void createPayment_responseWith400_whenReferenceIsNumeric() throws IOException {
+    public void createPayment_responseWith400_whenDescriptionIsNumeric() throws IOException {
 
         String payload = "{" +
                 "  \"amount\" : 9900," +
-                "  \"reference\" : 1234," +
-                "  \"description\" : \"Some description\"," +
+                "  \"description\" : 1234," +
+                "  \"reference\" : \"Some reference\"," +
                 "  \"return_url\" : \"https://example.com\"" +
                 "}";
 
@@ -44,18 +44,18 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(3))
-                .assertThat("$.field", is("reference"))
+                .assertThat("$.field", is("description"))
                 .assertThat("$.code", is("P0102"))
-                .assertThat("$.description", is("Invalid attribute value: reference. Must be a valid string format"));
+                .assertThat("$.description", is("Invalid attribute value: description. Must be a valid string format"));
     }
 
     @Test
-    public void createPayment_responseWith400_whenReferenceIsEmpty() throws IOException {
+    public void createPayment_responseWith400_whenDescriptionIsEmpty() throws IOException {
 
         String payload = "{" +
                 "  \"amount\" : 9900," +
-                "  \"reference\" : \"\"," +
-                "  \"description\" : \"Some description\"," +
+                "  \"description\" : \"\"," +
+                "  \"reference\" : \"Some reference\"," +
                 "  \"return_url\" : \"https://example.com\"" +
                 "}";
 
@@ -67,18 +67,18 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(3))
-                .assertThat("$.field", is("reference"))
+                .assertThat("$.field", is("description"))
                 .assertThat("$.code", is("P0101"))
-                .assertThat("$.description", is("Missing mandatory attribute: reference"));
+                .assertThat("$.description", is("Missing mandatory attribute: description"));
     }
 
     @Test
-    public void createPayment_responseWith400_whenReferenceIsBlank() throws IOException {
+    public void createPayment_responseWith400_whenDescriptionIsBlank() throws IOException {
 
         String payload = "{" +
                 "  \"amount\" : 9900," +
-                "  \"reference\" : \"    \"," +
-                "  \"description\" : \"Some description\"," +
+                "  \"description\" : \"    \"," +
+                "  \"reference\" : \"Some reference\"," +
                 "  \"return_url\" : \"https://example.com\"" +
                 "}";
 
@@ -90,17 +90,17 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(3))
-                .assertThat("$.field", is("reference"))
+                .assertThat("$.field", is("description"))
                 .assertThat("$.code", is("P0101"))
-                .assertThat("$.description", is("Missing mandatory attribute: reference"));
+                .assertThat("$.description", is("Missing mandatory attribute: description"));
     }
 
     @Test
-    public void createPayment_responseWith400_whenReferenceIsMissing() throws IOException {
+    public void createPayment_responseWith400_whenDescriptionIsMissing() throws IOException {
 
         String payload = "{" +
                 "  \"amount\" : 9900," +
-                "  \"description\" : \"Some description\"," +
+                "  \"reference\" : \"Some reference\"," +
                 "  \"return_url\" : \"https://example.com\"" +
                 "}";
 
@@ -112,19 +112,19 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(3))
-                .assertThat("$.field", is("reference"))
+                .assertThat("$.field", is("description"))
                 .assertThat("$.code", is("P0101"))
-                .assertThat("$.description", is("Missing mandatory attribute: reference"));
+                .assertThat("$.description", is("Missing mandatory attribute: description"));
     }
 
     @Test
-    public void createPayment_responseWith400_whenReferenceIsNull() throws IOException {
+    public void createPayment_responseWith400_whenDescriptionIsNull() throws IOException {
 
 
         String payload = "{" +
                 "  \"amount\" : 9900," +
-                "  \"reference\" : null," +
-                "  \"description\" : \"Some description\"," +
+                "  \"description\" : null," +
+                "  \"reference\" : \"Some reference\"," +
                 "  \"return_url\" : \"https://example.com\"" +
                 "}";
 
@@ -136,20 +136,20 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(3))
-                .assertThat("$.field", is("reference"))
+                .assertThat("$.field", is("description"))
                 .assertThat("$.code", is("P0101"))
-                .assertThat("$.description", is("Missing mandatory attribute: reference"));
+                .assertThat("$.description", is("Missing mandatory attribute: description"));
     }
 
     @Test
-    public void createPayment_responseWith422_whenReferenceSizeIsGreaterThanMaxLength() throws IOException {
+    public void createPayment_responseWith422_whenDescriptionSizeIsGreaterThanMaxLength() throws IOException {
 
         String aVeryLongReference = RandomStringUtils.randomAlphanumeric(256);
 
         String payload = "{" +
                 "  \"amount\" : 9900," +
-                "  \"reference\" : \"" + aVeryLongReference + "\"," +
-                "  \"description\" : \"Some description\"," +
+                "  \"description\" : \"" + aVeryLongReference + "\"," +
+                "  \"reference\" : \"Some reference\"," +
                 "  \"return_url\" : \"https://www.example.com/return_url\"" +
                 "}";
 
@@ -161,18 +161,18 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(3))
-                .assertThat("$.field", is("reference"))
+                .assertThat("$.field", is("description"))
                 .assertThat("$.code", is("P0102"))
-                .assertThat("$.description", is("Invalid attribute value: reference. Must be less than or equal to 255 characters length"));
+                .assertThat("$.description", is("Invalid attribute value: description. Must be less than or equal to 255 characters length"));
     }
 
     @Test
-    public void createPayment_responseWith400_whenReferenceHasNotAValidJsonValue() throws IOException {
+    public void createPayment_responseWith400_whenDescriptionHasNotAValidJsonValue() throws IOException {
 
         String payload = "{" +
                 "  \"amount\" : 9900," +
-                "  \"reference\" : " +
-                "  \"description\" : \"Some description\"," +
+                "  \"description\" : " +
+                "  \"reference\" : \"Some reference\"," +
                 "  \"return_url\" : \"https://example.com\"" +
                 "}";
 
@@ -189,12 +189,12 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
     }
 
     @Test
-    public void createPayment_responseWith400_whenReferenceFieldIsNotExpectedJsonField() throws IOException {
+    public void createPayment_responseWith400_whenDescriptionFieldIsNotExpectedJsonField() throws IOException {
 
         String payload = "{" +
                 "  \"amount\" : 9900," +
-                "  \"reference\" : {\"whatever\" : 1}," +
-                "  \"description\" : \"Some description\"," +
+                "  \"description\" : {\"whatever\" : 1}," +
+                "  \"reference\" : \"Some reference\"," +
                 "  \"return_url\" : \"https://example.com\"" +
                 "}";
 
@@ -206,9 +206,9 @@ public class PaymentsResourceReferenceValidationITest extends PaymentResourceITe
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(3))
-                .assertThat("$.field", is("reference"))
+                .assertThat("$.field", is("description"))
                 .assertThat("$.code", is("P0102"))
-                .assertThat("$.description", is("Invalid attribute value: reference. Must be a valid string format"));
+                .assertThat("$.description", is("Invalid attribute value: description. Must be a valid string format"));
     }
 
     private ValidatableResponse postPaymentResponse(String bearerToken, String payload) {

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceEmailValidationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceEmailValidationIT.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.core.Is.is;
 
-public class PaymentsResourceEmailValidationITest extends PaymentResourceITestBase {
+public class PaymentsResourceEmailValidationIT extends PaymentResourceITestBase {
 
     private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
 

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceLanguageValidationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceLanguageValidationIT.java
@@ -17,7 +17,7 @@ import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.api.utils.mocks.CreateChargeRequestParams.CreateChargeRequestParamsBuilder.aCreateChargeRequestParams;
 
 @RunWith(JUnitParamsRunner.class)
-public class PaymentsResourceLanguageValidationITest extends PaymentResourceITestBase {
+public class PaymentsResourceLanguageValidationIT extends PaymentResourceITestBase {
 
     private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
     private ConnectorMockClient connectorMockClient = new ConnectorMockClient(connectorMock);

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceReferenceValidationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceReferenceValidationIT.java
@@ -17,7 +17,7 @@ import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 
-public class PaymentsResourceDescriptionValidationITest extends PaymentResourceITestBase {
+public class PaymentsResourceReferenceValidationIT extends PaymentResourceITestBase {
 
     private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
     
@@ -27,12 +27,12 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
     }
 
     @Test
-    public void createPayment_responseWith400_whenDescriptionIsNumeric() throws IOException {
+    public void createPayment_responseWith400_whenReferenceIsNumeric() throws IOException {
 
         String payload = "{" +
                 "  \"amount\" : 9900," +
-                "  \"description\" : 1234," +
-                "  \"reference\" : \"Some reference\"," +
+                "  \"reference\" : 1234," +
+                "  \"description\" : \"Some description\"," +
                 "  \"return_url\" : \"https://example.com\"" +
                 "}";
 
@@ -44,18 +44,18 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(3))
-                .assertThat("$.field", is("description"))
+                .assertThat("$.field", is("reference"))
                 .assertThat("$.code", is("P0102"))
-                .assertThat("$.description", is("Invalid attribute value: description. Must be a valid string format"));
+                .assertThat("$.description", is("Invalid attribute value: reference. Must be a valid string format"));
     }
 
     @Test
-    public void createPayment_responseWith400_whenDescriptionIsEmpty() throws IOException {
+    public void createPayment_responseWith400_whenReferenceIsEmpty() throws IOException {
 
         String payload = "{" +
                 "  \"amount\" : 9900," +
-                "  \"description\" : \"\"," +
-                "  \"reference\" : \"Some reference\"," +
+                "  \"reference\" : \"\"," +
+                "  \"description\" : \"Some description\"," +
                 "  \"return_url\" : \"https://example.com\"" +
                 "}";
 
@@ -67,18 +67,18 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(3))
-                .assertThat("$.field", is("description"))
+                .assertThat("$.field", is("reference"))
                 .assertThat("$.code", is("P0101"))
-                .assertThat("$.description", is("Missing mandatory attribute: description"));
+                .assertThat("$.description", is("Missing mandatory attribute: reference"));
     }
 
     @Test
-    public void createPayment_responseWith400_whenDescriptionIsBlank() throws IOException {
+    public void createPayment_responseWith400_whenReferenceIsBlank() throws IOException {
 
         String payload = "{" +
                 "  \"amount\" : 9900," +
-                "  \"description\" : \"    \"," +
-                "  \"reference\" : \"Some reference\"," +
+                "  \"reference\" : \"    \"," +
+                "  \"description\" : \"Some description\"," +
                 "  \"return_url\" : \"https://example.com\"" +
                 "}";
 
@@ -90,17 +90,17 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(3))
-                .assertThat("$.field", is("description"))
+                .assertThat("$.field", is("reference"))
                 .assertThat("$.code", is("P0101"))
-                .assertThat("$.description", is("Missing mandatory attribute: description"));
+                .assertThat("$.description", is("Missing mandatory attribute: reference"));
     }
 
     @Test
-    public void createPayment_responseWith400_whenDescriptionIsMissing() throws IOException {
+    public void createPayment_responseWith400_whenReferenceIsMissing() throws IOException {
 
         String payload = "{" +
                 "  \"amount\" : 9900," +
-                "  \"reference\" : \"Some reference\"," +
+                "  \"description\" : \"Some description\"," +
                 "  \"return_url\" : \"https://example.com\"" +
                 "}";
 
@@ -112,19 +112,19 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(3))
-                .assertThat("$.field", is("description"))
+                .assertThat("$.field", is("reference"))
                 .assertThat("$.code", is("P0101"))
-                .assertThat("$.description", is("Missing mandatory attribute: description"));
+                .assertThat("$.description", is("Missing mandatory attribute: reference"));
     }
 
     @Test
-    public void createPayment_responseWith400_whenDescriptionIsNull() throws IOException {
+    public void createPayment_responseWith400_whenReferenceIsNull() throws IOException {
 
 
         String payload = "{" +
                 "  \"amount\" : 9900," +
-                "  \"description\" : null," +
-                "  \"reference\" : \"Some reference\"," +
+                "  \"reference\" : null," +
+                "  \"description\" : \"Some description\"," +
                 "  \"return_url\" : \"https://example.com\"" +
                 "}";
 
@@ -136,20 +136,20 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(3))
-                .assertThat("$.field", is("description"))
+                .assertThat("$.field", is("reference"))
                 .assertThat("$.code", is("P0101"))
-                .assertThat("$.description", is("Missing mandatory attribute: description"));
+                .assertThat("$.description", is("Missing mandatory attribute: reference"));
     }
 
     @Test
-    public void createPayment_responseWith422_whenDescriptionSizeIsGreaterThanMaxLength() throws IOException {
+    public void createPayment_responseWith422_whenReferenceSizeIsGreaterThanMaxLength() throws IOException {
 
         String aVeryLongReference = RandomStringUtils.randomAlphanumeric(256);
 
         String payload = "{" +
                 "  \"amount\" : 9900," +
-                "  \"description\" : \"" + aVeryLongReference + "\"," +
-                "  \"reference\" : \"Some reference\"," +
+                "  \"reference\" : \"" + aVeryLongReference + "\"," +
+                "  \"description\" : \"Some description\"," +
                 "  \"return_url\" : \"https://www.example.com/return_url\"" +
                 "}";
 
@@ -161,18 +161,18 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(3))
-                .assertThat("$.field", is("description"))
+                .assertThat("$.field", is("reference"))
                 .assertThat("$.code", is("P0102"))
-                .assertThat("$.description", is("Invalid attribute value: description. Must be less than or equal to 255 characters length"));
+                .assertThat("$.description", is("Invalid attribute value: reference. Must be less than or equal to 255 characters length"));
     }
 
     @Test
-    public void createPayment_responseWith400_whenDescriptionHasNotAValidJsonValue() throws IOException {
+    public void createPayment_responseWith400_whenReferenceHasNotAValidJsonValue() throws IOException {
 
         String payload = "{" +
                 "  \"amount\" : 9900," +
-                "  \"description\" : " +
-                "  \"reference\" : \"Some reference\"," +
+                "  \"reference\" : " +
+                "  \"description\" : \"Some description\"," +
                 "  \"return_url\" : \"https://example.com\"" +
                 "}";
 
@@ -189,12 +189,12 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
     }
 
     @Test
-    public void createPayment_responseWith400_whenDescriptionFieldIsNotExpectedJsonField() throws IOException {
+    public void createPayment_responseWith400_whenReferenceFieldIsNotExpectedJsonField() throws IOException {
 
         String payload = "{" +
                 "  \"amount\" : 9900," +
-                "  \"description\" : {\"whatever\" : 1}," +
-                "  \"reference\" : \"Some reference\"," +
+                "  \"reference\" : {\"whatever\" : 1}," +
+                "  \"description\" : \"Some description\"," +
                 "  \"return_url\" : \"https://example.com\"" +
                 "}";
 
@@ -206,9 +206,9 @@ public class PaymentsResourceDescriptionValidationITest extends PaymentResourceI
 
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(3))
-                .assertThat("$.field", is("description"))
+                .assertThat("$.field", is("reference"))
                 .assertThat("$.code", is("P0102"))
-                .assertThat("$.description", is("Invalid attribute value: description. Must be a valid string format"));
+                .assertThat("$.description", is("Invalid attribute value: reference. Must be a valid string format"));
     }
 
     private ValidatableResponse postPaymentResponse(String bearerToken, String payload) {

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -49,7 +49,7 @@ import static org.eclipse.jetty.http.HttpStatus.NO_CONTENT_204;
 import static org.eclipse.jetty.http.HttpStatus.OK_200;
 import static org.eclipse.jetty.http.HttpStatus.PRECONDITION_FAILED_412;
 import static org.eclipse.jetty.http.HttpStatus.UNPROCESSABLE_ENTITY_422;
-import static uk.gov.pay.api.it.GetPaymentITest.AWAITING_CAPTURE_REQUEST;
+import static uk.gov.pay.api.it.GetPaymentIT.AWAITING_CAPTURE_REQUEST;
 import static uk.gov.pay.api.it.fixtures.PaymentSingleResultBuilder.aSuccessfulSinglePayment;
 import static uk.gov.pay.api.utils.mocks.ChargeResponseFromConnector.ChargeResponseFromConnectorBuilder.aCreateOrGetChargeResponseFromConnector;
 import static uk.gov.pay.commons.model.ErrorIdentifier.GENERIC;


### PR DESCRIPTION
Integration tests are slow. They involve starting a PostgreSQL container and
instantiating Dropwizard.

Split them from the unit tests and run the unit tests with the surefire plugin
instead.

Rename integration tests to match the default include/exclude rules for the
surefire and failsafe maven plugins. By default, the failsafe plugin will
include any tests matching IT*.java, *IT.java and *ITCase.java. This was not
the naming scheme our integration tests had, so fix that.

Include Pact tests in the integration test suite as they spin up a Dropwizard
instance.

Since unit tests are so quick, we no longer need to skip them when running
local builds.

maven's 'package' target doesn't include running integration tests, so switch
to using the 'verify' target during CI builds, which is what we should've been
doing anyway.