### PR TITLE
PP-5298 Return P0101 Error for missing fields

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/ViolationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/ViolationExceptionMapper.java
@@ -2,6 +2,8 @@ package uk.gov.pay.api.exception.mapper;
 
 import com.google.common.base.CaseFormat;
 import io.dropwizard.jersey.validation.JerseyViolationException;
+import org.hibernate.validator.constraints.NotBlank;
+import org.hibernate.validator.constraints.NotEmpty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.model.PaymentError;
@@ -9,9 +11,11 @@ import uk.gov.pay.api.model.PaymentError;
 import javax.annotation.Priority;
 import javax.validation.ConstraintViolation;
 import javax.validation.Path;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
+import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_MISSING_FIELD_ERROR;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_VALIDATION_ERROR;
 
 @Priority(1)
@@ -22,10 +26,19 @@ public class ViolationExceptionMapper implements ExceptionMapper<JerseyViolation
     public Response toResponse(JerseyViolationException exception) {
         LOGGER.error(exception.getMessage());
         ConstraintViolation<?> firstException = exception.getConstraintViolations().iterator().next();
-        String message = firstException.getMessage();
         String fieldName = getApiFieldName(firstException.getPropertyPath());
-        PaymentError paymentError = PaymentError.aPaymentError(fieldName, CREATE_PAYMENT_VALIDATION_ERROR, message);
-
+        
+        PaymentError paymentError;
+        if (firstException.getConstraintDescriptor() != null &&
+                firstException.getConstraintDescriptor().getAnnotation() != null &&
+                firstException.getConstraintDescriptor().getAnnotation().annotationType() == NotBlank.class ||
+                firstException.getConstraintDescriptor().getAnnotation().annotationType() == NotEmpty.class ||
+                firstException.getConstraintDescriptor().getAnnotation().annotationType() == NotNull.class) {
+            paymentError = PaymentError.aPaymentError(fieldName, CREATE_PAYMENT_MISSING_FIELD_ERROR);
+        } else {
+            paymentError = PaymentError.aPaymentError(fieldName, CREATE_PAYMENT_VALIDATION_ERROR, firstException.getMessage());
+        }
+        
         return Response.status(422)
                 .entity(paymentError)
                 .build();

--- a/src/test/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResourceTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResourceTest.java
@@ -200,9 +200,8 @@ public class DirectDebitPaymentsResourceTest {
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(3))
                 .assertThat("$.field", Is.is("mandate_id"))
-                // TODO: make this return a P0101 error
-                .assertThat("$.code", Is.is("P0102"));
-//                .assertThat("$.description", Is.is("Missing mandatory attribute: mandate_id"));
+                .assertThat("$.code", Is.is("P0101"))
+                .assertThat("$.description", Is.is("Missing mandatory attribute: mandate_id"));
     }
     
     @Test
@@ -223,9 +222,8 @@ public class DirectDebitPaymentsResourceTest {
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(3))
                 .assertThat("$.field", Is.is("mandate_id"))
-                // TODO: make this return a P0101 error
-                .assertThat("$.code", Is.is("P0102"));
-//                .assertThat("$.description", Is.is("Missing mandatory attribute: mandate_id"));
+                .assertThat("$.code", Is.is("P0101"))
+                .assertThat("$.description", Is.is("Missing mandatory attribute: mandate_id"));
     }
     
     @Test
@@ -247,9 +245,8 @@ public class DirectDebitPaymentsResourceTest {
         JsonAssert.with(body)
                 .assertThat("$.*", hasSize(3))
                 .assertThat("$.field", Is.is("mandate_id"))
-                // TODO: make this return a P0101 error
-                .assertThat("$.code", Is.is("P0102"));
-//                .assertThat("$.description", Is.is("Missing mandatory attribute: mandate_id"));
+                .assertThat("$.code", Is.is("P0101"))
+                .assertThat("$.description", Is.is("Missing mandatory attribute: mandate_id"));
     }
     
     @Test


### PR DESCRIPTION
When Jersey validation fails for a model on the @NotNull, @NotEmpty or
@NotBlank validations, return a P0101 error which indicates that a value
is missing for a mandatory field.