### PR TITLE
PP-5346: Specify operationIds for directdebit mandates/payments

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
@@ -66,6 +66,7 @@ public class DirectDebitPaymentsResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @ApiOperation(
+            nickname = "createDirectDebitPayment",
             value = "Create new Direct Debit payment",
             notes = "Create a new Direct Debit payment for the account associated to the Authorisation token. " +
                     "The Authorisation token needs to be specified in the 'authorization' header " +
@@ -91,6 +92,7 @@ public class DirectDebitPaymentsResource {
     @Timed
     @Produces(APPLICATION_JSON)
     @ApiOperation(
+            nickname = "searchDirectDebitPayments",
             value = "Search Direct Debit payments",
             notes = "Search Direct Debit payments by reference, state, mandate id, and 'from' and 'to' dates. " +
                     "The Authorisation token needs to be specified in the 'Authorization' header " +
@@ -118,6 +120,7 @@ public class DirectDebitPaymentsResource {
     @Path("{paymentId}")
     @Produces(APPLICATION_JSON)
     @ApiOperation(
+            nickname = "getDirectDebitPayment",
             value = "Find direct debit payment by ID",
             notes = "Return information about the direct debit payment. " +
                     "The Authorisation token needs to be specified in the 'Authorization' header " +
@@ -130,8 +133,8 @@ public class DirectDebitPaymentsResource {
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
             @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
-    public Response getDirectDebitPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
-                                          @PathParam("paymentId") @ApiParam(value = "Payment identifier") String paymentId) {
+    public Response getPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
+                               @PathParam("paymentId") @ApiParam(value = "Payment identifier") String paymentId) {
 
         LOGGER.info("Direct Debit Payment request - paymentId={}", paymentId);
         DirectDebitPayment payment = getDirectDebitPaymentService.getDirectDebitPayment(account, paymentId);

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -202,7 +202,7 @@
       "get" : {
         "summary" : "Search Direct Debit payments",
         "description" : "Search Direct Debit payments by reference, state, mandate id, and 'from' and 'to' dates. The Authorisation token needs to be specified in the 'Authorization' header as 'Authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "searchPayments",
+        "operationId" : "searchDirectDebitPayments",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "reference",
@@ -293,7 +293,7 @@
       "post" : {
         "summary" : "Create new Direct Debit payment",
         "description" : "Create a new Direct Debit payment for the account associated to the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "createPayment",
+        "operationId" : "createDirectDebitPayment",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
         "responses" : {


### PR DESCRIPTION
This is for better naming and differentiation between direct debit payments and
card payments in the public API docs. The search operationId for card and
direct debit payments was 'searchPayments' previously, causing one to overwrite
the other.
