### PR TITLE
PP-5199 Use the Jedis client to flush redis

### DIFF
--- a/src/test/java/uk/gov/pay/api/it/rule/RedisContainer.java
+++ b/src/test/java/uk/gov/pay/api/it/rule/RedisContainer.java
@@ -128,12 +128,11 @@ class RedisContainer {
     }
 
     public void clearRedisCache() {
-        try {
-            String[] command = {"redis-cli", "FLUSHALL"};
-            String id = docker.execCreate(containerId, command).id();
-            docker.execStart(id);
-        } catch (DockerException | InterruptedException e) {
-            throw new RuntimeException(e);
+        Jedis jedis = new Jedis(host, port);
+        String response = jedis.flushAll();
+        if (!response.equals("OK")) {
+            logger.warn("Unexpected response from redis flushAll command: " + response);
         }
+        jedis.disconnect();
     }
 }


### PR DESCRIPTION
Instead of jumping into the container to run `redis-cli`, flush the database
from Java. This should be more efficient and make it easier to notice any
errors which might get thrown.