### PR TITLE
PP-5299: Remove next_url and next_url_post links

### DIFF
--- a/src/test/java/uk/gov/pay/api/service/MandatesServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/MandatesServiceTest.java
@@ -100,8 +100,8 @@ public class MandatesServiceTest {
     @Pacts(pacts = {"publicapi-direct-debit-connector-get-mandate"})
     public void shouldGetAMandateSuccessfully() {
         Account account = new Account("9ddfcc27-acf5-43f9-92d5-52247540714c", TokenPaymentType.DIRECT_DEBIT);
-        Response connectorResponse = mandatesService.getMandate(account, MANDATE_ID);
-        MandateConnectorResponse mandateConnectorResponse = connectorResponse.readEntity(MandateConnectorResponse.class);
+        Response response = mandatesService.getMandate(account, MANDATE_ID);
+        MandateConnectorResponse mandateConnectorResponse = response.readEntity(MandateConnectorResponse.class);
 
         assertThat(mandateConnectorResponse.getMandateId(), is(MANDATE_ID));
         assertThat(mandateConnectorResponse.getMandateReference(), is("410104"));
@@ -112,6 +112,7 @@ public class MandatesServiceTest {
         assertThat(mandateConnectorResponse.getCreatedDate(), is("2016-01-01T12:00:00Z"));
         assertThat(mandateConnectorResponse.getPayer().getEmail(), is("i.died@titanic.com"));
         assertThat(mandateConnectorResponse.getPayer().getName(), is("Jack"));
+        assertThat(mandateConnectorResponse.getLinks().size(), is(1));
         assertThat(mandateConnectorResponse.getLinks().get(0), is(new PaymentConnectorResponseLink(
                 "self",
                 "http://localhost:1234/v1/api/accounts/9ddfcc27-acf5-43f9-92d5-52247540714c/mandates/" + MANDATE_ID,
@@ -119,19 +120,7 @@ public class MandatesServiceTest {
                 null,
                 null
         )));
-        assertThat(mandateConnectorResponse.getLinks().get(1), is(new PaymentConnectorResponseLink(
-                "next_url",
-                "http://frontend_direct_debit/secure/token_1234567asdf",
-                "GET",
-                null,
-                null
-        )));
-        assertThat(mandateConnectorResponse.getLinks().get(2), is(new PaymentConnectorResponseLink(
-                "next_url_post",
-                "http://frontend_direct_debit/secure/",
-                "POST",
-                "application/x-www-form-urlencoded",
-                Collections.singletonMap("chargeTokenId", "token_1234567asdf")
-        )));
+        assertThat(mandateConnectorResponse.getLinks().stream().noneMatch(p -> p.getRel().equals("next_url")), is(true));
+        assertThat(mandateConnectorResponse.getLinks().stream().noneMatch(p -> p.getRel().equals("next_url_post")), is(true));
     }
 }

--- a/src/test/java/uk/gov/pay/api/service/MandatesServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/MandatesServiceTest.java
@@ -112,15 +112,16 @@ public class MandatesServiceTest {
         assertThat(mandateConnectorResponse.getCreatedDate(), is("2016-01-01T12:00:00Z"));
         assertThat(mandateConnectorResponse.getPayer().getEmail(), is("i.died@titanic.com"));
         assertThat(mandateConnectorResponse.getPayer().getName(), is("Jack"));
-        assertThat(mandateConnectorResponse.getLinks().size(), is(1));
-        assertThat(mandateConnectorResponse.getLinks().get(0), is(new PaymentConnectorResponseLink(
-                "self",
-                "http://localhost:1234/v1/api/accounts/9ddfcc27-acf5-43f9-92d5-52247540714c/mandates/" + MANDATE_ID,
-                "GET",
-                null,
-                null
-        )));
-        assertThat(mandateConnectorResponse.getLinks().stream().noneMatch(p -> p.getRel().equals("next_url")), is(true));
-        assertThat(mandateConnectorResponse.getLinks().stream().noneMatch(p -> p.getRel().equals("next_url_post")), is(true));
+        //TODO uncomment below when 
+//        assertThat(mandateConnectorResponse.getLinks().size(), is(1));
+//        assertThat(mandateConnectorResponse.getLinks().get(0), is(new PaymentConnectorResponseLink(
+//                "self",
+//                "http://localhost:1234/v1/api/accounts/9ddfcc27-acf5-43f9-92d5-52247540714c/mandates/" + MANDATE_ID,
+//                "GET",
+//                null,
+//                null
+//        )));
+//        assertThat(mandateConnectorResponse.getLinks().stream().noneMatch(p -> p.getRel().equals("next_url")), is(true));
+//        assertThat(mandateConnectorResponse.getLinks().stream().noneMatch(p -> p.getRel().equals("next_url_post")), is(true));
     }
 }

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-get-mandate.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-get-mandate.json
@@ -43,14 +43,7 @@
           "payer": {
             "name": "Jack",
             "email": "i.died@titanic.com"
-          },
-          "links": [
-            {
-              "href": "http://localhost:1234/v1/api/accounts/9ddfcc27-acf5-43f9-92d5-52247540714c/mandates/test_mandate_id_xyz",
-              "rel": "self",
-              "method": "GET"
-            }
-          ]
+          }
         },
         "matchingRules": {
           "body": {
@@ -108,13 +101,6 @@
               "matchers": [
                 {
                   "match": "type"
-                }
-              ]
-            },
-            "$.links[0].href": {
-              "matchers": [
-                {
-                  "regex": "http:\/\/.*\/v1\/api\/accounts\/9ddfcc27-acf5-43f9-92d5-52247540714c\/mandates\/test_mandate_id_xyz"
                 }
               ]
             }

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-get-mandate.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-get-mandate.json
@@ -49,20 +49,6 @@
               "href": "http://localhost:1234/v1/api/accounts/9ddfcc27-acf5-43f9-92d5-52247540714c/mandates/test_mandate_id_xyz",
               "rel": "self",
               "method": "GET"
-            },
-            {
-              "href": "http://frontend_direct_debit/secure/token_1234567asdf",
-              "rel": "next_url",
-              "method": "GET"
-            },
-            {
-              "href": "http://frontend_direct_debit/secure/",
-              "rel": "next_url_post",
-              "type": "application/x-www-form-urlencoded",
-              "params": {
-                "chargeTokenId": "token_1234567asdf"
-              },
-              "method": "POST"
             }
           ]
         },
@@ -129,27 +115,6 @@
               "matchers": [
                 {
                   "regex": "http:\/\/.*\/v1\/api\/accounts\/9ddfcc27-acf5-43f9-92d5-52247540714c\/mandates\/test_mandate_id_xyz"
-                }
-              ]
-            },
-            "$.links[1].href": {
-              "matchers": [
-                {
-                  "regex": "http:\/\/.*\/secure\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-                }
-              ]
-            },
-            "$.links[2].href": {
-              "matchers": [
-                {
-                  "regex": "http:\/\/.*\/secure"
-                }
-              ]
-            },
-            "$.links[2].params.chargeTokenId": {
-              "matchers": [
-                {
-                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
                 }
               ]
             }


### PR DESCRIPTION
next_url and next_url_post shouldn't be returned when GETting a confirmed mandate, as the
state for the pact test is "a gateway account with external id and a confirmed
mandate exists".

The only time when these links should be returned is when the mandate is in
"created" state.

In this PR however I've removed the entire "links" json from the publicapi-direct-debit-connector-get-mandate pact. In an ideal scenario, removing the next_url and next_url_post links would work,
even though direct-debit-connector still the returns the links currently.
However it does not as Postel's Law only seems to be followed for json keys and not
for json values - an array of links in this case.

As a reminder of what
Postel's Law is, from https://docs.pact.io/getting_started/matching/gotchas:

```
Be liberal in what you accept - when verifying a pact in the provider project,
the response body and headers may contain fields that were not defined in the
expectations, on the assumption that any extra field will be ignored by your
consumer. This allows a provider to evolve without breaking existing consumers
```

Therefore the way to get all this working is:
- Temporarily remove the links from the pact (this commit). This will enable
  this version of publicapi to be deployed through to production even though
  dd-connector is still returning the next_url and next_url_post links in
  production.
- Amend dd-connector to not return next_url and next_url_post and deploy that
  through to production.
- Put the links back into publicapi's pact. The only link that will exist is
  the "self" and deploy that to production.