### PR TITLE
PP-5133 Allow 0 amount payments

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRefundRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRefundRequest.java
@@ -9,7 +9,8 @@ import java.util.Optional;
 @ApiModel(value = "PaymentRefundRequest", description = "The Payment Refund Request Payload")
 public class CreatePaymentRefundRequest {
 
-    public static final String REFUND_AMOUNT_AVAILABLE="refund_amount_available";
+    public static final String REFUND_AMOUNT_AVAILABLE = "refund_amount_available";
+    public static final int REFUND_MIN_VALUE = 1;
 
     private int amount;
     @JsonProperty("refund_amount_available")
@@ -30,6 +31,7 @@ public class CreatePaymentRefundRequest {
 
     /**
      * This field should be made compulsory at a later stage
+     *
      * @return
      */
     @ApiModelProperty(value = "Amount in pence. Total amount still available before issuing the refund", required = false, allowableValues = "range[1, 10000000]", example = "200000")

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
@@ -40,7 +40,7 @@ public class CreatePaymentRequest {
     public static final String PREFILLED_ADDRESS_COUNTRY_FIELD_NAME = "country";
     public static final int REFERENCE_MAX_LENGTH = 255;
     public static final int AMOUNT_MAX_VALUE = 10000000;
-    public static final int AMOUNT_MIN_VALUE = 1;
+    public static final int AMOUNT_MIN_VALUE = 0;
     public static final int DESCRIPTION_MAX_LENGTH = 255;
     public static final int URL_MAX_LENGTH = 2000;
     

--- a/src/main/java/uk/gov/pay/api/validation/PaymentRefundRequestValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/PaymentRefundRequestValidator.java
@@ -5,9 +5,9 @@ import uk.gov.pay.api.model.CreatePaymentRefundRequest;
 import uk.gov.pay.api.model.PaymentError;
 
 import static java.lang.String.format;
+import static uk.gov.pay.api.model.CreatePaymentRefundRequest.REFUND_MIN_VALUE;
 import static uk.gov.pay.api.model.CreatePaymentRequest.AMOUNT_FIELD_NAME;
 import static uk.gov.pay.api.model.CreatePaymentRequest.AMOUNT_MAX_VALUE;
-import static uk.gov.pay.api.model.CreatePaymentRequest.AMOUNT_MIN_VALUE;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_REFUND_VALIDATION_ERROR;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 
@@ -18,8 +18,8 @@ public class PaymentRefundRequestValidator {
     }
 
     private void validateAmount(int amount) {
-        validate(amount >= AMOUNT_MIN_VALUE,
-                aPaymentError(AMOUNT_FIELD_NAME, CREATE_PAYMENT_REFUND_VALIDATION_ERROR, format("Must be greater than or equal to %d", AMOUNT_MIN_VALUE)));
+        validate(amount >= REFUND_MIN_VALUE,
+                aPaymentError(AMOUNT_FIELD_NAME, CREATE_PAYMENT_REFUND_VALIDATION_ERROR, format("Must be greater than or equal to %d", REFUND_MIN_VALUE)));
 
         validate(amount <= AMOUNT_MAX_VALUE,
                 aPaymentError(AMOUNT_FIELD_NAME, CREATE_PAYMENT_REFUND_VALIDATION_ERROR, format("Must be less than or equal to %d", AMOUNT_MAX_VALUE)));

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentITest.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentITest.java
@@ -406,6 +406,22 @@ public class CreatePaymentITest extends PaymentResourceITestBase {
     }
 
     @Test
+    public void createPayment_responseWith422_whenZeroAmountNotAllowed() {
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+
+        connectorMockClient.respondZeroAmountNotAllowed(GATEWAY_ACCOUNT_ID);
+
+        postPaymentResponse(SUCCESS_PAYLOAD)
+                .statusCode(422)
+                .contentType(JSON)
+                .body("code", is("P0102"))
+                .body("field", is("amount"))
+                .body("description", is("Invalid attribute value: amount. Must be greater than or equal to 1"));
+
+        connectorMockClient.verifyCreateChargeConnectorRequest(GATEWAY_ACCOUNT_ID, SUCCESS_PAYLOAD);
+    }
+
+    @Test
     public void createPayment_Returns401_WhenUnauthorised() {
         publicAuthMockClient.respondUnauthorised();
         postPaymentResponse(SUCCESS_PAYLOAD).statusCode(401);

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceAmountValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceAmountValidationITest.java
@@ -45,30 +45,7 @@ public class PaymentsResourceAmountValidationITest extends PaymentResourceITestB
                 .assertThat("$.*", hasSize(3))
                 .assertThat("$.field", is("amount"))
                 .assertThat("$.code", is("P0102"))
-                .assertThat("$.description", is("Invalid attribute value: amount. Must be greater than or equal to 1"));
-    }
-
-    @Test
-    public void createPayment_responseWith422_whenAmountIsLessThanMin() throws IOException {
-
-        String payload = "{" +
-                "  \"amount\" : 0," +
-                "  \"reference\" : \"Some reference\"," +
-                "  \"description\" : \"Some description\"," +
-                "  \"return_url\" : \"https://somewhere.gov.uk/rainbow/1\"" +
-                "}";
-
-        InputStream body = postPaymentResponse(API_KEY, payload)
-                .statusCode(422)
-                .contentType(JSON)
-                .extract()
-                .body().asInputStream();
-
-        JsonAssert.with(body)
-                .assertThat("$.*", hasSize(3))
-                .assertThat("$.field", is("amount"))
-                .assertThat("$.code", is("P0102"))
-                .assertThat("$.description", is("Invalid attribute value: amount. Must be greater than or equal to 1"));
+                .assertThat("$.description", is("Invalid attribute value: amount. Must be greater than or equal to 0"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -2,7 +2,6 @@ package uk.gov.pay.api.utils.mocks;
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
-import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
 import org.mockserver.model.Parameter;
@@ -49,15 +48,15 @@ import static org.eclipse.jetty.http.HttpStatus.NOT_FOUND_404;
 import static org.eclipse.jetty.http.HttpStatus.NO_CONTENT_204;
 import static org.eclipse.jetty.http.HttpStatus.OK_200;
 import static org.eclipse.jetty.http.HttpStatus.PRECONDITION_FAILED_412;
+import static org.eclipse.jetty.http.HttpStatus.UNPROCESSABLE_ENTITY_422;
 import static uk.gov.pay.api.it.GetPaymentITest.AWAITING_CAPTURE_REQUEST;
 import static uk.gov.pay.api.it.fixtures.PaymentSingleResultBuilder.aSuccessfulSinglePayment;
-import static uk.gov.pay.api.utils.JsonStringBuilder.jsonString;
 import static uk.gov.pay.api.utils.mocks.ChargeResponseFromConnector.ChargeResponseFromConnectorBuilder.aCreateOrGetChargeResponseFromConnector;
-import static uk.gov.pay.api.utils.mocks.CreateChargeRequestParams.CreateChargeRequestParamsBuilder.aCreateChargeRequestParams;
 import static uk.gov.pay.commons.model.ErrorIdentifier.GENERIC;
 import static uk.gov.pay.commons.model.ErrorIdentifier.INVALID_MANDATE_TYPE;
 import static uk.gov.pay.commons.model.ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH;
 import static uk.gov.pay.commons.model.ErrorIdentifier.REFUND_NOT_AVAILABLE;
+import static uk.gov.pay.commons.model.ErrorIdentifier.ZERO_AMOUNT_NOT_ALLOWED;
 
 public class ConnectorMockClient extends BaseConnectorMockClient {
 
@@ -225,6 +224,10 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
 
     public void respondPreconditionFailed_whenCreateRefund(String gatewayAccountId, String errorMsg, String chargeId) {
         whenCreateRefund(gatewayAccountId, chargeId, withStatusAndErrorMessage(PRECONDITION_FAILED_412, errorMsg, REFUND_AMOUNT_AVAILABLE_MISMATCH));
+    }
+    
+    public void respondZeroAmountNotAllowed(String gatewayAccountId) {
+        mockCreateCharge(gatewayAccountId, withStatusAndErrorMessage(UNPROCESSABLE_ENTITY_422, "anything", ZERO_AMOUNT_NOT_ALLOWED));
     }
 
     public void respondWithChargeFound(String chargeTokenId, String gatewayAccountId, ChargeResponseFromConnector chargeResponseFromConnector) {


### PR DESCRIPTION
Change validation so that payments can be created with an amount of 0.
Handle error response from Connector when an amount of 0 is not allowed by the gateway account.