### PR TITLE
PP 5429 add endpoint for mandate search

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/SearchMandatesException.java
+++ b/src/main/java/uk/gov/pay/api/exception/SearchMandatesException.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.api.exception;
+
+import javax.ws.rs.core.Response;
+
+public class SearchMandatesException extends ConnectorResponseErrorException {
+
+    public SearchMandatesException(Response response) {
+        super(response);
+    }
+
+    public SearchMandatesException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateConnectorResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateConnectorResponse.java
@@ -17,7 +17,7 @@ public class MandateConnectorResponse {
     private String createdDate;
     private String paymentProvider;
     private MandateState state;
-    private List<PaymentConnectorResponseLink> links = new ArrayList<>();
+    private List<PaymentConnectorResponseLink> links;
     private String description;
     private String providerId;
     private Payer payer;
@@ -73,5 +73,98 @@ public class MandateConnectorResponse {
     @JsonProperty("provider_id")
     public String getProviderId() {
         return providerId;
+    }
+
+
+    public static final class MandateConnectorResponseBuilder {
+        private String mandateId;
+        private String mandateReference;
+        private String serviceReference;
+        private String returnUrl;
+        private String createdDate;
+        private String paymentProvider;
+        private MandateState state;
+        private List<PaymentConnectorResponseLink> links;
+        private String description;
+        private String providerId;
+        private Payer payer;
+
+        private MandateConnectorResponseBuilder() {
+        }
+
+        public static MandateConnectorResponseBuilder aMandateConnectorResponse() {
+            return new MandateConnectorResponseBuilder();
+        }
+
+        public MandateConnectorResponseBuilder withMandateId(String mandateId) {
+            this.mandateId = mandateId;
+            return this;
+        }
+
+        public MandateConnectorResponseBuilder withMandateReference(String mandateReference) {
+            this.mandateReference = mandateReference;
+            return this;
+        }
+
+        public MandateConnectorResponseBuilder withServiceReference(String serviceReference) {
+            this.serviceReference = serviceReference;
+            return this;
+        }
+
+        public MandateConnectorResponseBuilder withReturnUrl(String returnUrl) {
+            this.returnUrl = returnUrl;
+            return this;
+        }
+
+        public MandateConnectorResponseBuilder withCreatedDate(String createdDate) {
+            this.createdDate = createdDate;
+            return this;
+        }
+
+        public MandateConnectorResponseBuilder withPaymentProvider(String paymentProvider) {
+            this.paymentProvider = paymentProvider;
+            return this;
+        }
+
+        public MandateConnectorResponseBuilder withState(MandateState state) {
+            this.state = state;
+            return this;
+        }
+
+        public MandateConnectorResponseBuilder withLinks(List<PaymentConnectorResponseLink> links) {
+            this.links = List.copyOf(links);
+            return this;
+        }
+
+        public MandateConnectorResponseBuilder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public MandateConnectorResponseBuilder withProviderId(String providerId) {
+            this.providerId = providerId;
+            return this;
+        }
+
+        public MandateConnectorResponseBuilder withPayer(Payer payer) {
+            this.payer = payer;
+            return this;
+        }
+
+        public MandateConnectorResponse build() {
+            MandateConnectorResponse mandateConnectorResponse = new MandateConnectorResponse();
+            mandateConnectorResponse.returnUrl = this.returnUrl;
+            mandateConnectorResponse.links = this.links;
+            mandateConnectorResponse.providerId = this.providerId;
+            mandateConnectorResponse.mandateReference = this.mandateReference;
+            mandateConnectorResponse.paymentProvider = this.paymentProvider;
+            mandateConnectorResponse.description = this.description;
+            mandateConnectorResponse.state = this.state;
+            mandateConnectorResponse.mandateId = this.mandateId;
+            mandateConnectorResponse.serviceReference = this.serviceReference;
+            mandateConnectorResponse.payer = this.payer;
+            mandateConnectorResponse.createdDate = this.createdDate;
+            return mandateConnectorResponse;
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateResponse.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import uk.gov.pay.api.model.links.directdebit.MandateLinks;
+import uk.gov.pay.api.service.PublicApiUriGenerator;
+
+import static uk.gov.pay.api.model.links.directdebit.MandateLinks.MandateLinksBuilder.aMandateLinks;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class MandateResponse {
@@ -20,7 +23,15 @@ public class MandateResponse {
     private final String paymentProvider;
     private final Payer payer;
 
-    public MandateResponse(MandateConnectorResponse mandate, MandateLinks links) {
+    public MandateResponse(MandateConnectorResponse mandate, PublicApiUriGenerator publicApiUriGenerator) {
+        var mandateLinks = aMandateLinks()
+                .withSelf(publicApiUriGenerator.getMandateURI(mandate.getMandateId()).toString())
+                .withPayments(publicApiUriGenerator.getMandatePaymentsURI(mandate.getMandateId()).toString())
+                .withNextUrl(mandate.getLinks())
+                .withNextUrlPost(mandate.getLinks())
+                .withEvents(publicApiUriGenerator.getMandateEventsURI(mandate.getMandateId()))
+                .build();
+        
         this.mandateId = mandate.getMandateId();
         this.providerId = mandate.getProviderId();
         this.reference = mandate.getServiceReference();
@@ -30,7 +41,7 @@ public class MandateResponse {
         this.createdDate = mandate.getCreatedDate();
         this.description = mandate.getDescription();
         this.paymentProvider = mandate.getPaymentProvider();
-        this.links = links;
+        this.links = mandateLinks;
         this.payer = mandate.getPayer();
     }
 
@@ -95,4 +106,5 @@ public class MandateResponse {
     public String getMandateReference() {
         return mandateReference;
     }
+
 }

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
@@ -39,6 +39,8 @@ public class DirectDebitSearchMandatesParams {
     @QueryParam("display_size")
     private int displaySize;
 
+    public DirectDebitSearchMandatesParams() { };
+
     private DirectDebitSearchMandatesParams(DirectDebitSearchMandatesParamsBuilder builder) {
         this.reference = builder.reference;
         this.state = builder.state;

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchMandateConnectorResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchMandateConnectorResponse.java
@@ -37,4 +37,55 @@ public class SearchMandateConnectorResponse {
     public SearchNavigationLinks getLinks() {
         return links;
     }
+
+
+    public static final class SearchMandateConnectorResponseBuilder {
+        private int total;
+        private int count;
+        private int page;
+        private List<MandateConnectorResponse> mandates;
+        private SearchNavigationLinks links = new SearchNavigationLinks();
+
+        private SearchMandateConnectorResponseBuilder() {
+        }
+
+        public static SearchMandateConnectorResponseBuilder aSearchMandateConnectorResponse() {
+            return new SearchMandateConnectorResponseBuilder();
+        }
+
+        public SearchMandateConnectorResponseBuilder withTotal(int total) {
+            this.total = total;
+            return this;
+        }
+
+        public SearchMandateConnectorResponseBuilder withCount(int count) {
+            this.count = count;
+            return this;
+        }
+
+        public SearchMandateConnectorResponseBuilder withPage(int page) {
+            this.page = page;
+            return this;
+        }
+
+        public SearchMandateConnectorResponseBuilder withMandates(List<MandateConnectorResponse> mandates) {
+            this.mandates = List.copyOf(mandates);
+            return this;
+        }
+
+        public SearchMandateConnectorResponseBuilder withLinks(SearchNavigationLinks links) {
+            this.links = links;
+            return this;
+        }
+
+        public SearchMandateConnectorResponse build() {
+            SearchMandateConnectorResponse searchMandateConnectorResponse = new SearchMandateConnectorResponse();
+            searchMandateConnectorResponse.mandates = this.mandates;
+            searchMandateConnectorResponse.links = this.links;
+            searchMandateConnectorResponse.total = this.total;
+            searchMandateConnectorResponse.page = this.page;
+            searchMandateConnectorResponse.count = this.count;
+            return searchMandateConnectorResponse;
+        }
+    }
 }

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchMandateConnectorResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchMandateConnectorResponse.java
@@ -25,4 +25,16 @@ public class SearchMandateConnectorResponse {
     public List<MandateConnectorResponse> getMandates() {
         return mandates;
     }
+
+    public int getTotal() {
+        return total;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public SearchNavigationLinks getLinks() {
+        return links;
+    }
 }

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchMandateResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchMandateResponse.java
@@ -1,0 +1,92 @@
+package uk.gov.pay.api.model.search.directdebit;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.api.model.directdebit.mandates.MandateResponse;
+import uk.gov.pay.api.model.links.SearchNavigationLinks;
+
+import java.util.List;
+
+public class SearchMandateResponse {
+    @JsonProperty("total")
+    private final int total;
+    @JsonProperty("count")
+    private final int count;
+    @JsonProperty("page")
+    private final int page;
+    @JsonProperty("results")
+    private final List<MandateResponse> mandates;
+    @JsonProperty("_links")
+    private final SearchNavigationLinks links;
+
+    private SearchMandateResponse(SearchMandateResponseBuilder builder) {
+        this.total = builder.total;
+        this.count = builder.count;
+        this.page = builder.page;
+        this.mandates = builder.mandates;
+        this.links = builder.links;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public List<MandateResponse> getMandates() {
+        return mandates;
+    }
+
+    public int getTotal() {
+        return total;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public SearchNavigationLinks getLinks() {
+        return links;
+    }
+
+    public static final class SearchMandateResponseBuilder {
+        private int total;
+        private int count;
+        private int page;
+        private List<MandateResponse> mandates;
+        private SearchNavigationLinks links = new SearchNavigationLinks();
+
+        private SearchMandateResponseBuilder() {
+        }
+
+        public static SearchMandateResponseBuilder aSearchMandateResponse() {
+            return new SearchMandateResponseBuilder();
+        }
+
+        public SearchMandateResponseBuilder withTotal(int total) {
+            this.total = total;
+            return this;
+        }
+
+        public SearchMandateResponseBuilder withCount(int count) {
+            this.count = count;
+            return this;
+        }
+
+        public SearchMandateResponseBuilder withPage(int page) {
+            this.page = page;
+            return this;
+        }
+
+        public SearchMandateResponseBuilder withMandates(List<MandateResponse> mandates) {
+            this.mandates = mandates;
+            return this;
+        }
+
+        public SearchMandateResponseBuilder withLinks(SearchNavigationLinks links) {
+            this.links = links;
+            return this;
+        }
+
+        public SearchMandateResponse build() {
+            return new SearchMandateResponse(this);
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchMandateResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/SearchMandateResponse.java
@@ -76,7 +76,7 @@ public class SearchMandateResponse {
         }
 
         public SearchMandateResponseBuilder withMandates(List<MandateResponse> mandates) {
-            this.mandates = mandates;
+            this.mandates = List.copyOf(mandates);
             return this;
         }
 

--- a/src/main/java/uk/gov/pay/api/service/MandatesService.java
+++ b/src/main/java/uk/gov/pay/api/service/MandatesService.java
@@ -51,12 +51,16 @@ public class MandatesService {
         Response connectorResponse = getMandate(account, mandateId);
         if (isFound(connectorResponse)) {
             MandateConnectorResponse mandate = connectorResponse.readEntity(MandateConnectorResponse.class);
-            MandateLinks mandateLinks = createLinksFromMandateResponse(mandate);
-            MandateResponse getMandateResponse = new MandateResponse(mandate, mandateLinks);
+            MandateResponse getMandateResponse = createMandateResponseFromMandateConnectorResponse(mandate);
             LOGGER.info("Mandate returned (get): [ {} ]", getMandateResponse);
             return getMandateResponse;
         }
         throw new GetMandateException(connectorResponse);
+    }
+
+    public MandateResponse createMandateResponseFromMandateConnectorResponse(MandateConnectorResponse mandate) {
+        MandateLinks mandateLinks = createLinksFromMandateResponse(mandate);
+        return new MandateResponse(mandate, mandateLinks);
     }
 
     private MandateLinks createLinksFromMandateResponse(MandateConnectorResponse mandate) {

--- a/src/main/java/uk/gov/pay/api/service/MandatesService.java
+++ b/src/main/java/uk/gov/pay/api/service/MandatesService.java
@@ -41,8 +41,7 @@ public class MandatesService {
 
     public MandateResponse create(Account account, CreateMandateRequest createMandateRequest) {
         MandateConnectorResponse mandate = createMandate(account, MandateConnectorRequest.from(createMandateRequest));
-        MandateLinks mandateLinks = createLinksFromMandateResponse(mandate);
-        MandateResponse createMandateResponse = new MandateResponse(mandate, mandateLinks);
+        MandateResponse createMandateResponse = new MandateResponse(mandate, publicApiUriGenerator);
         LOGGER.info("Mandate returned (created): [ {} ]", createMandateResponse);
         return createMandateResponse;
     }
@@ -51,26 +50,11 @@ public class MandatesService {
         Response connectorResponse = getMandate(account, mandateId);
         if (isFound(connectorResponse)) {
             MandateConnectorResponse mandate = connectorResponse.readEntity(MandateConnectorResponse.class);
-            MandateResponse getMandateResponse = createMandateResponseFromMandateConnectorResponse(mandate);
+            MandateResponse getMandateResponse = new MandateResponse(mandate, publicApiUriGenerator);
             LOGGER.info("Mandate returned (get): [ {} ]", getMandateResponse);
             return getMandateResponse;
         }
         throw new GetMandateException(connectorResponse);
-    }
-
-    public MandateResponse createMandateResponseFromMandateConnectorResponse(MandateConnectorResponse mandate) {
-        MandateLinks mandateLinks = createLinksFromMandateResponse(mandate);
-        return new MandateResponse(mandate, mandateLinks);
-    }
-
-    private MandateLinks createLinksFromMandateResponse(MandateConnectorResponse mandate) {
-        return aMandateLinks()
-                .withSelf(publicApiUriGenerator.getMandateURI(mandate.getMandateId()).toString())
-                .withPayments(publicApiUriGenerator.getMandatePaymentsURI(mandate.getMandateId()).toString())
-                .withNextUrl(mandate.getLinks())
-                .withNextUrlPost(mandate.getLinks())
-                .withEvents(publicApiUriGenerator.getMandateEventsURI(mandate.getMandateId()))
-                .build();
     }
 
     MandateConnectorResponse createMandate(Account account, MandateConnectorRequest mandateConnectorRequest) {

--- a/src/main/java/uk/gov/pay/api/service/PublicApiUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/PublicApiUriGenerator.java
@@ -7,6 +7,7 @@ import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -47,7 +48,14 @@ public class PublicApiUriGenerator {
                 .path("/v1/payments/{paymentId}/refunds")
                 .build(chargeId);
     }
-    
+
+    public URI getSearchMandatesURIWithQueryOf(String query) {
+        return UriBuilder.fromUri(baseUrl)
+                .replaceQuery(query)
+                .path("/v1/directdebit/mandates")
+                .build();
+    }
+
     public URI getMandateURI(String mandateId) {
         return UriBuilder.fromUri(baseUrl)
                 .path("/v1/directdebit/mandates/{mandateId}")

--- a/src/main/java/uk/gov/pay/api/service/directdebit/DirectDebitMandateSearchService.java
+++ b/src/main/java/uk/gov/pay/api/service/directdebit/DirectDebitMandateSearchService.java
@@ -5,12 +5,11 @@ import uk.gov.pay.api.model.directdebit.mandates.MandateResponse;
 import uk.gov.pay.api.model.search.directdebit.DirectDebitSearchMandatesParams;
 import uk.gov.pay.api.model.search.directdebit.SearchMandateConnectorResponse;
 import uk.gov.pay.api.model.search.directdebit.SearchMandateResponse;
-import uk.gov.pay.api.service.MandatesService;
+import uk.gov.pay.api.service.PublicApiUriGenerator;
 
 import javax.inject.Inject;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -21,21 +20,21 @@ public class DirectDebitMandateSearchService {
 
     private final Client client;
     private final DirectDebitConnectorUriGenerator directDebitConnectorUriGenerator;
-    private final MandatesService mandatesService;
+    private final PublicApiUriGenerator publicApiUriGenerator;
     
     
     @Inject
-    public DirectDebitMandateSearchService(Client client, DirectDebitConnectorUriGenerator directDebitConnectorUriGenerator, MandatesService mandatesService) {
+    public DirectDebitMandateSearchService(Client client, DirectDebitConnectorUriGenerator directDebitConnectorUriGenerator, PublicApiUriGenerator publicApiUriGenerator) {
         this.client = client;
         this.directDebitConnectorUriGenerator = directDebitConnectorUriGenerator;
-        this.mandatesService = mandatesService;
+        this.publicApiUriGenerator = publicApiUriGenerator;
     }
     
     public SearchMandateResponse search(Account account, DirectDebitSearchMandatesParams params) {
         SearchMandateConnectorResponse connectorResponse = getMandatesFromDDConnector(account, params);
 
         var mandateResponse = connectorResponse.getMandates().stream()
-                .map(mandatesService::createMandateResponseFromMandateConnectorResponse)
+                .map(connMandate -> new MandateResponse(connMandate, publicApiUriGenerator))
                 .collect(Collectors.toUnmodifiableList());
 
         return aSearchMandateResponse()

--- a/src/test/java/uk/gov/pay/api/it/directdebit/MandateResourceGetMandateIT.java
+++ b/src/test/java/uk/gov/pay/api/it/directdebit/MandateResourceGetMandateIT.java
@@ -22,7 +22,7 @@ import static uk.gov.pay.api.utils.Urls.mandateLocationFor;
 import static uk.gov.pay.api.utils.mocks.DDConnectorResponseToGetMandateParams.DDConnectorResponseToGetMandateParamsBuilder.aDDConnectorResponseToGetMandateParams;
 import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
-public class GetMandateIT extends PaymentResourceITestBase {
+public class MandateResourceGetMandateIT extends PaymentResourceITestBase {
 
     private ConnectorDDMockClient connectorDDMockClient = new ConnectorDDMockClient(connectorDDMock);
     private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);

--- a/src/test/java/uk/gov/pay/api/it/directdebit/MandateResourceSearchMandateIT.java
+++ b/src/test/java/uk/gov/pay/api/it/directdebit/MandateResourceSearchMandateIT.java
@@ -1,0 +1,121 @@
+package uk.gov.pay.api.it.directdebit;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+import org.junit.Test;
+import uk.gov.pay.api.it.PaymentResourceITestBase;
+import uk.gov.pay.api.model.PaymentConnectorResponseLink;
+import uk.gov.pay.api.model.directdebit.mandates.MandateConnectorResponse;
+import uk.gov.pay.api.model.directdebit.mandates.MandateState;
+import uk.gov.pay.api.model.directdebit.mandates.Payer;
+import uk.gov.pay.api.model.links.SearchNavigationLinks;
+import uk.gov.pay.api.model.search.directdebit.SearchMandateConnectorResponse;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
+import uk.gov.pay.api.utils.mocks.ConnectorDDMockClient;
+import uk.gov.pay.commons.validation.DateTimeUtils;
+
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
+import static uk.gov.pay.api.model.directdebit.mandates.MandateConnectorResponse.MandateConnectorResponseBuilder.aMandateConnectorResponse;
+import static uk.gov.pay.api.model.search.directdebit.SearchMandateConnectorResponse.SearchMandateConnectorResponseBuilder.aSearchMandateConnectorResponse;
+import static uk.gov.pay.api.utils.Urls.mandateLocationFor;
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
+
+public class MandateResourceSearchMandateIT extends PaymentResourceITestBase {
+
+    private ConnectorDDMockClient connectorDDMockClient = new ConnectorDDMockClient(connectorDDMock);
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+
+    private static final String MANDATE_ID = "mandateId";
+    private static final String MANDATE_REFERENCE = "test_mandate_reference";
+    private static final String SERVICE_REFERENCE = "test_service_reference";
+    private static final String RETURN_URL = "https://service-name.gov.uk/transactions/12345";
+    private static final String PROVIDER_ID = "MD1234";
+    private static final String CREATED_DATE = ISO_INSTANT_MILLISECOND_PRECISION.format(ZonedDateTime.parse("2016-01-01T12:00:00Z"));
+    private static final String PAYER_NAME = "payer";
+    private static final String PAYER_EMAIL = "payer@example.com";
+    public static final String DD_CONNECTOR_BASE_SEARCH_URL = "https://connector/v1/api/accounts/%s/mandates?page=1&display_size=500";
+
+    @Test
+    public void searchMandate() throws JsonProcessingException {
+
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, DIRECT_DEBIT);
+
+        var searchNavigationLinksFromConnector = new SearchNavigationLinks()
+                .withFirstLink(DD_CONNECTOR_BASE_SEARCH_URL + "&firstLink")
+                .withLastLink(DD_CONNECTOR_BASE_SEARCH_URL + "&lastLink")
+                .withNextLink(DD_CONNECTOR_BASE_SEARCH_URL + "&nextLink")
+                .withSelfLink(DD_CONNECTOR_BASE_SEARCH_URL + "&selfLink");
+        
+        var selfLink = new PaymentConnectorResponseLink("self", "https://connector", "GET", null, null);
+
+        MandateConnectorResponse mandate = aMandateConnectorResponse()
+                .withMandateId(MANDATE_ID)
+                .withMandateReference(MANDATE_REFERENCE)
+                .withServiceReference(SERVICE_REFERENCE)
+                .withReturnUrl(RETURN_URL)
+                .withState(new MandateState("created", false, "example details"))
+                .withProviderId(PROVIDER_ID)
+                .withCreatedDate(CREATED_DATE)
+                .withPayer(new Payer(PAYER_NAME, PAYER_EMAIL))
+                .withLinks(Collections.singletonList(selfLink))
+                .build();
+
+        SearchMandateConnectorResponse connectorResponse = aSearchMandateConnectorResponse()
+                .withCount(1)
+                .withPage(1)
+                .withTotal(1)
+                .withMandates(Collections.singletonList(mandate))
+                .withLinks(searchNavigationLinksFromConnector)
+                .build();
+
+        Map<String, StringValuePattern>  searchParams = Map.of(
+                "reference", equalTo(SERVICE_REFERENCE),
+                "page", equalTo("1"),
+                "display_size", equalTo("500")
+        );
+
+        connectorDDMockClient.respondOk_whenSearchMandatesRequest(searchParams, connectorResponse, GATEWAY_ACCOUNT_ID);
+
+        given().port(app.getLocalPort())
+                .accept(JSON)
+                .contentType(JSON)
+                .header(AUTHORIZATION, "Bearer " + API_KEY)
+                .queryParam("reference", SERVICE_REFERENCE)
+                .get("/v1/directdebit/mandates/")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("total", is(1))
+                .body("count", is(1))
+                .body("page", is(1))
+                .body("results[0].mandate_id", is(MANDATE_ID))
+                .body("results[0].provider_id", is(PROVIDER_ID))
+                .body("results[0].reference", is(SERVICE_REFERENCE))
+                .body("results[0].return_url", is(RETURN_URL))
+                .body("results[0].state.status", is("created"))
+                .body("results[0].state.details", is("example details"))
+                .body("results[0].created_date", is(CREATED_DATE))
+                .body("results[0].payer.name", is(PAYER_NAME))
+                .body("results[0].payer.email", is(PAYER_EMAIL))
+                .body("results[0]._links.self.href", is(mandateLocationFor(MANDATE_ID)))
+                .body("results[0]._links.self.method", is("GET"))
+                .body("results[0]._links.payments.href", is("http://publicapi.url/v1/directdebit/payments?mandate_id=" + MANDATE_ID))
+                .body("results[0]._links.payments.method", is("GET"))
+                .body("results[0]._links.events.href", is(format("http://publicapi.url/v1/directdebit/mandates/%s/events", MANDATE_ID)))
+                .body("results[0]._links.events.method", is("GET"))
+                .body("_links.self.href", is("http://publicapi.url/v1/directdebit/mandates?page=1&display_size=500&selfLink"))
+                .body("_links.first_page.href", is("http://publicapi.url/v1/directdebit/mandates?page=1&display_size=500&firstLink"))
+                .body("_links.last_page.href", is("http://publicapi.url/v1/directdebit/mandates?page=1&display_size=500&lastLink"))
+                .body("_links.next_page.href", is("http://publicapi.url/v1/directdebit/mandates?page=1&display_size=500&nextLink"));
+    }
+}

--- a/src/test/java/uk/gov/pay/api/service/directdebit/DirectDebitMandateSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/directdebit/DirectDebitMandateSearchServiceTest.java
@@ -23,8 +23,6 @@ import uk.gov.pay.commons.testing.pact.consumers.Pacts;
 
 import javax.ws.rs.client.Client;
 
-import java.util.Collections;
-
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -42,9 +40,7 @@ public class DirectDebitMandateSearchServiceTest {
 
     @Mock
     private PublicApiConfig configuration;
-    
-    MandatesService mandatesService;
-    
+
     DirectDebitMandateSearchService searchService;
     
     @Before
@@ -54,9 +50,8 @@ public class DirectDebitMandateSearchServiceTest {
 
         Client client = RestClientFactory.buildClient(new RestClientConfig(false));
         var directDebitConnectorUriGenerator = new DirectDebitConnectorUriGenerator(configuration);
-        var publicapiUriGenerator = new PublicApiUriGenerator(configuration);
-        mandatesService = new MandatesService(client, publicapiUriGenerator, directDebitConnectorUriGenerator);
-        searchService = new DirectDebitMandateSearchService(client, directDebitConnectorUriGenerator, mandatesService);
+        var publicApiUriGenerator = new PublicApiUriGenerator(configuration);
+        searchService = new DirectDebitMandateSearchService(client, directDebitConnectorUriGenerator, publicApiUriGenerator);
     }
 
     @Test
@@ -77,8 +72,6 @@ public class DirectDebitMandateSearchServiceTest {
         assertThat(searchResponse.getPage(), is(1));
         
         assertThat(searchResponse.getMandates().size(), is(1));
-        
-        
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/service/directdebit/DirectDebitMandateSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/directdebit/DirectDebitMandateSearchServiceTest.java
@@ -11,13 +11,21 @@ import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.api.model.directdebit.mandates.MandateState;
 import uk.gov.pay.api.model.search.directdebit.SearchMandateConnectorResponse;
+import uk.gov.pay.api.model.search.directdebit.SearchMandateResponse;
+import uk.gov.pay.api.service.MandatesService;
+import uk.gov.pay.api.service.PublicApiUriGenerator;
 import uk.gov.pay.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.pay.commons.testing.pact.consumers.Pacts;
 
 import javax.ws.rs.client.Client;
 
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
@@ -26,19 +34,51 @@ import static uk.gov.pay.api.model.search.directdebit.DirectDebitSearchMandatesP
 @RunWith(MockitoJUnitRunner.class)
 public class DirectDebitMandateSearchServiceTest {
 
+    private static final String MANDATE_ID = "test_mandate_id_xyz";
+    private static final String SERVICE_REFERENCE = "test_service_reference";
+
     @Rule
     public PactProviderRule connectorRule = new PactProviderRule("direct-debit-connector", this);
 
     @Mock
     private PublicApiConfig configuration;
     
+    MandatesService mandatesService;
+    
     DirectDebitMandateSearchService searchService;
     
     @Before
     public void setUp() {
         when(configuration.getConnectorDDUrl()).thenReturn(connectorRule.getUrl());
+        when(configuration.getBaseUrl()).thenReturn(connectorRule.getUrl());
+
         Client client = RestClientFactory.buildClient(new RestClientConfig(false));
-        searchService = new DirectDebitMandateSearchService(client, new DirectDebitConnectorUriGenerator(configuration));
+        var directDebitConnectorUriGenerator = new DirectDebitConnectorUriGenerator(configuration);
+        var publicapiUriGenerator = new PublicApiUriGenerator(configuration);
+        mandatesService = new MandatesService(client, publicapiUriGenerator, directDebitConnectorUriGenerator);
+        searchService = new DirectDebitMandateSearchService(client, directDebitConnectorUriGenerator, mandatesService);
+    }
+
+    @Test
+    @PactVerification({"direct-debit-connector"})
+    @Pacts(pacts = {"publicapi-direct-debit-connector-search-mandates"})
+    public void shouldSearchSuccessfully() {
+        Account account = new Account("9ddfcc27-acf5-43f9-92d5-52247540714c", TokenPaymentType.DIRECT_DEBIT);
+        String expectedBankStatementReference = "410104";
+
+        var searchParams = aDirectDebitSearchMandatesParams()
+                .withBankStatementReference(expectedBankStatementReference)
+                .build();
+
+        SearchMandateResponse searchResponse = searchService.search(account, searchParams);
+
+        assertThat(searchResponse.getCount(), is(1));
+        assertThat(searchResponse.getTotal(), is(1));
+        assertThat(searchResponse.getPage(), is(1));
+        
+        assertThat(searchResponse.getMandates().size(), is(1));
+        
+        
     }
 
     @Test
@@ -47,6 +87,13 @@ public class DirectDebitMandateSearchServiceTest {
     public void shouldGetMandateSearchResponseFromDirectDebitConnector() {
         Account account = new Account("9ddfcc27-acf5-43f9-92d5-52247540714c", TokenPaymentType.DIRECT_DEBIT);
         String expectedBankStatementReference = "410104";
+        var expectedMandateLinks = new PaymentConnectorResponseLink(
+                "self",
+                "http://localhost:1234/v1/api/accounts/9ddfcc27-acf5-43f9-92d5-52247540714c/mandates/" + MANDATE_ID,
+                "GET",
+                null,
+                null
+        );
 
         var searchParams = aDirectDebitSearchMandatesParams()
                 .withBankStatementReference(expectedBankStatementReference)
@@ -54,7 +101,20 @@ public class DirectDebitMandateSearchServiceTest {
 
         SearchMandateConnectorResponse searchResponse = searchService.getMandatesFromDDConnector(account, searchParams);
 
-        assertThat(searchResponse.getCount(), is(1));
-        assertThat(searchResponse.getMandates().get(0).getMandateReference(), is(expectedBankStatementReference));
+        var mandateConnectorResponse = searchResponse.getMandates().get(0);
+
+        assertThat(mandateConnectorResponse.getMandateId(), is(MANDATE_ID));
+        assertThat(mandateConnectorResponse.getMandateReference(), is("410104"));
+        assertThat(mandateConnectorResponse.getProviderId(), is("MD1234"));
+        assertThat(mandateConnectorResponse.getServiceReference(), is(SERVICE_REFERENCE));
+        assertThat(mandateConnectorResponse.getReturnUrl(), is("https://example.com/return"));
+        assertThat(mandateConnectorResponse.getState(), is(new MandateState("created", false, null)));
+        assertThat(mandateConnectorResponse.getCreatedDate(), is("2016-01-01T12:00:00Z"));
+        assertThat(mandateConnectorResponse.getPayer().getEmail(), is("payer@example.com"));
+        assertThat(mandateConnectorResponse.getPayer().getName(), is("payer"));
+        assertThat(mandateConnectorResponse.getLinks().size(), is(1));
+        assertThat(mandateConnectorResponse.getLinks().get(0), is(expectedMandateLinks));
+        assertThat(mandateConnectorResponse.getLinks().stream().noneMatch(p -> p.getRel().equals("next_url")), is(true));
+        assertThat(mandateConnectorResponse.getLinks().stream().noneMatch(p -> p.getRel().equals("next_url_post")), is(true));
     }
 }

--- a/src/test/java/uk/gov/pay/api/service/directdebit/DirectDebitMandateSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/directdebit/DirectDebitMandateSearchServiceTest.java
@@ -15,15 +15,12 @@ import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.directdebit.mandates.MandateState;
 import uk.gov.pay.api.model.search.directdebit.SearchMandateConnectorResponse;
-import uk.gov.pay.api.model.search.directdebit.SearchMandateResponse;
-import uk.gov.pay.api.service.MandatesService;
 import uk.gov.pay.api.service.PublicApiUriGenerator;
 import uk.gov.pay.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.pay.commons.testing.pact.consumers.Pacts;
 
 import javax.ws.rs.client.Client;
 
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
@@ -52,26 +49,6 @@ public class DirectDebitMandateSearchServiceTest {
         var directDebitConnectorUriGenerator = new DirectDebitConnectorUriGenerator(configuration);
         var publicApiUriGenerator = new PublicApiUriGenerator(configuration);
         searchService = new DirectDebitMandateSearchService(client, directDebitConnectorUriGenerator, publicApiUriGenerator);
-    }
-
-    @Test
-    @PactVerification({"direct-debit-connector"})
-    @Pacts(pacts = {"publicapi-direct-debit-connector-search-mandates"})
-    public void shouldSearchSuccessfully() {
-        Account account = new Account("9ddfcc27-acf5-43f9-92d5-52247540714c", TokenPaymentType.DIRECT_DEBIT);
-        String expectedBankStatementReference = "410104";
-
-        var searchParams = aDirectDebitSearchMandatesParams()
-                .withBankStatementReference(expectedBankStatementReference)
-                .build();
-
-        SearchMandateResponse searchResponse = searchService.search(account, searchParams);
-
-        assertThat(searchResponse.getCount(), is(1));
-        assertThat(searchResponse.getTotal(), is(1));
-        assertThat(searchResponse.getPage(), is(1));
-        
-        assertThat(searchResponse.getMandates().size(), is(1));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorDDMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorDDMockClient.java
@@ -4,12 +4,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
 import uk.gov.pay.api.model.DirectDebitPaymentState;
 import uk.gov.pay.api.model.directdebit.DirectDebitConnectorPaymentResponse;
 import uk.gov.pay.api.model.directdebit.mandates.MandateConnectorRequest;
 import uk.gov.pay.api.model.directdebit.mandates.MandateState;
+import uk.gov.pay.api.model.search.directdebit.DirectDebitSearchMandatesParams;
+import uk.gov.pay.api.model.search.directdebit.SearchMandateConnectorResponse;
 import uk.gov.pay.api.utils.JsonStringBuilder;
 import uk.gov.pay.commons.model.ErrorIdentifier;
 
@@ -101,6 +104,17 @@ public class ConnectorDDMockClient extends BaseConnectorMockClient {
                         .withStatus(200)
                         .withHeader(CONTENT_TYPE, APPLICATION_JSON)
                         .withBody(buildGetMandateResponse(params)));
+    }
+    
+    public void respondOk_whenSearchMandatesRequest(Map<String, StringValuePattern> searchParams, SearchMandateConnectorResponse response, String gatewayAccountId) throws JsonProcessingException {
+        String responseAsJson = new ObjectMapper().writeValueAsString(response);
+        wireMockClassRule.stubFor(get(urlPathEqualTo(format(CONNECTOR_MOCK_MANDATES_PATH, gatewayAccountId)))
+                .withHeader(ACCEPT, matching(APPLICATION_JSON))
+                .withQueryParams(searchParams)
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                        .withBody(responseAsJson)));
     }
 
     public void respondBadRequest_whenCreateAgreementRequest(String gatewayAccountId, String errorMsg) {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -130,7 +130,7 @@
           "description" : "requestPayload",
           "required" : true,
           "schema" : {
-            "$ref" : "#/definitions/CreateCardPaymentRequest"
+            "$ref" : "#/definitions/CreatePaymentRequest"
           }
         } ],
         "responses" : {
@@ -686,9 +686,9 @@
       },
       "description" : "A structure representing the payment card"
     },
-    "CreateCardPaymentRequest" : {
+    "CreatePaymentRequest" : {
       "type" : "object",
-      "required" : [ "amount", "description", "reference", "return_url" ],
+      "required" : [ "amount", "description", "reference" ],
       "properties" : {
         "amount" : {
           "type" : "integer",
@@ -727,29 +727,6 @@
           "example" : "Joe.Bogs@example.org",
           "description" : "email",
           "readOnly" : true
-        },
-        "return_url" : {
-          "type" : "string",
-          "example" : "https://service-name.gov.uk/transactions/12345",
-          "description" : "service return url",
-          "readOnly" : true,
-          "minLength" : 0,
-          "maxLength" : 2000
-        },
-        "delayed_capture" : {
-          "type" : "boolean",
-          "example" : false,
-          "description" : "delayed capture flag",
-          "readOnly" : true
-        },
-        "metadata" : {
-          "readOnly" : true,
-          "$ref" : "#/definitions/ExternalMetadata"
-        },
-        "prefilled_cardholder_details" : {
-          "description" : "prefilled_cardholder_details",
-          "readOnly" : true,
-          "$ref" : "#/definitions/PrefilledCardholderDetails"
         }
       },
       "description" : "The Payment Request Payload"
@@ -843,17 +820,6 @@
       },
       "description" : "An error response"
     },
-    "ExternalMetadata" : {
-      "type" : "object",
-      "properties" : {
-        "metadata" : {
-          "type" : "object",
-          "additionalProperties" : {
-            "type" : "object"
-          }
-        }
-      }
-    },
     "GetPaymentResult" : {
       "type" : "object",
       "properties" : {
@@ -861,6 +827,9 @@
           "type" : "integer",
           "format" : "int64",
           "example" : 1200
+        },
+        "state" : {
+          "$ref" : "#/definitions/PaymentState"
         },
         "description" : {
           "type" : "string",
@@ -884,9 +853,6 @@
         "email" : {
           "type" : "string",
           "example" : "your email"
-        },
-        "state" : {
-          "$ref" : "#/definitions/PaymentState"
         },
         "payment_id" : {
           "type" : "string",
@@ -992,6 +958,9 @@
           "format" : "int64",
           "example" : 1200
         },
+        "state" : {
+          "$ref" : "#/definitions/PaymentState"
+        },
         "description" : {
           "type" : "string",
           "example" : "Your Service Description"
@@ -1014,9 +983,6 @@
         "email" : {
           "type" : "string",
           "example" : "your email"
-        },
-        "state" : {
-          "$ref" : "#/definitions/PaymentState"
         },
         "payment_id" : {
           "type" : "string",
@@ -1365,23 +1331,6 @@
         }
       },
       "description" : "A POST link related to a payment"
-    },
-    "PrefilledCardholderDetails" : {
-      "type" : "object",
-      "properties" : {
-        "cardholder_name" : {
-          "type" : "string",
-          "example" : "J. Bogs",
-          "description" : "prefilled cardholder name",
-          "minLength" : 0,
-          "maxLength" : 255
-        },
-        "billing_address" : {
-          "description" : "prefilled billing address",
-          "readOnly" : true,
-          "$ref" : "#/definitions/Address"
-        }
-      }
     },
     "Refund" : {
       "type" : "object",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -130,7 +130,7 @@
           "description" : "requestPayload",
           "required" : true,
           "schema" : {
-            "$ref" : "#/definitions/CreatePaymentRequest"
+            "$ref" : "#/definitions/CreateCardPaymentRequest"
           }
         } ],
         "responses" : {
@@ -686,9 +686,9 @@
       },
       "description" : "A structure representing the payment card"
     },
-    "CreatePaymentRequest" : {
+    "CreateCardPaymentRequest" : {
       "type" : "object",
-      "required" : [ "amount", "description", "reference" ],
+      "required" : [ "amount", "description", "reference", "return_url" ],
       "properties" : {
         "amount" : {
           "type" : "integer",
@@ -727,6 +727,29 @@
           "example" : "Joe.Bogs@example.org",
           "description" : "email",
           "readOnly" : true
+        },
+        "return_url" : {
+          "type" : "string",
+          "example" : "https://service-name.gov.uk/transactions/12345",
+          "description" : "service return url",
+          "readOnly" : true,
+          "minLength" : 0,
+          "maxLength" : 2000
+        },
+        "delayed_capture" : {
+          "type" : "boolean",
+          "example" : false,
+          "description" : "delayed capture flag",
+          "readOnly" : true
+        },
+        "metadata" : {
+          "readOnly" : true,
+          "$ref" : "#/definitions/ExternalMetadata"
+        },
+        "prefilled_cardholder_details" : {
+          "description" : "prefilled_cardholder_details",
+          "readOnly" : true,
+          "$ref" : "#/definitions/PrefilledCardholderDetails"
         }
       },
       "description" : "The Payment Request Payload"
@@ -820,6 +843,17 @@
       },
       "description" : "An error response"
     },
+    "ExternalMetadata" : {
+      "type" : "object",
+      "properties" : {
+        "metadata" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "object"
+          }
+        }
+      }
+    },
     "GetPaymentResult" : {
       "type" : "object",
       "properties" : {
@@ -827,9 +861,6 @@
           "type" : "integer",
           "format" : "int64",
           "example" : 1200
-        },
-        "state" : {
-          "$ref" : "#/definitions/PaymentState"
         },
         "description" : {
           "type" : "string",
@@ -853,6 +884,9 @@
         "email" : {
           "type" : "string",
           "example" : "your email"
+        },
+        "state" : {
+          "$ref" : "#/definitions/PaymentState"
         },
         "payment_id" : {
           "type" : "string",
@@ -958,9 +992,6 @@
           "format" : "int64",
           "example" : 1200
         },
-        "state" : {
-          "$ref" : "#/definitions/PaymentState"
-        },
         "description" : {
           "type" : "string",
           "example" : "Your Service Description"
@@ -983,6 +1014,9 @@
         "email" : {
           "type" : "string",
           "example" : "your email"
+        },
+        "state" : {
+          "$ref" : "#/definitions/PaymentState"
         },
         "payment_id" : {
           "type" : "string",
@@ -1331,6 +1365,23 @@
         }
       },
       "description" : "A POST link related to a payment"
+    },
+    "PrefilledCardholderDetails" : {
+      "type" : "object",
+      "properties" : {
+        "cardholder_name" : {
+          "type" : "string",
+          "example" : "J. Bogs",
+          "description" : "prefilled cardholder name",
+          "minLength" : 0,
+          "maxLength" : 255
+        },
+        "billing_address" : {
+          "description" : "prefilled billing address",
+          "readOnly" : true,
+          "$ref" : "#/definitions/Address"
+        }
+      }
     },
     "Refund" : {
       "type" : "object",


### PR DESCRIPTION
Continue to build out mandate search functionality in PublicApi. This introduces most of the feature but will require more tests around failure paths.