### PR TITLE
PP-5248 Rename Direct Debit “transaction” to “payment”

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -1173,7 +1173,7 @@ GET /v1/payments
 | `results[i].reference`                | Yes            | There reference issued by the government service for this payment |
 | `results[i].email`                    | Yes            | The email address of the user of this payment                     |
 | `results[i].name`                     | Yes            | The name of the user of this payment                              |
-| `results[i].transaction_id`           | Yes            | The transaction id associated to this payment                     |
+| `results[i].payment_id`               | Yes            | The payment ID associated with this payment                     |
 | `results[i].created_date`             | Yes            | The created date in ISO_8601 format (```yyyy-MM-ddTHH:mm:ssZ```)  |
 | `results[i].agreement_id`             | Yes            | The external id of the agreement this payment was made against    |
 | `results[i]._links.self`              | Yes            | Link to the payment                                               |

--- a/src/main/java/uk/gov/pay/api/model/links/directdebit/DirectDebitEvent.java
+++ b/src/main/java/uk/gov/pay/api/model/links/directdebit/DirectDebitEvent.java
@@ -18,7 +18,7 @@ public class DirectDebitEvent {
     private String event;
 
     private String mandateExternalId;
-    private String transactionExternalId;
+    private String paymentExternalId;
 
     @JsonProperty("event_type")
     private String eventType;
@@ -51,8 +51,8 @@ public class DirectDebitEvent {
     }
 
     @JsonProperty("payment_id")
-    public String getTransactionExternalId() {
-        return transactionExternalId;
+    public String getPaymentExternalId() {
+        return paymentExternalId;
     }
 
     public String getEventType() {
@@ -78,8 +78,8 @@ public class DirectDebitEvent {
     }
 
     @JsonProperty("transaction_external_id")
-    public void setTransactionExternalId(String transactionExternalId) {
-        this.transactionExternalId = transactionExternalId;
+    public void setPaymentExternalId(String paymentExternalId) {
+        this.paymentExternalId = paymentExternalId;
     }
 
     public void setEventType(String eventType) {

--- a/src/main/java/uk/gov/pay/api/model/links/directdebit/DirectDebitEvent.java
+++ b/src/main/java/uk/gov/pay/api/model/links/directdebit/DirectDebitEvent.java
@@ -77,7 +77,7 @@ public class DirectDebitEvent {
         this.mandateExternalId = mandateExternalId;
     }
 
-    @JsonProperty("transaction_external_id")
+    @JsonProperty("payment_external_id")
     public void setPaymentExternalId(String paymentExternalId) {
         this.paymentExternalId = paymentExternalId;
     }

--- a/src/main/java/uk/gov/pay/api/model/links/directdebit/DirectDebitEventsResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/links/directdebit/DirectDebitEventsResponse.java
@@ -109,7 +109,7 @@ public class DirectDebitEventsResponse {
 
             private String convertLink(String link) {
                 return link.replace("mandate_external_", "agreement_")
-                        .replace("transaction_external_", "payment_");
+                        .replace("payment_external_", "payment_");
             }
         }
     }

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitPaymentForSearch.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitPaymentForSearch.java
@@ -12,7 +12,7 @@ import java.net.URI;
 public class DirectDebitPaymentForSearch {
 
     private Long amount;
-    @JsonProperty("transaction_id")
+    @JsonProperty("payment_id")
     private String paymentId;
     private DirectDebitPaymentState state;
     private String description;

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitPaymentForSearch.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitPaymentForSearch.java
@@ -13,7 +13,7 @@ public class DirectDebitPaymentForSearch {
 
     private Long amount;
     @JsonProperty("transaction_id")
-    private String transactionId;
+    private String paymentId;
     private DirectDebitPaymentState state;
     private String description;
     private String reference;
@@ -28,11 +28,11 @@ public class DirectDebitPaymentForSearch {
     
     
     
-    private DirectDebitPaymentForSearch(Long amount, String transactionId, DirectDebitPaymentState state, String description,
+    private DirectDebitPaymentForSearch(Long amount, String paymentId, DirectDebitPaymentState state, String description,
                                         String reference, String email, String name, String createdDate, URI selfLink,
                                         String agreementId) {
         this.amount = amount;
-        this.transactionId = transactionId;
+        this.paymentId = paymentId;
         this.state = state;
         this.description = description;
         this.reference = reference;
@@ -45,7 +45,7 @@ public class DirectDebitPaymentForSearch {
 
     public Long getAmount() { return amount; }
 
-    public String getTransactionId() { return transactionId; }
+    public String getPaymentId() { return paymentId; }
 
     public DirectDebitPaymentState getState() { return state; }
 
@@ -66,7 +66,7 @@ public class DirectDebitPaymentForSearch {
     public static DirectDebitPaymentForSearch valueOf(DirectDebitPaymentFromResponse forSearch, URI selfLink) {
         return new DirectDebitPaymentForSearch(
                 forSearch.getAmount(),
-                forSearch.getTransactionId(),
+                forSearch.getPaymentId(),
                 forSearch.getState(),
                 forSearch.getDescription(),
                 forSearch.getReference(),

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitPaymentForSearch.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitPaymentForSearch.java
@@ -3,13 +3,13 @@ package uk.gov.pay.api.model.search.directdebit;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import uk.gov.pay.api.model.search.links.DDTransactionLinksForSearch;
+import uk.gov.pay.api.model.search.links.DDPaymentLinksForSearch;
 
 import java.net.URI;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class DirectDebitTransactionForSearch {
+public class DirectDebitPaymentForSearch {
 
     private Long amount;
     @JsonProperty("transaction_id")
@@ -24,13 +24,13 @@ public class DirectDebitTransactionForSearch {
     @JsonProperty("agreement_id")
     private String agreementId;
     @JsonProperty("links")
-    private DDTransactionLinksForSearch links = new DDTransactionLinksForSearch();
+    private DDPaymentLinksForSearch links = new DDPaymentLinksForSearch();
     
     
     
-    private DirectDebitTransactionForSearch(Long amount, String transactionId, DirectDebitPaymentState state, String description,
-                                            String reference, String email, String name, String createdDate, URI selfLink,
-                                            String agreementId) {
+    private DirectDebitPaymentForSearch(Long amount, String transactionId, DirectDebitPaymentState state, String description,
+                                        String reference, String email, String name, String createdDate, URI selfLink,
+                                        String agreementId) {
         this.amount = amount;
         this.transactionId = transactionId;
         this.state = state;
@@ -61,10 +61,10 @@ public class DirectDebitTransactionForSearch {
 
     public String getAgreementId() { return agreementId; }
 
-    public DDTransactionLinksForSearch getLinks() { return links; }
+    public DDPaymentLinksForSearch getLinks() { return links; }
     
-    public static DirectDebitTransactionForSearch valueOf(DirectDebitTransactionFromResponse forSearch, URI selfLink) {
-        return new DirectDebitTransactionForSearch(
+    public static DirectDebitPaymentForSearch valueOf(DirectDebitPaymentFromResponse forSearch, URI selfLink) {
+        return new DirectDebitPaymentForSearch(
                 forSearch.getAmount(),
                 forSearch.getTransactionId(),
                 forSearch.getState(),

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitPaymentFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitPaymentFromResponse.java
@@ -12,7 +12,7 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DirectDebitPaymentFromResponse {
     private Long amount;
-    @JsonProperty("transaction_id")
+    @JsonProperty("payment_id")
     private String paymentId;
     private DirectDebitPaymentState state;
     private String description;

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitPaymentFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitPaymentFromResponse.java
@@ -13,7 +13,7 @@ import java.util.List;
 public class DirectDebitPaymentFromResponse {
     private Long amount;
     @JsonProperty("transaction_id")
-    private String transactionId;
+    private String paymentId;
     private DirectDebitPaymentState state;
     private String description;
     private String reference;
@@ -28,7 +28,7 @@ public class DirectDebitPaymentFromResponse {
 
     public Long getAmount() { return amount; }
 
-    public String getTransactionId() { return transactionId; }
+    public String getPaymentId() { return paymentId; }
 
     public DirectDebitPaymentState getState() { return state; }
 

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitPaymentFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitPaymentFromResponse.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class DirectDebitTransactionFromResponse {
+public class DirectDebitPaymentFromResponse {
     private Long amount;
     @JsonProperty("transaction_id")
     private String transactionId;

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchResponse.java
@@ -19,11 +19,11 @@ public class DirectDebitSearchResponse implements SearchPagination {
     @JsonProperty("page")
     private int page;
     @JsonProperty("results")
-    private List<DirectDebitTransactionFromResponse> payments;
+    private List<DirectDebitPaymentFromResponse> payments;
     @JsonProperty("_links")
     private SearchNavigationLinks links = new SearchNavigationLinks();
 
-    public List<DirectDebitTransactionFromResponse> getPayments() {
+    public List<DirectDebitPaymentFromResponse> getPayments() {
         return payments;
     }
 

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchDirectDebitPayments.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchDirectDebitPayments.java
@@ -51,7 +51,7 @@ public class SearchDirectDebitPayments extends SearchPaymentsBase {
     @Override
     public Response getSearchResponse(Account account, Map<String, String> queryParams) {
         validateSupportedSearchParams(queryParams);
-        String url = connectorUriGenerator.directDebitTransactionsURI(account, queryParams);
+        String url = connectorUriGenerator.directDebitPaymentsURI(account, queryParams);
         Response connectorResponse = client
                 .target(url)
                 .request()
@@ -74,16 +74,16 @@ public class SearchDirectDebitPayments extends SearchPaymentsBase {
             JsonNode responseJson = directDebitResponse.readEntity(JsonNode.class);
             TypeReference<DirectDebitSearchResponse> typeRef = new TypeReference<DirectDebitSearchResponse>() {};
             DirectDebitSearchResponse searchResponse = objectMapper.readValue(responseJson.traverse(), typeRef);
-            List<DirectDebitPaymentForSearch> transactionFromResponse =
+            List<DirectDebitPaymentForSearch> paymentFromResponse =
                     searchResponse
                             .getPayments()
                             .stream()
-                            .map(transaction -> DirectDebitPaymentForSearch.valueOf(
-                                    transaction,
-                                    paymentUriGenerator.getPaymentURI(baseUrl, transaction.getTransactionId())
+                            .map(payment -> DirectDebitPaymentForSearch.valueOf(
+                                    payment,
+                                    paymentUriGenerator.getPaymentURI(baseUrl, payment.getPaymentId())
                             )).collect(Collectors.toList());
             HalRepresentation.HalRepresentationBuilder halRepresentation = HalRepresentation.builder()
-                    .addProperty("results", transactionFromResponse);
+                    .addProperty("results", paymentFromResponse);
             return Response.ok().entity(decoratePagination(halRepresentation, searchResponse, PAYMENT_PATH).build().toString()).build();
         } catch (IOException | ProcessingException ex) {
             throw new SearchPaymentsException(ex);

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchDirectDebitPayments.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchDirectDebitPayments.java
@@ -57,7 +57,7 @@ public class SearchDirectDebitPayments extends SearchPaymentsBase {
                 .request()
                 .header(HttpHeaders.ACCEPT, APPLICATION_JSON)
                 .get();
-        logger.info("response from dd connector for transaction search: {}", connectorResponse);
+        logger.info("response from dd connector for payment search: {}", connectorResponse);
         if (connectorResponse.getStatus() == SC_OK) {
             return processResponse(connectorResponse);
         }

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchDirectDebitPayments.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchDirectDebitPayments.java
@@ -74,11 +74,11 @@ public class SearchDirectDebitPayments extends SearchPaymentsBase {
             JsonNode responseJson = directDebitResponse.readEntity(JsonNode.class);
             TypeReference<DirectDebitSearchResponse> typeRef = new TypeReference<DirectDebitSearchResponse>() {};
             DirectDebitSearchResponse searchResponse = objectMapper.readValue(responseJson.traverse(), typeRef);
-            List<DirectDebitTransactionForSearch> transactionFromResponse =
+            List<DirectDebitPaymentForSearch> transactionFromResponse =
                     searchResponse
                             .getPayments()
                             .stream()
-                            .map(transaction -> DirectDebitTransactionForSearch.valueOf(
+                            .map(transaction -> DirectDebitPaymentForSearch.valueOf(
                                     transaction,
                                     paymentUriGenerator.getPaymentURI(baseUrl, transaction.getTransactionId())
                             )).collect(Collectors.toList());

--- a/src/main/java/uk/gov/pay/api/model/search/links/DDPaymentLinksForSearch.java
+++ b/src/main/java/uk/gov/pay/api/model/search/links/DDPaymentLinksForSearch.java
@@ -4,7 +4,7 @@ import uk.gov.pay.api.model.links.Link;
 
 import static javax.ws.rs.HttpMethod.GET;
 
-public class DDTransactionLinksForSearch {
+public class DDPaymentLinksForSearch {
     private Link self;
 
     public void addSelf(String href) { this.self = new Link(href, GET); }

--- a/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
@@ -3,9 +3,6 @@ package uk.gov.pay.api.service;
 import com.google.common.collect.Maps;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
-import uk.gov.pay.api.model.CreateCardPaymentRequest;
-import uk.gov.pay.api.model.CreatePaymentRequest;
-import uk.gov.pay.api.model.TokenPaymentType;
 
 import javax.inject.Inject;
 import javax.ws.rs.core.UriBuilder;
@@ -54,7 +51,7 @@ public class ConnectorUriGenerator {
         return buildConnectorUri(account, path);
     }
 
-    public String directDebitTransactionsURI(Account account, Map<String, String> queryParams) {
+    public String directDebitPaymentsURI(Account account, Map<String, String> queryParams) {
         String path = String.format("/v1/api/accounts/%s/transactions/view", account.getAccountId());
         return buildConnectorUri(account, path, queryParams);
     }

--- a/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
@@ -52,7 +52,7 @@ public class ConnectorUriGenerator {
     }
 
     public String directDebitPaymentsURI(Account account, Map<String, String> queryParams) {
-        String path = String.format("/v1/api/accounts/%s/transactions/view", account.getAccountId());
+        String path = String.format("/v1/api/accounts/%s/payments/view", account.getAccountId());
         return buildConnectorUri(account, path, queryParams);
     }
 
@@ -93,7 +93,7 @@ public class ConnectorUriGenerator {
             params.put("mandate_external_id", agreementId);
 
         if (paymentId != null)
-            params.put("transaction_external_id", paymentId);
+            params.put("payment_external_id", paymentId);
 
         params.put("page", Optional.ofNullable(page).orElse(1).toString());
         params.put("display_size", Optional.ofNullable(displaySize).orElse(500).toString());

--- a/src/main/java/uk/gov/pay/api/service/DirectDebitEventService.java
+++ b/src/main/java/uk/gov/pay/api/service/DirectDebitEventService.java
@@ -46,8 +46,8 @@ public class DirectDebitEventService {
                 agreementLink = publicApiUriGenerator.getAgreementURI(event.getMandateExternalId()).toString();
             }
 
-            if (event.getTransactionExternalId() != null) {
-                paymentLink = publicApiUriGenerator.getPaymentURI(event.getTransactionExternalId()).toString();
+            if (event.getPaymentExternalId() != null) {
+                paymentLink = publicApiUriGenerator.getPaymentURI(event.getPaymentExternalId()).toString();
             }
 
             event.setLinks(new DirectDebitEvent.Links(agreementLink, paymentLink));

--- a/src/test/java/uk/gov/pay/api/service/ConnectorUriGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/api/service/ConnectorUriGeneratorTest.java
@@ -9,11 +9,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
-import uk.gov.pay.api.model.CreateCardPaymentRequest;
-import uk.gov.pay.api.model.CreateDirectDebitPaymentRequest;
-import uk.gov.pay.api.model.CreatePaymentRequest;
-import uk.gov.pay.api.model.CreatePaymentRequestBuilder;
-import uk.gov.pay.api.model.TokenPaymentType;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -129,6 +124,6 @@ public class ConnectorUriGeneratorTest {
     @Test
     public void buildEventsURIFromAllParameters() throws UnsupportedEncodingException {
         String uri = connectorUriGenerator.eventsURI(cardAccount, Optional.of(ZonedDateTime.parse("2018-03-13T10:00:05.000Z")), Optional.of(ZonedDateTime.parse("2018-03-13T10:00:05Z")), 1, 300, "1", "2");
-        assertThat(URLDecoder.decode(uri, "UTF-8"), is("https://bla.test/v1/events?to_date=2018-03-13T10:00:05.000Z&from_date=2018-03-13T10:00:05.000Z&mandate_external_id=1&transaction_external_id=2&page=1&display_size=300"));
+        assertThat(URLDecoder.decode(uri, "UTF-8"), is("https://bla.test/v1/events?to_date=2018-03-13T10:00:05.000Z&from_date=2018-03-13T10:00:05.000Z&mandate_external_id=1&payment_external_id=2&page=1&display_size=300"));
     }
 }

--- a/src/test/java/uk/gov/pay/api/service/DirectDebitPaymentSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/DirectDebitPaymentSearchServiceTest.java
@@ -91,7 +91,7 @@ public class DirectDebitPaymentSearchServiceTest {
     @Test
     @PactVerification({"direct-debit-connector"})
     @Pacts(pacts = {"publicapi-direct-debit-connector-search-by-mandate-three-results"})
-    public void doSearchShouldReturnADirectDebitSearchResponseWithThreeTransactions() {
+    public void doSearchShouldReturnADirectDebitSearchResponseWithThreePayments() {
         Account account = new Account("2po9ycynwq8yxdgg2qwq9e9qpyrtre", TokenPaymentType.DIRECT_DEBIT);
         String agreementId = "jkdjsvd8f78ffkwfek2q";
         Response response =

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-get-events.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-get-events.json
@@ -16,7 +16,7 @@
             "event": "CHARGE_CREATED",
             "mandate_external_id": "1",
             "event_id": "100",
-            "transaction_external_id": "2",
+            "payment_external_id": "2",
             "event_date": "2018-03-13T10:00:04.666Z",
             "external_id": "101"
           }
@@ -28,7 +28,7 @@
             "event": "PAYMENT_ACKNOWLEDGED_BY_PROVIDER",
             "mandate_external_id": "1",
             "event_id": "200",
-            "transaction_external_id": "4",
+            "payment_external_id": "4",
             "event_date": "2018-03-13T10:00:04.666Z",
             "external_id": "201"
           }
@@ -59,7 +59,7 @@
               "external_id": "201",
               "event": "PAYMENT_ACKNOWLEDGED_BY_PROVIDER",
               "mandate_external_id": "1",
-              "transaction_external_id": "4",
+              "payment_external_id": "4",
               "event_type": "CHARGE",
               "event_date": "2018-03-13T10:00:04.666Z"
             },
@@ -67,7 +67,7 @@
               "external_id": "101",
               "event": "CHARGE_CREATED",
               "mandate_external_id": "1",
-              "transaction_external_id": "2",
+              "payment_external_id": "2",
               "event_type": "MANDATE",
               "event_date": "2018-03-13T10:00:04.666Z"
             }

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-search-by-mandate-three-results.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-search-by-mandate-three-results.json
@@ -7,10 +7,10 @@
   },
   "interactions": [
     {
-      "description": "search transactions",
+      "description": "search payments",
       "providerStates": [
         {
-          "name": "three transaction records exist",
+          "name": "three payment records exist",
           "params": {
             "gateway_account_id": "2po9ycynwq8yxdgg2qwq9e9qpyrtre",
             "agreement_id": "jkdjsvd8f78ffkwfek2q"

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-search-by-mandate-three-results.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-search-by-mandate-three-results.json
@@ -19,7 +19,7 @@
       ],
       "request": {
         "method": "GET",
-        "path": "/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/transactions/view",
+        "path": "/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/payments/view",
         "query": {
           "agreement_id": [
             "jkdjsvd8f78ffkwfek2q"
@@ -38,7 +38,7 @@
           "results": [
             {
               "amount": 1234,
-              "transaction_id": "askd87sfnsadn489nfd8ddnv",
+              "payment_id": "askd87sfnsadn489nfd8ddnv",
               "name": "J. Citizen",
               "email": "j.citizen@mail.fake",
               "state": {
@@ -59,7 +59,7 @@
             },
             {
               "amount": 1245,
-              "transaction_id": "askd87sfnsadn489nfd8ddnvprq",
+              "payment_id": "askd87sfnsadn489nfd8ddnvprq",
               "name": "J. Citizen",
               "email": "j.citizen@mail.fake",
               "state": {
@@ -80,7 +80,7 @@
             },
             {
               "amount": 1256,
-              "transaction_id": "askd87sfnsadn489nfd8ddt64e",
+              "payment_id": "askd87sfnsadn489nfd8ddt64e",
               "name": "J. Citizen",
               "email": "j.citizen@mail.fake",
               "state": {
@@ -102,13 +102,13 @@
           ],
           "_links": {
             "self": {
-              "href": "http://localhost:1234/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/transaction/view?agreement_id=jkdjsvd8f78ffkwfek2q&page=1&display_size=500"
+              "href": "http://localhost:1234/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/payment/view?agreement_id=jkdjsvd8f78ffkwfek2q&page=1&display_size=500"
             },
             "last_page": {
-              "href": "http://localhost:1234/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/transaction/view?agreement_id=jkdjsvd8f78ffkwfek2q&page=1&display_size=500"
+              "href": "http://localhost:1234/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/payment/view?agreement_id=jkdjsvd8f78ffkwfek2q&page=1&display_size=500"
             },
             "first_page": {
-              "href": "http://localhost:1234/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/transaction/view?agreement_id=jkdjsvd8f78ffkwfek2q&page=1&display_size=500"
+              "href": "http://localhost:1234/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/payment/view?agreement_id=jkdjsvd8f78ffkwfek2q&page=1&display_size=500"
             }
           }
         },
@@ -117,7 +117,7 @@
             "Location": {
               "matchers": [
                 {
-                  "regex": "http:\/\/.*\/v1\/api\/accounts\/2po9ycynwq8yxdgg2qwq9e9qpyrtre\/transactions\/view*"
+                  "regex": "http:\/\/.*\/v1\/api\/accounts\/2po9ycynwq8yxdgg2qwq9e9qpyrtre\/payments\/view*"
                 }
               ]
             }
@@ -165,7 +165,7 @@
                 }
               ]
             },
-            "$.results[*].transaction_id": {
+            "$.results[*].payment_id": {
               "matchers": [
                 {
                   "regex": "[a-z0-9]*"
@@ -245,21 +245,21 @@
             "$._links.self": {
               "matchers": [
                 {
-                  "regex": "http:\/\/.*\/v1\/api\/accounts\/2po9ycynwq8yxdgg2qwq9e9qpyrtre\/transactions\/view.*"
+                  "regex": "http:\/\/.*\/v1\/api\/accounts\/2po9ycynwq8yxdgg2qwq9e9qpyrtre\/payments\/view.*"
                 }
               ]
             },
             "$._links.first_page": {
               "matchers": [
                 {
-                  "regex": "http:\/\/.*\/v1\/api\/accounts\/2po9ycynwq8yxdgg2qwq9e9qpyrtre\/transactions\/view.*"
+                  "regex": "http:\/\/.*\/v1\/api\/accounts\/2po9ycynwq8yxdgg2qwq9e9qpyrtre\/payments\/view.*"
                 }
               ]
             },
             "$._links.last_page": {
               "matchers": [
                 {
-                  "regex": "http:\/\/.*\/v1\/api\/accounts\/2po9ycynwq8yxdgg2qwq9e9qpyrtre\/transactions\/view.*"
+                  "regex": "http:\/\/.*\/v1\/api\/accounts\/2po9ycynwq8yxdgg2qwq9e9qpyrtre\/payments\/view.*"
                 }
               ]
             }


### PR DESCRIPTION
In preparation for the Direct Debit connector API changing from “transaction” to “payment”, rename things in public API.

This change is separated into logical several commits, so it might be easiest to review commit by commit.