### PR TITLE
PP-5474 Remove Finished From Pact State

### DIFF
--- a/src/test/resources/pacts/publicapi-direct-debit-connector-collect-payment.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-collect-payment.json
@@ -42,8 +42,7 @@
           "description": "a description",
           "mandate_id": "a mandate id",
           "state": {
-            "status": "created",
-            "finished": false
+            "status": "created"
           },
           "created_date": "2010-12-31T22:59:59.132Z"
         },

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-create-mandate.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-create-mandate.json
@@ -39,8 +39,7 @@
           "created_date": "2016-01-01T12:00:00.000Z",
           "payment_provider": "sandbox",
           "state": {
-            "status": "created",
-            "finished": false
+            "status": "created"
           },
           "links": [
             {
@@ -119,13 +118,6 @@
               ]
             },
             "$.state.status": {
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
-            "$.state.finished": {
               "matchers": [
                 {
                   "match": "type"

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-get-directdebit-payment.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-get-directdebit-payment.json
@@ -33,8 +33,7 @@
           "amount": 1000,
           "state": {
             "status": "pending",
-            "details": "payment_state_details",
-            "finished": false
+            "details": "payment_state_details"
           },
           "mandate_id": "aaaa1111",
           "description": "a description",
@@ -54,13 +53,6 @@
               ]
             },
             "$.state.status": {
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
-            "$.state.finished": {
               "matchers": [
                 {
                   "match": "type"

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-get-mandate.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-get-mandate.json
@@ -37,8 +37,7 @@
           "created_date": "2016-01-01T12:00:00Z",
           "state": {
             "status": "created",
-            "details": "mandate_state_details",
-            "finished": false
+            "details": "mandate_state_details"
           },
           "payer": {
             "name": "Jack",
@@ -77,13 +76,6 @@
               ]
             },
             "$.state.status": {
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
-            "$.state.finished": {
               "matchers": [
                 {
                   "match": "type"

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-search-by-mandate-three-results.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-search-by-mandate-three-results.json
@@ -40,8 +40,7 @@
               "amount": 1234,
               "state": {
                 "status": "success",
-                "details": "mandate_state_details",
-                "finished": "true"
+                "details": "mandate_state_details"
               },
               "mandate_id": "jkdjsvd8f78ffkwfek2q",
               "description": "A payment made for crossing the bridge the first time",
@@ -55,8 +54,7 @@
               "amount": 1245,
               "state": {
                 "status": "pending",
-                "details": "payment_state_details",
-                "finished": "false"
+                "details": "payment_state_details"
               },
               "mandate_id": "jkdjsvd8f78ffkwfek2q",
               "description": "A payment made for crossing the bridge the second time",
@@ -70,8 +68,7 @@
               "amount": 1256,
               "state": {
                 "status": "cancelled",
-                "details": "payment_state_details",
-                "finished": "true"
+                "details": "payment_state_details"
               },
               "mandate_id": "jkdjsvd8f78ffkwfek2q",
               "description": "A payment made for crossing the bridge the third time",
@@ -158,19 +155,6 @@
               "matchers": [
                 {
                   "match": "type"
-                }
-              ]
-            },
-            "$.results[*].state.finished": {
-              "combine": "OR",
-              "matchers": [
-                {
-                  "match": "include",
-                  "value": "true"
-                },
-                {
-                  "match": "include",
-                  "value": "false"
                 }
               ]
             },

--- a/src/test/resources/pacts/publicapi-direct-debit-connector-search-mandates.json
+++ b/src/test/resources/pacts/publicapi-direct-debit-connector-search-mandates.json
@@ -54,8 +54,7 @@
               "created_date": "2016-01-01T12:00:00Z",
               "state": {
                 "status": "created",
-                "details": "mandate_state_details",
-                "finished": false
+                "details": "mandate_state_details"
               },
               "payer": {
                 "name": "payer",


### PR DESCRIPTION
- Removes the 'finished' boolean field from the Pact tests, enabling
them to pass when the state is removed from the return object

