### PR TITLE
PP-5499 Ledger for refunds search

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/ledger/RefundTransactionFromLedger.java
+++ b/src/main/java/uk/gov/pay/api/model/ledger/RefundTransactionFromLedger.java
@@ -14,6 +14,7 @@ public class RefundTransactionFromLedger {
     String createdDate;
     String refundedBy;
     String transactionId;
+    String parentTransactionId;
     TransactionState state;
 
     public Long getAmount() {
@@ -38,6 +39,10 @@ public class RefundTransactionFromLedger {
 
     public String getTransactionId() {
         return transactionId;
+    }
+
+    public String getParentTransactionId() {
+        return parentTransactionId;
     }
 
     public TransactionState getState() {

--- a/src/main/java/uk/gov/pay/api/model/ledger/SearchRefundsResponseFromLedger.java
+++ b/src/main/java/uk/gov/pay/api/model/ledger/SearchRefundsResponseFromLedger.java
@@ -1,0 +1,49 @@
+package uk.gov.pay.api.model.ledger;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.api.model.links.SearchNavigationLinks;
+import uk.gov.pay.api.model.search.SearchPagination;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SearchRefundsResponseFromLedger implements SearchPagination {
+
+    @JsonProperty("total")
+    private int total;
+
+    @JsonProperty("count")
+    private int count;
+
+    @JsonProperty("page")
+    private int page;
+
+    @JsonProperty("results")
+    private List<RefundTransactionFromLedger> refunds;
+
+    @JsonProperty("_links")
+    private SearchNavigationLinks links = new SearchNavigationLinks();
+
+    public List<RefundTransactionFromLedger> getRefunds() {
+        return refunds;
+    }
+
+    public int getTotal() {
+        return total;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public SearchNavigationLinks getLinks() {
+        return links;
+    }
+}

--- a/src/main/java/uk/gov/pay/api/model/search/PaginationDecorator.java
+++ b/src/main/java/uk/gov/pay/api/model/search/PaginationDecorator.java
@@ -10,11 +10,14 @@ import javax.inject.Inject;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Optional;
 
 public class PaginationDecorator {
 
     private final String baseUrl;
+    private final List<String> queryParametersToBeExcluded
+            = List.of("account_id", "gateway_account_id", "transaction_type");
 
     @Inject
     public PaginationDecorator(PublicApiConfig config) {
@@ -41,15 +44,14 @@ public class PaginationDecorator {
     public SearchNavigationLinks transformLinksToPublicApiUri(
             SearchNavigationLinks links, String path) {
         try {
-            links.withSelfLink(transformIntoPublicUriAsString(baseUrl, links.getSelf(), path));
-            links.withFirstLink(transformIntoPublicUriAsString(baseUrl, links.getFirstPage(), path));
-            links.withLastLink(transformIntoPublicUriAsString(baseUrl, links.getLastPage(), path));
-            links.withPrevLink(transformIntoPublicUriAsString(baseUrl, links.getPrevPage(), path));
-            links.withNextLink(transformIntoPublicUriAsString(baseUrl, links.getNextPage(), path));
+            return links.withSelfLink(transformIntoPublicUriAsString(baseUrl, links.getSelf(), path))
+                    .withFirstLink(transformIntoPublicUriAsString(baseUrl, links.getFirstPage(), path))
+                    .withLastLink(transformIntoPublicUriAsString(baseUrl, links.getLastPage(), path))
+                    .withPrevLink(transformIntoPublicUriAsString(baseUrl, links.getPrevPage(), path))
+                    .withNextLink(transformIntoPublicUriAsString(baseUrl, links.getNextPage(), path));
         } catch (URISyntaxException ex) {
             throw new SearchPaymentsException(ex);
         }
-        return links;
     }
 
     private HalRepresentation.HalRepresentationBuilder addPaginationProperties(HalRepresentation.HalRepresentationBuilder halRepresentationBuilder,
@@ -68,20 +70,31 @@ public class PaginationDecorator {
     }
 
     private String transformIntoPublicUriAsString(String baseUrl, Link link, String path) throws URISyntaxException {
-        URI uri = transformIntoPublicUri(baseUrl, link, path);
+        UriBuilder uriBuilder = getUriBuilder(baseUrl, link, path);
 
-        return Optional.ofNullable(uri)
-                .map(URI::toString)
+        return Optional.ofNullable(uriBuilder)
+                .map(builder -> {
+                    // breaks the order of query parameters 
+                    queryParametersToBeExcluded.forEach(queryParam ->
+                            uriBuilder.replaceQueryParam(queryParam, (Object[]) null));
+                    return builder.build().toString();
+                })
                 .orElse(null);
     }
 
     private URI transformIntoPublicUri(String baseUrl, Link link, String path) throws URISyntaxException {
+        UriBuilder uriBuilder = getUriBuilder(baseUrl, link, path);
+        return Optional.ofNullable(uriBuilder)
+                .map(builder -> builder.build())
+                .orElse(null);
+    }
+
+    private UriBuilder getUriBuilder(String baseUrl, Link link, String path) throws URISyntaxException {
         if (link == null)
             return null;
 
         return UriBuilder.fromUri(baseUrl)
                 .path(path)
-                .replaceQuery(new URI(link.getHref()).getQuery())
-                .build();
+                .replaceQuery(new URI(link.getHref()).getQuery());
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import uk.gov.pay.api.model.ledger.RefundTransactionFromLedger;
 import uk.gov.pay.api.model.links.RefundLinksForSearch;
 
 import java.net.URI;
@@ -89,6 +90,17 @@ public class RefundForSearchRefundsResult {
                 refundResult.getCreatedDate(),
                 refundResult.getStatus(),
                 refundResult.getChargeId(),
+                refundResult.getAmount(),
+                paymentURI,
+                refundsURI);
+    }
+
+    public static RefundForSearchRefundsResult valueOf(RefundTransactionFromLedger refundResult, URI paymentURI, URI refundsURI) {
+        return new RefundForSearchRefundsResult(
+                refundResult.getTransactionId(),
+                refundResult.getCreatedDate(),
+                refundResult.getState().getStatus(),
+                refundResult.getParentTransactionId(),
                 refundResult.getAmount(),
                 paymentURI,
                 refundsURI);

--- a/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
@@ -18,6 +18,7 @@ import uk.gov.pay.api.service.SearchRefundsService;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
@@ -67,13 +68,16 @@ public class SearchRefundsResource {
                                   @ApiParam(value = "Page number requested for the search, should be a positive integer (optional, defaults to 1)", hidden = false)
                                   @QueryParam("page") String pageNumber,
                                   @ApiParam(value = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)", hidden = false)
-                                  @QueryParam("display_size") String displaySize) {
+                                  @QueryParam("display_size") String displaySize, 
+                                  @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
 
-        logger.info("Refunds search request - [ {} ]",
+        logger.info("Refunds search request with strategy [{}]- [ {} ]", strategyName,
                 format("from_date: %s, to_date: %s, page: %s, display_size: %s",
                         fromDate, toDate, pageNumber, displaySize));
 
         RefundsParams refundsParams = new RefundsParams(fromDate, toDate, pageNumber, displaySize);
-        return searchRefundsService.searchConnectorRefunds(account, refundsParams);
+        SearchRefundsStrategy strategy = new SearchRefundsStrategy(strategyName, account, refundsParams, searchRefundsService);
+
+        return strategy.validateAndExecute();
     }
 }

--- a/src/main/java/uk/gov/pay/api/resources/SearchRefundsStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchRefundsStrategy.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.api.resources;
+
+
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.model.search.card.SearchRefundsResults;
+import uk.gov.pay.api.service.RefundsParams;
+import uk.gov.pay.api.service.SearchRefundsService;
+
+public class SearchRefundsStrategy extends LedgerOrConnectorStrategyTemplate<SearchRefundsResults> {
+
+    private final Account account;
+    private RefundsParams refundsParams;
+    private final SearchRefundsService searchRefundsService;
+
+    public SearchRefundsStrategy(String strategy, Account account, RefundsParams refundsParams,
+                                 SearchRefundsService searchRefundsService) {
+        super(strategy);
+        this.account = account;
+        this.refundsParams = refundsParams;
+        this.searchRefundsService = searchRefundsService;
+    }
+
+    @Override
+    protected SearchRefundsResults executeLedgerOnlyStrategy() {
+        return searchRefundsService.searchLedgerRefunds(account, refundsParams);
+    }
+
+    @Override
+    protected SearchRefundsResults executeFutureBehaviourStrategy() {
+        return executeLedgerOnlyStrategy();
+    }
+
+    @Override
+    protected SearchRefundsResults executeDefaultStrategy() {
+        return searchRefundsService.searchConnectorRefunds(account, refundsParams);
+    }
+}

--- a/src/main/java/uk/gov/pay/api/service/RefundsParams.java
+++ b/src/main/java/uk/gov/pay/api/service/RefundsParams.java
@@ -1,6 +1,17 @@
 package uk.gov.pay.api.service;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
 public class RefundsParams {
+
+    private static final String PAGE = "page";
+    private static final String DISPLAY_SIZE = "display_size";
+    private static final String DEFAULT_PAGE = "1";
+    private static final String DEFAULT_DISPLAY_SIZE = "500";
+    private static final String FROM_DATE = "from_date";
+    private static final String TO_DATE = "to_date";
     
     private String fromDate;
     private String toDate;
@@ -12,6 +23,16 @@ public class RefundsParams {
         this.toDate = toDate;
         this.page = page;
         this.displaySize = displaySize;
+    }
+
+    public Map<String, String> getParamsAsMap() {
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put(FROM_DATE, fromDate);
+        params.put(TO_DATE, toDate);
+        params.put(PAGE, Optional.ofNullable(page).orElse(DEFAULT_PAGE));
+        params.put(DISPLAY_SIZE, Optional.ofNullable(displaySize).orElse(DEFAULT_DISPLAY_SIZE));
+        
+        return params;
     }
 
     public String getPage() {

--- a/src/main/java/uk/gov/pay/api/service/SearchRefundsService.java
+++ b/src/main/java/uk/gov/pay/api/service/SearchRefundsService.java
@@ -3,16 +3,14 @@ package uk.gov.pay.api.service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.model.ledger.SearchRefundsResponseFromLedger;
 import uk.gov.pay.api.model.search.PaginationDecorator;
 import uk.gov.pay.api.model.search.card.RefundForSearchRefundsResult;
 import uk.gov.pay.api.model.search.card.SearchRefundsResponseFromConnector;
 import uk.gov.pay.api.model.search.card.SearchRefundsResults;
 
 import javax.inject.Inject;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static uk.gov.pay.api.validation.RefundSearchValidator.validateSearchParameters;
@@ -21,49 +19,58 @@ public class SearchRefundsService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SearchRefundsService.class);
     private static final String REFUNDS_PATH = "/v1/refunds";
-
-    private static final String PAGE = "page";
-    private static final String DISPLAY_SIZE = "display_size";
-    private static final String DEFAULT_PAGE = "1";
-    private static final String DEFAULT_DISPLAY_SIZE = "500";
-    private static final String FROM_DATE = "from_date";
-    private static final String TO_DATE = "to_date";
-
-    private final PublicApiUriGenerator publicApiUriGenerator;
     private final PaginationDecorator paginationDecorator;
+    private LedgerService ledgerService;
+    private PublicApiUriGenerator publicApiUriGenerator;
     private ConnectorService connectorService;
 
     @Inject
     public SearchRefundsService(ConnectorService connectorService,
+                                LedgerService ledgerService,
                                 PublicApiUriGenerator publicApiUriGenerator,
                                 PaginationDecorator paginationDecorator) {
 
         this.connectorService = connectorService;
+        this.ledgerService = ledgerService;
         this.publicApiUriGenerator = publicApiUriGenerator;
         this.paginationDecorator = paginationDecorator;
     }
 
     public SearchRefundsResults searchConnectorRefunds(Account account, RefundsParams params) {
         validateSearchParameters(params);
-        Map<String, String> queryParams = buildQueryString(params);
-        return getConnectorSearchRefundsResponse(account, queryParams);
+        SearchRefundsResponseFromConnector searchRefundsResponseFromConnector
+                = connectorService.searchRefunds(account, params.getParamsAsMap());
+        return processConnectorResponse(searchRefundsResponseFromConnector);
     }
 
-    private Map<String, String> buildQueryString(RefundsParams params) {
-        Map<String, String> queryParams = new LinkedHashMap<>();
-        queryParams.put(FROM_DATE, params.getFromDate());
-        queryParams.put(TO_DATE, params.getToDate());
-        queryParams.put(PAGE, Optional.ofNullable(params.getPage()).orElse(DEFAULT_PAGE));
-        queryParams.put(DISPLAY_SIZE, Optional.ofNullable(params.getDisplaySize()).orElse(DEFAULT_DISPLAY_SIZE));
-        return queryParams;
+    public SearchRefundsResults searchLedgerRefunds(Account account, RefundsParams params) {
+        validateSearchParameters(params);
+        SearchRefundsResponseFromLedger refunds
+                = ledgerService.searchRefunds(account, params.getParamsAsMap());
+        return processLedgerResponse(refunds);
     }
 
-    private SearchRefundsResults getConnectorSearchRefundsResponse(Account account, Map<String, String> queryParams) {
-        SearchRefundsResponseFromConnector searchRefundsResponseFromConnector = connectorService.searchRefunds(account, queryParams);
-        return processResponse(searchRefundsResponseFromConnector);
+    private SearchRefundsResults processLedgerResponse(SearchRefundsResponseFromLedger searchResponse) {
+        List<RefundForSearchRefundsResult> results = searchResponse.getRefunds()
+                .stream()
+                .map(refund -> RefundForSearchRefundsResult.valueOf(
+                        refund,
+                        publicApiUriGenerator.getPaymentURI(refund.getTransactionId()),
+                        publicApiUriGenerator.getRefundsURI(refund.getParentTransactionId(),
+                                refund.getTransactionId()))
+                )
+                .collect(Collectors.toList());
+
+        return new SearchRefundsResults(
+                searchResponse.getTotal(),
+                searchResponse.getCount(),
+                searchResponse.getPage(),
+                results,
+                paginationDecorator.transformLinksToPublicApiUri(searchResponse.getLinks(), REFUNDS_PATH)
+        );
     }
 
-    private SearchRefundsResults processResponse(SearchRefundsResponseFromConnector searchResponse) {
+    private SearchRefundsResults processConnectorResponse(SearchRefundsResponseFromConnector searchResponse) {
         List<RefundForSearchRefundsResult> results = searchResponse.getRefunds()
                 .stream()
                 .map(refund -> RefundForSearchRefundsResult.valueOf(refund,

--- a/src/test/java/uk/gov/pay/api/resources/SearchRefundsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/SearchRefundsStrategyTest.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.api.resources;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.api.service.RefundsParams;
+import uk.gov.pay.api.service.SearchRefundsService;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@RunWith(JUnitParamsRunner.class)
+public class SearchRefundsStrategyTest {
+
+    private SearchRefundsService mockSearchRefundsService = mock(SearchRefundsService.class);
+    private SearchRefundsStrategy searchRefundsStrategy;
+
+    private RefundsParams refundsParams;
+    private Account account = new Account("account-id", TokenPaymentType.CARD);
+
+    @Test
+    @Parameters({"ledger-only", "future-behaviour"})
+    public void validateAndExecuteShouldUseLedgerOnlyForListedStrategies(String strategy) {
+        searchRefundsStrategy = new SearchRefundsStrategy(strategy, account, refundsParams, mockSearchRefundsService);
+        searchRefundsStrategy.validateAndExecute();
+
+        verify(mockSearchRefundsService).searchLedgerRefunds(account, refundsParams);
+        verify(mockSearchRefundsService, never()).searchConnectorRefunds(account, refundsParams);
+    }
+
+    @Test
+    @Parameters({"", "unknown"})
+    public void validateAndExecuteShouldUseConnectorOnlyForDefaultOrUnknownStrategy(String strategy) {
+        searchRefundsStrategy = new SearchRefundsStrategy(strategy, account, refundsParams, mockSearchRefundsService);
+
+        searchRefundsStrategy.validateAndExecute();
+
+        verify(mockSearchRefundsService).searchConnectorRefunds(account, refundsParams);
+        verify(mockSearchRefundsService, never()).searchLedgerRefunds(account, refundsParams);
+    }
+}

--- a/src/test/java/uk/gov/pay/api/service/SearchRefundsServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/SearchRefundsServiceTest.java
@@ -13,6 +13,7 @@ import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.RefundsValidationException;
+import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.search.PaginationDecorator;
 import uk.gov.pay.api.model.search.card.SearchRefundsResults;
@@ -47,9 +48,11 @@ public class SearchRefundsServiceTest {
 
         Client client = RestClientFactory.buildClient(new RestClientConfig(false));
         ConnectorUriGenerator connectorUriGenerator = new ConnectorUriGenerator(mockConfiguration);
+        LedgerUriGenerator ledgerUriGenerator = new LedgerUriGenerator(mockConfiguration);
 
         searchRefundsService = new SearchRefundsService(
                 new ConnectorService(client, connectorUriGenerator),
+                new LedgerService(client, ledgerUriGenerator),
                 new PublicApiUriGenerator(mockConfiguration),
                 new PaginationDecorator(mockConfiguration));
     }
@@ -86,7 +89,7 @@ public class SearchRefundsServiceTest {
         assertThat(results.getResults().get(1).getLinks().getSelf().getHref(), is(format("http://publicapi.test.localhost/v1/payments/%s/refunds/%s", extChargeId, refundId2)));
         assertThat(results.getResults().get(1).getLinks().getPayment().getHref(), is(format("http://publicapi.test.localhost/v1/payments/%s", extChargeId)));
 
-        assertThat(results.getLinks().getSelf().getHref(), is("http://publicapi.test.localhost/v1/refunds?page=1&display_size=2"));
+        assertThat(results.getLinks().getSelf().getHref(), is("http://publicapi.test.localhost/v1/refunds?display_size=2&page=1"));
     }
 
     @Test
@@ -133,7 +136,7 @@ public class SearchRefundsServiceTest {
         assertThat(results.getResults().get(1).getLinks().getSelf().getHref(), is(format("http://publicapi.test.localhost/v1/payments/%s/refunds/%s", extChargeId, refundId2)));
         assertThat(results.getResults().get(1).getLinks().getPayment().getHref(), is(format("http://publicapi.test.localhost/v1/payments/%s", extChargeId)));
 
-        assertThat(results.getLinks().getSelf().getHref(), is("http://publicapi.test.localhost/v1/refunds?from_date=2016-01-25T13%3A22%3A55Z&to_date=2016-01-25T13%3A24%3A55Z&page=1&display_size=500"));
+        assertThat(results.getLinks().getSelf().getHref(), is("http://publicapi.test.localhost/v1/refunds?from_date=2016-01-25T13%3A22%3A55Z&to_date=2016-01-25T13%3A24%3A55Z&display_size=500&page=1"));
     }
 
     @Test


### PR DESCRIPTION
## WHAT
- Adds `SearchRefundsStrategy` to use ledger based on X-Ledger header
- LedgerService now supports search refunds
- `PaginationDecorator` - Excludes specific parameters (acount_id, transaction_type...) from ledger as they are not required in transformed publicapi URI