### PR TITLE
PP-5133 Add pact test for zero amount not allowed error

### DIFF
--- a/src/test/resources/pacts/publicapi-connector-create-payment-with-zero-amount-not-allowed.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment-with-zero-amount-not-allowed.json
@@ -1,0 +1,48 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "a create charge request with zero amount when zero amount is not allowed",
+      "providerStates": [
+        {
+          "name": "a gateway account with external id exists",
+          "params": {
+            "gateway_account_id": "123456"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/v1/api/accounts/123456/charges",
+        "body": {
+          "amount": 0,
+          "reference": "a reference",
+          "description": "a description",
+          "return_url": "https://somewhere.gov.uk/rainbow/1"
+        }
+      },
+      "response": {
+        "status": 422,
+        "headers": {
+          "Content-Type": "application/json",
+        },
+        "body": {
+          "error_identifier": "ZERO_AMOUNT_NOT_ALLOWED"
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
Test the contract with connector that connector will give the expected error response when a request is made with a 0 amount and the flag on the gateway account is not enabled to allow this.