### PR TITLE
PP-5298 Ignore unknown properties on create payment request

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CreateDirectDebitPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateDirectDebitPaymentRequest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -11,13 +12,14 @@ import javax.validation.constraints.Size;
 import java.util.StringJoiner;
 
 @ApiModel(description = "The Direct Debit Payment Request Payload")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CreateDirectDebitPaymentRequest {
 
     public static final int REFERENCE_MAX_LENGTH = 255;
     public static final int AMOUNT_MAX_VALUE = 10000000;
     public static final int AMOUNT_MIN_VALUE = 1;
     public static final int DESCRIPTION_MAX_LENGTH = 255;
-    public static final int AGREEMENT_ID_MAX_LENGTH = 26;
+    public static final int MANDATE_ID_MAX_LENGTH = 26;
 
     @JsonProperty("amount")
     @Min(value = AMOUNT_MIN_VALUE, message = "Must be greater than or equal to {value}")
@@ -34,7 +36,7 @@ public class CreateDirectDebitPaymentRequest {
     private String description;
 
     @JsonProperty("mandate_id")
-    @Size(max = AGREEMENT_ID_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
+    @Size(max = MANDATE_ID_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     @NotBlank
     private String mandateId;
     

--- a/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
@@ -13,7 +13,7 @@ import static org.apache.commons.lang3.StringUtils.join;
 import static org.eclipse.jetty.util.StringUtil.isBlank;
 import static uk.gov.pay.api.model.CreateCardPaymentRequest.EMAIL_MAX_LENGTH;
 import static uk.gov.pay.api.model.CreateCardPaymentRequest.REFERENCE_MAX_LENGTH;
-import static uk.gov.pay.api.model.CreateDirectDebitPaymentRequest.AGREEMENT_ID_MAX_LENGTH;
+import static uk.gov.pay.api.model.CreateDirectDebitPaymentRequest.MANDATE_ID_MAX_LENGTH;
 import static uk.gov.pay.api.model.PaymentError.Code.SEARCH_PAYMENTS_VALIDATION_ERROR;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
@@ -69,7 +69,7 @@ public class PaymentSearchValidator {
     }
 
     private static void validateAgreement(String agreement, List<String> validationErrors) {
-        if (!isValid(agreement, AGREEMENT_ID_MAX_LENGTH)){
+        if (!isValid(agreement, MANDATE_ID_MAX_LENGTH)){
             validationErrors.add("agreement_id");
         }
     }


### PR DESCRIPTION
This is our standard practice.

While here, also rename a constant name to contain mandate rather than
agreement