### PR TITLE
PP-5475 Remove Finished From State In Pact

### DIFF
--- a/src/test/resources/pacts/publicapi-direct-debit-connector-collect-payment.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-collect-payment.json
@@ -40,8 +40,7 @@
           "description": "a description",
           "mandate_id": "a mandate id",
           "state": {
-            "status": "created",
-            "finished": false
+            "status": "created"
           },
           "created_date": "2010-12-31T22:59:59.132Z"
         },

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-create-mandate.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-create-mandate.json
@@ -39,8 +39,7 @@
           "created_date": "2016-01-01T12:00:00.000Z",
           "payment_provider": "sandbox",
           "state": {
-            "status": "created",
-            "finished": false
+            "status": "created"
           },
           "links": [
             {
@@ -119,13 +118,6 @@
               ]
             },
             "$.state.status": {
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
-            "$.state.finished": {
               "matchers": [
                 {
                   "match": "type"

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-get-directdebit-payment.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-get-directdebit-payment.json
@@ -32,8 +32,7 @@
         "body": {
           "amount": 1000,
           "state": {
-            "status": "pending",
-            "finished": false
+            "status": "pending"
           },
           "mandate_id": "aaaa1111",
           "description": "a description",
@@ -53,13 +52,6 @@
               ]
             },
             "$.state.status": {
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
-            "$.state.finished": {
               "matchers": [
                 {
                   "match": "type"

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-get-mandate.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-get-mandate.json
@@ -37,7 +37,6 @@
           "created_date": "2016-01-01T12:00:00Z",
           "state": {
             "status": "created",
-            "finished": false,
             "details": "example details"
           },
           "payer": {
@@ -77,13 +76,6 @@
               ]
             },
             "$.state.status": {
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
-            "$.state.finished": {
               "matchers": [
                 {
                   "match": "type"

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-search-by-mandate-three-results.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-search-by-mandate-three-results.json
@@ -40,7 +40,6 @@
               "amount": 1234,
               "state": {
                 "status": "success",
-                "finished": "true",
                 "details": "example details"
               },
               "mandate_id": "jkdjsvd8f78ffkwfek2q",
@@ -55,7 +54,6 @@
               "amount": 1245,
               "state": {
                 "status": "pending",
-                "finished": "false",
                 "details": "example details"
               },
               "mandate_id": "jkdjsvd8f78ffkwfek2q",
@@ -70,7 +68,6 @@
               "amount": 1256,
               "state": {
                 "status": "cancelled",
-                "finished": "true",
                 "details": "example details"
               },
               "mandate_id": "jkdjsvd8f78ffkwfek2q",
@@ -158,19 +155,6 @@
               "matchers": [
                 {
                   "match": "type"
-                }
-              ]
-            },
-            "$.results[*].state.finished": {
-              "combine": "OR",
-              "matchers": [
-                {
-                  "match": "include",
-                  "value": "true"
-                },
-                {
-                  "match": "include",
-                  "value": "false"
                 }
               ]
             },


### PR DESCRIPTION
- Removes the 'finished' boolean field from the state object in pact,
allowing tests to pass when this is removed from the actual return
object.
