### PR TITLE
PP-5298 Validate numeric types for jackson deserialization

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/JsonProcessingExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/JsonProcessingExceptionMapper.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.api.exception.mapper;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import io.dropwizard.jersey.errors.LoggingExceptionMapper;
 import org.apache.http.HttpStatus;
 import uk.gov.pay.api.exception.PaymentValidationException;
@@ -9,6 +10,8 @@ import uk.gov.pay.api.model.PaymentError;
 import javax.annotation.Priority;
 import javax.ws.rs.core.Response;
 
+import static uk.gov.pay.api.model.PaymentError.aPaymentError;
+
 @Priority(1)
 public class JsonProcessingExceptionMapper extends LoggingExceptionMapper<JsonProcessingException> {
     @Override
@@ -16,8 +19,24 @@ public class JsonProcessingExceptionMapper extends LoggingExceptionMapper<JsonPr
         if (exception.getCause() instanceof PaymentValidationException) {
             PaymentError paymentError = ((PaymentValidationException) exception.getCause()).getPaymentError();
             return Response.status(HttpStatus.SC_UNPROCESSABLE_ENTITY).entity(paymentError).build();
+        } else if (exception instanceof MismatchedInputException) {
+            MismatchedInputException mismatchedInputException = (MismatchedInputException) exception;
+            String typeName = isNumeric(mismatchedInputException.getTargetType()) ?
+                    "numeric" :
+                    mismatchedInputException.getTargetType().getSimpleName();
+
+            String message = String.format("Must be a valid %s format", typeName);
+            var paymentError = aPaymentError(mismatchedInputException.getPath().get(0).getFieldName(),
+                    PaymentError.Code.CREATE_PAYMENT_VALIDATION_ERROR,
+                    message);
+            
+            return Response.status(HttpStatus.SC_UNPROCESSABLE_ENTITY).entity(paymentError).build();
         } else {
             return super.toResponse(exception);
         }
+    }
+    
+    private boolean isNumeric(Class type) {
+        return type == int.class || type == long.class || type == double.class || Number.class.isAssignableFrom(type);
     }
 }

--- a/src/test/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResourceIT.java
+++ b/src/test/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResourceIT.java
@@ -137,6 +137,16 @@ public class DirectDebitPaymentsResourceIT extends DirectDebitResourceITBase {
                         .withErrorField("amount")
                         .build(),
                 someParameters()
+                        .withAmount("NaN")
+                        .withErrorMessage("Invalid attribute value: amount. Must be a valid numeric format")
+                        .withErrorField("amount")
+                        .build(),
+                someParameters()
+                        .withAmount(false)
+                        .withErrorMessage("Invalid attribute value: amount. Must be a valid numeric format")
+                        .withErrorField("amount")
+                        .build(),
+                someParameters()
                         .withReference(null)
                         .withErrorMessage("Missing mandatory attribute: reference")
                         .withErrorField("reference")
@@ -161,10 +171,30 @@ public class DirectDebitPaymentsResourceIT extends DirectDebitResourceITBase {
                         .withErrorCode("P0102")
                         .build(),
                 someParameters()
+                        .withReference(123)
+                        .withErrorMessage("Invalid attribute value: reference. Must be of type String")
+                        .withErrorField("reference")
+                        .build(),
+                someParameters()
+                        .withReference(false)
+                        .withErrorMessage("Invalid attribute value: reference. Must be of type String")
+                        .withErrorField("reference")
+                        .build(),
+                someParameters()
                         .withDescription(RandomStringUtils.randomAlphanumeric(256))
                         .withErrorMessage("Invalid attribute value: description. Must be less than or equal to 255 characters length")
                         .withErrorField("description")
                         .withErrorCode("P0102")
+                        .build(),
+                someParameters()
+                        .withDescription(123)
+                        .withErrorMessage("Invalid attribute value: description. Must be of type String")
+                        .withErrorField("description")
+                        .build(),
+                someParameters()
+                        .withDescription(false)
+                        .withErrorMessage("Invalid attribute value: description. Must be of type String")
+                        .withErrorField("description")
                         .build(),
                 someParameters()
                         .withMandateId(null)
@@ -190,14 +220,24 @@ public class DirectDebitPaymentsResourceIT extends DirectDebitResourceITBase {
                         .withErrorField("mandate_id")
                         .withErrorCode("P0102")
                         .build(),
+                someParameters()
+                        .withMandateId(123)
+                        .withErrorMessage("Invalid attribute value: mandate_id. Must be of type String")
+                        .withErrorField("mandate_id")
+                        .build(),
+                someParameters()
+                        .withMandateId(false)
+                        .withErrorMessage("Invalid attribute value: mandate_id. Must be of type String")
+                        .withErrorField("mandate_id")
+                        .build(),
         };
     }
     
     public static class CreatePaymentRequestValidationParameters {
-        public Long amount;
-        public String reference;
-        public String description;
-        public String mandateId;
+        public Object amount;
+        public Object reference;
+        public Object description;
+        public Object mandateId;
         public String expectedErrorCode;
         public String expectedErrorField;
         public String expectedErrorMessage;
@@ -221,11 +261,24 @@ public class DirectDebitPaymentsResourceIT extends DirectDebitResourceITBase {
             return payload;
         }
 
+        @Override
+        public String toString() {
+            return "CreatePaymentRequestValidationParameters{" +
+                    "amount=" + amount +
+                    ", reference=" + reference +
+                    ", description=" + description +
+                    ", mandateId=" + mandateId +
+                    ", expectedErrorCode='" + expectedErrorCode + '\'' +
+                    ", expectedErrorField='" + expectedErrorField + '\'' +
+                    ", expectedErrorMessage='" + expectedErrorMessage + '\'' +
+                    '}';
+        }
+
         static class  CreatePaymentRequestValidationParametersBuilder {
-            public Long amount = AMOUNT;
-            public String reference = REFERENCE;
-            public String description = DESCRIPTION;
-            public String mandateId = MANDATE_ID;
+            public Object amount = AMOUNT;
+            public Object reference = REFERENCE;
+            public Object description = DESCRIPTION;
+            public Object mandateId = MANDATE_ID;
             public String expectedErrorCode = "P0102";
             public String expectedErrorField;
             public String expectedErrorMessage;
@@ -234,22 +287,22 @@ public class DirectDebitPaymentsResourceIT extends DirectDebitResourceITBase {
                 return new CreatePaymentRequestValidationParametersBuilder();
             }
 
-            CreatePaymentRequestValidationParametersBuilder withAmount(Long amount) {
+            CreatePaymentRequestValidationParametersBuilder withAmount(Object amount) {
                 this.amount = amount;
                 return this;
             }
 
-            CreatePaymentRequestValidationParametersBuilder withReference(String reference) {
+            CreatePaymentRequestValidationParametersBuilder withReference(Object reference) {
                 this.reference = reference;
                 return this;
             }
 
-            CreatePaymentRequestValidationParametersBuilder withDescription(String description) {
+            CreatePaymentRequestValidationParametersBuilder withDescription(Object description) {
                 this.description = description;
                 return this;
             }
 
-            CreatePaymentRequestValidationParametersBuilder withMandateId(String mandateId) {
+            CreatePaymentRequestValidationParametersBuilder withMandateId(Object mandateId) {
                 this.mandateId = mandateId;
                 return this;
             }


### PR DESCRIPTION
Handle exception thrown when a JSON field cannot be deserialized due to
a mismatch in type.
Add tests for the direct debit payment request that these exceptions are
mapped into the appropriate errors.

Co-authored-by: Rory Malcolm <rory.malcolm@digital.cabinet-office.gov.uk>