### PR TITLE
PP-5242 Return errors if agreement_id or return_url missing

### DIFF
--- a/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
+++ b/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
@@ -42,6 +42,7 @@ import static uk.gov.pay.api.model.CreateCardPaymentRequest.PREFILLED_CARDHOLDER
 import static uk.gov.pay.api.model.CreateCardPaymentRequest.PREFILLED_CARDHOLDER_NAME_FIELD_NAME;
 import static uk.gov.pay.api.model.CreatePaymentRequest.REFERENCE_FIELD_NAME;
 import static uk.gov.pay.api.model.CreateCardPaymentRequest.RETURN_URL_FIELD_NAME;
+import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_INDETERMINABLE_TYPE;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_MISSING_FIELD_ERROR;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_REFUND_MISSING_FIELD_ERROR;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_REFUND_VALIDATION_ERROR;
@@ -72,6 +73,9 @@ class RequestJsonParser {
         if (paymentRequest.has(DELAYED_CAPTURE_FIELD_NAME))
             builder.delayedCapture(validateAndGetDelayedCapture(paymentRequest));
 
+        if (!(paymentRequest.has(AGREEMENT_ID_FIELD_NAME) || paymentRequest.has(RETURN_URL_FIELD_NAME)))
+            throw new BadRequestException(aPaymentError(CREATE_PAYMENT_INDETERMINABLE_TYPE));
+        
         if (paymentRequest.has(AGREEMENT_ID_FIELD_NAME))
             builder.agreementId(validateAndGetAgreementId(paymentRequest));
         else

--- a/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
@@ -3,6 +3,8 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.exception.BadRequestException;
 import uk.gov.pay.api.utils.JsonStringBuilder;
 import uk.gov.pay.api.validation.ValidReturnUrl;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
@@ -11,6 +13,8 @@ import javax.validation.Valid;
 import javax.validation.constraints.Size;
 import java.util.Optional;
 import java.util.StringJoiner;
+
+import static uk.gov.pay.api.model.CreateDirectDebitPaymentRequest.AGREEMENT_ID_FIELD_NAME;
 
 @ApiModel(value = "CreatePaymentRequest", description = "The Payment Request Payload")
 public class CreateCardPaymentRequest extends CreatePaymentRequest {
@@ -48,11 +52,6 @@ public class CreateCardPaymentRequest extends CreatePaymentRequest {
         this.delayedCapture = createPaymentRequestBuilder.getDelayedCapture();
         this.returnUrl = createPaymentRequestBuilder.getReturnUrl();
         this.metadata = createPaymentRequestBuilder.getMetadata();
-    }
-
-    @Override
-    public TokenPaymentType getRequestType() {
-        return TokenPaymentType.CARD;
     }
 
     @ApiModelProperty(value = "service return url", required = true, example = "https://service-name.gov.uk/transactions/12345")
@@ -101,6 +100,13 @@ public class CreateCardPaymentRequest extends CreatePaymentRequest {
         });
         
         return request.build();
+    }
+
+    @Override
+    public void validateRequestType(Account account) {
+        if (account.getPaymentType() != TokenPaymentType.CARD) {
+            throw new BadRequestException(PaymentError.aPaymentError(AGREEMENT_ID_FIELD_NAME, PaymentError.Code.CREATE_PAYMENT_MISSING_FIELD_ERROR));
+        }
     }
 
     /**

--- a/src/main/java/uk/gov/pay/api/model/CreateDirectDebitPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateDirectDebitPaymentRequest.java
@@ -3,12 +3,15 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.exception.BadRequestException;
 import uk.gov.pay.api.utils.JsonStringBuilder;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
-import java.util.Optional;
 import java.util.StringJoiner;
+
+import static uk.gov.pay.api.model.CreateCardPaymentRequest.RETURN_URL_FIELD_NAME;
 
 @ApiModel(value = "CreatePaymentRequest", description = "The Payment Request Payload")
 public class CreateDirectDebitPaymentRequest extends CreatePaymentRequest{
@@ -38,11 +41,6 @@ public class CreateDirectDebitPaymentRequest extends CreatePaymentRequest{
     }
 
     @Override
-    public TokenPaymentType getRequestType() {
-        return TokenPaymentType.DIRECT_DEBIT;
-    }
-
-    @Override
     public String toConnectorPayload() {
         JsonStringBuilder request = new JsonStringBuilder()
                 .add("amount", this.getAmount())
@@ -53,6 +51,13 @@ public class CreateDirectDebitPaymentRequest extends CreatePaymentRequest{
         getEmail().ifPresent(email -> request.add("email", email));
 
         return request.build();
+    }
+
+    @Override
+    public void validateRequestType(Account account) {
+        if (account.getPaymentType() != TokenPaymentType.DIRECT_DEBIT) {
+            throw new BadRequestException(PaymentError.aPaymentError(RETURN_URL_FIELD_NAME, PaymentError.Code.CREATE_PAYMENT_MISSING_FIELD_ERROR));
+        }
     }
 
     /**

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.hibernate.validator.constraints.Length;
+import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import javax.validation.constraints.Max;
@@ -25,7 +26,7 @@ public abstract class CreatePaymentRequest {
     public static final int AMOUNT_MAX_VALUE = 10000000;
     public static final int AMOUNT_MIN_VALUE = 0;
     public static final int DESCRIPTION_MAX_LENGTH = 255;
-    
+
     // Even though the minimum is 0, this is only allowed for accounts this is enabled for and is a hidden feature
     // so the validation error message will always state that the minimum is 1 for consistency.
     @Min(value = AMOUNT_MIN_VALUE, message = "Must be greater than or equal to 1")
@@ -37,12 +38,12 @@ public abstract class CreatePaymentRequest {
 
     @Size(max = DESCRIPTION_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     private final String description;
-    
+
     private final SupportedLanguage language;
 
     @Length(max = EMAIL_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     private final String email;
-    
+
     public CreatePaymentRequest(CreatePaymentRequestBuilder createPaymentRequestBuilder) {
         this.amount = createPaymentRequestBuilder.getAmount();
         this.reference = createPaymentRequestBuilder.getReference();
@@ -53,7 +54,7 @@ public abstract class CreatePaymentRequest {
 
     public abstract String toConnectorPayload();
 
-    public abstract TokenPaymentType getRequestType();
+    public abstract void validateRequestType(Account account);
 
     @ApiModelProperty(value = "amount in pence", required = true, allowableValues = "range[1, 10000000]", example = "12000")
     public int getAmount() {

--- a/src/main/java/uk/gov/pay/api/model/PaymentError.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentError.java
@@ -18,6 +18,7 @@ public class PaymentError {
         CREATE_PAYMENT_CONNECTOR_ERROR("P0198", "Downstream system error"),
         CREATE_PAYMENT_PARSING_ERROR("P0197", "Unable to parse JSON"),
         CREATE_PAYMENT_MISSING_FIELD_ERROR("P0101", "Missing mandatory attribute: %s"),
+        CREATE_PAYMENT_INDETERMINABLE_TYPE("P0101", "Missing either return_url or agreement_id attribute"),
         CREATE_PAYMENT_VALIDATION_ERROR("P0102", "Invalid attribute value: %s. %s"),
 
         CREATE_PAYMENT_AGREEMENT_TYPE_ERROR("P0140", "Can't collect payment from this type of agreement"),

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -15,7 +15,6 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CaptureChargeException;
 import uk.gov.pay.api.exception.GetEventsException;
-import uk.gov.pay.api.exception.PaymentValidationException;
 import uk.gov.pay.api.model.CreatePaymentRequest;
 import uk.gov.pay.api.model.CreatePaymentResult;
 import uk.gov.pay.api.model.PaymentError;
@@ -50,9 +49,6 @@ import java.net.URI;
 import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.http.HttpStatus.SC_OK;
-import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_VALIDATION_ERROR;
-import static uk.gov.pay.api.model.PaymentError.aPaymentError;
-import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
 
 @Path("/")
 @Api(value = "/", description = "Public Api Endpoints")
@@ -248,7 +244,9 @@ public class PaymentsResource {
     public Response createNewPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                      @ApiParam(value = "requestPayload", required = true) @Valid CreatePaymentRequest createPaymentRequest) {
         logger.info("Payment create request parsed to {}", createPaymentRequest);
-        
+
+        createPaymentRequest.validateRequestType(account);
+
         PaymentWithAllLinks createdPayment = createPaymentService.create(account, createPaymentRequest);
 
         Response response = Response

--- a/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
@@ -27,9 +27,9 @@ public class ConnectorUriGenerator {
         this.configuration = configuration;
     }
 
-    String chargesURI(Account account, TokenPaymentType tokenPaymentType) {
+    String chargesURI(Account account) {
         String chargePath = "/v1/api/accounts/%s/charges";
-        if (account.getPaymentType().equals(DIRECT_DEBIT) && DIRECT_DEBIT.equals(tokenPaymentType)) {
+        if (account.getPaymentType().equals(DIRECT_DEBIT)) {
             chargePath += "/collect";
         }
         return buildConnectorUri(account, format(chargePath, account.getAccountId()));

--- a/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
@@ -5,7 +5,6 @@ import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CreateChargeException;
 import uk.gov.pay.api.model.ChargeFromResponse;
 import uk.gov.pay.api.model.CreatePaymentRequest;
-import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 
 import javax.inject.Inject;
@@ -29,8 +28,8 @@ public class CreatePaymentService {
         this.connectorUriGenerator = connectorUriGenerator;
     }
 
-    public PaymentWithAllLinks create(Account account, CreatePaymentRequest validCreatePaymentRequest) {
-        Response connectorResponse = createCharge(account, validCreatePaymentRequest);
+    public PaymentWithAllLinks create(Account account, CreatePaymentRequest createPaymentRequest) {
+        Response connectorResponse = createCharge(account, createPaymentRequest);
 
         if (!createdSuccessfully(connectorResponse)) {
             throw new CreateChargeException(connectorResponse);
@@ -57,7 +56,7 @@ public class CreatePaymentService {
 
     private Response createCharge(Account account, CreatePaymentRequest validCreatePaymentRequest) {
         return client
-                .target(connectorUriGenerator.chargesURI(account, validCreatePaymentRequest.getRequestType()))
+                .target(connectorUriGenerator.chargesURI(account))
                 .request()
                 .accept(MediaType.APPLICATION_JSON)
                 .post(buildChargeRequestPayload(validCreatePaymentRequest));

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
@@ -423,7 +423,7 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
     }
 
     @Test
-    public void createPayment_responseWith422_whenZeroAmountForDirectDebitAccount() {
+    public void createDirectDebitPayment_responseWith422_whenZeroAmount() {
         publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, DIRECT_DEBIT);
 
         String payload = new JsonStringBuilder()
@@ -439,6 +439,44 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
                 .body("code", is("P0102"))
                 .body("field", is("amount"))
                 .body("description", is("Invalid attribute value: amount. Must be greater than or equal to 1"));
+    }
+
+    @Test
+    public void createDirectDebitPayment_responseWith400_whenReturnUrlAndNoAgreementId() {
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, DIRECT_DEBIT);
+
+        String payload = new JsonStringBuilder()
+                .add("amount", AMOUNT)
+                .add("reference", REFERENCE)
+                .add("description", DESCRIPTION)
+                .add("return_url", RETURN_URL)
+                .build();
+
+        postPaymentResponse(payload)
+                .statusCode(400)
+                .contentType(JSON)
+                .body("code", is("P0101"))
+                .body("field", is("agreement_id"))
+                .body("description", is("Missing mandatory attribute: agreement_id"));
+    }
+
+    @Test
+    public void createCardPayment_responseWith400_whenAgreementIdAndNoReturnUrl() {
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, CARD);
+
+        String payload = new JsonStringBuilder()
+                .add("amount", AMOUNT)
+                .add("reference", REFERENCE)
+                .add("description", DESCRIPTION)
+                .add("agreement_id", "1234")
+                .build();
+
+        postPaymentResponse(payload)
+                .statusCode(400)
+                .contentType(JSON)
+                .body("code", is("P0101"))
+                .body("field", is("return_url"))
+                .body("description", is("Missing mandatory attribute: return_url"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentReturnUrlValidationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentReturnUrlValidationIT.java
@@ -125,10 +125,9 @@ public class CreatePaymentReturnUrlValidationIT extends PaymentResourceITestBase
                 .body().asInputStream();
 
         JsonAssert.with(body)
-                .assertThat("$.*", hasSize(3))
-                .assertThat("$.field", is("return_url"))
+                .assertThat("$.*", hasSize(2))
                 .assertThat("$.code", is("P0101"))
-                .assertThat("$.description", is("Missing mandatory attribute: return_url"));
+                .assertThat("$.description", is("Missing either return_url or agreement_id attribute"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/json/CreatePaymentRequestDeserializerTest.java
+++ b/src/test/java/uk/gov/pay/api/json/CreatePaymentRequestDeserializerTest.java
@@ -246,7 +246,7 @@ public class CreatePaymentRequestDeserializerTest {
                 "  \"description\": \"Some description\"\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: return_url"));
+        expectedException.expect(aBadRequestExceptionWithError("P0101", "Missing either return_url or agreement_id attribute"));
 
         deserializer.deserialize(jsonFactory.createParser(json), ctx);
     }

--- a/src/test/java/uk/gov/pay/api/json/RequestJsonParserTest.java
+++ b/src/test/java/uk/gov/pay/api/json/RequestJsonParserTest.java
@@ -334,7 +334,7 @@ public class RequestJsonParserTest {
 
         JsonNode jsonNode = objectMapper.readTree(payload);
 
-        expectedException.expect(aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: return_url"));
+        expectedException.expect(aBadRequestExceptionWithError("P0101", "Missing either return_url or agreement_id attribute"));
 
         parsePaymentRequest(jsonNode);
     }

--- a/src/test/java/uk/gov/pay/api/service/ConnectorUriGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/api/service/ConnectorUriGeneratorTest.java
@@ -46,7 +46,7 @@ public class ConnectorUriGeneratorTest {
 
     @Test
     public void shouldGenerateTheRightChargeURIForCardConnector() {
-        String uri = connectorUriGenerator.chargesURI(cardAccount, null);
+        String uri = connectorUriGenerator.chargesURI(cardAccount);
         assertThat(uri, is("https://bla.test/v1/api/accounts/accountId/charges"));
     }
     
@@ -58,26 +58,12 @@ public class ConnectorUriGeneratorTest {
         ));
         assertThat(uri, is("https://bla.test/v1/api/accounts/accountId/refunds?param1=value1&param2=value2"));
     }
-    
-    @Test
-    public void shouldGenerateTheRightChargeURIForCardConnectorIfAgreementIdIsPassed() {
-        String uri = connectorUriGenerator.chargesURI(cardAccount, DIRECT_DEBIT);
-        assertThat(uri, is("https://bla.test/v1/api/accounts/accountId/charges"));
-    }
 
     @Test
-    public void shouldGenerateTheRightChargeURIForDirectDebitConnector_ONEOFF() {
-        Account account = new Account("accountId", DIRECT_DEBIT);
-
-        String uri = connectorUriGenerator.chargesURI(account, CARD);
-        assertThat(uri, is("https://dd-bla.test/v1/api/accounts/accountId/charges"));
-    }
-
-    @Test
-    public void shouldGenerateTheRightChargeURIForDirectDebitConnectorIfAgreementIdIsPassed() {
+    public void shouldGenerateTheRightChargeURIForDirectDebitConnector() {
         Account account = new Account("accountId", DIRECT_DEBIT);
         
-        String uri = connectorUriGenerator.chargesURI(account, DIRECT_DEBIT);
+        String uri = connectorUriGenerator.chargesURI(account);
         assertThat(uri, is("https://dd-bla.test/v1/api/accounts/accountId/charges/collect"));
     }
 


### PR DESCRIPTION
We determine whether a create payment request is a card or direct debit request when we deserialise the JSON (using RequestJsonParser.js). At this point we do not know whether the account is a card or direct debit account, so we look at whether the request contains a return_url or an agreement_id.

Previously, if there was no agreement_id or return_url, the error would always state that the return_url was missing. However, this is only true for card payments, so the error now states that one or the other of return_url or agreement_id is required.

Additionally, there was no validation done to check that the correct form of the request was made for the correct account type (card/dd). Now, if there is a mismatch an error will be returned stating either that the return_url or agreement_id is missing, as appropriate.