### PR TITLE
PP-5292 Removes links matches from pact files in publicapi

### DIFF
--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-cardholder-name.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-cardholder-name.json
@@ -94,39 +94,6 @@
         },
         "matchingRules": {
           "body": {
-            "$.results[*].links[0].href": {
-              "matchers": [
-                {
-                  "regex": "https.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/charge8133029783750964639"
-                }
-              ]
-            },
-            "$.results[*].links[1].href": {
-              "matchers": [
-                {
-                  "regex": "https.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/charge8133029783750964639\/refunds"
-                }
-              ]
-            },
-            "$.results[*].links[2].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/secure\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-                }
-              ]
-            },
-            "$.results[*].links[3].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/secure"
-                }
-              ]
-            },
-            "$.results[*].links[3].params.chargeTokenId": {
-              "matchers": [
-                {"match": "type"}
-              ]
-            },
             "$._links.self.href": {
               "matchers": [
                 {

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-first-digits-card-number.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-first-digits-card-number.json
@@ -96,39 +96,6 @@
         },
         "matchingRules": {
           "body": {
-            "$.results[*].links[0].href": {
-              "matchers": [
-                {
-                  "regex": "https.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/charge8133029783750964639"
-                }
-              ]
-            },
-            "$.results[*].links[1].href": {
-              "matchers": [
-                {
-                  "regex": "https.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/charge8133029783750964639\/refunds"
-                }
-              ]
-            },
-            "$.results[*].links[2].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/secure\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-                }
-              ]
-            },
-            "$.results[*].links[3].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/secure"
-                }
-              ]
-            },
-            "$.results[*].links[3].params.chargeTokenId": {
-              "matchers": [
-                {"match": "type"}
-              ]
-            },
             "$._links.self.href": {
               "matchers": [
                 {

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-last-digits-card-number.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-last-digits-card-number.json
@@ -96,39 +96,6 @@
         },
         "matchingRules": {
           "body": {
-            "$.results[*].links[0].href": {
-              "matchers": [
-                {
-                  "regex": "https.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/charge8133029783750964639"
-                }
-              ]
-            },
-            "$.results[*].links[1].href": {
-              "matchers": [
-                {
-                  "regex": "https.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/charge8133029783750964639\/refunds"
-                }
-              ]
-            },
-            "$.results[*].links[2].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/secure\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-                }
-              ]
-            },
-            "$.results[*].links[3].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/secure"
-                }
-              ]
-            },
-            "$.results[*].links[3].params.chargeTokenId": {
-              "matchers": [
-                {"match": "type"}
-              ]
-            },
             "$._links.self.href": {
               "matchers": [
                 {


### PR DESCRIPTION
## WHAT YOU DID

This removes the links matchers (e.g. "$.results[*].links[0].href") from publicapi-connector-search-payment-by-cardholder-name.json, publicapi-connector-search-payment-by-first-digits-card-number.json and publicapi-connector-search-payment-by-last-digits-card-number.json.

We do this because we have removed the links list from the pact file and so we have to remove the links matchers. This is because in PP-5292 Connector build we no longer have the next_url and next_url_post fields in the JSON and so the pact files have to be modified.

This PR is linked to the previous PP-5292 where we removed next_url and next_url_post from the pact files.


