### PR TITLE
PP-5519 Switch To Unused P Code

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/PaymentError.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentError.java
@@ -51,7 +51,7 @@ public class PaymentError {
         CREATE_PAYMENT_REFUND_AMOUNT_AVAILABLE_MISMATCH("P0604", "Refund amount available mismatch."),
         CREATE_PAYMENT_MANDATE_STATE_INVALID("P1103",
                 "Can't create payment. The mandate's state must be pending or active."),
-        CREATE_PAYMENT_MANDATE_ID_INVALID("P1100",
+        CREATE_PAYMENT_MANDATE_ID_INVALID("P1200",
                 "Can't create payment. A mandate with the ID provided does not exist."),
 
         GET_PAYMENT_REFUND_NOT_FOUND_ERROR("P0700", "Not found"),

--- a/src/main/java/uk/gov/pay/api/model/PaymentError.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentError.java
@@ -49,7 +49,7 @@ public class PaymentError {
         CREATE_PAYMENT_REFUND_VALIDATION_ERROR("P0602", "Invalid attribute value: %s. %s"),
         CREATE_PAYMENT_REFUND_NOT_AVAILABLE("P0603", "The payment is not available for refund. Payment refund status: %s"),
         CREATE_PAYMENT_REFUND_AMOUNT_AVAILABLE_MISMATCH("P0604", "Refund amount available mismatch."),
-        CREATE_PAYMENT_MANDATE_STATE_INVALID("P1103",
+        CREATE_PAYMENT_MANDATE_STATE_INVALID("P1203",
                 "Can't create payment. The mandate's state must be pending or active."),
         CREATE_PAYMENT_MANDATE_ID_INVALID("P1200",
                 "Can't create payment. A mandate with the ID provided does not exist."),


### PR DESCRIPTION
- We are currently returning a P code which is already used by another
error, causing a conflict between the two messages, this commit resolves
this.
