### PR TITLE
PP-5607 RateLimiterFilter - Improve logging

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -43,16 +43,16 @@ import uk.gov.pay.api.exception.mapper.ViolationExceptionMapper;
 import uk.gov.pay.api.filter.AuthorizationValidationFilter;
 import uk.gov.pay.api.filter.RateLimiterFilter;
 import uk.gov.pay.api.healthcheck.Ping;
-import uk.gov.pay.api.resources.MandatesResource;
 import uk.gov.pay.api.ledger.resource.TransactionsResource;
 import uk.gov.pay.api.resources.DirectDebitEventsResource;
 import uk.gov.pay.api.resources.HealthCheckResource;
-import uk.gov.pay.api.resources.telephone.TelephonePaymentNotificationResource;
+import uk.gov.pay.api.resources.MandatesResource;
 import uk.gov.pay.api.resources.PaymentRefundsResource;
 import uk.gov.pay.api.resources.PaymentsResource;
 import uk.gov.pay.api.resources.RequestDeniedResource;
 import uk.gov.pay.api.resources.SearchRefundsResource;
 import uk.gov.pay.api.resources.directdebit.DirectDebitPaymentsResource;
+import uk.gov.pay.api.resources.telephone.TelephonePaymentNotificationResource;
 import uk.gov.pay.api.validation.InjectingValidationFeature;
 import uk.gov.pay.commons.utils.logging.LoggingFilter;
 
@@ -102,11 +102,9 @@ public class PublicApi extends Application<PublicApiConfig> {
         environment.jersey().register(injector.getInstance(TransactionsResource.class));
         environment.jersey().register(injector.getInstance(TelephonePaymentNotificationResource.class));
         environment.jersey().register(new InjectingValidationFeature(injector));
-
+        environment.jersey().register(injector.getInstance(RateLimiterFilter.class));
+        
         environment.servlets().addFilter("AuthorizationValidationFilter", injector.getInstance(AuthorizationValidationFilter.class))
-                .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
-
-        environment.servlets().addFilter("RateLimiterFilter", injector.getInstance(RateLimiterFilter.class))
                 .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
 
         environment.servlets().addFilter("LoggingFilter", injector.getInstance(LoggingFilter.class))

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
@@ -67,7 +67,7 @@ public class RateLimiterFilter implements ContainerRequestFilter {
 
         String accountId = getAccountId(requestContext);
         try {
-            rateLimiter.checkRateOf(method + "-" + authorization, method);
+            rateLimiter.checkRateOf(accountId, method + "-" + authorization, method);
         } catch (RateLimitException e) {
             LOGGER.info("Rate limit reached for current service and account [{}]. Sending response '429 Too Many Requests'", accountId);
             setTooManyRequestsError();

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
@@ -69,7 +69,7 @@ public class RateLimiterFilter implements ContainerRequestFilter {
         try {
             rateLimiter.checkRateOf(accountId, method + "-" + authorization, method);
         } catch (RateLimitException e) {
-            LOGGER.info("Rate limit reached for current service and account [{}]. Sending response '429 Too Many Requests'", accountId);
+            LOGGER.info("Rate limit reached for current service [account - {}, method - {}]. Sending response '429 Too Many Requests'", accountId, method);
             setTooManyRequestsError();
         }
     }

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
@@ -1,22 +1,27 @@
 package uk.gov.pay.api.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.filter.ratelimit.RateLimitException;
 import uk.gov.pay.api.filter.ratelimit.RateLimiter;
 import uk.gov.pay.api.resources.error.ApiErrorResponse.Code;
+
+import javax.annotation.Priority;
 import javax.inject.Inject;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Variant;
+import javax.ws.rs.ext.Provider;
 import java.io.IOException;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import java.util.Optional;
+
 import static uk.gov.pay.api.resources.error.ApiErrorResponse.anApiErrorResponse;
 
 /**
@@ -25,7 +30,9 @@ import static uk.gov.pay.api.resources.error.ApiErrorResponse.anApiErrorResponse
  * <p>
  * 429 Too Many Requests will be returned when rate limit is reached.
  */
-public class RateLimiterFilter implements Filter {
+@Provider
+@Priority(Priorities.USER)
+public class RateLimiterFilter implements ContainerRequestFilter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RateLimiterFilter.class);
     private static final int TOO_MANY_REQUESTS_STATUS_CODE = 429;
@@ -43,31 +50,34 @@ public class RateLimiterFilter implements Filter {
         this.objectMapper = objectMapper;
     }
 
-    @Override
-    public void init(FilterConfig filterConfig) {}
+    private void setTooManyRequestsError() throws IOException {
+        String errorResponse = objectMapper.writeValueAsString(anApiErrorResponse(Code.TOO_MANY_REQUESTS_ERROR));
+        Response.ResponseBuilder builder = Response.status(TOO_MANY_REQUESTS_STATUS_CODE)
+                .entity(errorResponse)
+                .encoding(UTF8_CHARACTER_ENCODING)
+                .variant(new Variant(MediaType.APPLICATION_JSON_TYPE, "", UTF8_CHARACTER_ENCODING));
+
+        throw new WebApplicationException(builder.build());
+    }
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        final String authorization = requestContext.getHeaderString("Authorization");
+        final String method = requestContext.getMethod();
 
-        final String authorization = ((HttpServletRequest) request).getHeader("Authorization");
-        final String method = ((HttpServletRequest) request).getMethod();
-
+        String accountId = getAccountId(requestContext);
         try {
             rateLimiter.checkRateOf(method + "-" + authorization, method);
-            chain.doFilter(request, response);
         } catch (RateLimitException e) {
-            LOGGER.info("Rate limit reached for current service. Sending response '429 Too Many Requests'");
-            setTooManyRequestsError((HttpServletResponse) response);
-        } 
+            LOGGER.info("Rate limit reached for current service and account [{}]. Sending response '429 Too Many Requests'", accountId);
+            setTooManyRequestsError();
+        }
     }
 
-    private void setTooManyRequestsError(HttpServletResponse response) throws IOException {
-        response.setStatus(TOO_MANY_REQUESTS_STATUS_CODE);
-        response.setContentType(APPLICATION_JSON);
-        response.setCharacterEncoding(UTF8_CHARACTER_ENCODING);
-        response.getWriter().print(objectMapper.writeValueAsString(anApiErrorResponse(Code.TOO_MANY_REQUESTS_ERROR)));
+    private String getAccountId(ContainerRequestContext requestContext) {
+        Account account = (Account) requestContext.getSecurityContext().getUserPrincipal();
+        return Optional.ofNullable(account)
+                .map(Account::getAccountId)
+                .orElse(StringUtils.EMPTY);
     }
-
-    @Override
-    public void destroy() {}
 }

--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimit.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimit.java
@@ -37,4 +37,12 @@ final class RateLimit {
             throw new RateLimitException();
         }
     }
+
+    public int getNoOfReq() {
+        return noOfReq;
+    }
+
+    public int getRequestCount() {
+        return requestCount;
+    }
 }

--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimiter.java
@@ -17,9 +17,9 @@ public class RateLimiter {
         this.redisRateLimiter = redisRateLimiter;
     }
 
-    public void checkRateOf(String key, String method) throws RateLimitException {
+    public void checkRateOf(String accountId, String key, String method) throws RateLimitException {
         try {
-            redisRateLimiter.checkRateOf(key, method);
+            redisRateLimiter.checkRateOf(accountId, key, method);
         } catch (RedisException e) {
             LOGGER.warn("Exception occurred checking rate limits using RedisRateLimiter, falling back to LocalRateLimiter");
 

--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimiter.java
@@ -23,7 +23,7 @@ public class RateLimiter {
         } catch (RedisException e) {
             LOGGER.warn("Exception occurred checking rate limits using RedisRateLimiter, falling back to LocalRateLimiter");
 
-            localRateLimiter.checkRateOf(key, method);
+            localRateLimiter.checkRateOf(accountId, key, method);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
@@ -43,7 +43,7 @@ public class RedisRateLimiter {
         }
 
         if (count != null && count > getNoOfReqForMethod(method)) {
-            LOGGER.info(String.format("rate limit exceeded for account [%s] and method [%s] - count: %d, rate allowed: %d", accountId, method, count, getNoOfReqForMethod(method)));
+            LOGGER.info(String.format("RedisRateLimiter - Rate limit exceeded for account [%s] and method [%s] - count: %d, rate allowed: %d", accountId, method, count, getNoOfReqForMethod(method)));
             throw new RateLimitException();
         }
     }

--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
@@ -30,7 +30,7 @@ public class RedisRateLimiter {
     /**
      * @throws RateLimitException
      */
-    synchronized void checkRateOf(String key, String method)
+    synchronized void checkRateOf(String accountId, String key, String method)
             throws RedisException, RateLimitException {
 
         Long count;
@@ -43,7 +43,7 @@ public class RedisRateLimiter {
         }
 
         if (count != null && count > getNoOfReqForMethod(method)) {
-            LOGGER.info(String.format("rate exceeded - count: %d, rate: %d", count, getNoOfReqForMethod(method)));
+            LOGGER.info(String.format("rate limit exceeded for account [%s] and method [%s] - count: %d, rate allowed: %d", accountId, method, count, getNoOfReqForMethod(method)));
             throw new RateLimitException();
         }
     }

--- a/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
@@ -2,80 +2,73 @@ package uk.gov.pay.api.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.filter.ratelimit.RateLimitException;
 import uk.gov.pay.api.filter.ratelimit.RateLimiter;
+import uk.gov.pay.api.model.TokenPaymentType;
 
-import javax.servlet.FilterChain;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.PrintWriter;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RateLimiterFilterTest {
 
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    private String authorization = "Bearer whateverAuthorizationToken";
     private RateLimiterFilter rateLimiterFilter;
-
     private RateLimiter rateLimiter;
-
     @Mock
-    private HttpServletRequest mockPostRequest;
-    @Mock
-    private HttpServletRequest mockGetRequest;
-    @Mock
-    private HttpServletResponse mockResponse;
-    @Mock
-    private FilterChain mockFilterChain;
-
-    String authorization = "Bearer whateverAuthorizationToken";
+    private ContainerRequestContext mockContainerRequestContext;
 
     @Before
     public void setup() {
         rateLimiter = mock(RateLimiter.class);
         rateLimiterFilter = new RateLimiterFilter(rateLimiter, new ObjectMapper());
 
-        when(mockPostRequest.getHeader("Authorization")).thenReturn(authorization);
-        when(mockPostRequest.getMethod()).thenReturn("POST");
+        Account account = new Account("account-id", TokenPaymentType.CARD);
+        SecurityContext mockSecurityContext = mock(SecurityContext.class);
+        when(mockSecurityContext.getUserPrincipal()).thenReturn(account);
 
-        when(mockGetRequest.getHeader("Authorization")).thenReturn(authorization);
-        when(mockGetRequest.getMethod()).thenReturn("GET");
+        when(mockContainerRequestContext.getSecurityContext()).thenReturn(mockSecurityContext);
+
+        when(mockContainerRequestContext.getHeaderString("Authorization")).thenReturn(authorization);
+        when(mockContainerRequestContext.getMethod()).thenReturn("GET");
     }
 
     @Test
-    public void shouldProcessFilterChain_whenRequestsAreWithinTheRate() throws Exception {
-        rateLimiterFilter.doFilter(mockPostRequest, mockResponse, mockFilterChain);
-        rateLimiterFilter.doFilter(mockGetRequest, mockResponse, mockFilterChain);
-
-        verify(mockFilterChain, times(1)).doFilter(mockPostRequest, mockResponse);
-        verify(mockFilterChain, times(1)).doFilter(mockGetRequest, mockResponse);
+    public void shouldCheckRateLimitsWhenFilterIsInvoked() throws Exception {
+        rateLimiterFilter.filter(mockContainerRequestContext);
+        verify(rateLimiter).checkRateOf(any(), any());
     }
 
     @Test
     public void shouldSendErrorResponse_whenRateLimitExceeded() throws Exception {
-        PrintWriter mockPrinter = mock(PrintWriter.class);
-        when(mockResponse.getWriter()).thenReturn(mockPrinter);
-
-        rateLimiterFilter.doFilter(mockGetRequest, mockResponse, mockFilterChain);
-
         doThrow(RateLimitException.class).when(rateLimiter).checkRateOf("GET-" + authorization, "GET");
-        rateLimiterFilter.doFilter(mockGetRequest, mockResponse, mockFilterChain);
 
-        verify(mockFilterChain, times(1)).doFilter(mockGetRequest, mockResponse);
-        verify(mockResponse).setStatus(429);
-        verify(mockResponse).setContentType("application/json");
-        verify(mockResponse).setCharacterEncoding("utf-8");
-        verify(mockResponse).getWriter();
-        verify(mockPrinter).print("{\"code\":\"P0900\",\"description\":\"Too many requests\"}");
-        verifyNoMoreInteractions(mockResponse);
+        try {
+            rateLimiterFilter.filter(mockContainerRequestContext);
+        } catch (WebApplicationException e) {
+            Response response = e.getResponse();
+            assertEquals(429, response.getStatus());
+            assertEquals("application/json", response.getHeaderString("Content-Type"));
+            assertEquals("utf-8", response.getHeaderString("Content-Encoding"));
+            assertEquals("{\"code\":\"P0900\",\"description\":\"Too many requests\"}", response.getEntity());
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
@@ -54,12 +54,12 @@ public class RateLimiterFilterTest {
     @Test
     public void shouldCheckRateLimitsWhenFilterIsInvoked() throws Exception {
         rateLimiterFilter.filter(mockContainerRequestContext);
-        verify(rateLimiter).checkRateOf(any(), any());
+        verify(rateLimiter).checkRateOf(any(), any(), any());
     }
 
     @Test
     public void shouldSendErrorResponse_whenRateLimitExceeded() throws Exception {
-        doThrow(RateLimitException.class).when(rateLimiter).checkRateOf("GET-" + authorization, "GET");
+        doThrow(RateLimitException.class).when(rateLimiter).checkRateOf("account-id", "GET-" + authorization, "GET");
 
         try {
             rateLimiterFilter.filter(mockContainerRequestContext);

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimiterTest.java
@@ -45,6 +45,6 @@ public class RateLimiterTest {
         rateLimiter.checkRateOf(accountId, key, POST);
         rateLimiter.checkRateOf(accountId, key, POST);
 
-        verify(localRateLimiter, times(2)).checkRateOf(key, POST);
+        verify(localRateLimiter, times(2)).checkRateOf(accountId, key, POST);
     }
 }

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimiterTest.java
@@ -1,9 +1,7 @@
 package uk.gov.pay.api.filter.ratelimit;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -16,15 +14,12 @@ import static org.mockito.Mockito.verify;
 public class RateLimiterTest {
 
     private static final String POST = "POST";
-
+    private static final String accountId = "account-id";
     @Mock
     LocalRateLimiter localRateLimiter;
     @Mock
     RedisRateLimiter redisRateLimiter;
-
     RateLimiter rateLimiter;
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setup() {
@@ -35,20 +30,20 @@ public class RateLimiterTest {
     public void shouldInvokeRedisRateLimiter_whenRedisDbIsAvaiable() throws Exception {
         String key = "key1";
 
-        rateLimiter.checkRateOf(key, POST);
-        rateLimiter.checkRateOf(key, POST);
+        rateLimiter.checkRateOf(accountId, key, POST);
+        rateLimiter.checkRateOf(accountId, key, POST);
 
-        verify(redisRateLimiter, times(2)).checkRateOf(key, "POST");
+        verify(redisRateLimiter, times(2)).checkRateOf(accountId, key, "POST");
     }
 
     @Test
     public void shouldInvokeLocalRateLimiter_whenRedisIsNotAvaiable() throws Exception {
         String key = "key2";
 
-        doThrow(new RedisException()).when(redisRateLimiter).checkRateOf(key, POST);
+        doThrow(new RedisException()).when(redisRateLimiter).checkRateOf(accountId, key, POST);
 
-        rateLimiter.checkRateOf(key, POST);
-        rateLimiter.checkRateOf(key, POST);
+        rateLimiter.checkRateOf(accountId, key, POST);
+        rateLimiter.checkRateOf(accountId, key, POST);
 
         verify(localRateLimiter, times(2)).checkRateOf(key, POST);
     }

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiterTest.java
@@ -74,7 +74,7 @@ public class RedisRateLimiterTest {
     }
 
     @Test(expected = RateLimitException.class)
-    public void rateLimiterSetTo_2CallsPerSecond_shouldAFailWhen3ConsecutiveCallsWithSameKeysAreMade() throws Exception {
+    public void rateLimiterSetTo_2CallsPerSecond_shouldFailWhen3ConsecutiveCallsWithSameKeysAreMade() throws Exception {
         String key = "Key3";
         redisRateLimiter = new RedisRateLimiter(2, 2, 1000, jedisPool);
 
@@ -87,7 +87,7 @@ public class RedisRateLimiterTest {
         } catch (RedisException | RateLimitException e) {
             verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
             List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-            assertEquals("rate limit exceeded for account [account-id] and method [POST] - count: 3, rate allowed: 2",
+            assertEquals("RedisRateLimiter - Rate limit exceeded for account [account-id] and method [POST] - count: 3, rate allowed: 2",
                     loggingEvents.get(0).getFormattedMessage());
             
             throw e;

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiterTest.java
@@ -1,74 +1,96 @@
 package uk.gov.pay.api.filter.ratelimit;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RedisRateLimiterTest {
 
+    private static final String POST = "POST";
+    private static final String accountId = "account-id";
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
     @Mock
     JedisPool jedisPool;
     @Mock
     Jedis jedis;
-
-    private static final String POST = "POST";
-
+    @Captor
+    ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
     private RedisRateLimiter redisRateLimiter;
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+    private Appender<ILoggingEvent> mockAppender;
 
     @Before
     public void setup() {
         when(jedisPool.getResource()).thenReturn(jedis);
+
+        Logger root = (Logger) LoggerFactory.getLogger(RedisRateLimiter.class);
+        mockAppender = mock(Appender.class);
+        root.setLevel(Level.INFO);
+        root.addAppender(mockAppender);
     }
 
     @Test
     public void rateLimiterSetTo_1CallPerSecond_shouldAllowSingleCall() throws Exception {
-
-        String key = "Key1";
         redisRateLimiter = new RedisRateLimiter(1, 1, 1000, jedisPool);
 
         when(jedis.incr(anyString())).thenReturn(1L, 2L);
-        redisRateLimiter.checkRateOf("Key1", POST);
+        redisRateLimiter.checkRateOf(accountId, "Key1", POST);
     }
 
     @Test
     public void rateLimiterSetTo_2CallsPerSecond_shouldAllow2ConsecutiveCallsWithSameKeys() throws Exception {
-
         String key = "Key2";
         redisRateLimiter = new RedisRateLimiter(2, 2, 1000, jedisPool);
 
         when(jedis.incr(anyString())).thenReturn(1L, 2L, 3L);
 
-        redisRateLimiter.checkRateOf(key, POST);
-        redisRateLimiter.checkRateOf(key, POST);
+        redisRateLimiter.checkRateOf(accountId, key, POST);
+        redisRateLimiter.checkRateOf(accountId, key, POST);
 
     }
 
-    @Test
+    @Test(expected = RateLimitException.class)
     public void rateLimiterSetTo_2CallsPerSecond_shouldAFailWhen3ConsecutiveCallsWithSameKeysAreMade() throws Exception {
-
         String key = "Key3";
         redisRateLimiter = new RedisRateLimiter(2, 2, 1000, jedisPool);
 
         when(jedis.incr(anyString())).thenReturn(1L, 2L, 3L);
 
-        redisRateLimiter.checkRateOf(key, POST);
-        redisRateLimiter.checkRateOf(key, POST);
-
-        expectedException.expect(RateLimitException.class);
-        redisRateLimiter.checkRateOf(key, POST);
-
+        try {
+            redisRateLimiter.checkRateOf(accountId, key, POST);
+            redisRateLimiter.checkRateOf(accountId, key, POST);
+            redisRateLimiter.checkRateOf(accountId, key, POST);
+        } catch (RedisException | RateLimitException e) {
+            verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+            List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+            assertEquals("rate limit exceeded for account [account-id] and method [POST] - count: 3, rate allowed: 2",
+                    loggingEvents.get(0).getFormattedMessage());
+            
+            throw e;
+        }
     }
 }


### PR DESCRIPTION
## WHAT YOU DID

- Updated RateLimiterFilter type to ContainerRequestFilter (from Filter) so security context is available for the filter (that holds `Account` principal object)
- Assigned priority `@Priority(Priorities.USER)` so that the filter comes after `OAuthCredentialAuthFilter`(dropwizard) which authorises token and creates security context
- RedisRateLimiter & LocalRateLimiter now logs account ID and HTTP method if requests are rate limited
- Updated relevant tests