### PR TITLE
PP-5133 Change negative amount error

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
@@ -44,7 +44,9 @@ public class CreatePaymentRequest {
     public static final int DESCRIPTION_MAX_LENGTH = 255;
     public static final int URL_MAX_LENGTH = 2000;
     
-    @Min(value = AMOUNT_MIN_VALUE, message = "Must be greater than or equal to {value}")
+    // Even though the minimum is 0, this is only allowed for accounts this is enabled for and is a hidden feature
+    // so the validation error message will always state that the minimum is 1 for consistency.
+    @Min(value = AMOUNT_MIN_VALUE, message = "Must be greater than or equal to 1")
     @Max(value = AMOUNT_MAX_VALUE, message = "Must be less than or equal to {value}")
     private final int amount;
 

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceAmountValidationITest.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceAmountValidationITest.java
@@ -45,7 +45,7 @@ public class PaymentsResourceAmountValidationITest extends PaymentResourceITestB
                 .assertThat("$.*", hasSize(3))
                 .assertThat("$.field", is("amount"))
                 .assertThat("$.code", is("P0102"))
-                .assertThat("$.description", is("Invalid attribute value: amount. Must be greater than or equal to 0"));
+                .assertThat("$.description", is("Invalid attribute value: amount. Must be greater than or equal to 1"));
     }
 
     @Test


### PR DESCRIPTION
When a create payment request is made with a negative amount, the error message will now always state that it has to be greater than or equal to 1. This will be incorrect when zero amounts are allowed for the account but this is a hidden feature, so it's better that the error is consistent for most services, which will not have this enabled.