### PR TITLE
PP-5278 Reject creation of agreement when GoCardless account is unlinked

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapper.java
@@ -25,7 +25,10 @@ public class CreateAgreementExceptionMapper implements ExceptionMapper<CreateAgr
             agreementError = anAgreementError(AgreementError.Code.CREATE_AGREEMENT_ACCOUNT_ERROR);
         } else if (exception.getErrorIdentifier() == ErrorIdentifier.INVALID_MANDATE_TYPE) {
             agreementError = anAgreementError(Code.CREATE_AGREEMENT_TYPE_ERROR);
-        } else {
+        } else if (exception.getErrorIdentifier() == ErrorIdentifier.GO_CARDLESS_ACCOUNT_NOT_LINKED) {
+            agreementError = anAgreementError(Code.CREATE_AGREEMENT_ACCOUNT_ERROR);
+        }
+        else {
             agreementError = anAgreementError(AgreementError.Code.CREATE_AGREEMENT_CONNECTOR_ERROR);
         }
 

--- a/src/test/java/uk/gov/pay/api/it/directdebit/AgreementsResourceIT.java
+++ b/src/test/java/uk/gov/pay/api/it/directdebit/AgreementsResourceIT.java
@@ -127,6 +127,34 @@ public class AgreementsResourceIT extends PaymentResourceITestBase {
                 .extract().body().asString();
     }
 
+
+    @Test
+    public void createPayment_respondsWith500_whenConnectorResponseIsGCAccountNotLinked() {
+
+        String errorMessage = "something went wrong";
+
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, DIRECT_DEBIT);
+
+        connectorDDMockClient.respondWithGCAccountNotLinked_whenCreateAgreementRequest(
+                GATEWAY_ACCOUNT_ID,
+                errorMessage
+        );
+
+        String payload = agreementPayload("https://service-name.gov.uk/transactions/12345");
+        given().port(app.getLocalPort())
+                .body(payload)
+                .accept(JSON)
+                .contentType(JSON)
+                .header(AUTHORIZATION, "Bearer " + API_KEY)
+                .post("/v1/agreements")
+                .then()
+                .statusCode(500)
+                .contentType(JSON)
+                .body("code", is("P0199"))
+                .body("description", is("There is an error with this account. Please contact support"))
+                .extract().body().asString();
+    }
+    
     @Test
     public void shouldGetADirectDebitAgreement_withReference() {
 

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorDDMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorDDMockClient.java
@@ -24,9 +24,11 @@ import static javax.ws.rs.core.HttpHeaders.LOCATION;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.jetty.http.HttpStatus.BAD_REQUEST_400;
 import static org.eclipse.jetty.http.HttpStatus.CREATED_201;
+import static org.eclipse.jetty.http.HttpStatus.FORBIDDEN_403;
 import static org.eclipse.jetty.http.HttpStatus.OK_200;
 import static org.eclipse.jetty.http.HttpStatus.PRECONDITION_FAILED_412;
 import static uk.gov.pay.commons.model.ErrorIdentifier.GENERIC;
+import static uk.gov.pay.commons.model.ErrorIdentifier.GO_CARDLESS_ACCOUNT_NOT_LINKED;
 import static uk.gov.pay.commons.model.ErrorIdentifier.INVALID_MANDATE_TYPE;
 
 public class ConnectorDDMockClient extends BaseConnectorMockClient {
@@ -106,6 +108,11 @@ public class ConnectorDDMockClient extends BaseConnectorMockClient {
     public void respondWithMandateTypeInvalid_whenCreateAgreementRequest(String gatewayAccountId, String errorMsg) {
         setupCreateAgreement(gatewayAccountId, withStatusAndErrorMessage(PRECONDITION_FAILED_412, errorMsg, INVALID_MANDATE_TYPE));
     }
+
+    public void respondWithGCAccountNotLinked_whenCreateAgreementRequest(String gatewayAccountId, String errorMsg) {
+        setupCreateAgreement(gatewayAccountId, withStatusAndErrorMessage(FORBIDDEN_403, errorMsg, GO_CARDLESS_ACCOUNT_NOT_LINKED));
+    }
+
 
     private String buildCreateAgreementResponse(String mandateId,
                                                 String mandateReference,


### PR DESCRIPTION
- Will now respond with an error when a user attempts to create an agreement without an unlinked GoCardless account
