### PR TITLE
Pp 5133 dont allow zero amount for dd accounts

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -20,7 +20,6 @@ import uk.gov.pay.api.model.CreatePaymentRequest;
 import uk.gov.pay.api.model.CreatePaymentResult;
 import uk.gov.pay.api.model.PaymentError;
 import uk.gov.pay.api.model.PaymentEvents;
-import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.ValidCreatePaymentRequest;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 import uk.gov.pay.api.model.search.card.GetPaymentResult;
@@ -54,6 +53,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.http.HttpStatus.SC_OK;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_VALIDATION_ERROR;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
+import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
 
 @Path("/")
 @Api(value = "/", description = "Public Api Endpoints")
@@ -250,7 +250,7 @@ public class PaymentsResource {
                                      @ApiParam(value = "requestPayload", required = true) @Valid CreatePaymentRequest createPaymentRequest) {
         logger.info("Payment create request parsed to {}", createPaymentRequest);
 
-        if (account.getPaymentType().equals(TokenPaymentType.DIRECT_DEBIT) && createPaymentRequest.getAmount() == 0) {
+        if (account.getPaymentType().equals(DIRECT_DEBIT) && createPaymentRequest.getAmount() == 0) {
             throw new PaymentValidationException(aPaymentError("amount", CREATE_PAYMENT_VALIDATION_ERROR,
                     "Must be greater than or equal to 1"));
         }

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -15,10 +15,12 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CaptureChargeException;
 import uk.gov.pay.api.exception.GetEventsException;
+import uk.gov.pay.api.exception.PaymentValidationException;
 import uk.gov.pay.api.model.CreatePaymentRequest;
 import uk.gov.pay.api.model.CreatePaymentResult;
 import uk.gov.pay.api.model.PaymentError;
 import uk.gov.pay.api.model.PaymentEvents;
+import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.ValidCreatePaymentRequest;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 import uk.gov.pay.api.model.search.card.GetPaymentResult;
@@ -50,6 +52,8 @@ import java.net.URI;
 import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.http.HttpStatus.SC_OK;
+import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_VALIDATION_ERROR;
+import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 
 @Path("/")
 @Api(value = "/", description = "Public Api Endpoints")
@@ -246,6 +250,11 @@ public class PaymentsResource {
                                      @ApiParam(value = "requestPayload", required = true) @Valid CreatePaymentRequest createPaymentRequest) {
         logger.info("Payment create request parsed to {}", createPaymentRequest);
 
+        if (account.getPaymentType().equals(TokenPaymentType.DIRECT_DEBIT) && createPaymentRequest.getAmount() == 0) {
+            throw new PaymentValidationException(aPaymentError("amount", CREATE_PAYMENT_VALIDATION_ERROR,
+                    "Must be greater than or equal to 1"));
+        }
+        
         ValidCreatePaymentRequest validCreatePaymentRequest = new ValidCreatePaymentRequest(createPaymentRequest);
         logger.info("Payment create request passed validation and parsed to {}", validCreatePaymentRequest);
 


### PR DESCRIPTION
We never want to allow 0 amounts for direct debit accounts, however we allow them for connector accounts and handle an error from connector if they are disallowed for the account in question