### PR TITLE
PP-5433 Correct min amount for a Direct Debit Payment

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CreateDirectDebitPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateDirectDebitPaymentRequest.java
@@ -17,7 +17,7 @@ public class CreateDirectDebitPaymentRequest {
 
     public static final int REFERENCE_MAX_LENGTH = 255;
     public static final int AMOUNT_MAX_VALUE = 10000000;
-    public static final int AMOUNT_MIN_VALUE = 1;
+    public static final int AMOUNT_MIN_VALUE = 100;
     public static final int DESCRIPTION_MAX_LENGTH = 255;
     public static final int MANDATE_ID_MAX_LENGTH = 26;
 

--- a/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
@@ -81,7 +81,7 @@ public class DirectDebitPaymentsResource {
             @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
     public Response createPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
-                                  @Valid CreateDirectDebitPaymentRequest request) {
+                                  @ApiParam(value = "requestPayload", required = true) @Valid CreateDirectDebitPaymentRequest request) {
         DirectDebitPayment payment = createDirectDebitPaymentsService.create(account, request);
         return Response.created(publicApiUriGenerator.getDirectDebitPaymentURI(payment.getPaymentId()))
                 .entity(payment).build();

--- a/src/test/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResourceCreatePaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResourceCreatePaymentIT.java
@@ -124,12 +124,12 @@ public class DirectDebitPaymentsResourceCreatePaymentIT extends DirectDebitResou
         return new CreatePaymentRequestValidationParameters[]{
                 someParameters()
                         .withAmount(null)
-                        .withErrorMessage("Invalid attribute value: amount. Must be greater than or equal to 1")
+                        .withErrorMessage("Invalid attribute value: amount. Must be greater than or equal to 100")
                         .withErrorField("amount")
                         .build(),
                 someParameters()
                         .withAmount(0L)
-                        .withErrorMessage("Invalid attribute value: amount. Must be greater than or equal to 1")
+                        .withErrorMessage("Invalid attribute value: amount. Must be greater than or equal to 100")
                         .withErrorField("amount")
                         .build(),
                 someParameters()

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -307,6 +307,15 @@
         "operationId" : "createDirectDebitPayment",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "body",
+          "description" : "requestPayload",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/CreateDirectDebitPaymentRequest"
+          }
+        } ],
         "responses" : {
           "201" : {
             "description" : "Created",
@@ -1136,6 +1145,46 @@
         }
       },
       "description" : "The Payment Request Payload"
+    },
+    "CreateDirectDebitPaymentRequest" : {
+      "type" : "object",
+      "required" : [ "amount", "description", "reference" ],
+      "properties" : {
+        "amount" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 12000,
+          "description" : "amount in pence",
+          "readOnly" : true,
+          "minimum" : 100,
+          "maximum" : 10000000
+        },
+        "reference" : {
+          "type" : "string",
+          "example" : "12345",
+          "description" : "payment reference",
+          "readOnly" : true,
+          "minLength" : 0,
+          "maxLength" : 255
+        },
+        "description" : {
+          "type" : "string",
+          "example" : "New passport application",
+          "description" : "payment description",
+          "readOnly" : true,
+          "minLength" : 0,
+          "maxLength" : 255
+        },
+        "mandate_id" : {
+          "type" : "string",
+          "example" : "33890b55-b9ea-4e2f-90fd-77ae0e9009e2",
+          "description" : "ID of the mandates being used to collect the payment",
+          "readOnly" : true,
+          "minLength" : 0,
+          "maxLength" : 26
+        }
+      },
+      "description" : "The Direct Debit Payment Request Payload"
     },
     "CreateMandateRequest" : {
       "type" : "object",


### PR DESCRIPTION
The minimum amount that gocardless accept for a payment is 100 pence so increasing
the current min to 100 from 1. Also adding swagger annotation to include the payload
for creating a direct debit payment.