### PR TITLE
Swagger: specify that "expiry_date" format is MM/yy

### DIFF
--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1079,7 +1079,8 @@
         },
         "expiry_date" : {
           "type" : "string",
-          "example" : "12/20",
+          "example" : "04/24",
+          "description" : "The expiry date of the card in MM/yy format",
           "readOnly" : true
         },
         "billing_address" : {


### PR DESCRIPTION
Document that the format of the `"expiry_date"` inside `"card_details"` is MM/yy.

Change the example date from 12/20 to 04/24 to make it clear that months have leading zeros.