### PR TITLE
PP-5419: remove transaction links from expected ledger response

### DIFF
--- a/src/test/resources/pacts/publicapi-ledger-get-payment-with-corporate-surcharge.json
+++ b/src/test/resources/pacts/publicapi-ledger-get-payment-with-corporate-surcharge.json
@@ -38,18 +38,6 @@
           "description": "Test description",
           "reference": "aReference",
           "language": "en",
-          "links": [
-            {
-              "rel": "self",
-              "method": "GET",
-              "href": "https://ledger/v1/transaction/ch_123abc456xyz"
-            },
-            {
-              "rel": "refunds",
-              "method": "GET",
-              "href": "https://ledger/v1/transaction/ch_123abc456xyz/refunds"
-            }
-          ],
           "transaction_id": "ch_123abc456xyz",
           "return_url": "https://somewhere.gov.uk/rainbow/1",
           "payment_provider": "sandbox",
@@ -76,21 +64,7 @@
             "$.description": {
               "matchers": [{"match": "type"}]
             },
-            "$.links[0].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/v1\/transaction\/ch_123abc456xyz"
-                }
-              ]
-            },
-            "$.links[1].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/v1\/transaction\/ch_123abc456xyz\/refunds"
-                }
-              ]
-            },
-            "$.return_url": {
+             "$.return_url": {
               "matchers": [{"match": "type"}]
             },
             "$.created_date": {

--- a/src/test/resources/pacts/publicapi-ledger-get-payment-with-delayed-capture-true.json
+++ b/src/test/resources/pacts/publicapi-ledger-get-payment-with-delayed-capture-true.json
@@ -38,18 +38,6 @@
           "description": "Test description",
           "reference": "aReference",
           "language": "en",
-          "links": [
-            {
-              "rel": "self",
-              "method": "GET",
-              "href": "https://ledger/v1/transaction/ch_123abc456xyz"
-            },
-            {
-              "rel": "refunds",
-              "method": "GET",
-              "href": "https://ledger/v1/transaction/ch_123abc456xyz/refunds"
-            }
-          ],
           "transaction_id": "ch_123abc456xyz",
           "return_url": "https://somewhere.gov.uk/rainbow/1",
           "payment_provider": "sandbox",
@@ -73,20 +61,6 @@
             },
             "$.description": {
               "matchers": [{"match": "type"}]
-            },
-            "$.links[0].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/v1\/transaction\/ch_123abc456xyz"
-                }
-              ]
-            },
-            "$.links[1].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/v1\/transaction\/ch_123abc456xyz\/refunds"
-                }
-              ]
             },
             "$.return_url": {
               "matchers": [{"match": "type"}]

--- a/src/test/resources/pacts/publicapi-ledger-get-payment-with-fee-and-net-amount.json
+++ b/src/test/resources/pacts/publicapi-ledger-get-payment-with-fee-and-net-amount.json
@@ -40,18 +40,6 @@
           "description": "Test description",
           "reference": "aReference",
           "language": "en",
-          "links": [
-            {
-              "rel": "self",
-              "method": "GET",
-              "href": "https://ledger/v1/transaction/ch_123abc456xyz"
-            },
-            {
-              "rel": "refunds",
-              "method": "GET",
-              "href": "https://ledger/v1/transaction/ch_123abc456xyz/refunds"
-            }
-          ],
           "transaction_id": "ch_123abc456xyz",
           "return_url": "https://somewhere.gov.uk/rainbow/1",
           "payment_provider": "sandbox",
@@ -75,20 +63,6 @@
             },
             "$.description": {
               "matchers": [{"match": "type"}]
-            },
-            "$.links[0].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/v1\/transaction\/ch_123abc456xyz"
-                }
-              ]
-            },
-            "$.links[1].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/v1\/transaction\/ch_123abc456xyz\/refunds"
-                }
-              ]
             },
             "$.return_url": {
               "matchers": [{"match": "type"}]

--- a/src/test/resources/pacts/publicapi-ledger-get-payment-with-gateway-transaction-id.json
+++ b/src/test/resources/pacts/publicapi-ledger-get-payment-with-gateway-transaction-id.json
@@ -39,18 +39,6 @@
           "description": "Test description",
           "reference": "aReference",
           "language": "en",
-          "links": [
-            {
-              "rel": "self",
-              "method": "GET",
-              "href": "https://ledger/v1/transaction/ch_123abc456xyz"
-            },
-            {
-              "rel": "refunds",
-              "method": "GET",
-              "href": "https://ledger/v1/transaction/ch_123abc456xyz/refunds"
-            }
-          ],
           "transaction_id": "ch_123abc456xyz",
           "gateway_transaction_id": "gateway-tx-123456",
           "return_url": "https://somewhere.gov.uk/rainbow/1",
@@ -75,20 +63,6 @@
             },
             "$.description": {
               "matchers": [{"match": "type"}]
-            },
-            "$.links[0].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/v1\/transaction\/ch_123abc456xyz"
-                }
-              ]
-            },
-            "$.links[1].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/v1\/transaction\/ch_123abc456xyz\/refunds"
-                }
-              ]
             },
             "$.return_url": {
               "matchers": [{"match": "type"}]

--- a/src/test/resources/pacts/publicapi-ledger-get-payment-with-metadata.json
+++ b/src/test/resources/pacts/publicapi-ledger-get-payment-with-metadata.json
@@ -43,18 +43,6 @@
           "description": "Test description",
           "reference": "aReference",
           "language": "en",
-          "links": [
-            {
-              "rel": "self",
-              "method": "GET",
-              "href": "https://ledger/v1/transaction/ch_123abc456xyz"
-            },
-            {
-              "rel": "refunds",
-              "method": "GET",
-              "href": "https://ledger/v1/transaction/ch_123abc456xyz/refunds"
-            }
-          ],
           "transaction_id": "ch_123abc456xyz",
           "return_url": "https://somewhere.gov.uk/rainbow/1",
           "payment_provider": "sandbox",
@@ -78,20 +66,6 @@
             },
             "$.description": {
               "matchers": [{"match": "type"}]
-            },
-            "$.links[0].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/v1\/transaction\/ch_123abc456xyz"
-                }
-              ]
-            },
-            "$.links[1].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/v1\/transaction\/ch_123abc456xyz\/refunds"
-                }
-              ]
             },
             "$.return_url": {
               "matchers": [{"match": "type"}]

--- a/src/test/resources/pacts/publicapi-ledger-search-transaction.json
+++ b/src/test/resources/pacts/publicapi-ledger-search-transaction.json
@@ -45,18 +45,6 @@
               "description": "Test description",
               "reference": "aReference",
               "language": "en",
-              "links": [
-                {
-                  "rel": "self",
-                  "method": "GET",
-                  "href": "http://ledger.service.backend/v1/transaction/charge8133029783750964639"
-                },
-                {
-                  "rel": "refunds",
-                  "method": "GET",
-                  "href": "http://ledger.service.backend/v1/transaction/charge8133029783750964639/refunds"
-                }
-              ],
               "charge_id": "charge97837509646393e3C",
               "return_url": "https://example.org",
               "email": "someone@example.org",
@@ -90,20 +78,6 @@
         },
         "matchingRules": {
           "body": {
-            "$.results[*].links[0].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/v1\/transaction\/charge97837509646393e3C"
-                }
-              ]
-            },
-            "$.results[*].links[1].href": {
-              "matchers": [
-                {
-                  "regex": "http.*:\/\/.*\/v1\/transaction\/charge97837509646393e3C\/refunds"
-                }
-              ]
-            },
             "$._links.self.href": {
               "matchers": [
                 {


### PR DESCRIPTION
* they're not used in public api
* it will allow deprecating them in ledger