### PR TITLE
PP-5612 Add gateway account id to logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <jackson.version>2.9.9</jackson.version>
         <logback.version>1.2.3</logback.version>
         <docker-client.version>8.16.0</docker-client.version>
-        <pay-java-commons.version>1.0.20190816103843</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20190828103217</pay-java-commons.version>
         <pact.version>3.6.12</pact.version>
         <PACT_BROKER_URL/>
         <PACT_BROKER_USERNAME/>
@@ -51,6 +51,11 @@
         <dependency>
             <groupId>uk.gov.pay</groupId>
             <artifactId>validation</artifactId>
+            <version>${pay-java-commons.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.pay</groupId>
+            <artifactId>logging</artifactId>
             <version>${pay-java-commons.version}</version>
         </dependency>
         <dependency>

--- a/src/main/java/uk/gov/pay/api/filter/ClearMdcValuesFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ClearMdcValuesFilter.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.api.filter;
+
+import org.slf4j.MDC;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+
+/**
+ * This filter will remove MDC values at the end of a request to clear them from the thread
+ * before it is re-used. This filter should be registered first so that the `finally` block is
+ * called after all other application logic has finished.
+ */
+public class ClearMdcValuesFilter implements Filter {
+
+    @Override
+    public void init(FilterConfig filterConfig) { }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            MDC.clear();
+        }
+    }
+
+    @Override
+    public void destroy() {}
+
+}

--- a/src/main/java/uk/gov/pay/api/filter/GatewayAccountIdFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/GatewayAccountIdFilter.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.api.filter;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.MDC;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.ext.Provider;
+import java.security.Principal;
+import java.util.Optional;
+
+import static uk.gov.pay.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
+
+@Provider
+@Priority(Priorities.USER)
+public class GatewayAccountIdFilter implements ContainerRequestFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        MDC.put(GATEWAY_ACCOUNT_ID, getAccountId(requestContext));
+    }
+
+    private String getAccountId(ContainerRequestContext requestContext) {
+        return Optional.ofNullable(requestContext.getSecurityContext().getUserPrincipal())
+                .map(Principal::getName)
+                .orElse(StringUtils.EMPTY);
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -13,7 +13,7 @@ logging:
       threshold: ALL
       timeZone: UTC
       target: stdout
-      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] - %msg%n"
+      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] [gateway_account_id=%X{gateway_account_id:-(none)}] - %msg%n"
 
 baseUrl: ${PUBLICAPI_BASE}
 connectorUrl: ${CONNECTOR_URL}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -13,7 +13,7 @@ logging:
       threshold: ALL
       timeZone: UTC
       target: stdout
-      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] - %msg%n"
+      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] [gateway_account_id=%X{gateway_account_id:-(none)}] - %msg%n"
 
 baseUrl: http://publicapi.url/
 connectorUrl: http://connector_card.url/


### PR DESCRIPTION
PP-5612 Add gateway account id to logs
    
    To aid debugging this adds the gateway account id to the MDC using a
    `ContainerRequestFilter` so it can be logged in subsequent lines. The value is
    cleared by  a new `ClearMdcValuesFilter` class which is a
    `ServletFilter` at the head of the filter chain, this allows it to clean the
    mdc values within a `finally` block after calling `chain.doFilter()`.
    
    An alternative to using the `ClearMdcValuesFilter` to clean up at the
    end of the request would be follow the pattern of the `LoggingFilter`
    which we use to add the request-id. This will replace the request-id if
    it already exists, else set it a new. Although this seems simpler it
    has the risk of any log lines printed prior to `LoggingFilter`
    containing a stale request-id; instead it seems safer to clean the mdc
    values once the request has completed and the thread released to the
    pool.
    
    Ultimately it seems dealing with MDC and threadpools is a little tricky
    but we think this is a reasonable solution.

## How to test
Checked this by looking at the log output from IT and checking when the gateway account id appears and is removed.

Worth noting that this logs the gateway account id in the event of a 422 response (which triggered the need to make this change).
```
[2019-09-03 10:55:29.320] [thread=dw-62] [level=INFO ] [logger=u.g.p.c.u.l.LoggingFilter] [requestID=(none)] [gateway_account_id=GATEWAY_ACCOUNT_ID] - POST to /v1/payments/ ended - total time 233ms
127.0.0.1 - - [03/Sep/2019:09:55:29 +0000] "POST /v1/payments/ HTTP/1.1" 422 117 "-" "Apache-HttpClient/4.5.9 (Java/11)" 243
```
