### PR TITLE
PP-5224 Split up CreatePaymentRequest

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/ViolationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/ViolationExceptionMapper.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.exception.mapper;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.CaseFormat;
 import io.dropwizard.jersey.validation.JerseyViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,12 +9,8 @@ import uk.gov.pay.api.model.PaymentError;
 import javax.annotation.Priority;
 import javax.validation.ConstraintViolation;
 import javax.validation.Path;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
-import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.Optional;
 
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_VALIDATION_ERROR;
 
@@ -27,7 +23,7 @@ public class ViolationExceptionMapper implements ExceptionMapper<JerseyViolation
         LOGGER.error(exception.getMessage());
         ConstraintViolation<?> firstException = exception.getConstraintViolations().iterator().next();
         String message = firstException.getMessage();
-        String fieldName = getApiFieldName(firstException);
+        String fieldName = getApiFieldName(firstException.getPropertyPath());
         PaymentError paymentError = PaymentError.aPaymentError(fieldName, CREATE_PAYMENT_VALIDATION_ERROR, message);
 
         return Response.status(422)
@@ -35,30 +31,8 @@ public class ViolationExceptionMapper implements ExceptionMapper<JerseyViolation
                 .build();
     }
 
-    private String getApiFieldName(ConstraintViolation<?> firstException) {
-        Field field = getField(firstException);
-        return getJacksonPropertyName(field).orElse(field.getName());
-    }
-
-    private Optional<String> getJacksonPropertyName(Field field) {
-        return Arrays.stream(field.getAnnotations())
-                .filter(annotation -> annotation instanceof JsonProperty)
-                .findFirst()
-                .map(annotation -> ((JsonProperty) annotation).value());
-    }
-    
-    private Field getField(ConstraintViolation<?> firstException) {
-        Class<?> leafBean = firstException.getLeafBean().getClass();
-        String fieldName = getFieldNameFromPath(firstException.getPropertyPath());
-        try {
-            Field f = leafBean.getDeclaredField(fieldName);
-            f.setAccessible(true);
-            return f;
-        } catch (NoSuchFieldException e) {
-            LOGGER.error(String.format("Cannot process violation exception. " +
-                    "Field %s does not exist or is not public on class %s", fieldName, leafBean.toString()));
-            throw new WebApplicationException(e);
-        }
+    private String getApiFieldName(Path path) {
+        return CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, getFieldNameFromPath(path));
     }
     
     private String getFieldNameFromPath(Path path) {

--- a/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
+++ b/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.api.exception.BadRequestException;
 import uk.gov.pay.api.model.CreatePaymentRefundRequest;
 import uk.gov.pay.api.model.CreatePaymentRequest;
+import uk.gov.pay.api.model.CreatePaymentRequestBuilder;
 import uk.gov.pay.api.model.PaymentError;
 import uk.gov.pay.api.model.PaymentError.Code;
 import uk.gov.pay.commons.model.SupportedLanguage;
@@ -24,23 +25,23 @@ import java.util.stream.Collectors;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
 import static uk.gov.pay.api.model.CreatePaymentRefundRequest.REFUND_AMOUNT_AVAILABLE;
-import static uk.gov.pay.api.model.CreatePaymentRequest.AGREEMENT_ID_FIELD_NAME;
+import static uk.gov.pay.api.model.CreateDirectDebitPaymentRequest.AGREEMENT_ID_FIELD_NAME;
 import static uk.gov.pay.api.model.CreatePaymentRequest.AMOUNT_FIELD_NAME;
-import static uk.gov.pay.api.model.CreatePaymentRequest.DELAYED_CAPTURE_FIELD_NAME;
+import static uk.gov.pay.api.model.CreateCardPaymentRequest.DELAYED_CAPTURE_FIELD_NAME;
 import static uk.gov.pay.api.model.CreatePaymentRequest.DESCRIPTION_FIELD_NAME;
 import static uk.gov.pay.api.model.CreatePaymentRequest.EMAIL_FIELD_NAME;
 import static uk.gov.pay.api.model.CreatePaymentRequest.LANGUAGE_FIELD_NAME;
-import static uk.gov.pay.api.model.CreatePaymentRequest.METADATA;
-import static uk.gov.pay.api.model.CreatePaymentRequest.PREFILLED_ADDRESS_CITY_FIELD_NAME;
-import static uk.gov.pay.api.model.CreatePaymentRequest.PREFILLED_ADDRESS_COUNTRY_FIELD_NAME;
-import static uk.gov.pay.api.model.CreatePaymentRequest.PREFILLED_ADDRESS_LINE1_FIELD_NAME;
-import static uk.gov.pay.api.model.CreatePaymentRequest.PREFILLED_ADDRESS_LINE2_FIELD_NAME;
-import static uk.gov.pay.api.model.CreatePaymentRequest.PREFILLED_ADDRESS_POSTCODE_FIELD_NAME;
-import static uk.gov.pay.api.model.CreatePaymentRequest.PREFILLED_BILLING_ADDRESS_FIELD_NAME;
-import static uk.gov.pay.api.model.CreatePaymentRequest.PREFILLED_CARDHOLDER_DETAILS_FIELD_NAME;
-import static uk.gov.pay.api.model.CreatePaymentRequest.PREFILLED_CARDHOLDER_NAME_FIELD_NAME;
+import static uk.gov.pay.api.model.CreateCardPaymentRequest.METADATA;
+import static uk.gov.pay.api.model.CreateCardPaymentRequest.PREFILLED_ADDRESS_CITY_FIELD_NAME;
+import static uk.gov.pay.api.model.CreateCardPaymentRequest.PREFILLED_ADDRESS_COUNTRY_FIELD_NAME;
+import static uk.gov.pay.api.model.CreateCardPaymentRequest.PREFILLED_ADDRESS_LINE1_FIELD_NAME;
+import static uk.gov.pay.api.model.CreateCardPaymentRequest.PREFILLED_ADDRESS_LINE2_FIELD_NAME;
+import static uk.gov.pay.api.model.CreateCardPaymentRequest.PREFILLED_ADDRESS_POSTCODE_FIELD_NAME;
+import static uk.gov.pay.api.model.CreateCardPaymentRequest.PREFILLED_BILLING_ADDRESS_FIELD_NAME;
+import static uk.gov.pay.api.model.CreateCardPaymentRequest.PREFILLED_CARDHOLDER_DETAILS_FIELD_NAME;
+import static uk.gov.pay.api.model.CreateCardPaymentRequest.PREFILLED_CARDHOLDER_NAME_FIELD_NAME;
 import static uk.gov.pay.api.model.CreatePaymentRequest.REFERENCE_FIELD_NAME;
-import static uk.gov.pay.api.model.CreatePaymentRequest.RETURN_URL_FIELD_NAME;
+import static uk.gov.pay.api.model.CreateCardPaymentRequest.RETURN_URL_FIELD_NAME;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_MISSING_FIELD_ERROR;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_REFUND_MISSING_FIELD_ERROR;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_REFUND_VALIDATION_ERROR;
@@ -60,7 +61,7 @@ class RequestJsonParser {
 
     static CreatePaymentRequest parsePaymentRequest(JsonNode paymentRequest) {
 
-        var builder = CreatePaymentRequest.builder()
+        var builder = CreatePaymentRequestBuilder.builder()
                 .amount(validateAndGetAmount(paymentRequest, CREATE_PAYMENT_VALIDATION_ERROR, CREATE_PAYMENT_MISSING_FIELD_ERROR))
                 .reference(validateAndGetReference(paymentRequest))
                 .description(validateAndGetDescription(paymentRequest));
@@ -179,7 +180,7 @@ class RequestJsonParser {
         return metadata;
     }
 
-    private static void validatePrefilledCardholderDetails(JsonNode prefilledNode, CreatePaymentRequest.CreatePaymentRequestBuilder builder) {
+    private static void validatePrefilledCardholderDetails(JsonNode prefilledNode, CreatePaymentRequestBuilder builder) {
         if (prefilledNode.has(PREFILLED_CARDHOLDER_NAME_FIELD_NAME)) {
             String cardHolderName = validateSkipNullValueAndGetString(prefilledNode.get(PREFILLED_CARDHOLDER_NAME_FIELD_NAME),
                     aPaymentError(PREFILLED_CARDHOLDER_NAME_FIELD_NAME, CREATE_PAYMENT_VALIDATION_ERROR, "Field must be a string"));

--- a/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
@@ -1,0 +1,121 @@
+package uk.gov.pay.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import uk.gov.pay.api.utils.JsonStringBuilder;
+import uk.gov.pay.api.validation.ValidReturnUrl;
+import uk.gov.pay.commons.model.charge.ExternalMetadata;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Size;
+import java.util.Optional;
+import java.util.StringJoiner;
+
+@ApiModel(value = "CreatePaymentRequest", description = "The Payment Request Payload")
+public class CreateCardPaymentRequest extends CreatePaymentRequest {
+
+    public static final String RETURN_URL_FIELD_NAME = "return_url";
+    public static final int URL_MAX_LENGTH = 2000;
+    public static final String PREFILLED_CARDHOLDER_DETAILS_FIELD_NAME = "prefilled_cardholder_details";
+    public static final String PREFILLED_CARDHOLDER_NAME_FIELD_NAME = "cardholder_name";
+    public static final String PREFILLED_BILLING_ADDRESS_FIELD_NAME = "billing_address";
+    public static final String PREFILLED_ADDRESS_LINE1_FIELD_NAME = "line1";
+    public static final String PREFILLED_ADDRESS_LINE2_FIELD_NAME = "line2";
+    public static final String PREFILLED_ADDRESS_CITY_FIELD_NAME = "city";
+    public static final String PREFILLED_ADDRESS_POSTCODE_FIELD_NAME = "postcode";
+    public static final String PREFILLED_ADDRESS_COUNTRY_FIELD_NAME = "country";
+    public static final String DELAYED_CAPTURE_FIELD_NAME = "delayed_capture";
+    public static final String METADATA = "metadata";
+    private static final String PREFILLED_CARDHOLDER_DETAILS = "prefilled_cardholder_details";
+    private static final String BILLING_ADDRESS = "billing_address";
+
+    @ValidReturnUrl
+    @Size(max = URL_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
+    @JsonProperty("return_url")
+    private final String returnUrl;
+
+    private final Boolean delayedCapture;
+
+    private final ExternalMetadata metadata;
+
+    @Valid
+    private final PrefilledCardholderDetails prefilledCardholderDetails;
+
+    public CreateCardPaymentRequest(CreatePaymentRequestBuilder createPaymentRequestBuilder) {
+        super(createPaymentRequestBuilder);
+        this.prefilledCardholderDetails = createPaymentRequestBuilder.getPrefilledCardholderDetails();
+        this.delayedCapture = createPaymentRequestBuilder.getDelayedCapture();
+        this.returnUrl = createPaymentRequestBuilder.getReturnUrl();
+        this.metadata = createPaymentRequestBuilder.getMetadata();
+    }
+
+    @Override
+    public TokenPaymentType getRequestType() {
+        return TokenPaymentType.CARD;
+    }
+
+    @ApiModelProperty(value = "service return url", required = true, example = "https://service-name.gov.uk/transactions/12345")
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    @ApiModelProperty(value = "prefilled_cardholder_details", required = false)
+    @JsonProperty(CreateCardPaymentRequest.PREFILLED_CARDHOLDER_DETAILS_FIELD_NAME)
+    public Optional<PrefilledCardholderDetails> getPrefilledCardholderDetails() {
+        return Optional.ofNullable(prefilledCardholderDetails);
+    }
+
+    @ApiModelProperty(value = "delayed capture flag", required = false, example = "false")
+    @JsonProperty(DELAYED_CAPTURE_FIELD_NAME)
+    public Optional<Boolean> getDelayedCapture() {
+        return Optional.ofNullable(delayedCapture);
+    }
+
+    @JsonProperty("metadata")
+    public Optional<ExternalMetadata> getMetadata() {
+        return Optional.ofNullable(metadata);
+    }
+
+    @Override
+    public String toConnectorPayload() {
+        JsonStringBuilder request = new JsonStringBuilder()
+                .add("amount", this.getAmount())
+                .add("reference", this.getReference())
+                .add("description", this.getDescription())
+                .add("return_url", this.returnUrl);
+        getLanguage().ifPresent(language -> request.add("language", language.toString()));
+        getDelayedCapture().ifPresent(delayedCapture -> request.add("delayed_capture", delayedCapture));
+        getMetadata().ifPresent(metadata -> request.add("metadata", metadata.getMetadata()));
+        getEmail().ifPresent(email -> request.add("email", email));
+        
+        getPrefilledCardholderDetails().ifPresent(prefilledDetails -> {
+            prefilledDetails.getCardholderName().ifPresent(name -> request.addToMap(PREFILLED_CARDHOLDER_DETAILS, "cardholder_name", name));
+            prefilledDetails.getBillingAddress().ifPresent(address -> {
+                request.addToNestedMap("line1", address.getLine1(), PREFILLED_CARDHOLDER_DETAILS, BILLING_ADDRESS);
+                request.addToNestedMap("line2", address.getLine2(), PREFILLED_CARDHOLDER_DETAILS, BILLING_ADDRESS);
+                request.addToNestedMap("postcode", address.getPostcode(), PREFILLED_CARDHOLDER_DETAILS, BILLING_ADDRESS);
+                request.addToNestedMap("city", address.getCity(), PREFILLED_CARDHOLDER_DETAILS, BILLING_ADDRESS);
+                request.addToNestedMap("country", address.getCountry(), PREFILLED_CARDHOLDER_DETAILS, BILLING_ADDRESS);
+            });
+        });
+        
+        return request.build();
+    }
+
+    /**
+     * This looks JSONesque but is not identical to the received request
+     */
+    @Override
+    public String toString() {
+        // Some services put PII in the description, so don’t include it in the stringification
+        StringJoiner joiner = new StringJoiner(", ", "{", "}");
+        joiner.add("amount: ").add(String.valueOf(super.getAmount()));
+        joiner.add("reference: ").add(super.getReference());
+        joiner.add("return_url: ").add(returnUrl);
+        super.getLanguage().ifPresent(value -> joiner.add("language: ").add(value.toString()));
+        getDelayedCapture().ifPresent(value -> joiner.add("delayed_capture: ").add(value.toString()));
+        getMetadata().ifPresent(value -> joiner.add("metadata: ").add(value.toString()));
+        return joiner.toString();
+    }
+}

--- a/src/main/java/uk/gov/pay/api/model/CreateDirectDebitPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateDirectDebitPaymentRequest.java
@@ -1,0 +1,71 @@
+package uk.gov.pay.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import uk.gov.pay.api.utils.JsonStringBuilder;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Size;
+import java.util.Optional;
+import java.util.StringJoiner;
+
+@ApiModel(value = "CreatePaymentRequest", description = "The Payment Request Payload")
+public class CreateDirectDebitPaymentRequest extends CreatePaymentRequest{
+
+    public static final int AGREEMENT_ID_MAX_LENGTH = 26;
+    public static final String AGREEMENT_ID_FIELD_NAME = "agreement_id";
+
+    @Size(max = AGREEMENT_ID_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
+    @JsonProperty(value = AGREEMENT_ID_FIELD_NAME)
+    private final String agreementId;
+
+
+    public CreateDirectDebitPaymentRequest(CreatePaymentRequestBuilder createPaymentRequestBuilder) {
+        super(createPaymentRequestBuilder);
+        this.agreementId = createPaymentRequestBuilder.getAgreementId();
+    }
+
+    @Override
+    @Min(value = 1, message = "Must be greater than or equal to 1")
+    public int getAmount() {
+        return super.getAmount();
+    }
+
+    @ApiModelProperty(value = "ID of the agreement being used to collect the payment", required = false, example = "33890b55-b9ea-4e2f-90fd-77ae0e9009e2")
+    public String getAgreementId() {
+        return agreementId;
+    }
+
+    @Override
+    public TokenPaymentType getRequestType() {
+        return TokenPaymentType.DIRECT_DEBIT;
+    }
+
+    @Override
+    public String toConnectorPayload() {
+        JsonStringBuilder request = new JsonStringBuilder()
+                .add("amount", this.getAmount())
+                .add("reference", this.getReference())
+                .add("description", this.getDescription())
+                .add("agreement_id", agreementId);
+        getLanguage().ifPresent(language -> request.add("language", language.toString()));
+        getEmail().ifPresent(email -> request.add("email", email));
+
+        return request.build();
+    }
+
+    /**
+     * This looks JSONesque but is not identical to the received request
+     */
+    @Override
+    public String toString() {
+        // Some services put PII in the description, so don’t include it in the stringification
+        StringJoiner joiner = new StringJoiner(", ", "{", "}");
+        joiner.add("amount: ").add(String.valueOf(super.getAmount()));
+        joiner.add("reference: ").add(super.getReference());
+        joiner.add("agreement_id: ").add(agreementId);
+        super.getLanguage().ifPresent(value -> joiner.add("language: ").add(value.toString()));
+        return joiner.toString();
+    }
+}

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
@@ -3,13 +3,9 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import org.apache.commons.lang3.StringUtils;
 import org.hibernate.validator.constraints.Length;
-import uk.gov.pay.api.validation.ValidReturnUrl;
 import uk.gov.pay.commons.model.SupportedLanguage;
-import uk.gov.pay.commons.model.charge.ExternalMetadata;
 
-import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
@@ -17,32 +13,18 @@ import java.util.Optional;
 import java.util.StringJoiner;
 
 @ApiModel(value = "CreatePaymentRequest", description = "The Payment Request Payload")
-public class CreatePaymentRequest {
+public abstract class CreatePaymentRequest {
 
-    public static final int AGREEMENT_ID_MAX_LENGTH = 26;
     public static final int EMAIL_MAX_LENGTH = 254;
     public static final String AMOUNT_FIELD_NAME = "amount";
-    public static final String RETURN_URL_FIELD_NAME = "return_url";
     public static final String REFERENCE_FIELD_NAME = "reference";
     public static final String DESCRIPTION_FIELD_NAME = "description";
-    public static final String AGREEMENT_ID_FIELD_NAME = "agreement_id";
     public static final String LANGUAGE_FIELD_NAME = "language";
-    public static final String DELAYED_CAPTURE_FIELD_NAME = "delayed_capture";
-    public static final String METADATA = "metadata";
     public static final String EMAIL_FIELD_NAME = "email";
-    public static final String PREFILLED_CARDHOLDER_DETAILS_FIELD_NAME = "prefilled_cardholder_details";
-    public static final String PREFILLED_CARDHOLDER_NAME_FIELD_NAME = "cardholder_name";
-    public static final String PREFILLED_BILLING_ADDRESS_FIELD_NAME = "billing_address";
-    public static final String PREFILLED_ADDRESS_LINE1_FIELD_NAME = "line1";
-    public static final String PREFILLED_ADDRESS_LINE2_FIELD_NAME = "line2";
-    public static final String PREFILLED_ADDRESS_CITY_FIELD_NAME = "city";
-    public static final String PREFILLED_ADDRESS_POSTCODE_FIELD_NAME = "postcode";
-    public static final String PREFILLED_ADDRESS_COUNTRY_FIELD_NAME = "country";
     public static final int REFERENCE_MAX_LENGTH = 255;
     public static final int AMOUNT_MAX_VALUE = 10000000;
     public static final int AMOUNT_MIN_VALUE = 0;
     public static final int DESCRIPTION_MAX_LENGTH = 255;
-    public static final int URL_MAX_LENGTH = 2000;
     
     // Even though the minimum is 0, this is only allowed for accounts this is enabled for and is a hidden feature
     // so the validation error message will always state that the minimum is 1 for consistency.
@@ -50,45 +32,28 @@ public class CreatePaymentRequest {
     @Max(value = AMOUNT_MAX_VALUE, message = "Must be less than or equal to {value}")
     private final int amount;
 
-    @ValidReturnUrl
-    @Size(max = URL_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
-    @JsonProperty("return_url")
-    private final String returnUrl;
-
     @Size(max = REFERENCE_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     private final String reference;
 
     @Size(max = DESCRIPTION_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     private final String description;
-
-    @Size(max = AGREEMENT_ID_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
-    @JsonProperty(value = "agreement_id")
-    private final String agreementId;
     
     private final SupportedLanguage language;
-    
-    private final Boolean delayedCapture;
-    
-    private final ExternalMetadata metadata;
 
     @Length(max = EMAIL_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     private final String email;
     
-    @Valid
-    private final PrefilledCardholderDetails prefilledCardholderDetails;
-    
-    private CreatePaymentRequest(CreatePaymentRequestBuilder createPaymentRequestBuilder) {
-        this.amount = createPaymentRequestBuilder.amount;
-        this.returnUrl = createPaymentRequestBuilder.returnUrl;
-        this.reference = createPaymentRequestBuilder.reference;
-        this.description = createPaymentRequestBuilder.description;
-        this.agreementId = createPaymentRequestBuilder.agreementId;
-        this.language = createPaymentRequestBuilder.language;
-        this.delayedCapture = createPaymentRequestBuilder.delayedCapture;
-        this.metadata = createPaymentRequestBuilder.metadata;
-        this.email = createPaymentRequestBuilder.email;
-        this.prefilledCardholderDetails = createPaymentRequestBuilder.getPrefilledCardholderDetails();
+    public CreatePaymentRequest(CreatePaymentRequestBuilder createPaymentRequestBuilder) {
+        this.amount = createPaymentRequestBuilder.getAmount();
+        this.reference = createPaymentRequestBuilder.getReference();
+        this.description = createPaymentRequestBuilder.getDescription();
+        this.language = createPaymentRequestBuilder.getLanguage();
+        this.email = createPaymentRequestBuilder.getEmail();
     }
+
+    public abstract String toConnectorPayload();
+
+    public abstract TokenPaymentType getRequestType();
 
     @ApiModelProperty(value = "amount in pence", required = true, allowableValues = "range[1, 10000000]", example = "12000")
     public int getAmount() {
@@ -105,65 +70,16 @@ public class CreatePaymentRequest {
         return description;
     }
 
-    @ApiModelProperty(value = "service return url", required = true, example = "https://service-name.gov.uk/transactions/12345")
-    @JsonProperty("return_url")
-    public Optional<String> getReturnUrl() {
-        return Optional.ofNullable(returnUrl);
-    }
-
-    @ApiModelProperty(value = "ID of the agreement being used to collect the payment", required = false, example = "33890b55-b9ea-4e2f-90fd-77ae0e9009e2")
-    @JsonProperty(AGREEMENT_ID_FIELD_NAME)
-    public Optional<String> getAgreementId() {
-        return Optional.ofNullable(agreementId);
-    }
-
     @ApiModelProperty(value = "ISO-639-1 Alpha-2 code of a supported language to use on the payment pages", required = false, example = "en")
     @JsonProperty(LANGUAGE_FIELD_NAME)
     public Optional<SupportedLanguage> getLanguage() {
         return Optional.ofNullable(language);
     }
 
-    @ApiModelProperty(value = "delayed capture flag", required = false, example = "false")
-    @JsonProperty(DELAYED_CAPTURE_FIELD_NAME)
-    public Optional<Boolean> getDelayedCapture() {
-        return Optional.ofNullable(delayedCapture);
-    }
-
-    @JsonProperty("metadata")
-    public Optional<ExternalMetadata> getMetadata() {
-        return Optional.ofNullable(metadata);
-    }
-
     @ApiModelProperty(value = "email", required = false, example = "Joe.Bogs@example.org")
     @JsonProperty(EMAIL_FIELD_NAME)
     public Optional<String> getEmail() {
         return Optional.ofNullable(email);
-    }
-
-    @ApiModelProperty(value = "prefilled_cardholder_details", required = false)
-    @JsonProperty(PREFILLED_CARDHOLDER_DETAILS_FIELD_NAME)
-    public Optional<PrefilledCardholderDetails> getPrefilledCardholderDetails() {
-        return Optional.ofNullable(prefilledCardholderDetails);
-    }
-
-    public boolean hasReturnUrl() {
-        return StringUtils.isNotBlank(returnUrl);
-    }
-
-    public boolean hasAgreementId() {
-        return StringUtils.isNotBlank(agreementId);
-    }
-
-    public boolean hasLanguage() {
-        return language != null;
-    }
-
-    public boolean hasEmail() {
-        return StringUtils.isNotBlank(email);
-    }
-
-    public boolean hasPrefilledCardholderDetails() {
-        return prefilledCardholderDetails != null;
     }
 
     /**
@@ -175,129 +91,7 @@ public class CreatePaymentRequest {
         StringJoiner joiner = new StringJoiner(", ", "{", "}");
         joiner.add("amount: ").add(String.valueOf(amount));
         joiner.add("reference: ").add(reference);
-        Optional.ofNullable(returnUrl).ifPresent(value -> joiner.add("return_url: ").add(value));
-        Optional.ofNullable(agreementId).ifPresent(value -> joiner.add("agreement_id: ").add(value));
         Optional.ofNullable(language).ifPresent(value -> joiner.add("language: ").add(value.toString()));
-        Optional.ofNullable(delayedCapture).ifPresent(value -> joiner.add("delayed_capture: ").add(value.toString()));
-        Optional.ofNullable(metadata).ifPresent(value -> joiner.add("metadata: ").add(value.toString()));
         return joiner.toString();
-    }
-
-    public static class CreatePaymentRequestBuilder {
-        private ExternalMetadata metadata;
-        private int amount;
-        private String returnUrl;
-        private String reference;
-        private String description;
-        private String agreementId;
-        private SupportedLanguage language;
-        private Boolean delayedCapture;
-        private String email;
-        private String cardholderName;
-        private String addressLine1;
-        private String addressLine2;
-        private String city;
-        private String postcode;
-        private String country;
-        private PrefilledCardholderDetails prefilledCardholderDetails;
-
-        public CreatePaymentRequestBuilder amount(int amount) {
-            this.amount = amount;
-            return this;
-        }
-
-        public CreatePaymentRequestBuilder returnUrl(String returnUrl) {
-            this.returnUrl = returnUrl;
-            return this;
-        }
-
-        public CreatePaymentRequestBuilder reference(String reference) {
-            this.reference = reference;
-            return this;
-        }
-
-        public CreatePaymentRequestBuilder description(String description) {
-            this.description = description;
-            return this;
-        }
-
-        public CreatePaymentRequestBuilder agreementId(String agreementId) {
-            this.agreementId = agreementId;
-            return this;
-        }
-
-        public CreatePaymentRequestBuilder language(SupportedLanguage language) {
-            this.language = language;
-            return this;
-        }
-
-        public CreatePaymentRequestBuilder delayedCapture(Boolean delayedCapture) {
-            this.delayedCapture = delayedCapture;
-            return this;
-        }
-
-        public CreatePaymentRequestBuilder metadata(ExternalMetadata metadata) {
-            this.metadata = metadata;
-            return this;
-        }
-
-        public CreatePaymentRequestBuilder email(String email) {
-            this.email = email;
-            return this;
-        }
-
-        public CreatePaymentRequestBuilder cardholderName(String cardHolderName) {
-            this.cardholderName = cardHolderName;
-            return this;
-        }
-
-        public CreatePaymentRequestBuilder addressLine1(String addressLine1) {
-            this.addressLine1 = addressLine1;
-            return this;
-        }
-
-        public CreatePaymentRequestBuilder addressLine2(String addressLine2) {
-            this.addressLine2 = addressLine2;
-            return this;
-        }
-
-        public CreatePaymentRequestBuilder city(String city) {
-            this.city = city;
-            return this;
-        }
-
-        public CreatePaymentRequestBuilder postcode(String postcode) {
-            this.postcode = postcode;
-            return this;
-        }
-
-        public CreatePaymentRequestBuilder country(String country) {
-            this.country = country;
-            return this;
-        }
-
-        private PrefilledCardholderDetails getPrefilledCardholderDetails() {
-            if (cardholderName != null) {
-                this.prefilledCardholderDetails = new PrefilledCardholderDetails();
-                this.prefilledCardholderDetails.setCardholderName(cardholderName);
-            }
-            if (addressLine1 != null || addressLine2 != null ||
-                    postcode != null || city != null || country != null) {
-                if (this.prefilledCardholderDetails == null) {
-                    this.prefilledCardholderDetails = new PrefilledCardholderDetails();
-                }
-                this.prefilledCardholderDetails.setAddress(addressLine1, addressLine2, postcode, city, country);
-            }
-            return prefilledCardholderDetails;
-        }
-
-
-        public CreatePaymentRequest build() {
-            return new CreatePaymentRequest(this);
-        }
-    }
-
-    public static CreatePaymentRequestBuilder builder() {
-        return new CreatePaymentRequestBuilder();
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRequestBuilder.java
@@ -1,0 +1,181 @@
+package uk.gov.pay.api.model;
+
+import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.commons.model.charge.ExternalMetadata;
+
+public class CreatePaymentRequestBuilder {
+    private ExternalMetadata metadata;
+    private int amount;
+    private String returnUrl;
+    private String reference;
+    private String description;
+    private String agreementId;
+    private SupportedLanguage language;
+    private Boolean delayedCapture;
+    private String email;
+    private String cardholderName;
+    private String addressLine1;
+    private String addressLine2;
+    private String city;
+    private String postcode;
+    private String country;
+    private PrefilledCardholderDetails prefilledCardholderDetails;
+
+    public CreatePaymentRequest build() {
+        return this.getAgreementId() == null ? new CreateCardPaymentRequest(this) : new CreateDirectDebitPaymentRequest(this);
+    }
+
+    public static CreatePaymentRequestBuilder builder() {
+        return new CreatePaymentRequestBuilder();
+    }
+
+    public CreatePaymentRequestBuilder amount(int amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    public CreatePaymentRequestBuilder returnUrl(String returnUrl) {
+        this.returnUrl = returnUrl;
+        return this;
+    }
+
+    public CreatePaymentRequestBuilder reference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    public CreatePaymentRequestBuilder description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public CreatePaymentRequestBuilder agreementId(String agreementId) {
+        this.agreementId = agreementId;
+        return this;
+    }
+
+    public CreatePaymentRequestBuilder language(SupportedLanguage language) {
+        this.language = language;
+        return this;
+    }
+
+    public CreatePaymentRequestBuilder delayedCapture(Boolean delayedCapture) {
+        this.delayedCapture = delayedCapture;
+        return this;
+    }
+
+    public CreatePaymentRequestBuilder metadata(ExternalMetadata metadata) {
+        this.metadata = metadata;
+        return this;
+    }
+
+    public CreatePaymentRequestBuilder email(String email) {
+        this.email = email;
+        return this;
+    }
+
+    public CreatePaymentRequestBuilder cardholderName(String cardHolderName) {
+        this.cardholderName = cardHolderName;
+        return this;
+    }
+
+    public CreatePaymentRequestBuilder addressLine1(String addressLine1) {
+        this.addressLine1 = addressLine1;
+        return this;
+    }
+
+    public CreatePaymentRequestBuilder addressLine2(String addressLine2) {
+        this.addressLine2 = addressLine2;
+        return this;
+    }
+
+    public CreatePaymentRequestBuilder city(String city) {
+        this.city = city;
+        return this;
+    }
+
+    public CreatePaymentRequestBuilder postcode(String postcode) {
+        this.postcode = postcode;
+        return this;
+    }
+
+    public CreatePaymentRequestBuilder country(String country) {
+        this.country = country;
+        return this;
+    }
+
+    public PrefilledCardholderDetails getPrefilledCardholderDetails() {
+        if (cardholderName != null) {
+            this.prefilledCardholderDetails = new PrefilledCardholderDetails();
+            this.prefilledCardholderDetails.setCardholderName(cardholderName);
+        }
+        if (addressLine1 != null || addressLine2 != null ||
+                postcode != null || city != null || country != null) {
+            if (this.prefilledCardholderDetails == null) {
+                this.prefilledCardholderDetails = new PrefilledCardholderDetails();
+            }
+            this.prefilledCardholderDetails.setAddress(addressLine1, addressLine2, postcode, city, country);
+        }
+        return prefilledCardholderDetails;
+    }
+
+    public ExternalMetadata getMetadata() {
+        return metadata;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getAgreementId() {
+        return agreementId;
+    }
+
+    public SupportedLanguage getLanguage() {
+        return language;
+    }
+
+    public Boolean getDelayedCapture() {
+        return delayedCapture;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getCardholderName() {
+        return cardholderName;
+    }
+
+    public String getAddressLine1() {
+        return addressLine1;
+    }
+
+    public String getAddressLine2() {
+        return addressLine2;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public String getPostcode() {
+        return postcode;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+}

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -248,11 +248,6 @@ public class PaymentsResource {
     public Response createNewPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                      @ApiParam(value = "requestPayload", required = true) @Valid CreatePaymentRequest createPaymentRequest) {
         logger.info("Payment create request parsed to {}", createPaymentRequest);
-
-        if (account.getPaymentType().equals(DIRECT_DEBIT) && createPaymentRequest.getAmount() == 0) {
-            throw new PaymentValidationException(aPaymentError("amount", CREATE_PAYMENT_VALIDATION_ERROR,
-                    "Must be greater than or equal to 1"));
-        }
         
         PaymentWithAllLinks createdPayment = createPaymentService.create(account, createPaymentRequest);
 

--- a/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
@@ -3,6 +3,9 @@ package uk.gov.pay.api.service;
 import com.google.common.collect.Maps;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.model.CreateCardPaymentRequest;
+import uk.gov.pay.api.model.CreatePaymentRequest;
+import uk.gov.pay.api.model.TokenPaymentType;
 
 import javax.inject.Inject;
 import javax.ws.rs.core.UriBuilder;
@@ -24,9 +27,9 @@ public class ConnectorUriGenerator {
         this.configuration = configuration;
     }
 
-    String chargesURI(Account account, String agreementId) {
+    String chargesURI(Account account, TokenPaymentType tokenPaymentType) {
         String chargePath = "/v1/api/accounts/%s/charges";
-        if (account.getPaymentType().equals(DIRECT_DEBIT) && agreementId != null) {
+        if (account.getPaymentType().equals(DIRECT_DEBIT) && DIRECT_DEBIT.equals(tokenPaymentType)) {
             chargePath += "/collect";
         }
         return buildConnectorUri(account, format(chargePath, account.getAccountId()));

--- a/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 import static org.apache.commons.lang3.StringUtils.join;
 import static org.eclipse.jetty.util.StringUtil.isBlank;
-import static uk.gov.pay.api.model.CreatePaymentRequest.AGREEMENT_ID_MAX_LENGTH;
+import static uk.gov.pay.api.model.CreateDirectDebitPaymentRequest.AGREEMENT_ID_MAX_LENGTH;
 import static uk.gov.pay.api.model.CreatePaymentRequest.EMAIL_MAX_LENGTH;
 import static uk.gov.pay.api.model.CreatePaymentRequest.REFERENCE_MAX_LENGTH;
 import static uk.gov.pay.api.model.PaymentError.Code.SEARCH_PAYMENTS_VALIDATION_ERROR;

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
@@ -430,7 +430,7 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
                 .add("amount", 0)
                 .add("reference", REFERENCE)
                 .add("description", DESCRIPTION)
-                .add("return_url", RETURN_URL)
+                .add("agreement_id", "1234")
                 .build();
 
         postPaymentResponse(payload)

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceAgreementIdValidationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceAgreementIdValidationIT.java
@@ -123,7 +123,6 @@ public class PaymentsResourceAgreementIdValidationIT extends PaymentResourceITes
     // Ignoring this for now as the return url will always be validated via the @ValidReturnUrl on the CreatePaymentRequest,
     // but the RequestJsonParser specifies that where there is an agreement Id, the return url will be null. We can fix 
     // this later as recurring payments aren't used in production at the moment.
-    @Ignore //TODO fixme
     @Test
     public void createPayment_responseWith422_whenAgreementIdSizeIsGreaterThanMaxLength() throws IOException {
 

--- a/src/test/java/uk/gov/pay/api/json/CreatePaymentRequestDeserializerTest.java
+++ b/src/test/java/uk/gov/pay/api/json/CreatePaymentRequestDeserializerTest.java
@@ -13,7 +13,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.api.exception.BadRequestException;
 import uk.gov.pay.api.model.Address;
-import uk.gov.pay.api.model.CreatePaymentRequest;
+import uk.gov.pay.api.model.CreateCardPaymentRequest;
+import uk.gov.pay.api.model.CreateDirectDebitPaymentRequest;
 import uk.gov.pay.api.model.PrefilledCardholderDetails;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
@@ -52,12 +53,12 @@ public class CreatePaymentRequestDeserializerTest {
                 "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
                 "}";
 
-        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
+        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
 
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl(), is(Optional.of("https://somewhere.gov.uk/rainbow/1")));
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
         assertThat(paymentRequest.getLanguage(), is(Optional.empty()));
         assertThat(paymentRequest.getDelayedCapture(), is(Optional.empty()));
         assertThat(paymentRequest.getEmail(), is(Optional.empty()));
@@ -75,12 +76,12 @@ public class CreatePaymentRequestDeserializerTest {
                 "  \"language\": \"en\"\n" +
                 "}";
 
-        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
+        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
 
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl(), is(Optional.of("https://somewhere.gov.uk/rainbow/1")));
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
         assertThat(paymentRequest.getLanguage(), is(Optional.of(SupportedLanguage.ENGLISH)));
     }
 
@@ -95,12 +96,12 @@ public class CreatePaymentRequestDeserializerTest {
                 "  \"language\": \"cy\"\n" +
                 "}";
 
-        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
+        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
 
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl(), is(Optional.of("https://somewhere.gov.uk/rainbow/1")));
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
         assertThat(paymentRequest.getLanguage(), is(Optional.of(SupportedLanguage.WELSH)));
     }
 
@@ -115,12 +116,12 @@ public class CreatePaymentRequestDeserializerTest {
                 "  \"delayed_capture\": true\n" +
                 "}";
 
-        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
+        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
 
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl(), is(Optional.of("https://somewhere.gov.uk/rainbow/1")));
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
         assertThat(paymentRequest.getDelayedCapture(), is(Optional.of(Boolean.TRUE)));
     }
 
@@ -135,12 +136,12 @@ public class CreatePaymentRequestDeserializerTest {
                 "  \"delayed_capture\": false\n" +
                 "}";
 
-        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
+        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
 
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl(), is(Optional.of("https://somewhere.gov.uk/rainbow/1")));
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
         assertThat(paymentRequest.getDelayedCapture(), is(Optional.of(Boolean.FALSE)));
     }
 
@@ -154,13 +155,12 @@ public class CreatePaymentRequestDeserializerTest {
                 "  \"description\": \"Some description\"\n" +
                 "}";
 
-        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
+        CreateDirectDebitPaymentRequest paymentRequest = (CreateDirectDebitPaymentRequest) deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
 
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl(), is(Optional.empty()));
-        assertThat(paymentRequest.getAgreementId(), is(Optional.of("abc123")));
+        assertThat(paymentRequest.getAgreementId(), is("abc123"));
     }
 
     @Test
@@ -499,11 +499,11 @@ public class CreatePaymentRequestDeserializerTest {
                 "\"country\": \"GB\"\n" +
                 "}" + "}" + "}";
 
-        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(payload), ctx);
+        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(payload), ctx);
         assertThat(paymentRequest.getAmount(), is(1000));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl(), is(Optional.of("https://somewhere.gov.uk/rainbow/1")));
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
         assertThat(paymentRequest.getLanguage(), is(Optional.empty()));
         assertThat(paymentRequest.getDelayedCapture(), is(Optional.empty()));
         assertThat(paymentRequest.getEmail(), is(Optional.of("j.bogs@example.org")));
@@ -534,11 +534,11 @@ public class CreatePaymentRequestDeserializerTest {
                 "\"cardholder_name\": \"J Bogs\"\n" +
                 "}" + "}";
 
-        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(payload), ctx);
+        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(payload), ctx);
         assertThat(paymentRequest.getAmount(), is(1000));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl(), is(Optional.of("https://somewhere.gov.uk/rainbow/1")));
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
         assertThat(paymentRequest.getEmail(), is(Optional.of("j.bogs@example.org")));
         assertThat(paymentRequest.getPrefilledCardholderDetails().isPresent(), is(true));
         assertThat(paymentRequest.getPrefilledCardholderDetails().get().getCardholderName().isPresent(), is(true));
@@ -564,11 +564,11 @@ public class CreatePaymentRequestDeserializerTest {
                 "\"country\": null\n" +
                 "}" + "}" + "}";
 
-        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(payload), ctx);
+        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(payload), ctx);
         assertThat(paymentRequest.getAmount(), is(1000));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl(), is(Optional.of("https://somewhere.gov.uk/rainbow/1")));
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
         assertThat(paymentRequest.getLanguage(), is(Optional.empty()));
         assertThat(paymentRequest.getDelayedCapture(), is(Optional.empty()));
         assertThat(paymentRequest.getPrefilledCardholderDetails().isPresent(), is(true));
@@ -600,11 +600,11 @@ public class CreatePaymentRequestDeserializerTest {
                 "\"country\": \"\"\n" +
                 "}" + "}" + "}";
 
-        CreatePaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(payload), ctx);
+        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(payload), ctx);
         assertThat(paymentRequest.getAmount(), is(1000));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
-        assertThat(paymentRequest.getReturnUrl(), is(Optional.of("https://somewhere.gov.uk/rainbow/1")));
+        assertThat(paymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
         assertThat(paymentRequest.getLanguage(), is(Optional.empty()));
         assertThat(paymentRequest.getDelayedCapture(), is(Optional.empty()));
 

--- a/src/test/java/uk/gov/pay/api/json/RequestJsonParserTest.java
+++ b/src/test/java/uk/gov/pay/api/json/RequestJsonParserTest.java
@@ -6,8 +6,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.api.model.Address;
+import uk.gov.pay.api.model.CreateCardPaymentRequest;
+import uk.gov.pay.api.model.CreateDirectDebitPaymentRequest;
 import uk.gov.pay.api.model.CreatePaymentRefundRequest;
-import uk.gov.pay.api.model.CreatePaymentRequest;
 import uk.gov.pay.api.model.PrefilledCardholderDetails;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
@@ -39,13 +40,13 @@ public class RequestJsonParserTest {
 
         JsonNode jsonNode = objectMapper.readTree(payload);
 
-        CreatePaymentRequest createPaymentRequest = parsePaymentRequest(jsonNode);
+        CreateCardPaymentRequest createPaymentRequest = (CreateCardPaymentRequest) parsePaymentRequest(jsonNode);
 
         assertThat(createPaymentRequest, is(notNullValue()));
         assertThat(createPaymentRequest.getAmount(), is(1000));
         assertThat(createPaymentRequest.getReference(), is("Some reference"));
         assertThat(createPaymentRequest.getDescription(), is("Some description"));
-        assertThat(createPaymentRequest.getReturnUrl(), is(Optional.of("https://somewhere.gov.uk/rainbow/1")));
+        assertThat(createPaymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
     }
 
     @Test
@@ -62,13 +63,13 @@ public class RequestJsonParserTest {
 
         JsonNode jsonNode = objectMapper.readTree(payload);
 
-        CreatePaymentRequest createPaymentRequest = parsePaymentRequest(jsonNode);
+        CreateCardPaymentRequest createPaymentRequest = (CreateCardPaymentRequest) parsePaymentRequest(jsonNode);
 
         assertThat(createPaymentRequest, is(notNullValue()));
         assertThat(createPaymentRequest.getAmount(), is(1000));
         assertThat(createPaymentRequest.getReference(), is("Some reference"));
         assertThat(createPaymentRequest.getDescription(), is("Some description"));
-        assertThat(createPaymentRequest.getReturnUrl(), is(Optional.of("https://somewhere.gov.uk/rainbow/1")));
+        assertThat(createPaymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
         assertThat(createPaymentRequest.getLanguage(), is(Optional.of(SupportedLanguage.ENGLISH)));
         assertThat(createPaymentRequest.getDelayedCapture(), is(Optional.of(true)));
     }
@@ -85,14 +86,13 @@ public class RequestJsonParserTest {
 
         JsonNode jsonNode = objectMapper.readTree(payload);
 
-        CreatePaymentRequest createPaymentRequest = parsePaymentRequest(jsonNode);
+        CreateDirectDebitPaymentRequest createPaymentRequest = (CreateDirectDebitPaymentRequest) parsePaymentRequest(jsonNode);
 
         assertThat(createPaymentRequest, is(notNullValue()));
         assertThat(createPaymentRequest.getAmount(), is(1000));
         assertThat(createPaymentRequest.getReference(), is("Some reference"));
         assertThat(createPaymentRequest.getDescription(), is("Some description"));
-        assertThat(createPaymentRequest.getAgreementId(), is(Optional.of("abcdef1234567890abcedf1234")));
-        assertThat(createPaymentRequest.getReturnUrl(), is(Optional.empty()));
+        assertThat(createPaymentRequest.getAgreementId(), is("abcdef1234567890abcedf1234"));
     }
 
     @Test
@@ -360,13 +360,13 @@ public class RequestJsonParserTest {
 
         JsonNode jsonNode = objectMapper.readTree(payload);
 
-        CreatePaymentRequest createPaymentRequest = parsePaymentRequest(jsonNode);
+        CreateCardPaymentRequest createPaymentRequest = (CreateCardPaymentRequest) parsePaymentRequest(jsonNode);
 
         assertThat(createPaymentRequest, is(notNullValue()));
         assertThat(createPaymentRequest.getAmount(), is(1000));
         assertThat(createPaymentRequest.getReference(), is("Some reference"));
         assertThat(createPaymentRequest.getDescription(), is("Some description"));
-        assertThat(createPaymentRequest.getReturnUrl(), is(Optional.of("https://somewhere.gov.uk/rainbow/1")));
+        assertThat(createPaymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
         assertThat(createPaymentRequest.getEmail(), is(Optional.of("j.bogs@example.org")));
         assertThat(createPaymentRequest.getPrefilledCardholderDetails(), is(notNullValue()));
         PrefilledCardholderDetails cardholderDetails = createPaymentRequest.getPrefilledCardholderDetails().get();
@@ -402,13 +402,13 @@ public class RequestJsonParserTest {
 
         JsonNode jsonNode = objectMapper.readTree(payload);
 
-        CreatePaymentRequest createPaymentRequest = parsePaymentRequest(jsonNode);
+        CreateCardPaymentRequest createPaymentRequest = (CreateCardPaymentRequest) parsePaymentRequest(jsonNode);
 
         assertThat(createPaymentRequest, is(notNullValue()));
         assertThat(createPaymentRequest.getAmount(), is(1000));
         assertThat(createPaymentRequest.getReference(), is("Some reference"));
         assertThat(createPaymentRequest.getDescription(), is("Some description"));
-        assertThat(createPaymentRequest.getReturnUrl(), is(Optional.of("https://somewhere.gov.uk/rainbow/1")));
+        assertThat(createPaymentRequest.getReturnUrl(), is("https://somewhere.gov.uk/rainbow/1"));
         assertThat(createPaymentRequest.getEmail(), is(Optional.empty()));
         assertThat(createPaymentRequest.getPrefilledCardholderDetails(), is(notNullValue()));
         assertThat(createPaymentRequest.getPrefilledCardholderDetails().isPresent(), is(true));

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -10,6 +10,7 @@ import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.Address;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.CreatePaymentRequest;
+import uk.gov.pay.api.model.CreatePaymentRequestBuilder;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.model.SettlementSummary;
@@ -82,7 +83,7 @@ public class PaymentsResourceCreatePaymentTest {
     @Test
     public void createNewPayment_withCardPayment_invokesCreatePaymentService() {
         final Account account = new Account("foo", TokenPaymentType.CARD);
-        final CreatePaymentRequest createPaymentRequest = CreatePaymentRequest.builder()
+        final CreatePaymentRequest createPaymentRequest = CreatePaymentRequestBuilder.builder()
                 .amount(100)
                 .returnUrl("https://somewhere.test")
                 .reference("my_ref")

--- a/src/test/java/uk/gov/pay/api/service/ConnectorUriGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/api/service/ConnectorUriGeneratorTest.java
@@ -9,6 +9,11 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.model.CreateCardPaymentRequest;
+import uk.gov.pay.api.model.CreateDirectDebitPaymentRequest;
+import uk.gov.pay.api.model.CreatePaymentRequest;
+import uk.gov.pay.api.model.CreatePaymentRequestBuilder;
+import uk.gov.pay.api.model.TokenPaymentType;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -56,21 +61,23 @@ public class ConnectorUriGeneratorTest {
     
     @Test
     public void shouldGenerateTheRightChargeURIForCardConnectorIfAgreementIdIsPassed() {
-        String uri = connectorUriGenerator.chargesURI(cardAccount, "shouldntbehere");
+        String uri = connectorUriGenerator.chargesURI(cardAccount, DIRECT_DEBIT);
         assertThat(uri, is("https://bla.test/v1/api/accounts/accountId/charges"));
     }
 
     @Test
-    public void shouldGenerateTheRightChargeURIForDirectDebitConnector() {
+    public void shouldGenerateTheRightChargeURIForDirectDebitConnector_ONEOFF() {
         Account account = new Account("accountId", DIRECT_DEBIT);
-        String uri = connectorUriGenerator.chargesURI(account, null);
+
+        String uri = connectorUriGenerator.chargesURI(account, CARD);
         assertThat(uri, is("https://dd-bla.test/v1/api/accounts/accountId/charges"));
     }
 
     @Test
     public void shouldGenerateTheRightChargeURIForDirectDebitConnectorIfAgreementIdIsPassed() {
         Account account = new Account("accountId", DIRECT_DEBIT);
-        String uri = connectorUriGenerator.chargesURI(account, "agreement_id");
+        
+        String uri = connectorUriGenerator.chargesURI(account, DIRECT_DEBIT);
         assertThat(uri, is("https://dd-bla.test/v1/api/accounts/accountId/charges/collect"));
     }
 

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -15,6 +15,7 @@ import uk.gov.pay.api.exception.CreateChargeException;
 import uk.gov.pay.api.model.Address;
 import uk.gov.pay.api.model.CardPayment;
 import uk.gov.pay.api.model.CreatePaymentRequest;
+import uk.gov.pay.api.model.CreatePaymentRequestBuilder;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.links.Link;
@@ -70,7 +71,7 @@ public class CreatePaymentServiceTest {
                 "ledger_code", 123, 
                 "fund_code", "ISIN122038", 
                 "cancellable", false);
-        CreatePaymentRequest requestPayload = CreatePaymentRequest.builder()
+        CreatePaymentRequest requestPayload = CreatePaymentRequestBuilder.builder()
                 .amount(100)
                 .returnUrl("https://somewhere.gov.uk/rainbow/1")
                 .reference("a reference")
@@ -88,7 +89,7 @@ public class CreatePaymentServiceTest {
     @Pacts(pacts = {"publicapi-connector-create-payment"})
     public void testCreatePayment() {
         Account account = new Account("123456", TokenPaymentType.CARD);
-        CreatePaymentRequest requestPayload = CreatePaymentRequest.builder()
+        CreatePaymentRequest requestPayload = CreatePaymentRequestBuilder.builder()
                 .amount(100)
                 .returnUrl("https://somewhere.gov.uk/rainbow/1")
                 .reference("a reference")
@@ -120,7 +121,7 @@ public class CreatePaymentServiceTest {
     @Pacts(pacts = {"publicapi-connector-create-payment-with-delayed-capture-true"})
     public void testCreatePaymentWithDelayedCaptureEqualsTrue() {
         Account account = new Account("123456", TokenPaymentType.CARD);
-        CreatePaymentRequest requestPayload = CreatePaymentRequest.builder()
+        CreatePaymentRequest requestPayload = CreatePaymentRequestBuilder.builder()
                 .amount(100)
                 .returnUrl("https://somewhere.gov.uk/rainbow/1")
                 .reference("a reference")
@@ -153,7 +154,7 @@ public class CreatePaymentServiceTest {
     @Pacts(pacts = {"publicapi-connector-create-payment-with-language-welsh"})
     public void testCreatePaymentWithWelshLanguage() {
         Account account = new Account("123456", TokenPaymentType.CARD);
-        CreatePaymentRequest requestPayload = CreatePaymentRequest.builder()
+        CreatePaymentRequest requestPayload = CreatePaymentRequestBuilder.builder()
                 .amount(100)
                 .returnUrl("https://somewhere.gov.uk/rainbow/1")
                 .reference("a reference")
@@ -185,7 +186,7 @@ public class CreatePaymentServiceTest {
     @Pacts(pacts = {"publicapi-connector-create-payment-with-prefilled-cardholder-details"})
     public void testCreatePaymentWithPrefilledCardholderDetails() {
         Account account = new Account("123456", TokenPaymentType.CARD);
-        CreatePaymentRequest createPaymentRequest = CreatePaymentRequest.builder()
+        CreatePaymentRequest createPaymentRequest = CreatePaymentRequestBuilder.builder()
                 .amount(100)
                 .returnUrl("https://somewhere.gov.uk/rainbow/1")
                 .reference("a reference")
@@ -223,7 +224,7 @@ public class CreatePaymentServiceTest {
     @Pacts(pacts = {"publicapi-connector-create-payment-with-zero-amount-not-allowed"})
     public void testCreatePaymentWithZeroAmountWhenZeroAmountNotAllowedForAccount() {
         Account account = new Account("123456", TokenPaymentType.CARD);
-        CreatePaymentRequest requestPayload = CreatePaymentRequest.builder()
+        CreatePaymentRequest requestPayload = CreatePaymentRequestBuilder.builder()
                 .amount(0)
                 .returnUrl("https://somewhere.gov.uk/rainbow/1")
                 .reference("a reference")


### PR DESCRIPTION
CreatePaymentRequest is currently used to represent both Card and DirectDebit payment
requests. This is becoming confusing and impractical as validation requirements
diverge between the two. This commit create dedicated sub-type for each.
1. Create CreatCardPaymentRequest and CreateDirectDebitRequest classes. Each
implementing the attributes and validation require beyond the base class of the
existing CreatePaymentRequest.
2. Simplify ViolationExceptionMapper to convert to the api field name using a
camel case to snake case conversion. This seems safe as it follows our convention
and avoids the complexity of reflection which would need extending to accomadate
the newly introduced hierarchy (if the field is not found on the sub-class then
it would have to search the super class).
3. Remove validation from PaymentResource method and into the new CreateDirect-
DebitPaymentRequest.
4. Reinstate ignored test now that a request can have either return_url or
agreement_id and validate independently.