### PR TITLE
bau: Remove wiremock-jre8-standalone dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,12 +121,6 @@
         </dependency>
         <!-- testing -->
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>2.24.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>uk.gov.pay</groupId>
             <artifactId>testing</artifactId>
             <version>${pay-java-commons.version}</version>


### PR DESCRIPTION
This isn't needed, as far as i can tell.
