### PR TITLE
BAU Add Local TLD Exemption

### DIFF
--- a/src/main/java/uk/gov/pay/api/validation/URLValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/URLValidator.java
@@ -27,7 +27,7 @@ public enum URLValidator {
     };
 
     static {
-        String[] otherValidTlds = new String[]{"internal"};
+        String[] otherValidTlds = new String[]{"internal", "local"};
         DomainValidator.updateTLDOverride(ArrayType.GENERIC_PLUS, otherValidTlds);
     }
 

--- a/src/test/java/uk/gov/pay/api/validation/URLValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/URLValidatorTest.java
@@ -99,6 +99,11 @@ public class URLValidatorTest {
     }
 
     @Test
+    public void whenUrlTldIsLocal_shouldAllowAsValid() {
+        assertThat(SECURITY_ENABLED.isValid("https://a-fake-test-env.fakeservice.local/public/web/govuk-return"), is(true));
+    }
+
+    @Test
     public void whenUrlIsNotAnAcceptedProtocol_disabledSecureConnection_shouldFailValidation() {
         assertThat(SECURITY_DISABLED.isValid("ftp://ftp.funet.fi/pub/standards/RFC/rfc959.txt"), is(false));
     }


### PR DESCRIPTION
- Adds a URLValidator exemption for the .local TLD & tests to ensure
that they are valid.