### PR TITLE
Use common entry point for all end to end tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
 
   parameters {
     booleanParam(defaultValue: false, description: '', name: 'runEndToEndTestsOnPR')
-    booleanParam(defaultValue: false, description: '', name: 'runZapTestsOnPR')
+    string(defaultValue: 'card,directdebit,products,zap', description: 'The tests to run', name: 'E2E_TESTS')
   }
 
   options {
@@ -20,7 +20,6 @@ pipeline {
   environment {
     DOCKER_HOST = "unix:///var/run/docker.sock"
     RUN_END_TO_END_ON_PR = "${params.runEndToEndTestsOnPR}"
-    RUN_ZAP_ON_PR = "${params.runZapTestsOnPR}"
     JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"
   }
 
@@ -117,7 +116,7 @@ pipeline {
     stage('Tests') {
       failFast true
       stages {
-        stage('Card Payment End-to-End Tests') {
+        stage('End-to-End Tests') {
             when {
                 anyOf {
                   branch 'master'
@@ -125,41 +124,8 @@ pipeline {
                 }
             }
             steps {
-                runCardPaymentsE2E("publicapi")
+                runAppE2E("publicapi", "${env.E2E_TESTS}")
             }
-        }
-        stage('Products End-to-End Tests') {
-            when {
-                anyOf {
-                  branch 'master'
-                  environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
-                }
-            }
-            steps {
-                runProductsE2E("publicapi")
-            }
-        }
-        stage('Direct-Debit End-to-End Tests') {
-            when {
-                anyOf {
-                  branch 'master'
-                  environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
-                }
-            }
-            steps {
-                runDirectDebitE2E("publicapi")
-            }
-        }
-        stage('ZAP Tests') {
-           when {
-               anyOf {
-                 branch 'master'
-                 environment name: 'RUN_ZAP_ON_PR', value: 'true'
-               }
-           }
-           steps {
-               runZap("publicapi")
-           }
         }
       }
     }


### PR DESCRIPTION
We now have a single entrypoint for running end to end tests. Let's try using it.
