### PR TITLE
PP-5459 Fix error message for invalid mandate state

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/PaymentError.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentError.java
@@ -50,7 +50,7 @@ public class PaymentError {
         CREATE_PAYMENT_REFUND_NOT_AVAILABLE("P0603", "The payment is not available for refund. Payment refund status: %s"),
         CREATE_PAYMENT_REFUND_AMOUNT_AVAILABLE_MISMATCH("P0604", "Refund amount available mismatch."),
         CREATE_PAYMENT_MANDATE_STATE_INVALID("P1103",
-                "Can't create payment. The mandate's state must be pending, submitted or active."),
+                "Can't create payment. The mandate's state must be pending or active."),
 
         GET_PAYMENT_REFUND_NOT_FOUND_ERROR("P0700", "Not found"),
         GET_PAYMENT_REFUND_CONNECTOR_ERROR("P0798", "Downstream system error"),


### PR DESCRIPTION
When collecting a payment the mandate must be in an external state of
`pending` or `active`. This commit corrects the error message when
attempting to collect a payment on a mandate with an invalid state.