### PR TITLE
API docs: specify that "expiry_date" format is MM/yy

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CardDetails.java
+++ b/src/main/java/uk/gov/pay/api/model/CardDetails.java
@@ -63,7 +63,7 @@ public class CardDetails {
         return cardHolderName;
     }
 
-    @ApiModelProperty(example = "12/20")
+    @ApiModelProperty(value = "The expiry date of the card in MM/yy format", example = "04/24")
     public String getExpiryDate() {
         return expiryDate;
     }


### PR DESCRIPTION
Document that the format of the `"expiry_date"` inside `"card_details"` is MM/yy.

Change the example date from 12/20 to 04/24 to make it clear that months have leading zeros.