### PR TITLE
PP-4769- Adds null check for PaymentOutcomeValidator to handle missing status

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/telephone/PaymentOutcome.java
+++ b/src/main/java/uk/gov/pay/api/model/telephone/PaymentOutcome.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.pay.api.validation.ValidPaymentOutcome;
 
-import javax.validation.constraints.NotNull;
 import java.util.Optional;
 
 @ValidPaymentOutcome

--- a/src/main/java/uk/gov/pay/api/model/telephone/PaymentOutcome.java
+++ b/src/main/java/uk/gov/pay/api/model/telephone/PaymentOutcome.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.pay.api.validation.ValidPaymentOutcome;
 
+import javax.validation.constraints.NotNull;
 import java.util.Optional;
 
 @ValidPaymentOutcome

--- a/src/main/java/uk/gov/pay/api/validation/PaymentOutcomeValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/PaymentOutcomeValidator.java
@@ -19,10 +19,14 @@ public class PaymentOutcomeValidator implements ConstraintValidator<ValidPayment
     @Override
     public boolean isValid(PaymentOutcome paymentOutcome, ConstraintValidatorContext context) {
         
+        if(paymentOutcome.getStatus() == null) {
+            return false;
+        }
+        
         if(paymentOutcome.getStatus().equals("success")) {
             return true;
         }
         
-        return paymentOutcome.getStatus().equals("failed")&& (ERROR_CODES.contains(paymentOutcome.getCode()));
+        return paymentOutcome.getStatus().equals("failed") && (ERROR_CODES.contains(paymentOutcome.getCode()));
     }
 }

--- a/src/test/java/uk/gov/pay/api/resources/telephone/PaymentOutcomeValidationResourceTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/telephone/PaymentOutcomeValidationResourceTest.java
@@ -91,4 +91,46 @@ public class PaymentOutcomeValidationResourceTest extends ValidationResourceTest
         Response response = sendPayload(payload);
         assertThat(response.getStatus(), is(422));
     }
+
+    @Test
+    public void respondWith422_whenPaymentOutcomeIsMissing() {
+
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("amount", 100);
+        map.put("reference", "Some reference");
+        map.put("description", "hi");
+        map.put("processor_id", "1PROC");
+        map.put("provider_id", "1PROV");
+        map.put("card_type", "visa");
+        map.put("card_expiry", "01/08");
+        map.put("last_four_digits", "1234");
+        map.put("first_six_digits", "123456");
+
+        String payload = toJson(map);
+
+        Response response = sendPayload(payload);
+        assertThat(response.getStatus(), is(422));
+    }
+
+    @Test
+    public void respondWith422_whenPaymentOutcomeStatusIsMissing() {
+
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("amount", 100);
+        map.put("reference", "Some reference");
+        map.put("description", "hi");
+        map.put("processor_id", "1PROC");
+        map.put("provider_id", "1PROV");
+        map.put("payment_outcome", Map.of(
+        ));
+        map.put("card_type", "visa");
+        map.put("card_expiry", "01/08");
+        map.put("last_four_digits", "1234");
+        map.put("first_six_digits", "123456");
+
+        String payload = toJson(map);
+
+        Response response = sendPayload(payload);
+        assertThat(response.getStatus(), is(422));
+    }
 }


### PR DESCRIPTION
This PR adds a null check in PaymentOutcomeValidator to ensure that the exception is handled when no status is provided in the PaymentOutcome section of the JSON. I have added 2 tests in the PaymentOutcomeValidationResourceTest to check this.

`"payment_outcome": { 
  }`