### PR TITLE
PP-5301 Validate dd search params using Jackson

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
@@ -1,0 +1,159 @@
+package uk.gov.pay.api.model.search.directdebit;
+
+import io.swagger.annotations.ApiParam;
+import uk.gov.pay.api.validation.ValidDate;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import javax.ws.rs.QueryParam;
+
+import java.util.Optional;
+
+import static uk.gov.pay.api.model.CreateDirectDebitPaymentRequest.MANDATE_ID_MAX_LENGTH;
+import static uk.gov.pay.api.model.CreateDirectDebitPaymentRequest.REFERENCE_MAX_LENGTH;
+
+public class DirectDebitSearchPaymentsParams {
+    
+    @QueryParam("reference")
+    @ApiParam(value = "Your payment reference to search")
+    @Size(max = REFERENCE_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
+    private String reference;
+    
+    @QueryParam("state")
+    @ApiParam(value = "State of payments to be searched. Example=success", allowableValues = "pending,success,failed,cancelled,expired")
+    @Pattern(regexp = "pending|success|failed|cancelled|expired",
+            flags = Pattern.Flag.CASE_INSENSITIVE,
+            message = "Must be one of pending, success, failed, cancelled or expired")
+    private String state;
+    
+    @QueryParam("mandate_id")
+    @ApiParam(value = "The GOV.UK Pay identifier for the mandate")
+    @Size(max = MANDATE_ID_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
+    private String mandateId;
+    
+    @QueryParam("from_date")
+    @ValidDate
+    private String fromDate;
+    
+    @QueryParam("to_date")
+    @ValidDate
+    private String toDate;
+    
+    @QueryParam("page")
+    @ApiParam(value = "Page number requested for the search, should be a positive integer (optional, defaults to 1)")
+    @Min(value = 1, message = "Must be greater than or equal to {value}")
+    private Integer page;
+    
+    @QueryParam("display_size")
+    @Min(value = 1, message = "Must be greater than or equal to {value}")
+    @Max(value = 500, message = "Must be less than or equal to {value}")
+    private Integer displaySize;
+    
+    public String getReference() {
+        return reference;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public String getMandateId() {
+        return mandateId;
+    }
+
+    public String getFromDate() {
+        return fromDate;
+    }
+
+    public String getToDate() {
+        return toDate;
+    }
+
+    public Optional<Integer> getPage() {
+        return Optional.ofNullable(page);
+    }
+
+    public Optional<Integer> getDisplaySize() {
+        return Optional.ofNullable(displaySize);
+    }
+
+    @Override
+    public String toString() {
+        return "DirectDebitSearchPaymentsParams{" +
+                "reference='" + reference + '\'' +
+                ", state='" + state + '\'' +
+                ", mandateId='" + mandateId + '\'' +
+                ", fromDate='" + fromDate + '\'' +
+                ", toDate='" + toDate + '\'' +
+                ", page='" + page + '\'' +
+                ", displaySize='" + displaySize + '\'' +
+                '}';
+    }
+
+
+    public static final class DirectDebitSearchPaymentsParamsBuilder {
+        private String reference;
+        private String state;
+        private String mandateId;
+        private String fromDate;
+        private String toDate;
+        private Integer page;
+        private Integer displaySize;
+
+        private DirectDebitSearchPaymentsParamsBuilder() {
+        }
+
+        public static DirectDebitSearchPaymentsParamsBuilder aDirectDebitSearchPaymentsParams() {
+            return new DirectDebitSearchPaymentsParamsBuilder();
+        }
+
+        public DirectDebitSearchPaymentsParamsBuilder withReference(String reference) {
+            this.reference = reference;
+            return this;
+        }
+
+        public DirectDebitSearchPaymentsParamsBuilder withState(String state) {
+            this.state = state;
+            return this;
+        }
+
+        public DirectDebitSearchPaymentsParamsBuilder withMandateId(String mandateId) {
+            this.mandateId = mandateId;
+            return this;
+        }
+
+        public DirectDebitSearchPaymentsParamsBuilder withFromDate(String fromDate) {
+            this.fromDate = fromDate;
+            return this;
+        }
+
+        public DirectDebitSearchPaymentsParamsBuilder withToDate(String toDate) {
+            this.toDate = toDate;
+            return this;
+        }
+
+        public DirectDebitSearchPaymentsParamsBuilder withPage(Integer page) {
+            this.page = page;
+            return this;
+        }
+
+        public DirectDebitSearchPaymentsParamsBuilder withDisplaySize(Integer displaySize) {
+            this.displaySize = displaySize;
+            return this;
+        }
+
+        public DirectDebitSearchPaymentsParams build() {
+            DirectDebitSearchPaymentsParams directDebitSearchPaymentsParams = new DirectDebitSearchPaymentsParams();
+            directDebitSearchPaymentsParams.mandateId = this.mandateId;
+            directDebitSearchPaymentsParams.displaySize = this.displaySize;
+            directDebitSearchPaymentsParams.reference = this.reference;
+            directDebitSearchPaymentsParams.state = this.state;
+            directDebitSearchPaymentsParams.toDate = this.toDate;
+            directDebitSearchPaymentsParams.fromDate = this.fromDate;
+            directDebitSearchPaymentsParams.page = this.page;
+            return directDebitSearchPaymentsParams;
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
@@ -14,6 +14,7 @@ import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.CreateDirectDebitPaymentRequest;
 import uk.gov.pay.api.model.PaymentError;
 import uk.gov.pay.api.model.directdebit.mandates.DirectDebitPayment;
+import uk.gov.pay.api.model.search.directdebit.DirectDebitSearchPaymentsParams;
 import uk.gov.pay.api.model.search.directdebit.DirectDebitSearchResponse;
 import uk.gov.pay.api.resources.error.ApiErrorResponse;
 import uk.gov.pay.api.service.GetDirectDebitPaymentService;
@@ -23,13 +24,13 @@ import uk.gov.pay.api.service.directdebit.DirectDebitPaymentSearchService;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
+import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -65,8 +66,8 @@ public class DirectDebitPaymentsResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @ApiOperation(
-            value = "Create new DirectDebit payment",
-            notes = "Create a new DirectDebit payment for the account associated to the Authorisation token. " +
+            value = "Create new Direct Debit payment",
+            notes = "Create a new Direct Debit payment for the account associated to the Authorisation token. " +
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             code = 201,
@@ -107,35 +108,14 @@ public class DirectDebitPaymentsResource {
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response searchPayments(@ApiParam(value = "accountId", hidden = true)
                                    @Auth Account account,
-                                   @ApiParam(value = "Your payment reference to search", hidden = false)
-                                   @QueryParam("reference") String reference,
-                                   @ApiParam(value = "State of payments to be searched. Example=success", hidden = false, allowableValues = "pending,success,failed,cancelled,expired")
-                                   @QueryParam("state") String state,
-                                   @ApiParam(value = "The GOV.UK Pay identifier for the mandate", hidden = false)
-                                   @QueryParam("mandate_id") String mandateId,
-                                   @ApiParam(value = "From date of payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z", hidden = false)
-                                   @QueryParam("from_date") String fromDate,
-                                   @ApiParam(value = "To date of payments to be searched (this date is exclusive). Example=2015-08-14T12:35:00Z", hidden = false)
-                                   @QueryParam("to_date") String toDate,
-                                   @ApiParam(value = "Page number requested for the search, should be a positive integer (optional, defaults to 1)", hidden = false)
-                                   @QueryParam("page") String pageNumber,
-                                   @ApiParam(value = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)", hidden = false)
-                                   @QueryParam("display_size") String displaySize,
+                                   @Valid @BeanParam DirectDebitSearchPaymentsParams searchPaymentsParams,
                                    @Context UriInfo uriInfo) {
 
-        LOGGER.info("Payments search request - [ {} ]",
-                format("reference:%s, status: %s, mandate_id %s, fromDate: %s, toDate: %s, page: %s, display_size: %s",
-                        reference, state, mandateId, fromDate, toDate, pageNumber, displaySize));
+        LOGGER.info("Payments search request - {}", searchPaymentsParams);
 
         return directDebitPaymentSearchService.doSearch(
                 account,
-                reference,
-                state,
-                mandateId,
-                fromDate,
-                toDate,
-                pageNumber,
-                displaySize);
+                searchPaymentsParams);
     }
 
     @GET

--- a/src/main/java/uk/gov/pay/api/service/directdebit/DirectDebitPaymentSearchService.java
+++ b/src/main/java/uk/gov/pay/api/service/directdebit/DirectDebitPaymentSearchService.java
@@ -5,6 +5,7 @@ import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.SearchPaymentsException;
 import uk.gov.pay.api.model.directdebit.mandates.DirectDebitPayment;
 import uk.gov.pay.api.model.search.PaginationDecorator;
+import uk.gov.pay.api.model.search.directdebit.DirectDebitSearchPaymentsParams;
 import uk.gov.pay.api.model.search.directdebit.DirectDebitSearchResponse;
 import uk.gov.pay.api.service.PublicApiUriGenerator;
 
@@ -20,7 +21,6 @@ import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.http.HttpStatus.SC_OK;
-import static uk.gov.pay.api.validation.PaymentSearchValidator.validateSearchParameters;
 
 public class DirectDebitPaymentSearchService {
 
@@ -49,21 +49,19 @@ public class DirectDebitPaymentSearchService {
         this.directDebitConnectorUriGenerator = directDebitConnectorUriGenerator;
         this.publicApiUriGenerator = publicApiUriGenerator;
     }
-
-    public Response doSearch(Account account, String reference, String state, String mandateId, String fromDate,
-                             String toDate, String pageNumber, String displaySize) {
-        // TODO: do validation in resource
-        validateSearchParameters(account, state, reference, null, null, fromDate, toDate, pageNumber,
-                displaySize, mandateId, null, null);
-
+    
+    public Response doSearch(Account account, DirectDebitSearchPaymentsParams searchPaymentsParams) {
         Map<String, String> queryParams = new LinkedHashMap<>();
-        queryParams.put(REFERENCE_KEY, reference);
-        queryParams.put(STATE_KEY, state);
-        queryParams.put(MANDATE_ID_KEY, mandateId);
-        queryParams.put(FROM_DATE_KEY, fromDate);
-        queryParams.put(TO_DATE_KEY, toDate);
-        queryParams.put(PAGE, pageNumber);
-        queryParams.put(DISPLAY_SIZE, displaySize);
+        queryParams.put(REFERENCE_KEY, searchPaymentsParams.getReference());
+        queryParams.put(STATE_KEY, searchPaymentsParams.getState());
+        queryParams.put(MANDATE_ID_KEY, searchPaymentsParams.getMandateId());
+        queryParams.put(FROM_DATE_KEY, searchPaymentsParams.getFromDate());
+        queryParams.put(TO_DATE_KEY, searchPaymentsParams.getToDate());
+        
+        searchPaymentsParams.getPage()
+                .ifPresent(pageNumber -> queryParams.put(PAGE, String.valueOf(pageNumber)));
+        searchPaymentsParams.getDisplaySize()
+                .ifPresent(displaySize -> queryParams.put(DISPLAY_SIZE, String.valueOf(displaySize)));
 
         return getSearchResponse(account, queryParams);
     }

--- a/src/main/java/uk/gov/pay/api/validation/DateValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/DateValidator.java
@@ -2,11 +2,19 @@ package uk.gov.pay.api.validation;
 
 import uk.gov.pay.api.utils.DateTimeUtils;
 
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
 import static org.eclipse.jetty.util.StringUtil.isBlank;
 
-public class DateValidator {
+public class DateValidator implements ConstraintValidator<ValidDate, String> {
+    
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return isValid(value);
+    }
 
-    public static boolean validate(String value) {
+    public static boolean isValid(String value) {
         return isBlank(value) || DateTimeUtils.toUTCZonedDateTime(value).isPresent();
     }
 }

--- a/src/main/java/uk/gov/pay/api/validation/DirectDebitEventSearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/DirectDebitEventSearchValidator.java
@@ -45,6 +45,6 @@ public class DirectDebitEventSearchValidator {
     }
 
     private static boolean validateDate(String value) {
-        return DateValidator.validate(value);
+        return DateValidator.isValid(value);
     }
 }

--- a/src/main/java/uk/gov/pay/api/validation/SearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/SearchValidator.java
@@ -20,13 +20,13 @@ class SearchValidator {
     }
 
     static void validateToDate(String toDate, List<String> validationErrors) {
-        if (!DateValidator.validate(toDate)) {
+        if (!DateValidator.isValid(toDate)) {
             validationErrors.add("to_date");
         }
     }
 
     static void validateFromDate(String fromDate, List<String> validationErrors) {
-        if (!DateValidator.validate(fromDate)) {
+        if (!DateValidator.isValid(fromDate)) {
             validationErrors.add("from_date");
         }
     }

--- a/src/main/java/uk/gov/pay/api/validation/ValidDate.java
+++ b/src/main/java/uk/gov/pay/api/validation/ValidDate.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.api.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({ FIELD, METHOD, PARAMETER, ANNOTATION_TYPE, TYPE_USE })
+@Retention(RUNTIME)
+@Constraint(validatedBy = DateValidator.class)
+@Documented
+public @interface ValidDate {
+    
+    String message() default "Must be a valid date";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/test/java/uk/gov/pay/api/service/DirectDebitPaymentSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/DirectDebitPaymentSearchServiceTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.api.model.search.directdebit.DirectDebitSearchPaymentsParams.DirectDebitSearchPaymentsParamsBuilder.aDirectDebitSearchPaymentsParams;
 
 @RunWith(MockitoJUnitRunner.class)
 @Ignore
@@ -38,6 +39,7 @@ public class DirectDebitPaymentSearchServiceTest {
 
     @Mock
     private PublicApiConfig configuration;
+    
     private DirectDebitPaymentSearchService directDebitPaymentSearchService;
 
     @Before
@@ -59,15 +61,14 @@ public class DirectDebitPaymentSearchServiceTest {
     public void doSearchShouldReturnADirectDebitSearchResponseWithThreePayments() {
         Account account = new Account("2po9ycynwq8yxdgg2qwq9e9qpyrtre", TokenPaymentType.DIRECT_DEBIT);
         String mandateId = "jkdjsvd8f78ffkwfek2q";
+        
+        var searchParams =  aDirectDebitSearchPaymentsParams()
+                .withMandateId(mandateId)
+                .build();
         Response response = directDebitPaymentSearchService.doSearch(
                 account,
-                null,
-                null,
-                mandateId,
-                null,
-                null,
-                null,
-                null);
+                searchParams);
+        
         JsonAssert.with(response.getEntity().toString())
                 .assertThat("count", is(3))
                 .assertThat("total", is(3))


### PR DESCRIPTION
Use annotations to provide validation for the query parameters for a
search direct debit payments request.

Add tests for validation.