### PR TITLE
PP-5298 Remove dead code

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapper.java
@@ -22,8 +22,6 @@ public class CreateAgreementExceptionMapper implements ExceptionMapper<CreateMan
         AgreementError agreementError;
         if (exception.getErrorStatus() == NOT_FOUND.getStatusCode()) {
             agreementError = anAgreementError(AgreementError.Code.CREATE_MANDATE_ACCOUNT_ERROR);
-        } else if (exception.getErrorIdentifier() == ErrorIdentifier.INVALID_MANDATE_TYPE) {
-            agreementError = anAgreementError(Code.CREATE_MANDATE_TYPE_ERROR);
         } else if (exception.getErrorIdentifier() == ErrorIdentifier.GO_CARDLESS_ACCOUNT_NOT_LINKED) {
             agreementError = anAgreementError(Code.CREATE_MANDATE_ACCOUNT_ERROR);
         }

--- a/src/test/java/uk/gov/pay/api/it/directdebit/CreateMandateIT.java
+++ b/src/test/java/uk/gov/pay/api/it/directdebit/CreateMandateIT.java
@@ -208,27 +208,6 @@ public class CreateMandateIT extends DirectDebitResourceITBase {
                 .extract().body().asString();
     }
 
-    @Test
-    public void respondWith500_whenConnectorResponseIsAgreementTypeInvalid() {
-
-        String errorMessage = "something went wrong";
-        
-        connectorDDMockClient.respondWithMandateTypeInvalid_whenCreateMandateRequest(GATEWAY_ACCOUNT_ID, errorMessage);
-
-        given().port(app.getLocalPort())
-                .body(createMandatePayload)
-                .accept(JSON)
-                .contentType(JSON)
-                .header(AUTHORIZATION, "Bearer " + API_KEY)
-                .post("/v1/directdebit/mandates")
-                .then()
-                .statusCode(500)
-                .contentType(JSON)
-                .body("code", is("P0197"))
-                .body("description", is("It is not possible to create a mandate of this type"))
-                .extract().body().asString();
-    }
-
 
     @Test
     public void respondWith500_whenConnectorResponseIsGCAccountNotLinked() {


### PR DESCRIPTION
Remove dead code relating to an error returned by direct debit connector
when trying to create an agreement of the wrong type. Agreement types
are no longer a thing.