### PR TITLE
PP-5100 Fix broken validation test

### DIFF
--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceAgreementIdValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceAgreementIdValidationITest.java
@@ -127,12 +127,14 @@ public class PaymentsResourceAgreementIdValidationITest extends PaymentResourceI
     public void createPayment_responseWith422_whenAgreementIdSizeIsGreaterThanMaxLength() throws IOException {
 
         String aTooLongAgreementId = RandomStringUtils.randomAlphanumeric(27);
-
-        String payload = toJson(Map.of("amount", 9900,
-                "reference", "Some ref",
-                "description","hi",
-                "return_url", "http://somewhere.gov.uk/",
-                "agreement_id", aTooLongAgreementId));
+        
+        String payload = "{" +
+                "  \"amount\" : 9900," +
+                "  \"reference\" : \"Some reference\"," +
+                "  \"description\" : \"Some description\"," +
+                "  \"return_url\" : \"https://somewhere.com\"," +
+                "  \"agreement_id\" : \"" + aTooLongAgreementId + "\"" +
+                "}";
 
         InputStream body = postPaymentResponse(API_KEY, payload)
                 .statusCode(422)


### PR DESCRIPTION
Was broken because http URLs are not allowed in the config.

Was somehow passing most of the time on CI, probably due to Dropwizard
ConfigOverrides, and the order of running tests meaning that allow http
was turned on by a previous test.