### PR TITLE
PP-5495 Remove Events Link From PublicAPI

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/directdebit/DirectDebitPaymentLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/DirectDebitPaymentLinks.java
@@ -3,6 +3,7 @@ package uk.gov.pay.api.model.directdebit;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import uk.gov.pay.api.model.links.Link;
 
 import java.net.URI;
@@ -16,6 +17,8 @@ public class DirectDebitPaymentLinks {
     @JsonProperty("self")
     private Link self;
 
+    //Hidden because it is currently unused
+    @ApiModelProperty(hidden = true)
     @JsonProperty("events")
     private Link events;
 

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/DirectDebitPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/DirectDebitPayment.java
@@ -76,7 +76,6 @@ public class DirectDebitPayment extends Payment {
         this.providerId = builder.providerId;
         this.links = aDirectDebitPaymentLinks()
                 .withSelf(builder.selfLink)
-                .withEvents(builder.eventsLink)
                 .withMandate(builder.mandateLink)
                 .build();
     }

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateResponse.java
@@ -29,7 +29,6 @@ public class MandateResponse {
                 .withPayments(publicApiUriGenerator.getMandatePaymentsURI(mandate.getMandateId()).toString())
                 .withNextUrl(mandate.getLinks())
                 .withNextUrlPost(mandate.getLinks())
-                .withEvents(publicApiUriGenerator.getMandateEventsURI(mandate.getMandateId()))
                 .build();
         
         this.mandateId = mandate.getMandateId();

--- a/src/main/java/uk/gov/pay/api/model/links/directdebit/MandateLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/directdebit/MandateLinks.java
@@ -32,7 +32,9 @@ public class MandateLinks {
 
     @JsonProperty(PAYMENTS)
     private final Link payments;
-    
+
+    //Hidden because it is currently unused
+    @ApiModelProperty(hidden = true)
     @JsonProperty(EVENTS)
     private final Link events;
 

--- a/src/main/java/uk/gov/pay/api/model/links/directdebit/MandateLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/directdebit/MandateLinks.java
@@ -32,8 +32,7 @@ public class MandateLinks {
 
     @JsonProperty(PAYMENTS)
     private final Link payments;
-
-    //Hidden because it is currently unused
+    
     @ApiModelProperty(hidden = true)
     @JsonProperty(EVENTS)
     private final Link events;
@@ -58,7 +57,7 @@ public class MandateLinks {
         return payments;
     }
 
-    @ApiModelProperty(value = EVENTS, dataType = "uk.gov.pay.api.model.links.Link")
+    @ApiModelProperty(value = EVENTS, dataType = "uk.gov.pay.api.model.links.Link", hidden = true)
     public Link getEvents() {
         return events;
     }

--- a/src/test/java/uk/gov/pay/api/it/directdebit/CreateMandateIT.java
+++ b/src/test/java/uk/gov/pay/api/it/directdebit/CreateMandateIT.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static java.lang.String.format;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
@@ -176,9 +175,7 @@ public class CreateMandateIT extends DirectDebitResourceITBase {
                 .body("_links.next_url_post.type", is("application/x-www-form-urlencoded"))
                 .body("_links.next_url_post.params.chargeTokenId", is(CHARGE_TOKEN_ID))
                 .body("_links.payments.href", is("http://publicapi.url/v1/directdebit/payments?mandate_id=" + MANDATE_ID))
-                .body("_links.payments.method", is("GET"))
-                .body("_links.events.href", is(format("http://publicapi.url/v1/directdebit/mandates/%s/events", MANDATE_ID)))
-                .body("_links.events.method", is("GET"));
+                .body("_links.payments.method", is("GET"));
 
         connectorDDMockClient.verifyCreateMandateConnectorRequest(
                 new MandateConnectorRequest(RETURN_URL, SERVICE_REFERENCE, description), GATEWAY_ACCOUNT_ID);

--- a/src/test/java/uk/gov/pay/api/it/directdebit/MandateResourceGetMandateIT.java
+++ b/src/test/java/uk/gov/pay/api/it/directdebit/MandateResourceGetMandateIT.java
@@ -13,7 +13,6 @@ import java.time.ZonedDateTime;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static java.lang.String.format;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
@@ -83,8 +82,6 @@ public class MandateResourceGetMandateIT extends PaymentResourceITestBase {
                 .body("_links.next_url_post.type", is("application/x-www-form-urlencoded"))
                 .body("_links.next_url_post.params.chargeTokenId", is(CHARGE_TOKEN_ID))
                 .body("_links.payments.href", is("http://publicapi.url/v1/directdebit/payments?mandate_id=" + MANDATE_ID))
-                .body("_links.payments.method", is("GET"))
-                .body("_links.events.href", is(format("http://publicapi.url/v1/directdebit/mandates/%s/events", MANDATE_ID)))
-                .body("_links.events.method", is("GET"));
+                .body("_links.payments.method", is("GET"));
     }
 }

--- a/src/test/java/uk/gov/pay/api/it/directdebit/MandateResourceSearchMandateIT.java
+++ b/src/test/java/uk/gov/pay/api/it/directdebit/MandateResourceSearchMandateIT.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static java.lang.String.format;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
@@ -213,8 +212,6 @@ public class MandateResourceSearchMandateIT extends PaymentResourceITestBase {
                 .body("results[0]._links.self.method", is("GET"))
                 .body("results[0]._links.payments.href", is("http://publicapi.url/v1/directdebit/payments?mandate_id=" + MANDATE_ID))
                 .body("results[0]._links.payments.method", is("GET"))
-                .body("results[0]._links.events.href", is(format("http://publicapi.url/v1/directdebit/mandates/%s/events", MANDATE_ID)))
-                .body("results[0]._links.events.method", is("GET"))
                 .body("_links.self.href", is("http://publicapi.url/v1/directdebit/mandates?page=1&display_size=500&selfLink"))
                 .body("_links.first_page.href", is("http://publicapi.url/v1/directdebit/mandates?page=1&display_size=500&firstLink"))
                 .body("_links.last_page.href", is("http://publicapi.url/v1/directdebit/mandates?page=1&display_size=500&lastLink"))

--- a/src/test/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResourceCreatePaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResourceCreatePaymentIT.java
@@ -71,8 +71,6 @@ public class DirectDebitPaymentsResourceCreatePaymentIT extends DirectDebitResou
                 .body("state.status", is(status))
                 .body("mandate_id", is(MANDATE_ID))
                 .body("provider_id", is(PROVIDER_ID))
-                .body("_links.events.href", is(paymentEventsLocationFor(PAYMENT_ID)))
-                .body("_links.events.method", is("GET"))
                 .body("_links.self.href", is(paymentLocationFor(PAYMENT_ID)))
                 .body("_links.self.method", is("GET"))
                 .body("_links.mandate.href", is(mandateLocationFor(MANDATE_ID)))

--- a/src/test/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResourceGetIT.java
+++ b/src/test/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResourceGetIT.java
@@ -57,8 +57,6 @@ public class DirectDebitPaymentsResourceGetIT extends DirectDebitResourceITBase 
                 .body("created_date", is("2018-06-11T19:40:56Z"))
                 .body("_links.self.href", is(paymentLocationFor("ch_ab2341da231434l")))
                 .body("_links.self.method", is("GET"))
-                .body("_links.events.href", is(paymentEventsLocationFor("ch_ab2341da231434l")))
-                .body("_links.events.method", is("GET"))
                 .body("_links.mandate.href", is(mandateLocationFor("mandate2000")))
                 .body("_links.mandate.method", is("GET"));
     }
@@ -109,8 +107,6 @@ public class DirectDebitPaymentsResourceGetIT extends DirectDebitResourceITBase 
                 .body("results[0].state.details", Matchers.is(payments.get(0).getState().getDetails()))
                 .body("results[0].mandate_id", Matchers.is(payments.get(0).getMandate_id()))
                 .body("results[0].provider_id", Matchers.is(payments.get(0).getProvider_id()))
-                .body("results[0]._links.events.href", Matchers.is(paymentEventsLocationFor(payments.get(0).getPayment_id())))
-                .body("results[0]._links.events.method", Matchers.is("GET"))
                 .body("results[0]._links.self.href", Matchers.is(paymentLocationFor(payments.get(0).getPayment_id())))
                 .body("results[0]._links.self.method", Matchers.is("GET"))
                 .body("results[0]._links.mandate.href", Matchers.is(mandateLocationFor(payments.get(0).getMandate_id())))

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1376,9 +1376,6 @@
         "self" : {
           "$ref" : "#/definitions/Link"
         },
-        "events" : {
-          "$ref" : "#/definitions/Link"
-        },
         "mandate" : {
           "$ref" : "#/definitions/Link"
         }
@@ -1614,6 +1611,10 @@
     "MandateLinks" : {
       "type" : "object",
       "properties" : {
+        "events" : {
+          "description" : "events",
+          "$ref" : "#/definitions/Link"
+        },
         "self" : {
           "description" : "self",
           "readOnly" : true,
@@ -1631,11 +1632,6 @@
         },
         "payments" : {
           "description" : "payments",
-          "readOnly" : true,
-          "$ref" : "#/definitions/Link"
-        },
-        "events" : {
-          "description" : "events",
           "readOnly" : true,
           "$ref" : "#/definitions/Link"
         }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1611,10 +1611,6 @@
     "MandateLinks" : {
       "type" : "object",
       "properties" : {
-        "events" : {
-          "description" : "events",
-          "$ref" : "#/definitions/Link"
-        },
         "self" : {
           "description" : "self",
           "readOnly" : true,


### PR DESCRIPTION
- Currently an unused events link is returned inside PublicAPI
responses, as this is currently unused it should be removed from the
builder classes so this confusing information is not returned to users.
