### PR TITLE
PP-5292-Add-links-without-next_url to pact file

### DIFF
--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-cardholder-name.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-cardholder-name.json
@@ -47,6 +47,18 @@
               "description": "Test description",
               "reference": "aReference",
               "language": "en",
+              "links": [
+                {
+                  "rel": "self",
+                  "method": "GET",
+                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639"
+                },
+                {
+                  "rel": "refunds",
+                  "method": "GET",
+                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639/refunds"
+                }
+              ],
               "charge_id": "charge8133029783750964639",
               "return_url": "aReturnUrl",
               "email": "test@test.com",

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-first-digits-card-number.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-first-digits-card-number.json
@@ -48,6 +48,18 @@
               "description": "Test description",
               "reference": "aReference",
               "language": "en",
+              "links": [
+                {
+                  "rel": "self",
+                  "method": "GET",
+                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639"
+                },
+                {
+                  "rel": "refunds",
+                  "method": "GET",
+                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639/refunds"
+                }
+              ],
               "charge_id": "charge8133029783750964639",
               "gateway_transaction_id": "txId-1234",
               "return_url": "aReturnUrl",

--- a/src/test/resources/pacts/publicapi-connector-search-payment-by-last-digits-card-number.json
+++ b/src/test/resources/pacts/publicapi-connector-search-payment-by-last-digits-card-number.json
@@ -48,6 +48,18 @@
               "description": "Test description",
               "reference": "aReference",
               "language": "en",
+              "links": [
+                {
+                  "rel": "self",
+                  "method": "GET",
+                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639"
+                },
+                {
+                  "rel": "refunds",
+                  "method": "GET",
+                  "href": "http://connector.service.backend/v1/api/accounts/123456/charges/charge8133029783750964639/refunds"
+                }
+              ],
               "charge_id": "charge8133029783750964639",
               "gateway_transaction_id": "txId-1234",
               "return_url": "aReturnUrl",


### PR DESCRIPTION
## WHAT YOU DID

This adds the links field to publicapi-connector-search-payment-by-first-digits-card-number.json pact file.

This is because we removed the next_url and next_url post from the JSON which Connector emits to publicapi. This requires a modification of the pact file in publicapi - we have to remove the links field first to ensure that publicapi isn't expecting next_url and next_url_post then we have to add the links field without next_url and next_url_post to ensure that the pact file is properly modified.


