### PR TITLE
PP-5516 Fix allowing uppercase states for DD payment search

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
@@ -25,7 +25,6 @@ public class DirectDebitSearchPaymentsParams {
     @QueryParam("state")
     @ApiParam(value = "State of payments to be searched. Example=success")
     @Pattern(regexp = "created|pending|success|failed|cancelled|paidout|indemnityclaim|error",
-            flags = Pattern.Flag.CASE_INSENSITIVE,
             message = "Must be one of created, pending, success, failed, cancelled, paidout, indemnityclaim or error")
     private String state;
     

--- a/src/test/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResourceGetIT.java
+++ b/src/test/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResourceGetIT.java
@@ -174,6 +174,11 @@ public class DirectDebitPaymentsResourceGetIT extends DirectDebitResourceITBase 
                         .withErrorMessage("Invalid attribute value: state. Must be one of created, pending, success, failed, cancelled, paidout, indemnityclaim or error")
                         .build(),
                 someParameters()
+                        .withQueryString("?state=PENDING")
+                        .withErrorField("state")
+                        .withErrorMessage("Invalid attribute value: state. Must be one of created, pending, success, failed, cancelled, paidout, indemnityclaim or error")
+                        .build(),
+                someParameters()
                         .withQueryString("?from_date=not_a_date")
                         .withErrorField("from_date")
                         .withErrorMessage("Invalid attribute value: from_date. Must be a valid date")


### PR DESCRIPTION
We don't want to allow uppercase states for the search direct debit payments endpoint. Currently we return a "Downstream system error" when trying to search by an upper case state because directdebit-connector only expects lowercase states