### PR TITLE
PP-5299: Update GET mandate pact

### DIFF
--- a/src/test/java/uk/gov/pay/api/service/MandatesServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/MandatesServiceTest.java
@@ -112,16 +112,15 @@ public class MandatesServiceTest {
         assertThat(mandateConnectorResponse.getCreatedDate(), is("2016-01-01T12:00:00Z"));
         assertThat(mandateConnectorResponse.getPayer().getEmail(), is("i.died@titanic.com"));
         assertThat(mandateConnectorResponse.getPayer().getName(), is("Jack"));
-        //TODO uncomment below when 
-//        assertThat(mandateConnectorResponse.getLinks().size(), is(1));
-//        assertThat(mandateConnectorResponse.getLinks().get(0), is(new PaymentConnectorResponseLink(
-//                "self",
-//                "http://localhost:1234/v1/api/accounts/9ddfcc27-acf5-43f9-92d5-52247540714c/mandates/" + MANDATE_ID,
-//                "GET",
-//                null,
-//                null
-//        )));
-//        assertThat(mandateConnectorResponse.getLinks().stream().noneMatch(p -> p.getRel().equals("next_url")), is(true));
-//        assertThat(mandateConnectorResponse.getLinks().stream().noneMatch(p -> p.getRel().equals("next_url_post")), is(true));
+        assertThat(mandateConnectorResponse.getLinks().size(), is(1));
+        assertThat(mandateConnectorResponse.getLinks().get(0), is(new PaymentConnectorResponseLink(
+                "self",
+                "http://localhost:1234/v1/api/accounts/9ddfcc27-acf5-43f9-92d5-52247540714c/mandates/" + MANDATE_ID,
+                "GET",
+                null,
+                null
+        )));
+        assertThat(mandateConnectorResponse.getLinks().stream().noneMatch(p -> p.getRel().equals("next_url")), is(true));
+        assertThat(mandateConnectorResponse.getLinks().stream().noneMatch(p -> p.getRel().equals("next_url_post")), is(true));
     }
 }

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-get-mandate.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-get-mandate.json
@@ -43,7 +43,14 @@
           "payer": {
             "name": "Jack",
             "email": "i.died@titanic.com"
-          }
+          },
+          "links": [
+            {
+              "href": "http://localhost:1234/v1/api/accounts/9ddfcc27-acf5-43f9-92d5-52247540714c/mandates/test_mandate_id_xyz",
+              "rel": "self",
+              "method": "GET"
+            }
+          ]
         },
         "matchingRules": {
           "body": {
@@ -101,6 +108,13 @@
               "matchers": [
                 {
                   "match": "type"
+                }
+              ]
+            },
+            "$.links[0].href": {
+              "matchers": [
+                {
+                  "regex": "http:\/\/.*\/v1\/api\/accounts\/9ddfcc27-acf5-43f9-92d5-52247540714c\/mandates\/test_mandate_id_xyz"
                 }
               ]
             }


### PR DESCRIPTION
The only link that should be present when GETting a confirmed mandate is the
"self" link.