### PR TITLE
Remove reference to ErrorIdentifier.INVALID_MANDATE_TYPE

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -13,7 +13,6 @@ import javax.ws.rs.ext.ExceptionMapper;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_ACCOUNT_ERROR;
-import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_AGREEMENT_TYPE_ERROR;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_CONNECTOR_ERROR;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_VALIDATION_ERROR;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
@@ -30,8 +29,6 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
 
         if (exception.getErrorStatus() == NOT_FOUND.getStatusCode()) {
             paymentError = aPaymentError(CREATE_PAYMENT_ACCOUNT_ERROR);
-        } else if (exception.getErrorIdentifier() == ErrorIdentifier.INVALID_MANDATE_TYPE) {
-            paymentError = aPaymentError(CREATE_PAYMENT_AGREEMENT_TYPE_ERROR);
         } else if (exception.getErrorIdentifier() == ErrorIdentifier.ZERO_AMOUNT_NOT_ALLOWED) {
             statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
             paymentError = aPaymentError("amount", CREATE_PAYMENT_VALIDATION_ERROR,

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
@@ -368,28 +368,6 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
     }
 
     @Test
-    public void createPayment_responseWith500_whenInvalidDirectDebitAgreementType() throws Exception {
-        String gatewayAccountId = "1234567";
-        String errorMessage = "something went wrong";
-
-        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, gatewayAccountId);
-
-        connectorMockClient.respondMandateTypeInvalid_whenCreateCharge(gatewayAccountId, errorMessage);
-
-        InputStream body = postPaymentResponse(SUCCESS_PAYLOAD)
-                .statusCode(500)
-                .contentType(JSON).extract()
-                .body().asInputStream();
-
-        JsonAssert.with(body)
-                .assertThat("$.*", hasSize(2))
-                .assertThat("$.code", is("P0140"))
-                .assertThat("$.description", is("Can't collect payment from this type of mandates"));
-
-        connectorMockClient.verifyCreateChargeConnectorRequest(gatewayAccountId, SUCCESS_PAYLOAD);
-    }
-
-    @Test
     public void createPayment_responseWith500_whenTokenForGatewayAccountIsValidButConnectorResponseIsNotFound() {
         String notFoundGatewayAccountId = "9876545";
         publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, notFoundGatewayAccountId);


### PR DESCRIPTION
This no longer exists.