### PR TITLE
PP-5248 Temporarily disable Direct Debit Pact tests

### DIFF
--- a/src/test/java/uk/gov/pay/api/it/GetDirectDebitEventsIT.java
+++ b/src/test/java/uk/gov/pay/api/it/GetDirectDebitEventsIT.java
@@ -3,6 +3,7 @@ package uk.gov.pay.api.it;
 import au.com.dius.pact.consumer.PactVerification;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.api.app.PublicApi;
@@ -23,6 +24,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
+@Ignore
 public class GetDirectDebitEventsIT {
 
     static final String API_KEY = ApiKeyGenerator.apiKeyValueOf("TEST_BEARER_TOKEN", "qwer9yuhgf");

--- a/src/test/java/uk/gov/pay/api/it/directdebit/pact/DirectDebitPaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/directdebit/pact/DirectDebitPaymentIT.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.api.it.directdebit.pact;
 
 import au.com.dius.pact.consumer.PactVerification;
-import com.jayway.jsonassert.JsonAssert;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import io.restassured.response.ValidatableResponse;
 import org.apache.http.client.fluent.Executor;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.api.app.PublicApi;
@@ -26,11 +26,10 @@ import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static uk.gov.pay.api.utils.Payloads.aSuccessfulPaymentPayload;
-import static uk.gov.pay.api.utils.Urls.directDebitFrontendSecureUrl;
 import static uk.gov.pay.api.utils.Urls.paymentLocationFor;
 import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
+@Ignore
 public class DirectDebitPaymentIT {
 
     private static final int AMOUNT = 100;


### PR DESCRIPTION
Temporarily disable Direct Debit Pact tests in preparation for the Direct Debit connector API switching from “transaction” to “payment”.