### PR TITLE
PP-5475 Build swagger with removed finished property

### DIFF
--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1393,9 +1393,6 @@
         },
         "status" : {
           "type" : "string"
-        },
-        "finished" : {
-          "type" : "boolean"
         }
       }
     },


### PR DESCRIPTION
The "finished" property has been removed from the "state" object for direct debit payment and mandate responses. This is the build swagger file for this change.