### PR TITLE
PP-5298 Rename dd connector request/response fields

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/directdebit/DirectDebitConnectorCreatePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/DirectDebitConnectorCreatePaymentRequest.java
@@ -30,7 +30,7 @@ public class DirectDebitConnectorCreatePaymentRequest {
         return description;
     }
 
-    @JsonProperty("agreement_id")
+    @JsonProperty("mandate_id")
     public String getMandateId() {
         return mandateId;
     }

--- a/src/main/java/uk/gov/pay/api/model/directdebit/DirectDebitConnectorCreatePaymentResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/DirectDebitConnectorCreatePaymentResponse.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DirectDebitConnectorCreatePaymentResponse {
-    @JsonProperty("charge_id")
+    @JsonProperty("payment_id")
     private String paymentExternalId;
 
     @JsonProperty

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-collect-payment.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-collect-payment.json
@@ -24,7 +24,7 @@
           "amount": 100,
           "reference": "a reference",
           "description": "a description",
-          "agreement_id": "test_mandate_id_xyz"
+          "mandate_id": "test_mandate_id_xyz"
         }
       },
       "response": {
@@ -34,7 +34,7 @@
           "Location": "/v1/api/accounts/GATEWAY_ACCOUNT_ID/charges/ch_ab2341da231434l"
         },
         "body": {
-          "charge_id": "ch_ab2341da231434l",
+          "payment_id": "ch_ab2341da231434l",
           "amount": 100,
           "reference": "a reference",
           "payment_provider": "SANDBOX",
@@ -70,7 +70,7 @@
                 }
               ]
             },
-            "$.charge_id": {
+            "$.payment_id": {
               "matchers": [
                 {
                   "match": "type"


### PR DESCRIPTION
Rename "agreement_id" in request to "mandate_id".
Rename "charge_id" in response to "payment_id".

This can be done because direct debit connector currently has
compatibility for both variations.