### PR TITLE
PP-5516 Fix state validation for search mandate

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
@@ -19,7 +19,8 @@ public class DirectDebitSearchMandatesParams {
     private String reference;
 
     @QueryParam("state")
-    @Pattern(regexp = "created|started|pending|submitted|active|inactive|cancelled", message = "state is not a valid mandate external state")
+    @Pattern(regexp = "created|started|pending|active|inactive|cancelled|failed|abandoned|error",
+            message = "Must be one of created, started, pending, active, inactive, cancelled, failed, abandoned or error")
     private String state;
 
     @QueryParam("bank_statement_reference")

--- a/src/test/java/uk/gov/pay/api/it/directdebit/MandateResourceSearchMandateIT.java
+++ b/src/test/java/uk/gov/pay/api/it/directdebit/MandateResourceSearchMandateIT.java
@@ -137,7 +137,7 @@ public class MandateResourceSearchMandateIT extends PaymentResourceITestBase {
                 .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
                 .body("field", is("state"))
                 .body("code", is("P0102"))
-                .body("description", is("Invalid attribute value: state. state is not a valid mandate external state"));
+                .body("description", is("Invalid attribute value: state. Must be one of created, started, pending, active, inactive, cancelled, failed, abandoned or error"));
     }
 
     @Test

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -27,7 +27,7 @@
           "in" : "query",
           "required" : false,
           "type" : "string",
-          "pattern" : "created|started|pending|submitted|active|inactive|cancelled"
+          "pattern" : "created|started|pending|active|inactive|cancelled|failed|abandoned|error"
         }, {
           "name" : "bank_statement_reference",
           "in" : "query",


### PR DESCRIPTION
Fix allowed states and improve error message if an invalid state is provided for the search mandates endpoint.