### PR TITLE
PP-5278 Reject creation of agreement when GoCardless account is unlinked

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <jackson.version>2.9.9</jackson.version>
         <logback.version>1.2.3</logback.version>
         <docker-client.version>8.16.0</docker-client.version>
-        <pay-java-commons.version>1.0.20190603150514</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20190606155120</pay-java-commons.version>
         <pact.version>3.6.2</pact.version>
         <PACT_BROKER_URL/>
         <PACT_BROKER_USERNAME/>

--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -22,23 +22,7 @@ import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.PublicApiModule;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.auth.AccountAuthenticator;
-import uk.gov.pay.api.exception.mapper.BadRefundsRequestExceptionMapper;
-import uk.gov.pay.api.exception.mapper.BadRequestExceptionMapper;
-import uk.gov.pay.api.exception.mapper.CancelChargeExceptionMapper;
-import uk.gov.pay.api.exception.mapper.CaptureChargeExceptionMapper;
-import uk.gov.pay.api.exception.mapper.CreateAgreementExceptionMapper;
-import uk.gov.pay.api.exception.mapper.CreateChargeExceptionMapper;
-import uk.gov.pay.api.exception.mapper.CreateRefundExceptionMapper;
-import uk.gov.pay.api.exception.mapper.GetAgreementExceptionMapper;
-import uk.gov.pay.api.exception.mapper.GetChargeExceptionMapper;
-import uk.gov.pay.api.exception.mapper.GetEventsExceptionMapper;
-import uk.gov.pay.api.exception.mapper.GetRefundExceptionMapper;
-import uk.gov.pay.api.exception.mapper.GetRefundsExceptionMapper;
-import uk.gov.pay.api.exception.mapper.PaymentValidationExceptionMapper;
-import uk.gov.pay.api.exception.mapper.RefundsValidationExceptionMapper;
-import uk.gov.pay.api.exception.mapper.SearchChargesExceptionMapper;
-import uk.gov.pay.api.exception.mapper.SearchRefundsExceptionMapper;
-import uk.gov.pay.api.exception.mapper.ViolationExceptionMapper;
+import uk.gov.pay.api.exception.mapper.*;
 import uk.gov.pay.api.filter.AuthorizationValidationFilter;
 import uk.gov.pay.api.filter.RateLimiterFilter;
 import uk.gov.pay.api.healthcheck.Ping;
@@ -159,6 +143,7 @@ public class PublicApi extends Application<PublicApiConfig> {
         jersey.register(CreateAgreementExceptionMapper.class);
         jersey.register(GetAgreementExceptionMapper.class);
         jersey.register(CaptureChargeExceptionMapper.class);
+        jersey.register(NoGatewayAccessTokenMapper.class);
     }
 
     private void initialiseMetrics(PublicApiConfig configuration, Environment environment) {

--- a/src/main/java/uk/gov/pay/api/exception/NoGatewayAccessTokenException.java
+++ b/src/main/java/uk/gov/pay/api/exception/NoGatewayAccessTokenException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.api.exception;
+
+import javax.ws.rs.core.Response;
+
+public class NoGatewayAccessTokenException extends ConnectorResponseErrorException {
+    public NoGatewayAccessTokenException(Response response) {
+        super(response);
+    }
+}

--- a/src/main/java/uk/gov/pay/api/exception/mapper/NoGatewayAccessTokenMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/NoGatewayAccessTokenMapper.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.api.exception.mapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.api.exception.NoGatewayAccessTokenException;
+import uk.gov.pay.api.model.PaymentError;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+
+public class NoGatewayAccessTokenMapper implements ExceptionMapper<NoGatewayAccessTokenException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NoGatewayAccessTokenMapper.class);
+    
+    @Override
+    public Response toResponse(NoGatewayAccessTokenException exception) {
+        PaymentError paymentError = PaymentError.aPaymentError(PaymentError.Code.CREATE_PAYMENT_ACCOUNT_ERROR);
+        LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}",
+                exception.getMessage(), FORBIDDEN, paymentError);
+        return Response.status(Response.Status.FORBIDDEN).entity(paymentError).build();
+    }
+}

--- a/src/main/java/uk/gov/pay/api/service/AgreementService.java
+++ b/src/main/java/uk/gov/pay/api/service/AgreementService.java
@@ -7,6 +7,7 @@ import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CreateAgreementException;
 import uk.gov.pay.api.exception.GetAgreementException;
+import uk.gov.pay.api.exception.NoGatewayAccessTokenException;
 import uk.gov.pay.api.model.directdebit.agreement.CreateAgreementRequest;
 import uk.gov.pay.api.model.directdebit.agreement.CreateAgreementResponse;
 import uk.gov.pay.api.model.directdebit.agreement.GetAgreementResponse;
@@ -51,9 +52,12 @@ public class AgreementService {
             CreateAgreementResponse createAgreementResponse = CreateAgreementResponse.from(mandate, agreementLinks);
             LOGGER.info("Agreement returned (created): [ {} ]", createAgreementResponse);
             return createAgreementResponse;
+        } else {
+            if(connectorResponse.getStatus() == 403) {
+                throw new NoGatewayAccessTokenException(connectorResponse);
+            }
+            throw new CreateAgreementException(connectorResponse);
         }
-
-        throw new CreateAgreementException(connectorResponse);
     }
 
     public GetAgreementResponse get(Account account, String agreementId) {


### PR DESCRIPTION
- Will now respond with an error when a user attempts to create an agreement without an unlinked GoCardless account
