### PR TITLE
PP-5493 Set up mandate correctly for DD collect payment tests

### DIFF
--- a/src/test/resources/pacts/publicapi-direct-debit-connector-collect-payment.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-collect-payment.json
@@ -10,10 +10,12 @@
       "description": "a collect charge request",
       "providerStates": [
         {
-          "name": "a gateway account with external id and a mandate with external id exist",
+          "name": "a gateway account with external id and a confirmed mandate exists",
           "params": {
             "gateway_account_id": "GATEWAY_ACCOUNT_ID",
-            "mandate_id": "test_mandate_id_xyz"
+            "mandate_id": "test_mandate_id_xyz",
+            "unique_identifier": "provider-mandate-id",
+            "bank_mandate_reference": "BANKREF"
           }
         }
       ],


### PR DESCRIPTION
To be able to collect a payment from a Direct Debit mandate, the mandate needs to have been submitted to a provider and have a provider ID.

The collect payment Pact tests didn’t set up the mandate with a provider ID. This has worked up until now because sandbox was lax about whether or not the mandate had been submitted but it’s getting stricter now, so the Pact test needs to set up the mandate in the correct state.