### PR TITLE
PP-5292-Creating token for charges in search

### DIFF
--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-cardholder-name.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-cardholder-name.json
@@ -47,18 +47,6 @@
               "description": "Test description",
               "reference": "aReference",
               "language": "en",
-              "links": [
-                {
-                  "rel": "self",
-                  "method": "GET",
-                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639"
-                },
-                {
-                  "rel": "refunds",
-                  "method": "GET",
-                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639/refunds"
-                }
-              ],
               "charge_id": "charge8133029783750964639",
               "return_url": "aReturnUrl",
               "email": "test@test.com",

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-cardholder-name.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-cardholder-name.json
@@ -57,20 +57,6 @@
                   "rel": "refunds",
                   "method": "GET",
                   "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639/refunds"
-                },
-                {
-                  "rel": "next_url",
-                  "method": "GET",
-                  "href": "http://Frontend/secure/ae749781-6562-4e0e-8f56-32d9639079dc"
-                },
-                {
-                  "rel": "next_url_post",
-                  "method": "POST",
-                  "href": "http://Frontend/secure",
-                  "type": "application/x-www-form-urlencoded",
-                  "params": {
-                    "chargeTokenId": "ae749781-6562-4e0e-8f56-32d9639079dc"
-                  }
                 }
               ],
               "charge_id": "charge8133029783750964639",

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-first-digits-card-number.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-first-digits-card-number.json
@@ -48,18 +48,6 @@
               "description": "Test description",
               "reference": "aReference",
               "language": "en",
-              "links": [
-                {
-                  "rel": "self",
-                  "method": "GET",
-                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639"
-                },
-                {
-                  "rel": "refunds",
-                  "method": "GET",
-                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639/refunds"
-                }
-              ],
               "charge_id": "charge8133029783750964639",
               "gateway_transaction_id": "txId-1234",
               "return_url": "aReturnUrl",

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-first-digits-card-number.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-first-digits-card-number.json
@@ -58,20 +58,6 @@
                   "rel": "refunds",
                   "method": "GET",
                   "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639/refunds"
-                },
-                {
-                  "rel": "next_url",
-                  "method": "GET",
-                  "href": "http://Frontend/secure/ae749781-6562-4e0e-8f56-32d9639079dc"
-                },
-                {
-                  "rel": "next_url_post",
-                  "method": "POST",
-                  "href": "http://Frontend/secure",
-                  "type": "application/x-www-form-urlencoded",
-                  "params": {
-                    "chargeTokenId": "ae749781-6562-4e0e-8f56-32d9639079dc"
-                  }
                 }
               ],
               "charge_id": "charge8133029783750964639",

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-last-digits-card-number.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-last-digits-card-number.json
@@ -48,18 +48,6 @@
               "description": "Test description",
               "reference": "aReference",
               "language": "en",
-              "links": [
-                {
-                  "rel": "self",
-                  "method": "GET",
-                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639"
-                },
-                {
-                  "rel": "refunds",
-                  "method": "GET",
-                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639/refunds"
-                }
-              ],
               "charge_id": "charge8133029783750964639",
               "gateway_transaction_id": "txId-1234",
               "return_url": "aReturnUrl",

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-last-digits-card-number.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-last-digits-card-number.json
@@ -58,20 +58,6 @@
                   "rel": "refunds",
                   "method": "GET",
                   "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639/refunds"
-                },
-                {
-                  "rel": "next_url",
-                  "method": "GET",
-                  "href": "http://Frontend/secure/ae749781-6562-4e0e-8f56-32d9639079dc"
-                },
-                {
-                  "rel": "next_url_post",
-                  "method": "POST",
-                  "href": "http://Frontend/secure",
-                  "type": "application/x-www-form-urlencoded",
-                  "params": {
-                    "chargeTokenId": "ae749781-6562-4e0e-8f56-32d9639079dc"
-                  }
                 }
               ],
               "charge_id": "charge8133029783750964639",


### PR DESCRIPTION
## WHAT YOU DID
This is linked to a PR for PP-5292-Creating token for changes in search in pay-connector. Connector no longer emits next_url and next_url_post for search results and so this requires the pact file in publicapi to be modified.

- This removes next_url and next_url_post from publicapi-connector-search-payment-by-last-digits-card-number.json
- This removes next_url and next_url_post from publicapi-connector-search-payment-by-first-digits-card-number.json
- This removes next_url and next_url_post from publicapi-connector-search-payment-by-cardholder-name.json
- This PR also removes the links section containing the above. This is so the pact tests can be properly modified.
- Then PP5292 Connector PR can be merged
- Then there will be a PR containing the following code:

`"links": [{"rel": "self", "method: "GET"...`