### PR TITLE
PP-5498: add strategy for get refund

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/ConnectorResponseErrorException.java
+++ b/src/main/java/uk/gov/pay/api/exception/ConnectorResponseErrorException.java
@@ -22,6 +22,12 @@ public class ConnectorResponseErrorException extends RuntimeException {
         response.close();
     }
 
+    ConnectorResponseErrorException(ConnectorResponseErrorException exception) {
+        super(exception);
+        this.status = exception.status;
+        this.error = exception.error;
+    }
+    
     ConnectorResponseErrorException(Throwable cause) {
         super(cause);
     }

--- a/src/main/java/uk/gov/pay/api/exception/GetRefundException.java
+++ b/src/main/java/uk/gov/pay/api/exception/GetRefundException.java
@@ -6,4 +6,8 @@ public class GetRefundException extends ConnectorResponseErrorException {
     public GetRefundException(Response response) {
         super(response);
     }
+
+    public GetRefundException(GetTransactionException exception) {
+        super(exception);
+    }
 }

--- a/src/main/java/uk/gov/pay/api/exception/GetTransactionException.java
+++ b/src/main/java/uk/gov/pay/api/exception/GetTransactionException.java
@@ -1,0 +1,10 @@
+package uk.gov.pay.api.exception;
+
+import javax.ws.rs.core.Response;
+
+public class GetTransactionException extends ConnectorResponseErrorException {
+
+    public GetTransactionException(Response response) {
+        super(response);
+    }
+}

--- a/src/main/java/uk/gov/pay/api/ledger/service/LedgerUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/ledger/service/LedgerUriGenerator.java
@@ -35,12 +35,12 @@ public class LedgerUriGenerator {
         return buildLedgerUri(path, Map.of("account_id", gatewayAccountId.getAccountId()));
     }
 
-    public String transactionURI(Account gatewayAccountId, String transactionId, String transactionType, String parentExternalId) {
-        String path = format("/v1/transaction/%s", transactionId);
+    public String transactionURI(Account gatewayAccountId, String refundId, String transactionType, String paymentId) {
+        String path = format("/v1/transaction/%s", refundId);
         return buildLedgerUri(path, Map.of(
                 "account_id", gatewayAccountId.getAccountId(),
                 "transaction_type", transactionType,
-                "parent_external_id", parentExternalId)
+                "parent_external_id", paymentId)
         );
     }
 

--- a/src/main/java/uk/gov/pay/api/ledger/service/LedgerUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/ledger/service/LedgerUriGenerator.java
@@ -35,11 +35,20 @@ public class LedgerUriGenerator {
         return buildLedgerUri(path, Map.of("account_id", gatewayAccountId.getAccountId()));
     }
 
+    public String transactionURI(Account gatewayAccountId, String transactionId, String transactionType, String parentExternalId) {
+        String path = format("/v1/transaction/%s", transactionId);
+        return buildLedgerUri(path, Map.of(
+                "account_id", gatewayAccountId.getAccountId(),
+                "transaction_type", transactionType,
+                "parent_external_id", parentExternalId)
+        );
+    }
+
     public String transactionEventsURI(Account gatewayAccountId, String paymentId) {
         String path = format("/v1/transaction/%s/event", paymentId);
         return buildLedgerUri(path, Map.of("gateway_account_id", gatewayAccountId.getAccountId()));
     }
-    
+
     public String transactionsForTransactionURI(String gatewayAccountId, String paymentId) {
         String path = format("/v1/transaction/%s/transaction", paymentId);
         return buildLedgerUri(path, Map.of("gateway_account_id", gatewayAccountId));

--- a/src/main/java/uk/gov/pay/api/model/RefundResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundResponse.java
@@ -56,6 +56,17 @@ public class RefundResponse {
         links.addPayment(paymentLink.toString());
     }
 
+    public RefundResponse(TransactionResponse transaction, URI selfLink, URI paymentLink) {
+        this.refundId = transaction.getTransactionId();
+        this.amount = transaction.getAmount();
+        this.status = transaction.getState().getStatus();
+        this.createdDate = transaction.getCreatedDate();
+        this.links = new RefundLinksForSearch();
+
+        links.addSelf(selfLink.toString());
+        links.addPayment(paymentLink.toString());
+    }
+
     public static RefundResponse from(RefundFromConnector refund, URI selfLink, URI paymentLink) {
         return new RefundResponse(refund, selfLink, paymentLink);
     }
@@ -64,6 +75,10 @@ public class RefundResponse {
         return new RefundResponse(refund, selfLink, paymentLink);
     }
 
+    public static RefundResponse from(TransactionResponse transaction, URI selfLink, URI paymentLink) {
+        return new RefundResponse(transaction, selfLink, paymentLink);
+    }
+    
     //todo: remove after full refactoring of PaymentRefundsResource (to use service layer) 
     public static RefundResponse valueOf(RefundFromConnector refundEntity, String paymentId, String baseUrl) {
         URI selfLink = UriBuilder.fromUri(baseUrl)

--- a/src/main/java/uk/gov/pay/api/model/RefundResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundResponse.java
@@ -56,27 +56,12 @@ public class RefundResponse {
         links.addPayment(paymentLink.toString());
     }
 
-    public RefundResponse(TransactionResponse transaction, URI selfLink, URI paymentLink) {
-        this.refundId = transaction.getTransactionId();
-        this.amount = transaction.getAmount();
-        this.status = transaction.getState().getStatus();
-        this.createdDate = transaction.getCreatedDate();
-        this.links = new RefundLinksForSearch();
-
-        links.addSelf(selfLink.toString());
-        links.addPayment(paymentLink.toString());
-    }
-
     public static RefundResponse from(RefundFromConnector refund, URI selfLink, URI paymentLink) {
         return new RefundResponse(refund, selfLink, paymentLink);
     }
 
     public static RefundResponse from(RefundTransactionFromLedger refund, URI selfLink, URI paymentLink) {
         return new RefundResponse(refund, selfLink, paymentLink);
-    }
-
-    public static RefundResponse from(TransactionResponse transaction, URI selfLink, URI paymentLink) {
-        return new RefundResponse(transaction, selfLink, paymentLink);
     }
     
     //todo: remove after full refactoring of PaymentRefundsResource (to use service layer) 

--- a/src/main/java/uk/gov/pay/api/resources/GetPaymentRefundStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/GetPaymentRefundStrategy.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.api.resources;
+
+
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.model.RefundResponse;
+import uk.gov.pay.api.service.GetPaymentRefundService;
+
+public class GetPaymentRefundStrategy extends LedgerOrConnectorStrategyTemplate<RefundResponse> {
+
+    private final Account account;
+    private final String paymentId;
+    private final String refundId;
+    private final GetPaymentRefundService getPaymentRefundsService;
+
+    public GetPaymentRefundStrategy(String strategy, Account account, String paymentId, String refundId,
+                                    GetPaymentRefundService getPaymentRefundsService) {
+        super(strategy);
+        this.account = account;
+        this.paymentId = paymentId;
+        this.refundId = refundId;
+        this.getPaymentRefundsService = getPaymentRefundsService;
+    }
+
+    @Override
+    protected RefundResponse executeLedgerOnlyStrategy() {
+        return getPaymentRefundsService.getLedgerPaymentRefund(account, paymentId, refundId);
+    }
+
+    @Override
+    protected RefundResponse executeFutureBehaviourStrategy() {
+        return getPaymentRefundsService.getPaymentRefund(account, paymentId, refundId);
+    }
+
+    @Override
+    protected RefundResponse executeDefaultStrategy() {
+        return getPaymentRefundsService.getConnectorPaymentRefund(account, paymentId, refundId);
+    }
+}

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -16,7 +16,6 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CreateRefundException;
-import uk.gov.pay.api.exception.GetRefundException;
 import uk.gov.pay.api.model.ChargeFromResponse;
 import uk.gov.pay.api.model.CreatePaymentRefundRequest;
 import uk.gov.pay.api.model.PaymentError;
@@ -49,7 +48,6 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.ACCEPTED;
 import static javax.ws.rs.core.UriBuilder.fromPath;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.apache.http.HttpStatus.SC_OK;
 
 @Path(PaymentRefundsResource.PAYMENT_REFUNDS_PATH)
 @Api(tags = "Refunding card payments", value = "/refunds")

--- a/src/main/java/uk/gov/pay/api/service/ConnectorService.java
+++ b/src/main/java/uk/gov/pay/api/service/ConnectorService.java
@@ -3,10 +3,12 @@ package uk.gov.pay.api.service;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.GetChargeException;
 import uk.gov.pay.api.exception.GetEventsException;
+import uk.gov.pay.api.exception.GetRefundException;
 import uk.gov.pay.api.exception.GetRefundsException;
 import uk.gov.pay.api.model.Charge;
 import uk.gov.pay.api.model.ChargeFromResponse;
 import uk.gov.pay.api.model.PaymentEvents;
+import uk.gov.pay.api.model.RefundFromConnector;
 import uk.gov.pay.api.model.RefundsFromConnector;
 
 import javax.inject.Inject;
@@ -65,5 +67,19 @@ public class ConnectorService {
         }
 
         throw new GetRefundsException(connectorResponse);
+    }
+
+    public RefundFromConnector getPaymentRefund(String accountId, String paymentId, String refundId) {
+        Response connectorResponse = client
+                .target(connectorUriGenerator.refundForPaymentURI(accountId, paymentId, refundId))
+                .request()
+                .accept(MediaType.APPLICATION_JSON)
+                .get();
+
+        if (connectorResponse.getStatus() == SC_OK) {
+            return connectorResponse.readEntity(RefundFromConnector.class);
+        }
+
+        throw new GetRefundException(connectorResponse);
     }
 }

--- a/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
@@ -82,6 +82,11 @@ public class ConnectorUriGenerator {
         return buildConnectorUri(path);
     }
 
+    String refundForPaymentURI(String accountId, String chargeId, String refundId) {
+        String path = format("/v1/api/accounts/%s/charges/%s/refunds/%s", accountId, chargeId, refundId);
+        return buildConnectorUri(path);
+    }
+
     // TODO: remove when direct debit endpoints entirely split out
     @Deprecated
     private String buildConnectorUri(Account account, String path) {

--- a/src/main/java/uk/gov/pay/api/service/GetPaymentRefundService.java
+++ b/src/main/java/uk/gov/pay/api/service/GetPaymentRefundService.java
@@ -6,6 +6,7 @@ import uk.gov.pay.api.exception.GetTransactionException;
 import uk.gov.pay.api.model.RefundFromConnector;
 import uk.gov.pay.api.model.RefundResponse;
 import uk.gov.pay.api.model.TransactionResponse;
+import uk.gov.pay.api.model.ledger.RefundTransactionFromLedger;
 
 import javax.inject.Inject;
 
@@ -36,10 +37,10 @@ public class GetPaymentRefundService {
 
     public RefundResponse getLedgerPaymentRefund(Account account, String paymentId, String refundId) {
         try {
-            TransactionResponse transaction = ledgerService.getTransaction(account, refundId, "REFUND", paymentId); //todo: rename the class (+ should be used by refund as well)
+            RefundTransactionFromLedger refund = ledgerService.getTransaction(account, refundId, "REFUND", paymentId);
 
             return RefundResponse.from(
-                    transaction,
+                    refund,
                     publicApiUriGenerator.getRefundsURI(paymentId, refundId),
                     publicApiUriGenerator.getPaymentURI(paymentId)
             );

--- a/src/main/java/uk/gov/pay/api/service/GetPaymentRefundService.java
+++ b/src/main/java/uk/gov/pay/api/service/GetPaymentRefundService.java
@@ -1,0 +1,58 @@
+package uk.gov.pay.api.service;
+
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.exception.GetRefundException;
+import uk.gov.pay.api.exception.GetTransactionException;
+import uk.gov.pay.api.model.RefundFromConnector;
+import uk.gov.pay.api.model.RefundResponse;
+import uk.gov.pay.api.model.TransactionResponse;
+
+import javax.inject.Inject;
+
+public class GetPaymentRefundService {
+
+    private final ConnectorService connectorService;
+    private final LedgerService ledgerService;
+    private PublicApiUriGenerator publicApiUriGenerator;
+
+    @Inject
+    public GetPaymentRefundService(ConnectorService connectorService,
+                                   LedgerService ledgerService,
+                                   PublicApiUriGenerator publicApiUriGenerator) {
+        this.connectorService = connectorService;
+        this.ledgerService = ledgerService;
+        this.publicApiUriGenerator = publicApiUriGenerator;
+    }
+
+    public RefundResponse getConnectorPaymentRefund(Account account, String paymentId, String refundId) {
+        RefundFromConnector refundFromConnector = connectorService.getPaymentRefund(account.getAccountId(), paymentId, refundId);
+
+        return RefundResponse.from(
+                refundFromConnector,
+                publicApiUriGenerator.getRefundsURI(paymentId, refundId),
+                publicApiUriGenerator.getPaymentURI(paymentId)
+        );
+    }
+
+    public RefundResponse getLedgerPaymentRefund(Account account, String paymentId, String refundId) {
+        try {
+            TransactionResponse transaction = ledgerService.getTransaction(account, refundId, "REFUND", paymentId); //todo: rename the class (+ should be used by refund as well)
+
+            return RefundResponse.from(
+                    transaction,
+                    publicApiUriGenerator.getRefundsURI(paymentId, refundId),
+                    publicApiUriGenerator.getPaymentURI(paymentId)
+            );
+        } catch (GetTransactionException exception) {
+            throw new GetRefundException(exception);
+        }
+    }
+
+    public RefundResponse getPaymentRefund(Account account, String paymentId, String refundId) {
+        try {
+            return getConnectorPaymentRefund(account, paymentId, refundId);
+        } catch (GetRefundException ex) {
+            return getLedgerPaymentRefund(account, paymentId, refundId);
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/api/service/LedgerService.java
+++ b/src/main/java/uk/gov/pay/api/service/LedgerService.java
@@ -3,6 +3,8 @@ package uk.gov.pay.api.service;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.GetChargeException;
 import uk.gov.pay.api.exception.GetEventsException;
+import uk.gov.pay.api.exception.GetRefundException;
+import uk.gov.pay.api.exception.GetTransactionException;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.Charge;
 import uk.gov.pay.api.model.TransactionEvents;
@@ -26,6 +28,7 @@ public class LedgerService {
         this.ledgerUriGenerator = ledgerUriGenerator;
     }
 
+    //todo: transaction type
     public Charge getTransaction(Account account, String paymentId) {
         Response response = client
                 .target(ledgerUriGenerator.transactionURI(account, paymentId))
@@ -38,6 +41,19 @@ public class LedgerService {
         }
 
         throw new GetChargeException(response);
+    }
+
+    public TransactionResponse getTransaction(Account account, String transactionId, String transactionType, String parentExternalId) {
+        Response response = client
+                .target(ledgerUriGenerator.transactionURI(account, transactionId, transactionType, parentExternalId))
+                .request()
+                .get();
+
+        if (response.getStatus() == SC_OK) {
+            return response.readEntity(TransactionResponse.class);
+        }
+
+        throw new GetTransactionException(response);
     }
 
     public TransactionEvents getTransactionEvents(Account account, String paymentId) {

--- a/src/main/java/uk/gov/pay/api/service/LedgerService.java
+++ b/src/main/java/uk/gov/pay/api/service/LedgerService.java
@@ -3,13 +3,13 @@ package uk.gov.pay.api.service;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.GetChargeException;
 import uk.gov.pay.api.exception.GetEventsException;
-import uk.gov.pay.api.exception.GetRefundException;
+import uk.gov.pay.api.exception.GetRefundsException;
 import uk.gov.pay.api.exception.GetTransactionException;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.Charge;
 import uk.gov.pay.api.model.TransactionEvents;
-import uk.gov.pay.api.exception.GetRefundsException;
 import uk.gov.pay.api.model.TransactionResponse;
+import uk.gov.pay.api.model.ledger.RefundTransactionFromLedger;
 import uk.gov.pay.api.model.ledger.RefundsFromLedger;
 
 import javax.inject.Inject;
@@ -43,14 +43,14 @@ public class LedgerService {
         throw new GetChargeException(response);
     }
 
-    public TransactionResponse getTransaction(Account account, String transactionId, String transactionType, String parentExternalId) {
+    public RefundTransactionFromLedger getTransaction(Account account, String transactionId, String transactionType, String parentExternalId) {
         Response response = client
                 .target(ledgerUriGenerator.transactionURI(account, transactionId, transactionType, parentExternalId))
                 .request()
                 .get();
 
         if (response.getStatus() == SC_OK) {
-            return response.readEntity(TransactionResponse.class);
+            return response.readEntity(RefundTransactionFromLedger.class);
         }
 
         throw new GetTransactionException(response);

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundStrategyTest.java
@@ -1,0 +1,60 @@
+package uk.gov.pay.api.resources;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.exception.GetRefundException;
+import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.api.service.GetPaymentRefundService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(JUnitParamsRunner.class)
+public class GetPaymentRefundStrategyTest {
+
+    private GetPaymentRefundService mockGetPaymentRefundService = mock(GetPaymentRefundService.class);
+    private GetPaymentRefundStrategy getPaymentRefundStrategy;
+
+    private String paymentId = "payment-id";
+    private String refundId = "refund-id";
+    private Account account = new Account("account-id", TokenPaymentType.CARD);
+    
+    @Test
+    public void validateAndExecuteUsesLedgerOnlyStrategy() {
+        String strategy = "ledger-only";
+        getPaymentRefundStrategy = new GetPaymentRefundStrategy(strategy, account, paymentId, refundId, mockGetPaymentRefundService);
+        getPaymentRefundStrategy.validateAndExecute();
+
+        verify(mockGetPaymentRefundService).getLedgerPaymentRefund(account, paymentId, refundId);
+        verify(mockGetPaymentRefundService, never()).getConnectorPaymentRefund(account, paymentId, refundId);
+        verify(mockGetPaymentRefundService, never()).getPaymentRefund(account, paymentId, refundId);
+    }
+
+    @Test
+    public void validateAndExecuteUsesFutureStrategyOnly() {
+        String strategy = "future-behaviour";
+        getPaymentRefundStrategy = new GetPaymentRefundStrategy(strategy, account, paymentId, refundId, mockGetPaymentRefundService);
+        getPaymentRefundStrategy.validateAndExecute();
+
+        verify(mockGetPaymentRefundService).getPaymentRefund(account, paymentId, refundId);
+    }
+
+    @Test
+    @Parameters({"", "unknown"})
+    public void validateAndExecuteShouldUseConnectorOnlyStrategy(String strategy) {
+        getPaymentRefundStrategy = new GetPaymentRefundStrategy(strategy, account, paymentId, refundId, mockGetPaymentRefundService);
+
+        getPaymentRefundStrategy.validateAndExecute();
+
+        verify(mockGetPaymentRefundService).getConnectorPaymentRefund(account, paymentId, refundId);
+        verify(mockGetPaymentRefundService, never()).getLedgerPaymentRefund(account, paymentId, refundId);
+        verify(mockGetPaymentRefundService, never()).getPaymentRefund(account, paymentId, refundId);
+    }
+}

--- a/src/test/java/uk/gov/pay/api/service/GetPaymentRefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentRefundServiceTest.java
@@ -1,0 +1,69 @@
+package uk.gov.pay.api.service;
+
+import au.com.dius.pact.consumer.PactVerification;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.api.app.RestClientFactory;
+import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.app.config.RestClientConfig;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
+import uk.gov.pay.api.model.RefundResponse;
+import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.commons.testing.pact.consumers.PactProviderRule;
+import uk.gov.pay.commons.testing.pact.consumers.Pacts;
+
+import javax.ws.rs.client.Client;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GetPaymentRefundServiceTest {
+
+    private static final String ACCOUNT_ID = "123456";
+    private static final String CHARGE_ID = "123456789";
+    private static final String REFUND_ID = "r_123abc456def";
+
+    private GetPaymentRefundService getPaymentService;
+
+    @Rule
+    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+
+    @Mock
+    private PublicApiConfig mockConfiguration;
+
+    @Before
+    public void setup() {
+        when(mockConfiguration.getConnectorUrl()).thenReturn(connectorRule.getUrl());
+        when(mockConfiguration.getBaseUrl()).thenReturn("http://publicapi.test.localhost/");
+
+        PublicApiUriGenerator publicApiUriGenerator = new PublicApiUriGenerator(mockConfiguration);
+        ConnectorUriGenerator connectorUriGenerator = new ConnectorUriGenerator(mockConfiguration);
+        LedgerUriGenerator ledgerUriGenerator = new LedgerUriGenerator(mockConfiguration);
+        Client client = RestClientFactory.buildClient(new RestClientConfig(false));
+        getPaymentService = new GetPaymentRefundService(new ConnectorService(client, connectorUriGenerator),
+                new LedgerService(client, ledgerUriGenerator), publicApiUriGenerator);
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector-get-payment-refund"})
+    public void testGetPayment() {
+        Account account = new Account(ACCOUNT_ID, TokenPaymentType.CARD);
+
+        RefundResponse refund = getPaymentService.getConnectorPaymentRefund(account, CHARGE_ID, REFUND_ID);
+
+        assertThat(refund.getRefundId(), is(REFUND_ID));
+        assertThat(refund.getStatus(), is("success"));
+        assertThat(refund.getAmount(), is(100L));
+        assertThat(refund.getCreatedDate(), is("2018-09-22T10:14:16.067Z"));
+        assertThat(refund.getLinks().getPayment().getHref(), is("http://publicapi.test.localhost/v1/payments/123456789"));
+        assertThat(refund.getLinks().getSelf().getHref(), is("http://publicapi.test.localhost/v1/payments/123456789/refunds/r_123abc456def"));
+    }
+}

--- a/src/test/resources/pacts/publicapi-connector-get-payment-refund.json
+++ b/src/test/resources/pacts/publicapi-connector-get-payment-refund.json
@@ -1,0 +1,81 @@
+
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "get payment refund",
+      "providerStates": [
+        {
+          "name": "a payment refund exists",
+          "params": {
+            "gateway_account_id": "123456",
+            "charge_id": "123456789",
+            "refund_id": "r_123abc456def",
+            "created_date": "2018-09-22T10:14:16.067Z"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/api/accounts/123456/charges/123456789/refunds/r_123abc456def"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+            "refund_id": "r_123abc456def",
+            "amount": 100,
+            "status": "success",
+            "created_date": "2018-09-22T10:14:16.067Z"
+        },
+        "matchingRules": {
+          "body": {
+            "$.amount": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.status": {
+              "matchers": [
+                {
+                  "match": "value"
+                }
+              ]
+            },
+            "$.created_date": {
+              "matchers": [
+                {
+                  "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+                }
+              ]
+            },
+            "$.refund_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
* created GetPaymentRefundStrategy + test
* created GetPaymentRefundService
* moved retrieving refund from Connector to ConnectorService
* added pact test for connector

Todo (outside of this PR):
* rename `TransactionResponse` to `TransactionFromLedger` (or similar)
  * Refunds should use it as well, that would allow a little bit of clean-up later on
* use transaction_type for getting payment as well (ideally merge two methods from LedgerService)
* pact test for ledger
 