### PR TITLE
PP-5442 Remove more state.details from Direct Debit connector pacts

### DIFF
--- a/src/test/java/uk/gov/pay/api/service/MandatesServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/MandatesServiceTest.java
@@ -110,7 +110,7 @@ public class MandatesServiceTest {
         assertThat(mandateConnectorResponse.getProviderId(), is("MD1234"));
         assertThat(mandateConnectorResponse.getServiceReference(), is(SERVICE_REFERENCE));
         assertThat(mandateConnectorResponse.getReturnUrl(), is("https://example.com/return"));
-        assertThat(mandateConnectorResponse.getState(), is(new MandateState("created", false, "example details")));
+        assertThat(mandateConnectorResponse.getState().getStatus(), is("created"));
         assertThat(mandateConnectorResponse.getCreatedDate(), is("2016-01-01T12:00:00Z"));
         assertThat(mandateConnectorResponse.getPayer().getEmail(), is("i.died@titanic.com"));
         assertThat(mandateConnectorResponse.getPayer().getName(), is("Jack"));

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-get-mandate.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-get-mandate.json
@@ -38,7 +38,6 @@
           "state": {
             "status": "created",
             "finished": false,
-            "details": "example details"
           },
           "payer": {
             "name": "Jack",
@@ -84,13 +83,6 @@
               ]
             },
             "$.state.finished": {
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
-            "$.state.details": {
               "matchers": [
                 {
                   "match": "type"


### PR DESCRIPTION
Temporarily remove the `state.details` property from the Direct Debit connector pacts while we make the changes to populate the property with real data.