### PR TITLE
PP-5377 Return 409 On Create Payment With Invalid Mandate State

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/ConnectorResponseErrorException.java
+++ b/src/main/java/uk/gov/pay/api/exception/ConnectorResponseErrorException.java
@@ -80,6 +80,11 @@ public class ConnectorResponseErrorException extends RuntimeException {
         private String reason;
 
         private Object message;
+        
+        // Needed for Jackson deserialization from Responses
+        public ConnectorErrorResponse() {
+            
+        }
 
         public ConnectorErrorResponse(ErrorIdentifier errorIdentifier, String reason, Object message) {
             this.errorIdentifier = errorIdentifier;

--- a/src/main/java/uk/gov/pay/api/exception/ConnectorResponseErrorException.java
+++ b/src/main/java/uk/gov/pay/api/exception/ConnectorResponseErrorException.java
@@ -76,10 +76,16 @@ public class ConnectorResponseErrorException extends RuntimeException {
 
         @JsonProperty("error_identifier")
         private ErrorIdentifier errorIdentifier;
-        
+
         private String reason;
-        
+
         private Object message;
+
+        public ConnectorErrorResponse(ErrorIdentifier errorIdentifier, String reason, Object message) {
+            this.errorIdentifier = errorIdentifier;
+            this.reason = reason;
+            this.message = message;
+        }
 
         public ErrorIdentifier getErrorIdentifier() {
             return errorIdentifier;

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -14,6 +14,7 @@ import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_ACCOUNT_ERROR;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_CONNECTOR_ERROR;
+import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_MANDATE_STATE_INVALID;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_VALIDATION_ERROR;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 
@@ -33,11 +34,15 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
             statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
             paymentError = aPaymentError("amount", CREATE_PAYMENT_VALIDATION_ERROR,
                     "Must be greater than or equal to 1");
+        } else if (exception.getErrorIdentifier() == ErrorIdentifier.MANDATE_STATE_INVALID) {
+            statusCode = HttpStatus.CONFLICT_409;
+            paymentError = aPaymentError(CREATE_PAYMENT_MANDATE_STATE_INVALID);
         } else {
             paymentError = aPaymentError(CREATE_PAYMENT_CONNECTOR_ERROR);
         }
 
-        LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}", exception.getMessage(), INTERNAL_SERVER_ERROR, paymentError);
+        LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}", 
+                exception.getMessage(), INTERNAL_SERVER_ERROR, paymentError);
 
         return Response
                 .status(statusCode)

--- a/src/main/java/uk/gov/pay/api/model/PaymentError.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentError.java
@@ -49,6 +49,8 @@ public class PaymentError {
         CREATE_PAYMENT_REFUND_VALIDATION_ERROR("P0602", "Invalid attribute value: %s. %s"),
         CREATE_PAYMENT_REFUND_NOT_AVAILABLE("P0603", "The payment is not available for refund. Payment refund status: %s"),
         CREATE_PAYMENT_REFUND_AMOUNT_AVAILABLE_MISMATCH("P0604", "Refund amount available mismatch."),
+        CREATE_PAYMENT_MANDATE_STATE_INVALID("P1103",
+                "Can't create payment. The mandate's state must be pending, submitted or active."),
 
         GET_PAYMENT_REFUND_NOT_FOUND_ERROR("P0700", "Not found"),
         GET_PAYMENT_REFUND_CONNECTOR_ERROR("P0798", "Downstream system error"),

--- a/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
@@ -35,7 +35,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
-import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/v1/directdebit/payments/")

--- a/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
+++ b/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
@@ -2,6 +2,9 @@ package uk.gov.pay.api.exception.mapper;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.api.exception.ConnectorResponseErrorException.ConnectorErrorResponse;
 import uk.gov.pay.api.exception.CreateChargeException;
 import uk.gov.pay.api.model.PaymentError;
@@ -16,7 +19,12 @@ import static org.mockito.Mockito.when;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_MANDATE_STATE_INVALID;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 
+@RunWith(MockitoJUnitRunner.class)
 public class CreateChargeExceptionMapperTest {
+
+
+    @Mock
+    private Response mockResponse = mock(Response.class);
 
     private CreateChargeExceptionMapper mapper;
     
@@ -27,17 +35,18 @@ public class CreateChargeExceptionMapperTest {
     
     @Test
     public void shouldThrow409_whenMandateStateInvalid(){
-        Response response = mock(Response.class);
-        when(response.readEntity(ConnectorErrorResponse.class))
+        when(mockResponse.readEntity(ConnectorErrorResponse.class))
                 .thenReturn(new ConnectorErrorResponse(
                         ErrorIdentifier.MANDATE_STATE_INVALID, null, null));
         
-        Response returnedResponse = mapper.toResponse(new CreateChargeException(response));
+        Response returnedResponse = mapper.toResponse(new CreateChargeException(mockResponse));
         PaymentError returnedError = (PaymentError) returnedResponse.getEntity();
+        PaymentError expectedError = aPaymentError(CREATE_PAYMENT_MANDATE_STATE_INVALID);
+        
         assertThat(returnedResponse.getStatus(), is(409));
         assertThat(returnedError.getDescription(), 
-                is(aPaymentError(CREATE_PAYMENT_MANDATE_STATE_INVALID).getDescription()));
-        assertThat(returnedError.getCode(), is(aPaymentError(CREATE_PAYMENT_MANDATE_STATE_INVALID).getCode()));
+                is(expectedError.getDescription()));
+        assertThat(returnedError.getCode(), is(expectedError.getCode()));
         
     }
     

--- a/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
+++ b/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.api.exception.mapper;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.api.exception.ConnectorResponseErrorException.ConnectorErrorResponse;
+import uk.gov.pay.api.exception.CreateChargeException;
+import uk.gov.pay.api.model.PaymentError;
+import uk.gov.pay.commons.model.ErrorIdentifier;
+
+import javax.ws.rs.core.Response;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_MANDATE_STATE_INVALID;
+import static uk.gov.pay.api.model.PaymentError.aPaymentError;
+
+public class CreateChargeExceptionMapperTest {
+
+    private CreateChargeExceptionMapper mapper;
+    
+    @Before
+    public void setUp() {
+        mapper = new CreateChargeExceptionMapper();
+    }
+    
+    @Test
+    public void shouldThrow409_whenMandateStateInvalid(){
+        Response response = mock(Response.class);
+        when(response.readEntity(ConnectorErrorResponse.class))
+                .thenReturn(new ConnectorErrorResponse(
+                        ErrorIdentifier.MANDATE_STATE_INVALID, null, null));
+        
+        Response returnedResponse = mapper.toResponse(new CreateChargeException(response));
+        PaymentError returnedError = (PaymentError) returnedResponse.getEntity();
+        assertThat(returnedResponse.getStatus(), is(409));
+        assertThat(returnedError.getDescription(), 
+                is(aPaymentError(CREATE_PAYMENT_MANDATE_STATE_INVALID).getDescription()));
+        assertThat(returnedError.getCode(), is(aPaymentError(CREATE_PAYMENT_MANDATE_STATE_INVALID).getCode()));
+        
+    }
+    
+}


### PR DESCRIPTION
- When a user tries to create a payment on a mandate which has an invalid
  state, they should receive a 409 error with a related error code.