### PR TITLE
Pp 5302 direct debit search mandates add service

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandateResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandateResponse.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.api.model.search.directdebit;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.api.model.directdebit.mandates.MandateConnectorResponse;
+import uk.gov.pay.api.model.links.SearchNavigationLinks;
+
+import java.util.List;
+
+public class DirectDebitSearchMandateResponse {
+    @JsonProperty("total")
+    private int total;
+    @JsonProperty("count")
+    private int count;
+    @JsonProperty("page")
+    private int page;
+    @JsonProperty("results")
+    private List<MandateConnectorResponse> mandates;
+    @JsonProperty("_links")
+    private SearchNavigationLinks links = new SearchNavigationLinks();
+
+    DirectDebitSearchMandateResponse() {
+        
+    }
+}

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
@@ -1,0 +1,175 @@
+package uk.gov.pay.api.model.search.directdebit;
+
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.QueryParam;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class DirectDebitSearchMandatesParams {
+
+    @QueryParam("reference")
+    private String reference;
+
+    @QueryParam("state")
+    private String state;
+
+    @QueryParam("bank_statement_reference")
+    private String bankStatementReference;
+
+    @QueryParam("email")
+    private String email;
+
+    @QueryParam("name")
+    private String name;
+
+    @QueryParam("from_date")
+    private ZonedDateTime fromDate;
+
+    @QueryParam("to_date")
+    private ZonedDateTime toDate;
+
+    @DefaultValue("1")
+    @QueryParam("page")
+    private int page;
+
+    @DefaultValue("500")
+    @QueryParam("display_size")
+    private int displaySize;
+
+    private DirectDebitSearchMandatesParams(DirectDebitSearchMandatesParamsBuilder builder) {
+        this.reference = builder.reference;
+        this.state = builder.state;
+        this.bankStatementReference = builder.bankStatementReference;
+        this.email = builder.email;
+        this.name = builder.name;
+        this.fromDate = builder.fromDate;
+        this.toDate = builder.toDate;
+        this.page = builder.page;
+        this.displaySize = builder.displaySize;
+    }
+
+    public Optional<String> getReference() {
+        return Optional.ofNullable(reference);
+    }
+
+    public Optional<String> getState() {
+        return Optional.ofNullable(state);
+    }
+
+    public Optional<String> getBankStatementReference() {
+        return Optional.ofNullable(bankStatementReference);
+    }
+
+    public Optional<String> getEmail() {
+        return Optional.ofNullable(email);
+    }
+
+    public Optional<String> getName() {
+        return Optional.ofNullable(name);
+    }
+
+    public Optional<ZonedDateTime> getFromDate() {
+        return Optional.ofNullable(fromDate);
+    }
+
+    public Optional<ZonedDateTime> getToDate() {
+        return Optional.ofNullable(toDate);
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public int getDisplaySize() {
+        return displaySize;
+    }
+
+    public Map<String, String> paramsAsMap() {
+        Map<String, String> returnableMap = new HashMap<>();
+
+        returnableMap.put("display_size", String.valueOf(this.getDisplaySize()));
+        returnableMap.put("page", String.valueOf(this.getPage()));
+
+        this.getBankStatementReference().ifPresent(bankStatementReference ->
+                returnableMap.put("bank_statement_reference", bankStatementReference));
+        this.getEmail().ifPresent(email -> returnableMap.put("email", email));
+        this.getName().ifPresent(name -> returnableMap.put("name", name));
+        this.getFromDate().ifPresent(fromDate -> returnableMap.put("from_date", String.valueOf(fromDate)));
+        this.getToDate().ifPresent(toDate -> returnableMap.put("to_date", String.valueOf(toDate)));
+        this.getReference().ifPresent(reference -> returnableMap.put("reference", reference));
+        this.getState().ifPresent(state -> returnableMap.put("state", state));
+
+        return Collections.unmodifiableMap(returnableMap);
+    }
+
+    public static final class DirectDebitSearchMandatesParamsBuilder {
+        private String reference;
+        private String state;
+        private String bankStatementReference;
+        private String email;
+        private String name;
+        private ZonedDateTime fromDate;
+        private ZonedDateTime toDate;
+        private int page;
+        private int displaySize;
+
+        private DirectDebitSearchMandatesParamsBuilder() {
+        }
+
+        public static DirectDebitSearchMandatesParamsBuilder aDirectDebitSearchMandatesParams() {
+            return new DirectDebitSearchMandatesParamsBuilder();
+        }
+
+        public DirectDebitSearchMandatesParamsBuilder withReference(String reference) {
+            this.reference = reference;
+            return this;
+        }
+
+        public DirectDebitSearchMandatesParamsBuilder withState(String state) {
+            this.state = state;
+            return this;
+        }
+
+        public DirectDebitSearchMandatesParamsBuilder withBankStatementReference(String bankStatementReference) {
+            this.bankStatementReference = bankStatementReference;
+            return this;
+        }
+
+        public DirectDebitSearchMandatesParamsBuilder withEmail(String email) {
+            this.email = email;
+            return this;
+        }
+
+        public DirectDebitSearchMandatesParamsBuilder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public DirectDebitSearchMandatesParamsBuilder withFromDate(ZonedDateTime fromDate) {
+            this.fromDate = fromDate;
+            return this;
+        }
+
+        public DirectDebitSearchMandatesParamsBuilder withToDate(ZonedDateTime toDate) {
+            this.toDate = toDate;
+            return this;
+        }
+
+        public DirectDebitSearchMandatesParamsBuilder withPage(int page) {
+            this.page = page;
+            return this;
+        }
+
+        public DirectDebitSearchMandatesParamsBuilder withDisplaySize(int displaySize) {
+            this.displaySize = displaySize;
+            return this;
+        }
+
+        public DirectDebitSearchMandatesParams build() {
+            return new DirectDebitSearchMandatesParams(this);
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
@@ -88,21 +88,21 @@ public class DirectDebitSearchMandatesParams {
     }
 
     public Map<String, String> paramsAsMap() {
-        Map<String, String> returnableMap = new HashMap<>();
+        var params = new HashMap<String, String>();
 
-        returnableMap.put("display_size", String.valueOf(this.getDisplaySize()));
-        returnableMap.put("page", String.valueOf(this.getPage()));
+        params.put("display_size", String.valueOf(this.getDisplaySize()));
+        params.put("page", String.valueOf(this.getPage()));
 
         this.getBankStatementReference().ifPresent(bankStatementReference ->
-                returnableMap.put("bank_statement_reference", bankStatementReference));
-        this.getEmail().ifPresent(email -> returnableMap.put("email", email));
-        this.getName().ifPresent(name -> returnableMap.put("name", name));
-        this.getFromDate().ifPresent(fromDate -> returnableMap.put("from_date", String.valueOf(fromDate)));
-        this.getToDate().ifPresent(toDate -> returnableMap.put("to_date", String.valueOf(toDate)));
-        this.getReference().ifPresent(reference -> returnableMap.put("reference", reference));
-        this.getState().ifPresent(state -> returnableMap.put("state", state));
+                params.put("bank_statement_reference", bankStatementReference));
+        this.getEmail().ifPresent(email -> params.put("email", email));
+        this.getName().ifPresent(name -> params.put("name", name));
+        this.getFromDate().ifPresent(fromDate -> params.put("from_date", String.valueOf(fromDate)));
+        this.getToDate().ifPresent(toDate -> params.put("to_date", String.valueOf(toDate)));
+        this.getReference().ifPresent(reference -> params.put("reference", reference));
+        this.getState().ifPresent(state -> params.put("state", state));
 
-        return Collections.unmodifiableMap(returnableMap);
+        return Collections.unmodifiableMap(params);
     }
 
     public static final class DirectDebitSearchMandatesParamsBuilder {
@@ -113,8 +113,8 @@ public class DirectDebitSearchMandatesParams {
         private String name;
         private ZonedDateTime fromDate;
         private ZonedDateTime toDate;
-        private int page;
-        private int displaySize;
+        private int page = 1;
+        private int displaySize = 500;
 
         private DirectDebitSearchMandatesParamsBuilder() {
         }

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchMandateConnectorResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchMandateConnectorResponse.java
@@ -6,7 +6,7 @@ import uk.gov.pay.api.model.links.SearchNavigationLinks;
 
 import java.util.List;
 
-public class DirectDebitSearchMandateResponse {
+public class SearchMandateConnectorResponse {
     @JsonProperty("total")
     private int total;
     @JsonProperty("count")
@@ -18,7 +18,11 @@ public class DirectDebitSearchMandateResponse {
     @JsonProperty("_links")
     private SearchNavigationLinks links = new SearchNavigationLinks();
 
-    DirectDebitSearchMandateResponse() {
-        
+    public int getCount() {
+        return count;
+    }
+
+    public List<MandateConnectorResponse> getMandates() {
+        return mandates;
     }
 }

--- a/src/main/java/uk/gov/pay/api/service/directdebit/DirectDebitConnectorUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/directdebit/DirectDebitConnectorUriGenerator.java
@@ -26,6 +26,10 @@ public class DirectDebitConnectorUriGenerator {
     public String chargesURIWithParams(Account account, Map<String, String> queryParams) {
         return buildConnectorUri(account, format("/v1/api/accounts/%s/charges", account.getAccountId()), queryParams);
     }
+    
+    public String mandatesURIWithParams(Account account, Map<String, String> queryParams) {
+        return buildConnectorUri(account, format("/v1/api/accounts/%s/mandates", account.getAccountId()), queryParams);
+    }
 
     public String directDebitPaymentsURI(Account account, Map<String, String> queryParams) {
         String path = String.format("/v1/api/accounts/%s/payments", account.getAccountId());

--- a/src/main/java/uk/gov/pay/api/service/directdebit/DirectDebitConnectorUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/directdebit/DirectDebitConnectorUriGenerator.java
@@ -23,12 +23,12 @@ public class DirectDebitConnectorUriGenerator {
         return buildConnectorUri(account, format(chargePath, account.getAccountId()));
     }
 
-    public String chargesURIWithParams(Account account, Map<String, String> queryParams) {
-        return buildConnectorUri(account, format("/v1/api/accounts/%s/charges", account.getAccountId()), queryParams);
+    public String singleMandateURI(Account account, String externalMandateId) {
+        return mandatesURI(account) + "/" + externalMandateId;
     }
     
-    public String mandatesURIWithParams(Account account, Map<String, String> queryParams) {
-        return buildConnectorUri(account, format("/v1/api/accounts/%s/mandates", account.getAccountId()), queryParams);
+    public String mandatesURI(Account account) {
+        return buildConnectorUri(account, format("/v1/api/accounts/%s/mandates", account.getAccountId()));
     }
 
     public String directDebitPaymentsURI(Account account, Map<String, String> queryParams) {

--- a/src/main/java/uk/gov/pay/api/service/directdebit/DirectDebitMandateSearchService.java
+++ b/src/main/java/uk/gov/pay/api/service/directdebit/DirectDebitMandateSearchService.java
@@ -1,0 +1,56 @@
+package uk.gov.pay.api.service.directdebit;
+
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.model.search.directdebit.DirectDebitSearchMandateResponse;
+import uk.gov.pay.api.model.search.directdebit.DirectDebitSearchMandatesParams;
+
+import javax.inject.Inject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import java.util.HashMap;
+import java.util.Map;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+public class DirectDebitMandateSearchService {
+
+    private final Client client;
+    private final DirectDebitConnectorUriGenerator uriGenerator;
+    
+    
+    @Inject
+    public DirectDebitMandateSearchService(Client client, DirectDebitConnectorUriGenerator uriGenerator) {
+        this.client = client;
+        this.uriGenerator = uriGenerator;
+    }
+    
+    public DirectDebitSearchMandateResponse searchMandates(Account account, DirectDebitSearchMandatesParams params) {
+        Map<String, String> mappedParams = parseParamsFromParamsObject(params);
+        WebTarget searchRequestBuilder = client
+                .target(uriGenerator.mandatesURIWithParams(account, parseParamsFromParamsObject(params)));
+        addQueryParamsToRequestFromMap(searchRequestBuilder, mappedParams);
+        return searchRequestBuilder.request()
+                .accept(APPLICATION_JSON)
+                .get()
+                .readEntity(DirectDebitSearchMandateResponse.class);
+    }
+    
+    private void addQueryParamsToRequestFromMap(WebTarget targetObject, Map<String, String> map) {
+        map.forEach(targetObject::queryParam);
+    }
+    
+    private Map<String, String> parseParamsFromParamsObject(DirectDebitSearchMandatesParams params) {
+        Map<String, String> returnableMap = new HashMap<>();
+        params.getBankStatementReference().ifPresent(x -> returnableMap.put("bank_statement_reference", x));
+        params.getEmail().ifPresent(x -> returnableMap.put("email", x));
+        params.getName().ifPresent(x -> returnableMap.put("name", x));
+        params.getFromDate().ifPresent(x -> returnableMap.put("from_date", String.valueOf(x)));
+        params.getToDate().ifPresent(x -> returnableMap.put("to_date", String.valueOf(x)));
+        params.getReference().ifPresent(x -> returnableMap.put("reference", x));
+        params.getState().ifPresent(x -> returnableMap.put("state", x.getStatus()));
+        returnableMap.put("display_size", String.valueOf(params.getDisplaySize()));
+        returnableMap.put("page", String.valueOf(params.getPage()));
+        return returnableMap;
+    }
+    
+}

--- a/src/main/java/uk/gov/pay/api/service/directdebit/DirectDebitMandateSearchService.java
+++ b/src/main/java/uk/gov/pay/api/service/directdebit/DirectDebitMandateSearchService.java
@@ -1,13 +1,12 @@
 package uk.gov.pay.api.service.directdebit;
 
 import uk.gov.pay.api.auth.Account;
-import uk.gov.pay.api.model.search.directdebit.DirectDebitSearchMandateResponse;
 import uk.gov.pay.api.model.search.directdebit.DirectDebitSearchMandatesParams;
+import uk.gov.pay.api.model.search.directdebit.SearchMandateConnectorResponse;
 
 import javax.inject.Inject;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
-import java.util.HashMap;
 import java.util.Map;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -15,42 +14,31 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 public class DirectDebitMandateSearchService {
 
     private final Client client;
-    private final DirectDebitConnectorUriGenerator uriGenerator;
+    private final DirectDebitConnectorUriGenerator directDebitConnectorUriGenerator;
     
     
     @Inject
-    public DirectDebitMandateSearchService(Client client, DirectDebitConnectorUriGenerator uriGenerator) {
+    public DirectDebitMandateSearchService(Client client, DirectDebitConnectorUriGenerator directDebitConnectorUriGenerator) {
         this.client = client;
-        this.uriGenerator = uriGenerator;
+        this.directDebitConnectorUriGenerator = directDebitConnectorUriGenerator;
     }
     
-    public DirectDebitSearchMandateResponse searchMandates(Account account, DirectDebitSearchMandatesParams params) {
-        Map<String, String> mappedParams = parseParamsFromParamsObject(params);
-        WebTarget searchRequestBuilder = client
-                .target(uriGenerator.mandatesURIWithParams(account, parseParamsFromParamsObject(params)));
-        addQueryParamsToRequestFromMap(searchRequestBuilder, mappedParams);
-        return searchRequestBuilder.request()
+    SearchMandateConnectorResponse getMandatesFromDDConnector(Account account, DirectDebitSearchMandatesParams params) {
+        WebTarget webTargetWithoutQuery = client.target(directDebitConnectorUriGenerator.mandatesURI(account));
+        WebTarget webTargetWithQuery = addQueryParams(params.paramsAsMap(), webTargetWithoutQuery);
+
+        return webTargetWithQuery
+                .request()
                 .accept(APPLICATION_JSON)
                 .get()
-                .readEntity(DirectDebitSearchMandateResponse.class);
+                .readEntity(SearchMandateConnectorResponse.class);
     }
-    
-    private void addQueryParamsToRequestFromMap(WebTarget targetObject, Map<String, String> map) {
-        map.forEach(targetObject::queryParam);
+
+    private WebTarget addQueryParams(Map<String, String> params, WebTarget originalWebTarget) {
+        WebTarget webTargetWithQueryParams = originalWebTarget;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            webTargetWithQueryParams = webTargetWithQueryParams.queryParam(entry.getKey(), entry.getValue());
+        }
+        return webTargetWithQueryParams;
     }
-    
-    private Map<String, String> parseParamsFromParamsObject(DirectDebitSearchMandatesParams params) {
-        Map<String, String> returnableMap = new HashMap<>();
-        params.getBankStatementReference().ifPresent(x -> returnableMap.put("bank_statement_reference", x));
-        params.getEmail().ifPresent(x -> returnableMap.put("email", x));
-        params.getName().ifPresent(x -> returnableMap.put("name", x));
-        params.getFromDate().ifPresent(x -> returnableMap.put("from_date", String.valueOf(x)));
-        params.getToDate().ifPresent(x -> returnableMap.put("to_date", String.valueOf(x)));
-        params.getReference().ifPresent(x -> returnableMap.put("reference", x));
-        params.getState().ifPresent(x -> returnableMap.put("state", x.getStatus()));
-        returnableMap.put("display_size", String.valueOf(params.getDisplaySize()));
-        returnableMap.put("page", String.valueOf(params.getPage()));
-        return returnableMap;
-    }
-    
 }

--- a/src/test/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParamsTest.java
+++ b/src/test/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParamsTest.java
@@ -6,16 +6,17 @@ import org.junit.Test;
 import java.time.ZonedDateTime;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static uk.gov.pay.api.model.search.directdebit.DirectDebitSearchMandatesParams.DirectDebitSearchMandatesParamsBuilder.aDirectDebitSearchMandatesParams;
 
 public class DirectDebitSearchMandatesParamsTest {
 
     @Test
-    public void paramsAsMap() {
-        
+    public void shouldCreateMapWithAllValues() {
+
         final var yesterday = ZonedDateTime.now().minusDays(1);
         final var tomorrow = ZonedDateTime.now().plusDays(1);
-        
+
         var params = aDirectDebitSearchMandatesParams()
                 .withBankStatementReference("a bank statement reference")
                 .withDisplaySize(10)
@@ -27,18 +28,18 @@ public class DirectDebitSearchMandatesParamsTest {
                 .withReference("a reference")
                 .withState("pending")
                 .build();
-        
+
         var paramsAsMap = params.paramsAsMap();
-        
-        assertThat(paramsAsMap, IsMapContaining.hasEntry("bank_statement_reference", "a bank statement reference"));
-        assertThat(paramsAsMap, IsMapContaining.hasEntry("display_size", String.valueOf(10)));
-        assertThat(paramsAsMap, IsMapContaining.hasEntry("email", "test@test.test"));
-        assertThat(paramsAsMap, IsMapContaining.hasEntry("from_date", yesterday.toString()));
-        assertThat(paramsAsMap, IsMapContaining.hasEntry("to_date", tomorrow.toString()));
-        assertThat(paramsAsMap, IsMapContaining.hasEntry("name", "test"));
-        assertThat(paramsAsMap, IsMapContaining.hasEntry("page", String.valueOf(1)));
-        assertThat(paramsAsMap, IsMapContaining.hasEntry("reference", "a reference"));
-        assertThat(paramsAsMap, IsMapContaining.hasEntry("state", "pending"));
-        assertThat(paramsAsMap, IsMapContaining.hasEntry("reference", "a reference"));
+
+        assertThat(paramsAsMap, hasEntry("bank_statement_reference", "a bank statement reference"));
+        assertThat(paramsAsMap, hasEntry("display_size", String.valueOf(10)));
+        assertThat(paramsAsMap, hasEntry("email", "test@test.test"));
+        assertThat(paramsAsMap, hasEntry("from_date", yesterday.toString()));
+        assertThat(paramsAsMap, hasEntry("to_date", tomorrow.toString()));
+        assertThat(paramsAsMap, hasEntry("name", "test"));
+        assertThat(paramsAsMap, hasEntry("page", String.valueOf(1)));
+        assertThat(paramsAsMap, hasEntry("reference", "a reference"));
+        assertThat(paramsAsMap, hasEntry("state", "pending"));
+        assertThat(paramsAsMap, hasEntry("reference", "a reference"));
     }
 }

--- a/src/test/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParamsTest.java
+++ b/src/test/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParamsTest.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.api.model.search.directdebit;
+
+import org.hamcrest.collection.IsMapContaining;
+import org.junit.Test;
+
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.api.model.search.directdebit.DirectDebitSearchMandatesParams.DirectDebitSearchMandatesParamsBuilder.aDirectDebitSearchMandatesParams;
+
+public class DirectDebitSearchMandatesParamsTest {
+
+    @Test
+    public void paramsAsMap() {
+        
+        final var yesterday = ZonedDateTime.now().minusDays(1);
+        final var tomorrow = ZonedDateTime.now().plusDays(1);
+        
+        var params = aDirectDebitSearchMandatesParams()
+                .withBankStatementReference("a bank statement reference")
+                .withDisplaySize(10)
+                .withEmail("test@test.test")
+                .withFromDate(yesterday)
+                .withToDate(tomorrow)
+                .withName("test")
+                .withPage(1)
+                .withReference("a reference")
+                .withState("pending")
+                .build();
+        
+        var paramsAsMap = params.paramsAsMap();
+        
+        assertThat(paramsAsMap, IsMapContaining.hasEntry("bank_statement_reference", "a bank statement reference"));
+        assertThat(paramsAsMap, IsMapContaining.hasEntry("display_size", String.valueOf(10)));
+        assertThat(paramsAsMap, IsMapContaining.hasEntry("email", "test@test.test"));
+        assertThat(paramsAsMap, IsMapContaining.hasEntry("from_date", yesterday.toString()));
+        assertThat(paramsAsMap, IsMapContaining.hasEntry("to_date", tomorrow.toString()));
+        assertThat(paramsAsMap, IsMapContaining.hasEntry("name", "test"));
+        assertThat(paramsAsMap, IsMapContaining.hasEntry("page", String.valueOf(1)));
+        assertThat(paramsAsMap, IsMapContaining.hasEntry("reference", "a reference"));
+        assertThat(paramsAsMap, IsMapContaining.hasEntry("state", "pending"));
+        assertThat(paramsAsMap, IsMapContaining.hasEntry("reference", "a reference"));
+    }
+}

--- a/src/test/java/uk/gov/pay/api/service/MandatesServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/MandatesServiceTest.java
@@ -16,6 +16,7 @@ import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.directdebit.mandates.MandateConnectorRequest;
 import uk.gov.pay.api.model.directdebit.mandates.MandateConnectorResponse;
 import uk.gov.pay.api.model.directdebit.mandates.MandateState;
+import uk.gov.pay.api.service.directdebit.DirectDebitConnectorUriGenerator;
 import uk.gov.pay.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.pay.commons.testing.pact.consumers.Pacts;
 
@@ -41,6 +42,7 @@ public class MandatesServiceTest {
 
     @Mock
     private PublicApiConfig mockConfiguration;
+    
     @Mock
     private PublicApiUriGenerator mockPublicApiUriGenerator;
 
@@ -49,7 +51,7 @@ public class MandatesServiceTest {
         // We will actually send real requests here, which will be intercepted by pact
         when(mockConfiguration.getConnectorDDUrl()).thenReturn(ddConnectorRule.getUrl());
         Client client = RestClientFactory.buildClient(new RestClientConfig(false));
-        mandatesService = new MandatesService(client, mockConfiguration, mockPublicApiUriGenerator);
+        mandatesService = new MandatesService(client, mockPublicApiUriGenerator, new DirectDebitConnectorUriGenerator(mockConfiguration));
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/api/service/directdebit/DirectDebitMandateSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/directdebit/DirectDebitMandateSearchServiceTest.java
@@ -1,0 +1,47 @@
+package uk.gov.pay.api.service.directdebit;
+
+import au.com.dius.pact.consumer.PactVerification;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.api.app.RestClientFactory;
+import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.app.config.RestClientConfig;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.commons.testing.pact.consumers.PactProviderRule;
+
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.api.model.search.directdebit.DirectDebitSearchMandatesParams.DirectDebitSearchMandatesParamsBuilder.aDirectDebitSearchMandatesParams;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DirectDebitMandateSearchServiceTest {
+
+    @Rule
+    public PactProviderRule connectorRule = new PactProviderRule("direct-debit-connector", this);
+
+    @Mock
+    private PublicApiConfig configuration;
+    
+    DirectDebitMandateSearchService searchService;
+    
+    @Before
+    void setUp() {
+        when(configuration.getConnectorDDUrl()).thenReturn(connectorRule.getUrl());
+        when(configuration.getBaseUrl()).thenReturn("http://publicapi.test.localhost/");
+        searchService = new DirectDebitMandateSearchService(
+                RestClientFactory.buildClient(new RestClientConfig(false)),
+                new DirectDebitConnectorUriGenerator(configuration));
+    }
+    
+    @Test
+    @PactVerification({"direct-debit-connector"})
+    public void searchMandates() {
+        Account account = new Account("TESTACCOUNTID", TokenPaymentType.DIRECT_DEBIT);
+        var params = aDirectDebitSearchMandatesParams().build();
+        searchService.searchMandates(account,params);
+    }
+}

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-search-mandates.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-search-mandates.json
@@ -1,0 +1,187 @@
+{
+  "provider": {
+    "name": "direct-debit-connector"
+  },
+  "consumer": {
+    "name": "publicapi"
+  },
+  "interactions": [
+    {
+      "description": "search for mandates",
+      "providerStates": [
+        {
+          "name": "a gateway account with external id and a confirmed mandate exists",
+          "params": {
+            "gateway_account_id": "9ddfcc27-acf5-43f9-92d5-52247540714c",
+            "mandate_id": "test_mandate_id_xyz",
+            "bank_mandate_reference": "410104",
+            "unique_identifier": "MD1234"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/api/accounts/9ddfcc27-acf5-43f9-92d5-52247540714c/mandates",
+        "query": "page=1&display_size=500&bank_statement_reference=410104"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "total" : 1,
+          "count" : 1,
+          "page": 1,
+          "_links": {
+            "self": {
+              "href": "http://localhost:1234/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/mandate?page=1&display_size=500&bank_statement_reference=expectedBankStatementReference"
+            },
+            "last_page": {
+              "href": "http://localhost:1234/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/mandate?page=1&display_size=500&bank_statement_reference=expectedBankStatementReference"
+            },
+            "first_page": {
+              "href": "http://localhost:1234/v1/api/accounts/2po9ycynwq8yxdgg2qwq9e9qpyrtre/mandate?page=1&display_size=500&bank_statement_reference=expectedBankStatementReference"
+            }
+          },
+          "results": [
+            {
+              "mandate_id": "test_mandate_id_xyz",
+              "mandate_reference": "410104",
+              "provider_id": "MD1234",
+              "service_reference": "test_service_reference",
+              "return_url": "https://example.com/return",
+              "created_date": "2016-01-01T12:00:00Z",
+              "state": {
+                "status": "created",
+                "finished": false
+              },
+              "payer": {
+                "name": "payer",
+                "email": "payer@example.com"
+              },
+              "links": [
+                {
+                  "href": "http://localhost:1234/v1/api/accounts/9ddfcc27-acf5-43f9-92d5-52247540714c/mandates/test_mandate_id_xyz",
+                  "rel": "self",
+                  "method": "GET"
+                }
+              ]
+            }
+          ]
+
+        },
+        "matchingRules": {
+          "body": {
+            "$.results[*].links[0].href": {
+              "matchers": [
+                {
+                  "regex": "http:\/\/.*\/v1\/api\/accounts\/9ddfcc27-acf5-43f9-92d5-52247540714c\/mandates\/test_mandate_id_xyz"
+                }
+              ]
+            },
+            "$._links.self.href": {
+              "matchers": [
+                {
+                  "regex": "http:\/\/.*\/v1\/api\/accounts\/9ddfcc27-acf5-43f9-92d5-52247540714c\/mandates\/?.*"
+                }
+              ]
+            },
+            "$._links.last_page.href": {
+              "matchers": [
+                {
+                  "regex": "http:\/\/.*\/v1\/api\/accounts\/9ddfcc27-acf5-43f9-92d5-52247540714c\/mandates\/?.*"
+                }
+              ]
+            },
+            "$._links.first_page.href": {
+              "matchers": [
+                {
+                  "regex": "http:\/\/.*\/v1\/api\/accounts\/9ddfcc27-acf5-43f9-92d5-52247540714c\/mandates\/?.*"
+                }
+              ]
+            },
+            "$.results[*].mandate_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].provider_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].service_reference": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].return_url": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].payment_provider": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].bank_statement_reference": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].created_date": {
+              "matchers": [
+                {
+                  "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+                }
+              ]
+            },
+            "$.results[*].payer.name": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].payer.email": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].state.status": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
This is a stepping stone to adding mandate search functionality to PublicAPi. I'm breaking it down to help review process but the final implementation will likely see `DirectDebitMandateSearchService.getMandatesFromDDConnector` become private under a public method that will return a client side api response. It looks big but it includes a new pact file (I've validated it locally against current master DDConnector) and a few POJOs to support the creation of query params and the mandate search response from DDConnector.

Any necessary API validation to `DirectDebitSearchMandatesParams` will be added when the end-point is added to the Resource.

with @RoryMalcolm 