### PR TITLE
BAU Make published swagger documentation more human readable

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -1489,5 +1489,5 @@ Content-Length: 44
 | ------------------ | -------------------------------------------------|
 | `P1101`            | Request parameters have Validation errors        |
 | `P1100`            | Requested page not found                         |
-| `P1102`            | Refunds not supported for direct debit accounts  |
+| `P1102`            | Refunds not supported for Direct Debit accounts  |
 | `P1898`            | Connector response was unrecognised to PublicAPI |

--- a/src/main/java/uk/gov/pay/api/model/RefundError.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundError.java
@@ -15,7 +15,7 @@ public class RefundError {
     public enum Code {
 
         SEARCH_REFUNDS_VALIDATION_ERROR("P1101", "Invalid parameters: %s. See Public API documentation for the correct data formats"),
-        SEARCH_REFUNDS_DIRECT_DEBIT_ERROR("P1102","Searching all refunds are not currently supported for direct debit accounts."),
+        SEARCH_REFUNDS_DIRECT_DEBIT_ERROR("P1102","Searching all refunds are not currently supported for Direct Debit accounts."),
         SEARCH_REFUNDS_NOT_FOUND("P1100", "Page not found"),
         SEARCH_REFUNDS_CONNECTOR_ERROR("P1898", "Downstream system error");
 

--- a/src/main/java/uk/gov/pay/api/model/RefundError.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundError.java
@@ -15,7 +15,7 @@ public class RefundError {
     public enum Code {
 
         SEARCH_REFUNDS_VALIDATION_ERROR("P1101", "Invalid parameters: %s. See Public API documentation for the correct data formats"),
-        SEARCH_REFUNDS_DIRECT_DEBIT_ERROR("P1102","Searching all refunds are not currently supported for Direct Debit accounts."),
+        SEARCH_REFUNDS_DIRECT_DEBIT_ERROR("P1102","Searching all refunds is not currently supported for Direct Debit accounts."),
         SEARCH_REFUNDS_NOT_FOUND("P1100", "Page not found"),
         SEARCH_REFUNDS_CONNECTOR_ERROR("P1898", "Downstream system error");
 

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
@@ -34,12 +34,12 @@ public class DirectDebitSearchPaymentsParams {
     private String mandateId;
     
     @QueryParam("from_date")
-    @ApiParam(value = "From date of direct debit payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z")
+    @ApiParam(value = "From date of Direct Debit payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z")
     @ValidDate
     private String fromDate;
     
     @QueryParam("to_date")
-    @ApiParam(value = "To date of direct debit payments to be searched (this date is exclusive). Example=2015-08-13T12:35:00Z")
+    @ApiParam(value = "To date of Direct Debit payments to be searched (this date is exclusive). Example=2015-08-13T12:35:00Z")
     @ValidDate
     private String toDate;
     

--- a/src/main/java/uk/gov/pay/api/resources/DirectDebitEventsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/DirectDebitEventsResource.java
@@ -46,7 +46,7 @@ public class DirectDebitEventsResource {
     @Path("/v1/events")
     @Produces(APPLICATION_JSON)
     @ApiOperation(
-            value = "Get direct debit events",
+            value = "Get Direct Debit events",
             notes = "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'")
     @ApiResponses(value = {

--- a/src/main/java/uk/gov/pay/api/resources/MandatesResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/MandatesResource.java
@@ -60,6 +60,7 @@ public class MandatesResource {
     @Path("/v1/directdebit/mandates/{mandateId}")
     @Produces(APPLICATION_JSON)
     @ApiOperation(
+            nickname = "Get a mandate",
             value = "Find mandate by ID",
             notes = "Return information about the mandate. " +
                     "The Authorisation token needs to be specified in the 'Authorization' header " +
@@ -84,6 +85,7 @@ public class MandatesResource {
     @Path("/v1/directdebit/mandates/")
     @Produces(APPLICATION_JSON)
     @ApiOperation(
+            nickname = "Search mandates",
             value = "Search mandates",
             notes = "Searches for mandates with the parameters provided. " +
                     "The Authorisation token needs to be specified in the 'Authorization' header " +
@@ -111,6 +113,7 @@ public class MandatesResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @ApiOperation(
+            nickname = "Create a mandate",
             value = "Create a new mandate",
             notes = "Create a new mandate for the account associated to the Authorisation token. " +
                     "The Authorisation token needs to be specified in the 'Authorization' header " +

--- a/src/main/java/uk/gov/pay/api/resources/MandatesResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/MandatesResource.java
@@ -38,7 +38,7 @@ import java.net.URI;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/")
-@Api(value = "/")
+@Api(tags = "Direct Debit", value = "/v1/directdebit/mandates")
 @Produces({"application/json"})
 public class MandatesResource {
 

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -88,6 +88,7 @@ public class PaymentRefundsResource {
     @Produces(APPLICATION_JSON)
     @ApiOperation(
             response = RefundForSearchResult.class,
+            nickname = "Get all refunds for a payment",
             value = "Get all refunds for a payment",
             notes = "Return refunds for a payment. " +
                     "The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
@@ -125,6 +126,7 @@ public class PaymentRefundsResource {
     @Produces(APPLICATION_JSON)
     @ApiOperation(
             response = RefundResult.class,
+            nickname = "Get a payment refund",
             value = "Find payment refund by ID",
             notes = "Return payment refund information by Refund ID " +
                     "The Authorisation token needs to be specified in the 'authorization' header " +
@@ -163,6 +165,7 @@ public class PaymentRefundsResource {
     @Consumes(APPLICATION_JSON)
     @ApiOperation(
             response = RefundResult.class,
+            nickname = "Submit a refund for a payment",
             value = "Submit a refund for a payment",
             notes = "Return issued refund information. " +
                     "The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -51,7 +51,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.http.HttpStatus.SC_OK;
 
 @Path(PaymentRefundsResource.PAYMENT_REFUNDS_PATH)
-@Api(tags = "Refunding payments", value = "/refunds")
+@Api(tags = "Refunding card payments", value = "/refunds")
 @Produces({"application/json"})
 public class PaymentRefundsResource {
     private static final Logger logger = LoggerFactory.getLogger(PaymentRefundsResource.class);

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -51,7 +51,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.http.HttpStatus.SC_OK;
 
 @Path(PaymentRefundsResource.PAYMENT_REFUNDS_PATH)
-@Api(tags = "refunds", value = "/refunds", description = "Public Api Endpoints for Refunds")
+@Api(tags = "Refunds", value = "/refunds")
 @Produces({"application/json"})
 public class PaymentRefundsResource {
     private static final Logger logger = LoggerFactory.getLogger(PaymentRefundsResource.class);
@@ -87,7 +87,6 @@ public class PaymentRefundsResource {
     @Timed
     @Produces(APPLICATION_JSON)
     @ApiOperation(
-            tags = "refunds",
             response = RefundForSearchResult.class,
             value = "Get all refunds for a payment",
             notes = "Return refunds for a payment. " +
@@ -125,7 +124,6 @@ public class PaymentRefundsResource {
     @Path("/{refundId}")
     @Produces(APPLICATION_JSON)
     @ApiOperation(
-            tags = "refunds",
             response = RefundResult.class,
             value = "Find payment refund by ID",
             notes = "Return payment refund information by Refund ID " +
@@ -164,7 +162,6 @@ public class PaymentRefundsResource {
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
     @ApiOperation(
-            tags = "refunds",
             response = RefundResult.class,
             value = "Submit a refund for a payment",
             notes = "Return issued refund information. " +

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -51,7 +51,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.http.HttpStatus.SC_OK;
 
 @Path(PaymentRefundsResource.PAYMENT_REFUNDS_PATH)
-@Api(tags = "Refunds", value = "/refunds")
+@Api(tags = "Refunding payments", value = "/refunds")
 @Produces({"application/json"})
 public class PaymentRefundsResource {
     private static final Logger logger = LoggerFactory.getLogger(PaymentRefundsResource.class);

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -52,7 +52,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.http.HttpStatus.SC_OK;
 
 @Path("/")
-@Api(tags="Card Payments", value = "/")
+@Api(tags = "Card payments", value = "/")
 @Produces({"application/json"})
 public class PaymentsResource {
 

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -52,7 +52,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.http.HttpStatus.SC_OK;
 
 @Path("/")
-@Api(value = "/", description = "Public Api Endpoints")
+@Api(tags="Card Payments", value = "/")
 @Produces({"application/json"})
 public class PaymentsResource {
 

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -91,6 +91,7 @@ public class PaymentsResource {
     @Path("/v1/payments/{paymentId}")
     @Produces(APPLICATION_JSON)
     @ApiOperation(
+            nickname = "Get a payment",
             value = "Find payment by ID",
             notes = "Return information about the payment " +
                     "The Authorisation token needs to be specified in the 'authorization' header " +
@@ -123,6 +124,7 @@ public class PaymentsResource {
     @Path("/v1/payments/{paymentId}/events")
     @Produces(APPLICATION_JSON)
     @ApiOperation(
+            nickname = "Get events for a payment",
             value = "Return payment events by ID",
             notes = "Return payment events information about a certain payment " +
                     "The Authorisation token needs to be specified in the 'authorization' header " +
@@ -171,6 +173,7 @@ public class PaymentsResource {
     @Path("/v1/payments")
     @Produces(APPLICATION_JSON)
     @ApiOperation(
+            nickname = "Search payments",
             value = "Search payments",
             notes = "Search payments by reference, state, 'from' and 'to' date. " +
                     "The Authorisation token needs to be specified in the 'authorization' header " +
@@ -229,12 +232,12 @@ public class PaymentsResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @ApiOperation(
+            nickname = "Create a payment",
             value = "Create new payment",
             notes = "Create a new payment for the account associated to the Authorisation token. " +
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             code = 201,
-            nickname = "newPayment",
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {
             @ApiResponse(code = 201, message = "Created", response = CreatePaymentResult.class),
@@ -263,6 +266,7 @@ public class PaymentsResource {
     @Path("/v1/payments/{paymentId}/cancel")
     @Produces(APPLICATION_JSON)
     @ApiOperation(
+            nickname = "Cancel a payment",
             value = "Cancel payment",
             notes = "Cancel a payment based on the provided payment ID and the Authorisation token. " +
                     "The Authorisation token needs to be specified in the 'authorization' header " +
@@ -294,6 +298,7 @@ public class PaymentsResource {
     @Path("/v1/payments/{paymentId}/capture")
     @Produces(APPLICATION_JSON)
     @ApiOperation(
+            nickname = "Capture a payment",
             value = "Capture payment",
             notes = "Capture a payment based on the provided payment ID and the Authorisation token. " +
                     "The Authorisation token needs to be specified in the 'authorization' header " +

--- a/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
@@ -27,7 +27,7 @@ import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/")
-@Api(tags="Refunds", value = "/")
+@Api(tags = "Refunding payments", value = "/")
 @Produces({"application/json"})
 public class SearchRefundsResource {
 

--- a/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
@@ -27,7 +27,7 @@ import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/")
-@Api(tags = "Refunding payments", value = "/")
+@Api(tags = "Refunding card payments", value = "/")
 @Produces({"application/json"})
 public class SearchRefundsResource {
 

--- a/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
@@ -27,7 +27,7 @@ import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/")
-@Api(value = "/", description = "Public Api Endpoint to get all Refunds")
+@Api(tags="Refunds", value = "/")
 @Produces({"application/json"})
 public class SearchRefundsResource {
 
@@ -45,7 +45,6 @@ public class SearchRefundsResource {
     @Path("/v1/refunds")
     @Produces(APPLICATION_JSON)
     @ApiOperation(
-            tags = "refunds",
             value = "Search refunds",
             notes = "Search refunds by 'from' and 'to' date. " +
                     "The Authorisation token needs to be specified in the 'authorization' header " +

--- a/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
@@ -45,6 +45,7 @@ public class SearchRefundsResource {
     @Path("/v1/refunds")
     @Produces(APPLICATION_JSON)
     @ApiOperation(
+            nickname = "Search refunds",
             value = "Search refunds",
             notes = "Search refunds by 'from' and 'to' date. " +
                     "The Authorisation token needs to be specified in the 'authorization' header " +

--- a/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
@@ -67,7 +67,7 @@ public class DirectDebitPaymentsResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @ApiOperation(
-            nickname = "Create a direct debit payment",
+            nickname = "Collect a Direct Debit payment",
             value = "Create new Direct Debit payment",
             notes = "Create a new Direct Debit payment for the account associated to the Authorisation token. " +
                     "The Authorisation token needs to be specified in the 'authorization' header " +
@@ -93,7 +93,7 @@ public class DirectDebitPaymentsResource {
     @Timed
     @Produces(APPLICATION_JSON)
     @ApiOperation(
-            nickname = "Search direct debit payments",
+            nickname = "Search Direct Debit payments",
             value = "Search Direct Debit payments",
             notes = "Search Direct Debit payments by reference, state, mandate id, and 'from' and 'to' dates. " +
                     "The Authorisation token needs to be specified in the 'Authorization' header " +
@@ -121,7 +121,7 @@ public class DirectDebitPaymentsResource {
     @Path("{paymentId}")
     @Produces(APPLICATION_JSON)
     @ApiOperation(
-            nickname = "Get a direct debit payment",
+            nickname = "Get a Direct Debit payment",
             value = "Find direct debit payment by ID",
             notes = "Return information about the direct debit payment. " +
                     "The Authorisation token needs to be specified in the 'Authorization' header " +

--- a/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
@@ -40,6 +40,7 @@ import javax.ws.rs.core.UriInfo;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/v1/directdebit/payments/")
+@Api(tags = "Direct Debit", value = "/v1/directdebit/payments")
 @Produces({"application/json"})
 public class DirectDebitPaymentsResource {
 

--- a/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
@@ -122,8 +122,8 @@ public class DirectDebitPaymentsResource {
     @Produces(APPLICATION_JSON)
     @ApiOperation(
             nickname = "Get a Direct Debit payment",
-            value = "Find direct debit payment by ID",
-            notes = "Return information about the direct debit payment. " +
+            value = "Find Direct Debit payment by ID",
+            notes = "Return information about the Direct Debit payment. " +
                     "The Authorisation token needs to be specified in the 'Authorization' header " +
                     "as 'Authorization: Bearer YOUR_API_KEY_HERE'",
             code = 200,

--- a/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
@@ -67,7 +67,7 @@ public class DirectDebitPaymentsResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @ApiOperation(
-            nickname = "createDirectDebitPayment",
+            nickname = "Create a direct debit payment",
             value = "Create new Direct Debit payment",
             notes = "Create a new Direct Debit payment for the account associated to the Authorisation token. " +
                     "The Authorisation token needs to be specified in the 'authorization' header " +
@@ -93,7 +93,7 @@ public class DirectDebitPaymentsResource {
     @Timed
     @Produces(APPLICATION_JSON)
     @ApiOperation(
-            nickname = "searchDirectDebitPayments",
+            nickname = "Search direct debit payments",
             value = "Search Direct Debit payments",
             notes = "Search Direct Debit payments by reference, state, mandate id, and 'from' and 'to' dates. " +
                     "The Authorisation token needs to be specified in the 'Authorization' header " +
@@ -121,7 +121,7 @@ public class DirectDebitPaymentsResource {
     @Path("{paymentId}")
     @Produces(APPLICATION_JSON)
     @ApiOperation(
-            nickname = "getDirectDebitPayment",
+            nickname = "Get a direct debit payment",
             value = "Find direct debit payment by ID",
             notes = "Return information about the direct debit payment. " +
                     "The Authorisation token needs to be specified in the 'Authorization' header " +

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -249,13 +249,13 @@
         }, {
           "name" : "from_date",
           "in" : "query",
-          "description" : "From date of direct debit payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z",
+          "description" : "From date of Direct Debit payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z",
           "required" : false,
           "type" : "string"
         }, {
           "name" : "to_date",
           "in" : "query",
-          "description" : "To date of direct debit payments to be searched (this date is exclusive). Example=2015-08-13T12:35:00Z",
+          "description" : "To date of Direct Debit payments to be searched (this date is exclusive). Example=2015-08-13T12:35:00Z",
           "required" : false,
           "type" : "string"
         }, {
@@ -368,8 +368,8 @@
     "/v1/directdebit/payments/{paymentId}" : {
       "get" : {
         "tags" : [ "Direct Debit" ],
-        "summary" : "Find direct debit payment by ID",
-        "description" : "Return information about the direct debit payment. The Authorisation token needs to be specified in the 'Authorization' header as 'Authorization: Bearer YOUR_API_KEY_HERE'",
+        "summary" : "Find Direct Debit payment by ID",
+        "description" : "Return information about the Direct Debit payment. The Authorisation token needs to be specified in the 'Authorization' header as 'Authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "Get a Direct Debit payment",
         "produces" : [ "application/json" ],
         "parameters" : [ {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -7,11 +7,11 @@
   },
   "host" : "publicapi.payments.service.gov.uk",
   "tags" : [ {
-    "name" : "Card Payments"
+    "name" : "Card payments"
   }, {
     "name" : "Direct Debit"
   }, {
-    "name" : "Refunds"
+    "name" : "Refunding payments"
   } ],
   "schemes" : [ "https" ],
   "paths" : {
@@ -221,7 +221,7 @@
         "tags" : [ "Direct Debit" ],
         "summary" : "Search Direct Debit payments",
         "description" : "Search Direct Debit payments by reference, state, mandate id, and 'from' and 'to' dates. The Authorisation token needs to be specified in the 'Authorization' header as 'Authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "Search direct debit payments",
+        "operationId" : "Search Direct Debit payments",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "reference",
@@ -313,7 +313,7 @@
         "tags" : [ "Direct Debit" ],
         "summary" : "Create new Direct Debit payment",
         "description" : "Create a new Direct Debit payment for the account associated to the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "Collect a direct debit payment",
+        "operationId" : "Collect a Direct Debit payment",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -370,7 +370,7 @@
         "tags" : [ "Direct Debit" ],
         "summary" : "Find direct debit payment by ID",
         "description" : "Return information about the direct debit payment. The Authorisation token needs to be specified in the 'Authorization' header as 'Authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "Get a direct debit payment",
+        "operationId" : "Get a Direct Debit payment",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "paymentId",
@@ -415,7 +415,7 @@
     },
     "/v1/payments" : {
       "get" : {
-        "tags" : [ "Card Payments" ],
+        "tags" : [ "Card payments" ],
         "summary" : "Search payments",
         "description" : "Search payments by reference, state, 'from' and 'to' date. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "Search payments",
@@ -522,7 +522,7 @@
         } ]
       },
       "post" : {
-        "tags" : [ "Card Payments" ],
+        "tags" : [ "Card payments" ],
         "summary" : "Create new payment",
         "description" : "Create a new payment for the account associated to the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "Create a payment",
@@ -579,7 +579,7 @@
     },
     "/v1/payments/{paymentId}" : {
       "get" : {
-        "tags" : [ "Card Payments" ],
+        "tags" : [ "Card payments" ],
         "summary" : "Find payment by ID",
         "description" : "Return information about the payment The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "Get a payment",
@@ -628,7 +628,7 @@
     },
     "/v1/payments/{paymentId}/cancel" : {
       "post" : {
-        "tags" : [ "Card Payments" ],
+        "tags" : [ "Card payments" ],
         "summary" : "Cancel payment",
         "description" : "Cancel a payment based on the provided payment ID and the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be cancelled if it's in a state that isn't finished.",
         "operationId" : "Cancel a payment",
@@ -686,7 +686,7 @@
     },
     "/v1/payments/{paymentId}/capture" : {
       "post" : {
-        "tags" : [ "Card Payments" ],
+        "tags" : [ "Card payments" ],
         "summary" : "Capture payment",
         "description" : "Capture a payment based on the provided payment ID and the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be captured if it's in 'submitted' state",
         "operationId" : "Capture a payment",
@@ -744,7 +744,7 @@
     },
     "/v1/payments/{paymentId}/events" : {
       "get" : {
-        "tags" : [ "Card Payments" ],
+        "tags" : [ "Card payments" ],
         "summary" : "Return payment events by ID",
         "description" : "Return payment events information about a certain payment The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "Get events for a payment",
@@ -793,7 +793,7 @@
     },
     "/v1/payments/{paymentId}/refunds" : {
       "get" : {
-        "tags" : [ "Refunds" ],
+        "tags" : [ "Refunding payments" ],
         "summary" : "Get all refunds for a payment",
         "description" : "Return refunds for a payment. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "Get all refunds for a payment",
@@ -838,7 +838,7 @@
         } ]
       },
       "post" : {
-        "tags" : [ "Refunds" ],
+        "tags" : [ "Refunding payments" ],
         "summary" : "Submit a refund for a payment",
         "description" : "Return issued refund information. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "Submit a refund for a payment",
@@ -901,7 +901,7 @@
     },
     "/v1/payments/{paymentId}/refunds/{refundId}" : {
       "get" : {
-        "tags" : [ "Refunds" ],
+        "tags" : [ "Refunding payments" ],
         "summary" : "Find payment refund by ID",
         "description" : "Return payment refund information by Refund ID The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "Get a payment refund",
@@ -953,7 +953,7 @@
     },
     "/v1/refunds" : {
       "get" : {
-        "tags" : [ "Refunds" ],
+        "tags" : [ "Refunding payments" ],
         "summary" : "Search refunds",
         "description" : "Search refunds by 'from' and 'to' date. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "Search refunds",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -20,7 +20,7 @@
         "tags" : [ "Direct Debit" ],
         "summary" : "Search mandates",
         "description" : "Searches for mandates with the parameters provided. The Authorisation token needs to be specified in the 'Authorization' header as 'Authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "searchMandates",
+        "operationId" : "Search mandates",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "reference",
@@ -123,7 +123,7 @@
         "tags" : [ "Direct Debit" ],
         "summary" : "Create a new mandate",
         "description" : "Create a new mandate for the account associated to the Authorisation token. The Authorisation token needs to be specified in the 'Authorization' header as 'Authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "createMandate",
+        "operationId" : "Create a mandate",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -174,7 +174,7 @@
         "tags" : [ "Direct Debit" ],
         "summary" : "Find mandate by ID",
         "description" : "Return information about the mandate. The Authorisation token needs to be specified in the 'Authorization' header as 'Authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "getMandate",
+        "operationId" : "Get a mandate",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "mandateId",
@@ -221,7 +221,7 @@
         "tags" : [ "Direct Debit" ],
         "summary" : "Search Direct Debit payments",
         "description" : "Search Direct Debit payments by reference, state, mandate id, and 'from' and 'to' dates. The Authorisation token needs to be specified in the 'Authorization' header as 'Authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "searchDirectDebitPayments",
+        "operationId" : "Search direct debit payments",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "reference",
@@ -313,7 +313,7 @@
         "tags" : [ "Direct Debit" ],
         "summary" : "Create new Direct Debit payment",
         "description" : "Create a new Direct Debit payment for the account associated to the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "createDirectDebitPayment",
+        "operationId" : "Collect a direct debit payment",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -370,7 +370,7 @@
         "tags" : [ "Direct Debit" ],
         "summary" : "Find direct debit payment by ID",
         "description" : "Return information about the direct debit payment. The Authorisation token needs to be specified in the 'Authorization' header as 'Authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "getDirectDebitPayment",
+        "operationId" : "Get a direct debit payment",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "paymentId",
@@ -418,7 +418,7 @@
         "tags" : [ "Card Payments" ],
         "summary" : "Search payments",
         "description" : "Search payments by reference, state, 'from' and 'to' date. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "searchPayments",
+        "operationId" : "Search payments",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "reference",
@@ -525,7 +525,7 @@
         "tags" : [ "Card Payments" ],
         "summary" : "Create new payment",
         "description" : "Create a new payment for the account associated to the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "newPayment",
+        "operationId" : "Create a payment",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -582,7 +582,7 @@
         "tags" : [ "Card Payments" ],
         "summary" : "Find payment by ID",
         "description" : "Return information about the payment The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "getPayment",
+        "operationId" : "Get a payment",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "paymentId",
@@ -631,7 +631,7 @@
         "tags" : [ "Card Payments" ],
         "summary" : "Cancel payment",
         "description" : "Cancel a payment based on the provided payment ID and the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be cancelled if it's in a state that isn't finished.",
-        "operationId" : "cancelPayment",
+        "operationId" : "Cancel a payment",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "paymentId",
@@ -689,7 +689,7 @@
         "tags" : [ "Card Payments" ],
         "summary" : "Capture payment",
         "description" : "Capture a payment based on the provided payment ID and the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be captured if it's in 'submitted' state",
-        "operationId" : "capturePayment",
+        "operationId" : "Capture a payment",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "paymentId",
@@ -747,7 +747,7 @@
         "tags" : [ "Card Payments" ],
         "summary" : "Return payment events by ID",
         "description" : "Return payment events information about a certain payment The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "getPaymentEvents",
+        "operationId" : "Get events for a payment",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "paymentId",
@@ -796,7 +796,7 @@
         "tags" : [ "Refunds" ],
         "summary" : "Get all refunds for a payment",
         "description" : "Return refunds for a payment. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "getRefunds",
+        "operationId" : "Get all refunds for a payment",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "paymentId",
@@ -841,7 +841,7 @@
         "tags" : [ "Refunds" ],
         "summary" : "Submit a refund for a payment",
         "description" : "Return issued refund information. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "submitRefund",
+        "operationId" : "Submit a refund for a payment",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -904,7 +904,7 @@
         "tags" : [ "Refunds" ],
         "summary" : "Find payment refund by ID",
         "description" : "Return payment refund information by Refund ID The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "getRefundById",
+        "operationId" : "Get a payment refund",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "paymentId",
@@ -956,7 +956,7 @@
         "tags" : [ "Refunds" ],
         "summary" : "Search refunds",
         "description" : "Search refunds by 'from' and 'to' date. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
-        "operationId" : "searchRefunds",
+        "operationId" : "Search refunds",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "from_date",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -11,7 +11,7 @@
   }, {
     "name" : "Direct Debit"
   }, {
-    "name" : "Refunding payments"
+    "name" : "Refunding card payments"
   } ],
   "schemes" : [ "https" ],
   "paths" : {
@@ -793,7 +793,7 @@
     },
     "/v1/payments/{paymentId}/refunds" : {
       "get" : {
-        "tags" : [ "Refunding payments" ],
+        "tags" : [ "Refunding card payments" ],
         "summary" : "Get all refunds for a payment",
         "description" : "Return refunds for a payment. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "Get all refunds for a payment",
@@ -838,7 +838,7 @@
         } ]
       },
       "post" : {
-        "tags" : [ "Refunding payments" ],
+        "tags" : [ "Refunding card payments" ],
         "summary" : "Submit a refund for a payment",
         "description" : "Return issued refund information. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "Submit a refund for a payment",
@@ -901,7 +901,7 @@
     },
     "/v1/payments/{paymentId}/refunds/{refundId}" : {
       "get" : {
-        "tags" : [ "Refunding payments" ],
+        "tags" : [ "Refunding card payments" ],
         "summary" : "Find payment refund by ID",
         "description" : "Return payment refund information by Refund ID The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "Get a payment refund",
@@ -953,7 +953,7 @@
     },
     "/v1/refunds" : {
       "get" : {
-        "tags" : [ "Refunding payments" ],
+        "tags" : [ "Refunding card payments" ],
         "summary" : "Search refunds",
         "description" : "Search refunds by 'from' and 'to' date. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "Search refunds",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -7,12 +7,17 @@
   },
   "host" : "publicapi.payments.service.gov.uk",
   "tags" : [ {
-    "name" : "refunds"
+    "name" : "Card Payments"
+  }, {
+    "name" : "Direct Debit"
+  }, {
+    "name" : "Refunds"
   } ],
   "schemes" : [ "https" ],
   "paths" : {
     "/v1/directdebit/mandates" : {
       "get" : {
+        "tags" : [ "Direct Debit" ],
         "summary" : "Search mandates",
         "description" : "Searches for mandates with the parameters provided. The Authorisation token needs to be specified in the 'Authorization' header as 'Authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "searchMandates",
@@ -115,6 +120,7 @@
         } ]
       },
       "post" : {
+        "tags" : [ "Direct Debit" ],
         "summary" : "Create a new mandate",
         "description" : "Create a new mandate for the account associated to the Authorisation token. The Authorisation token needs to be specified in the 'Authorization' header as 'Authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "createMandate",
@@ -165,6 +171,7 @@
     },
     "/v1/directdebit/mandates/{mandateId}" : {
       "get" : {
+        "tags" : [ "Direct Debit" ],
         "summary" : "Find mandate by ID",
         "description" : "Return information about the mandate. The Authorisation token needs to be specified in the 'Authorization' header as 'Authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "getMandate",
@@ -211,6 +218,7 @@
     },
     "/v1/directdebit/payments" : {
       "get" : {
+        "tags" : [ "Direct Debit" ],
         "summary" : "Search Direct Debit payments",
         "description" : "Search Direct Debit payments by reference, state, mandate id, and 'from' and 'to' dates. The Authorisation token needs to be specified in the 'Authorization' header as 'Authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "searchDirectDebitPayments",
@@ -302,6 +310,7 @@
         } ]
       },
       "post" : {
+        "tags" : [ "Direct Debit" ],
         "summary" : "Create new Direct Debit payment",
         "description" : "Create a new Direct Debit payment for the account associated to the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "createDirectDebitPayment",
@@ -358,6 +367,7 @@
     },
     "/v1/directdebit/payments/{paymentId}" : {
       "get" : {
+        "tags" : [ "Direct Debit" ],
         "summary" : "Find direct debit payment by ID",
         "description" : "Return information about the direct debit payment. The Authorisation token needs to be specified in the 'Authorization' header as 'Authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "getDirectDebitPayment",
@@ -405,6 +415,7 @@
     },
     "/v1/payments" : {
       "get" : {
+        "tags" : [ "Card Payments" ],
         "summary" : "Search payments",
         "description" : "Search payments by reference, state, 'from' and 'to' date. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "searchPayments",
@@ -511,6 +522,7 @@
         } ]
       },
       "post" : {
+        "tags" : [ "Card Payments" ],
         "summary" : "Create new payment",
         "description" : "Create a new payment for the account associated to the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "newPayment",
@@ -567,6 +579,7 @@
     },
     "/v1/payments/{paymentId}" : {
       "get" : {
+        "tags" : [ "Card Payments" ],
         "summary" : "Find payment by ID",
         "description" : "Return information about the payment The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "getPayment",
@@ -615,6 +628,7 @@
     },
     "/v1/payments/{paymentId}/cancel" : {
       "post" : {
+        "tags" : [ "Card Payments" ],
         "summary" : "Cancel payment",
         "description" : "Cancel a payment based on the provided payment ID and the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be cancelled if it's in a state that isn't finished.",
         "operationId" : "cancelPayment",
@@ -672,6 +686,7 @@
     },
     "/v1/payments/{paymentId}/capture" : {
       "post" : {
+        "tags" : [ "Card Payments" ],
         "summary" : "Capture payment",
         "description" : "Capture a payment based on the provided payment ID and the Authorisation token. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be captured if it's in 'submitted' state",
         "operationId" : "capturePayment",
@@ -729,6 +744,7 @@
     },
     "/v1/payments/{paymentId}/events" : {
       "get" : {
+        "tags" : [ "Card Payments" ],
         "summary" : "Return payment events by ID",
         "description" : "Return payment events information about a certain payment The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "getPaymentEvents",
@@ -777,7 +793,7 @@
     },
     "/v1/payments/{paymentId}/refunds" : {
       "get" : {
-        "tags" : [ "refunds" ],
+        "tags" : [ "Refunds" ],
         "summary" : "Get all refunds for a payment",
         "description" : "Return refunds for a payment. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "getRefunds",
@@ -822,7 +838,7 @@
         } ]
       },
       "post" : {
-        "tags" : [ "refunds" ],
+        "tags" : [ "Refunds" ],
         "summary" : "Submit a refund for a payment",
         "description" : "Return issued refund information. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "submitRefund",
@@ -885,7 +901,7 @@
     },
     "/v1/payments/{paymentId}/refunds/{refundId}" : {
       "get" : {
-        "tags" : [ "refunds" ],
+        "tags" : [ "Refunds" ],
         "summary" : "Find payment refund by ID",
         "description" : "Return payment refund information by Refund ID The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "getRefundById",
@@ -937,7 +953,7 @@
     },
     "/v1/refunds" : {
       "get" : {
-        "tags" : [ "refunds" ],
+        "tags" : [ "Refunds" ],
         "summary" : "Search refunds",
         "description" : "Search refunds by 'from' and 'to' date. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "searchRefunds",


### PR DESCRIPTION
Group resources in public API documentation into 3 groups:
"Card Payments"
"Direct Debit"
"Refunds"

> NOTE: I think the resources currently in "Refunds" should go into "Card Payments" as they don't apply to Direct Debit. I'd like any opinions on this.

Add human readable names for the resources, which appear in the left hand navigation bar of the API documentation browser.

Find attached a built version of the API browser
[build.zip](https://github.com/alphagov/pay-publicapi/files/3452883/build.zip)
