### PR TITLE
PP-5604 use future strategy only

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
@@ -34,7 +34,7 @@ public class PublicApiConfig extends Configuration {
     private Boolean allowHttpForReturnUrl;
 
     @NotNull
-    private Boolean alwaysGetPaymentRefundStrategyTest.javaUseFutureStrategy;
+    private Boolean alwaysUseFutureStrategy;
 
     private String apiKeyHmacSecret;
 

--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
@@ -33,6 +33,9 @@ public class PublicApiConfig extends Configuration {
     @NotNull
     private Boolean allowHttpForReturnUrl;
 
+    @NotNull
+    private Boolean alwaysGetPaymentRefundStrategyTest.javaUseFutureStrategy;
+
     private String apiKeyHmacSecret;
 
     @NotNull
@@ -59,6 +62,7 @@ public class PublicApiConfig extends Configuration {
     public String getConnectorUrl() {
         return connectorUrl;
     }
+
     public String getConnectorDDUrl() {
         return connectorDDUrl;
     }
@@ -95,7 +99,15 @@ public class PublicApiConfig extends Configuration {
         return rateLimiterConfig;
     }
 
-    public CacheBuilderSpec getAuthenticationCachePolicy() { return authenticationCachePolicy; }
+    public CacheBuilderSpec getAuthenticationCachePolicy() {
+        return authenticationCachePolicy;
+    }
 
-    public JedisFactory getJedisFactory() { return redis;  }
+    public JedisFactory getJedisFactory() {
+        return redis;
+    }
+
+    public Boolean getAlwaysUseFutureStrategy() {
+        return alwaysUseFutureStrategy;
+    }
 }

--- a/src/main/java/uk/gov/pay/api/resources/GetOnePaymentStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/GetOnePaymentStrategy.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.resources;
 
+import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 import uk.gov.pay.api.service.GetPaymentService;
@@ -10,8 +11,8 @@ public class GetOnePaymentStrategy extends LedgerOrConnectorStrategyTemplate<Pay
     private final String paymentId;
     private final GetPaymentService getPaymentService;
 
-    public GetOnePaymentStrategy(String strategy, Account account, String paymentId, GetPaymentService getPaymentService) {
-        super(strategy);
+    public GetOnePaymentStrategy(PublicApiConfig configuration, String strategy, Account account, String paymentId, GetPaymentService getPaymentService) {
+        super(configuration, strategy);
         this.account = account;
         this.paymentId = paymentId;
         this.getPaymentService = getPaymentService;

--- a/src/main/java/uk/gov/pay/api/resources/GetPaymentEventsStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/GetPaymentEventsStrategy.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.resources;
 
+import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.PaymentEventsResponse;
 import uk.gov.pay.api.service.GetPaymentEventsService;
@@ -9,9 +10,9 @@ public class GetPaymentEventsStrategy extends LedgerOrConnectorStrategyTemplate<
     private final String paymentId;
     private final GetPaymentEventsService getPaymentEventsService;
 
-    public GetPaymentEventsStrategy(String strategyName, Account account, String paymentId,
+    public GetPaymentEventsStrategy(PublicApiConfig configuration, String strategyName, Account account, String paymentId,
                                     GetPaymentEventsService getPaymentEventsService) {
-        super(strategyName);
+        super(configuration, strategyName);
         this.account = account;
         this.paymentId = paymentId;
         this.getPaymentEventsService = getPaymentEventsService;

--- a/src/main/java/uk/gov/pay/api/resources/GetPaymentRefundStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/GetPaymentRefundStrategy.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.api.resources;
 
 
+import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.RefundResponse;
 import uk.gov.pay.api.service.GetPaymentRefundService;
@@ -12,9 +13,9 @@ public class GetPaymentRefundStrategy extends LedgerOrConnectorStrategyTemplate<
     private final String refundId;
     private final GetPaymentRefundService getPaymentRefundsService;
 
-    public GetPaymentRefundStrategy(String strategy, Account account, String paymentId, String refundId,
+    public GetPaymentRefundStrategy(PublicApiConfig configuration, String strategy, Account account, String paymentId, String refundId,
                                     GetPaymentRefundService getPaymentRefundsService) {
-        super(strategy);
+        super(configuration, strategy);
         this.account = account;
         this.paymentId = paymentId;
         this.refundId = refundId;

--- a/src/main/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategy.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.api.resources;
 
 
+import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.RefundsResponse;
 import uk.gov.pay.api.service.GetPaymentRefundsService;
@@ -11,9 +12,9 @@ public class GetPaymentRefundsStrategy extends LedgerOrConnectorStrategyTemplate
     private final String paymentId;
     private final GetPaymentRefundsService getPaymentRefundsService;
 
-    public GetPaymentRefundsStrategy(String strategy, Account account, String paymentId,
+    public GetPaymentRefundsStrategy(PublicApiConfig configuration, String strategy, Account account, String paymentId,
                                      GetPaymentRefundsService getPaymentRefundsService) {
-        super(strategy);
+        super(configuration, strategy);
         this.account = account;
         this.paymentId = paymentId;
         this.getPaymentRefundsService = getPaymentRefundsService;

--- a/src/main/java/uk/gov/pay/api/resources/LedgerOrConnectorStrategyTemplate.java
+++ b/src/main/java/uk/gov/pay/api/resources/LedgerOrConnectorStrategyTemplate.java
@@ -30,7 +30,7 @@ public abstract class LedgerOrConnectorStrategyTemplate<T> {
     public T validateAndExecute() {
         validate();
 
-        if ("future-behaviour".equals(strategy)) {
+        if (shouldAlwaysUseFutureStrategy || "future-behaviour".equals(strategy)) {
             return executeFutureBehaviourStrategy();
         } else if ("ledger-only".equals(strategy)) {
             return executeLedgerOnlyStrategy();

--- a/src/main/java/uk/gov/pay/api/resources/LedgerOrConnectorStrategyTemplate.java
+++ b/src/main/java/uk/gov/pay/api/resources/LedgerOrConnectorStrategyTemplate.java
@@ -13,32 +13,34 @@ public abstract class LedgerOrConnectorStrategyTemplate<T> {
     private static final Logger logger = LoggerFactory.getLogger(LedgerOrConnectorStrategyTemplate.class);
     private String strategy;
     private List<String> VALID_STRATEGIES = ImmutableList.of("ledger-only", "future-behaviour");
-    
+
     public LedgerOrConnectorStrategyTemplate(PublicApiConfig configuration, String strategy) {
         this.strategy = strategy;
     }
 
     private void validate() {
-        if(!StringUtils.isBlank(strategy) && !VALID_STRATEGIES.contains(strategy)) {
+        if (!StringUtils.isBlank(strategy) && !VALID_STRATEGIES.contains(strategy)) {
             logger.warn("Not valid strategy (valid values are \"ledger-only\", \"future-behaviour\" or empty); using the default strategy");
             strategy = null;
         }
     }
-    
+
     public T validateAndExecute() {
         validate();
 
-        if("ledger-only".equals(strategy)) {
-            return executeLedgerOnlyStrategy();
-        } else if ("future-behaviour".equals(strategy)) {
+        if ("future-behaviour".equals(strategy)) {
             return executeFutureBehaviourStrategy();
+        } else if ("ledger-only".equals(strategy)) {
+            return executeLedgerOnlyStrategy();
         }
-        
+
         return executeDefaultStrategy();
     }
-    
+
     protected abstract T executeLedgerOnlyStrategy();
+
     protected abstract T executeFutureBehaviourStrategy();
+
     protected abstract T executeDefaultStrategy();
 }
 

--- a/src/main/java/uk/gov/pay/api/resources/LedgerOrConnectorStrategyTemplate.java
+++ b/src/main/java/uk/gov/pay/api/resources/LedgerOrConnectorStrategyTemplate.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.api.app.config.PublicApiConfig;
 
 import java.util.List;
 
@@ -13,7 +14,7 @@ public abstract class LedgerOrConnectorStrategyTemplate<T> {
     private String strategy;
     private List<String> VALID_STRATEGIES = ImmutableList.of("ledger-only", "future-behaviour");
     
-    public LedgerOrConnectorStrategyTemplate(String strategy) {
+    public LedgerOrConnectorStrategyTemplate(PublicApiConfig configuration, String strategy) {
         this.strategy = strategy;
     }
 

--- a/src/main/java/uk/gov/pay/api/resources/LedgerOrConnectorStrategyTemplate.java
+++ b/src/main/java/uk/gov/pay/api/resources/LedgerOrConnectorStrategyTemplate.java
@@ -11,10 +11,12 @@ import java.util.List;
 public abstract class LedgerOrConnectorStrategyTemplate<T> {
 
     private static final Logger logger = LoggerFactory.getLogger(LedgerOrConnectorStrategyTemplate.class);
+    private final Boolean shouldAlwaysUseFutureStrategy;
     private String strategy;
     private List<String> VALID_STRATEGIES = ImmutableList.of("ledger-only", "future-behaviour");
 
     public LedgerOrConnectorStrategyTemplate(PublicApiConfig configuration, String strategy) {
+        this.shouldAlwaysUseFutureStrategy = configuration.getAlwaysUseFutureStrategy();
         this.strategy = strategy;
     }
 

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -74,6 +74,7 @@ public class PaymentRefundsResource {
     private final String baseUrl;
     private final Client client;
     private final String connectorUrl;
+    private PublicApiConfig configuration;
     private GetPaymentRefundsService getPaymentRefundsService;
     private GetPaymentRefundService getPaymentRefundService;
 
@@ -84,6 +85,7 @@ public class PaymentRefundsResource {
         this.client = client;
         this.baseUrl = configuration.getBaseUrl();
         this.connectorUrl = configuration.getConnectorUrl();
+        this.configuration = configuration;
         this.getPaymentRefundsService = getPaymentRefundsService;
         this.getPaymentRefundService = getPaymentRefundService;
     }
@@ -111,7 +113,7 @@ public class PaymentRefundsResource {
 
         logger.info("Get refunds for payment request - paymentId={} using strategy={}", paymentId, strategyName);
 
-        GetPaymentRefundsStrategy strategy = new GetPaymentRefundsStrategy(strategyName, account, paymentId, getPaymentRefundsService);
+        GetPaymentRefundsStrategy strategy = new GetPaymentRefundsStrategy(configuration, strategyName, account, paymentId, getPaymentRefundsService);
         RefundsResponse refundsResponse = strategy.validateAndExecute();
 
         logger.debug("refund returned - [ {} ]", refundsResponse);
@@ -144,7 +146,7 @@ public class PaymentRefundsResource {
 
         logger.info("Payment refund request - paymentId={}, refundId={}", paymentId, refundId);
 
-        var strategy = new GetPaymentRefundStrategy(strategyName, account, paymentId, refundId, getPaymentRefundService);
+        var strategy = new GetPaymentRefundStrategy(configuration, strategyName, account, paymentId, refundId, getPaymentRefundService);
         RefundResponse refundResponse = strategy.validateAndExecute();
 
         logger.info("refund returned - [ {} ]", refundResponse);

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.Authorization;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CaptureChargeException;
 import uk.gov.pay.api.model.CreateCardPaymentRequest;
@@ -61,6 +62,7 @@ public class PaymentsResource {
     private final CapturePaymentService capturePaymentService;
     private final CancelPaymentService cancelPaymentService;
     private final GetPaymentEventsService getPaymentEventsService;
+    private PublicApiConfig configuration;
 
     @Inject
     public PaymentsResource(CreatePaymentService createPaymentService,
@@ -69,7 +71,8 @@ public class PaymentsResource {
                             GetPaymentService getPaymentService,
                             CapturePaymentService capturePaymentService,
                             CancelPaymentService cancelPaymentService,
-                            GetPaymentEventsService getPaymentEventsService) {
+                            GetPaymentEventsService getPaymentEventsService,
+                            PublicApiConfig configuration) {
         this.createPaymentService = createPaymentService;
         this.publicApiUriGenerator = publicApiUriGenerator;
         this.paymentSearchService = paymentSearchService;
@@ -77,6 +80,7 @@ public class PaymentsResource {
         this.capturePaymentService = capturePaymentService;
         this.cancelPaymentService = cancelPaymentService;
         this.getPaymentEventsService = getPaymentEventsService;
+        this.configuration = configuration;
     }
 
     @GET
@@ -105,7 +109,7 @@ public class PaymentsResource {
 
         logger.info("Payment request - paymentId={}", paymentId);
 
-        var strategy = new GetOnePaymentStrategy(strategyName, account, paymentId, getPaymentService);
+        var strategy = new GetOnePaymentStrategy(configuration, strategyName, account, paymentId, getPaymentService);
         PaymentWithAllLinks payment = strategy.validateAndExecute();
 
         logger.info("Payment returned - [ {} ]", payment);
@@ -138,7 +142,7 @@ public class PaymentsResource {
 
         logger.info("Payment events request - payment_id={}", paymentId);
 
-        var strategy = new GetPaymentEventsStrategy(strategyName, account, paymentId, getPaymentEventsService);
+        var strategy = new GetPaymentEventsStrategy(configuration, strategyName, account, paymentId, getPaymentEventsService);
         PaymentEventsResponse paymentEventsResponse = strategy.validateAndExecute();
 
         logger.info("Payment events returned - [ {} ]", paymentEventsResponse);
@@ -216,7 +220,7 @@ public class PaymentsResource {
                 .withLastDigitsCardNumber(lastDigitsCardNumber)
                 .build();
 
-        var strategy = new SearchPaymentsStrategy(strategyName, account, paymentSearchParams, paymentSearchService);
+        var strategy = new SearchPaymentsStrategy(configuration, strategyName, account, paymentSearchParams, paymentSearchService);
         return strategy.validateAndExecute();
     }
 

--- a/src/main/java/uk/gov/pay/api/resources/SearchPaymentsStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchPaymentsStrategy.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.resources;
 
+import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.service.PaymentSearchParams;
 import uk.gov.pay.api.service.PaymentSearchService;
@@ -11,8 +12,8 @@ public class SearchPaymentsStrategy extends LedgerOrConnectorStrategyTemplate<Re
     private final PaymentSearchParams paymentSearchParams;
     private final PaymentSearchService paymentSearchService;
 
-    public SearchPaymentsStrategy(String strategyName, Account account, PaymentSearchParams paymentSearchParams, PaymentSearchService paymentSearchService) {
-        super(strategyName);
+    public SearchPaymentsStrategy(PublicApiConfig configuration, String strategyName, Account account, PaymentSearchParams paymentSearchParams, PaymentSearchService paymentSearchService) {
+        super(configuration, strategyName);
         this.account = account;
         this.paymentSearchParams = paymentSearchParams;
         this.paymentSearchService = paymentSearchService;

--- a/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
@@ -10,6 +10,7 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.RefundError;
 import uk.gov.pay.api.model.search.card.SearchRefundsResults;
@@ -34,10 +35,12 @@ public class SearchRefundsResource {
     private static final Logger logger = LoggerFactory.getLogger(SearchRefundsResource.class);
 
     private final SearchRefundsService searchRefundsService;
+    private PublicApiConfig configuration;
 
     @Inject
-    public SearchRefundsResource(SearchRefundsService searchRefundsService) {
+    public SearchRefundsResource(SearchRefundsService searchRefundsService, PublicApiConfig configuration) {
         this.searchRefundsService = searchRefundsService;
+        this.configuration = configuration;
     }
 
     @GET
@@ -76,7 +79,7 @@ public class SearchRefundsResource {
                         fromDate, toDate, pageNumber, displaySize));
 
         RefundsParams refundsParams = new RefundsParams(fromDate, toDate, pageNumber, displaySize);
-        SearchRefundsStrategy strategy = new SearchRefundsStrategy(strategyName, account, refundsParams, searchRefundsService);
+        SearchRefundsStrategy strategy = new SearchRefundsStrategy(configuration, strategyName, account, refundsParams, searchRefundsService);
 
         return strategy.validateAndExecute();
     }

--- a/src/main/java/uk/gov/pay/api/resources/SearchRefundsStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchRefundsStrategy.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.api.resources;
 
 
+import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.search.card.SearchRefundsResults;
 import uk.gov.pay.api.service.RefundsParams;
@@ -12,9 +13,9 @@ public class SearchRefundsStrategy extends LedgerOrConnectorStrategyTemplate<Sea
     private RefundsParams refundsParams;
     private final SearchRefundsService searchRefundsService;
 
-    public SearchRefundsStrategy(String strategy, Account account, RefundsParams refundsParams,
+    public SearchRefundsStrategy(PublicApiConfig configuration, String strategy, Account account, RefundsParams refundsParams,
                                  SearchRefundsService searchRefundsService) {
-        super(strategy);
+        super(configuration, strategy);
         this.account = account;
         this.refundsParams = refundsParams;
         this.searchRefundsService = searchRefundsService;

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -26,6 +26,8 @@ connectorDDUrl: ${CONNECTOR_DD_URL}
 publicAuthUrl: ${PUBLIC_AUTH_URL}
 ledgerUrl: ${LEDGER_URL}
 
+alwaysUseFutureStrategy: ${FEATURE_ALWAYS_USE_FUTURE_LEDGER_CONNECTOR_STRATEGY:-false}
+
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 

--- a/src/test/java/uk/gov/pay/api/resources/GetOnePaymentStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetOnePaymentStrategyTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -104,5 +105,15 @@ public class GetOnePaymentStrategyTest {
 
         verify(mockGetPaymentService, never()).getPayment(mockAccountId, mockPaymentId);
         verify(mockGetPaymentService).getConnectorCharge(mockAccountId, mockPaymentId);
+    }
+
+    @Test
+    public void whenSwitchingToFutureStrategyUsesFutureBehaviourStrategy() {
+        when(configuration.getAlwaysUseFutureStrategy()).thenReturn(true);
+        getOnePaymentStrategy = new GetOnePaymentStrategy(configuration, "ledger-only", mockAccountId, mockPaymentId, mockGetPaymentService);
+
+        getOnePaymentStrategy.validateAndExecute();
+
+        verify(mockGetPaymentService).getPayment(mockAccountId, mockPaymentId);
     }
 }

--- a/src/test/java/uk/gov/pay/api/resources/GetOnePaymentStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetOnePaymentStrategyTest.java
@@ -12,6 +12,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.service.GetPaymentService;
@@ -27,7 +28,10 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GetOnePaymentStrategyTest {
-    
+
+    @Mock
+    private PublicApiConfig configuration;
+
     @Mock
     private GetPaymentService mockGetPaymentService;
 
@@ -35,7 +39,7 @@ public class GetOnePaymentStrategyTest {
     ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
     private Appender<ILoggingEvent> mockAppender;
-    
+
     private GetOnePaymentStrategy getOnePaymentStrategy;
     private String mockPaymentId = "some-payment-id";
     private Account mockAccountId = new Account("some-account-id", TokenPaymentType.CARD);
@@ -49,8 +53,8 @@ public class GetOnePaymentStrategyTest {
 
     @Test
     public void whenNoStrategyProvidedUsesDefaultStrategy() {
-        getOnePaymentStrategy = new GetOnePaymentStrategy(null, mockAccountId, mockPaymentId, mockGetPaymentService);
-        
+        getOnePaymentStrategy = new GetOnePaymentStrategy(configuration, null, mockAccountId, mockPaymentId, mockGetPaymentService);
+
         getOnePaymentStrategy.validateAndExecute();
 
         verify(mockGetPaymentService, never()).getPayment(mockAccountId, mockPaymentId);
@@ -59,7 +63,7 @@ public class GetOnePaymentStrategyTest {
 
     @Test
     public void whenEmptyStrategyProvidedUsesDefaultStrategy() {
-        getOnePaymentStrategy = new GetOnePaymentStrategy("", mockAccountId, mockPaymentId, mockGetPaymentService);
+        getOnePaymentStrategy = new GetOnePaymentStrategy(configuration, "", mockAccountId, mockPaymentId, mockGetPaymentService);
 
         getOnePaymentStrategy.validateAndExecute();
 
@@ -69,7 +73,7 @@ public class GetOnePaymentStrategyTest {
 
     @Test
     public void whenLedgerOnlyStrategyProvidedUsesLedgerStrategy() {
-        getOnePaymentStrategy = new GetOnePaymentStrategy("ledger-only", mockAccountId, mockPaymentId, mockGetPaymentService);
+        getOnePaymentStrategy = new GetOnePaymentStrategy(configuration, "ledger-only", mockAccountId, mockPaymentId, mockGetPaymentService);
 
         getOnePaymentStrategy.validateAndExecute();
 
@@ -79,7 +83,7 @@ public class GetOnePaymentStrategyTest {
 
     @Test
     public void whenFutureBehaviourStrategyProvidedUsesFutureBehaviourStrategy() {
-        getOnePaymentStrategy = new GetOnePaymentStrategy("future-behaviour", mockAccountId, mockPaymentId, mockGetPaymentService);
+        getOnePaymentStrategy = new GetOnePaymentStrategy(configuration, "future-behaviour", mockAccountId, mockPaymentId, mockGetPaymentService);
 
         getOnePaymentStrategy.validateAndExecute();
 
@@ -88,7 +92,7 @@ public class GetOnePaymentStrategyTest {
 
     @Test
     public void whenNotValidStrategyProvidedUsesDefaultStrategy() {
-        getOnePaymentStrategy = new GetOnePaymentStrategy("not-valid-strategy-name", mockAccountId, mockPaymentId, mockGetPaymentService);
+        getOnePaymentStrategy = new GetOnePaymentStrategy(configuration, "not-valid-strategy-name", mockAccountId, mockPaymentId, mockGetPaymentService);
 
         getOnePaymentStrategy.validateAndExecute();
 

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentEventsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentEventsStrategyTest.java
@@ -12,6 +12,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.service.GetPaymentEventsService;
@@ -27,7 +28,10 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GetPaymentEventsStrategyTest {
-    
+
+    @Mock
+    private PublicApiConfig configuration;
+
     @Mock
     private GetPaymentEventsService getPaymentEventsService;
 
@@ -35,7 +39,7 @@ public class GetPaymentEventsStrategyTest {
     ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
     private Appender<ILoggingEvent> mockAppender;
-    
+
     private GetPaymentEventsStrategy getPaymentEventsStrategy;
     private String mockPaymentId = "some-payment-id";
     private Account mockAccountId = new Account("some-account-id", TokenPaymentType.CARD);
@@ -49,8 +53,8 @@ public class GetPaymentEventsStrategyTest {
 
     @Test
     public void whenNoStrategyProvidedUsesDefaultStrategy() {
-        getPaymentEventsStrategy = new GetPaymentEventsStrategy(null, mockAccountId, mockPaymentId, getPaymentEventsService);
-        
+        getPaymentEventsStrategy = new GetPaymentEventsStrategy(configuration, null, mockAccountId, mockPaymentId, getPaymentEventsService);
+
         getPaymentEventsStrategy.validateAndExecute();
 
         verify(getPaymentEventsService, never()).getPaymentEventsFromLedger(mockAccountId, mockPaymentId);
@@ -59,7 +63,7 @@ public class GetPaymentEventsStrategyTest {
 
     @Test
     public void whenEmptyStrategyProvidedUsesDefaultStrategy() {
-        getPaymentEventsStrategy = new GetPaymentEventsStrategy("", mockAccountId, mockPaymentId, getPaymentEventsService);
+        getPaymentEventsStrategy = new GetPaymentEventsStrategy(configuration, "", mockAccountId, mockPaymentId, getPaymentEventsService);
 
         getPaymentEventsStrategy.validateAndExecute();
 
@@ -69,7 +73,7 @@ public class GetPaymentEventsStrategyTest {
 
     @Test
     public void whenLedgerOnlyStrategyProvidedUsesLedgerStrategy() {
-        getPaymentEventsStrategy = new GetPaymentEventsStrategy("ledger-only", mockAccountId, mockPaymentId, getPaymentEventsService);
+        getPaymentEventsStrategy = new GetPaymentEventsStrategy(configuration, "ledger-only", mockAccountId, mockPaymentId, getPaymentEventsService);
 
         getPaymentEventsStrategy.validateAndExecute();
 
@@ -79,7 +83,7 @@ public class GetPaymentEventsStrategyTest {
 
     @Test
     public void whenFutureBehaviourStrategyProvidedUsesFutureBehaviourStrategy() {
-        getPaymentEventsStrategy = new GetPaymentEventsStrategy("future-behaviour", mockAccountId, mockPaymentId, getPaymentEventsService);
+        getPaymentEventsStrategy = new GetPaymentEventsStrategy(configuration, "future-behaviour", mockAccountId, mockPaymentId, getPaymentEventsService);
 
         getPaymentEventsStrategy.validateAndExecute();
 
@@ -89,7 +93,7 @@ public class GetPaymentEventsStrategyTest {
 
     @Test
     public void whenNotValidStrategyProvidedUsesDefaultStrategy() {
-        getPaymentEventsStrategy = new GetPaymentEventsStrategy("not-valid-strategy-name", mockAccountId, mockPaymentId, getPaymentEventsService);
+        getPaymentEventsStrategy = new GetPaymentEventsStrategy(configuration, "not-valid-strategy-name", mockAccountId, mockPaymentId, getPaymentEventsService);
 
         getPaymentEventsStrategy.validateAndExecute();
 

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentEventsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentEventsStrategyTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GetPaymentEventsStrategyTest {
@@ -105,5 +106,16 @@ public class GetPaymentEventsStrategyTest {
 
         verify(getPaymentEventsService, never()).getPaymentEventsFromLedger(mockAccountId, mockPaymentId);
         verify(getPaymentEventsService).getPaymentEventsFromConnector(mockAccountId, mockPaymentId);
+    }
+
+    @Test
+    public void whenSwitchingToFutureStrategyUsesFutureBehaviourStrategy() {
+        when(configuration.getAlwaysUseFutureStrategy()).thenReturn(true);
+        getPaymentEventsStrategy = new GetPaymentEventsStrategy(configuration, null, mockAccountId, mockPaymentId, getPaymentEventsService);
+
+        getPaymentEventsStrategy.validateAndExecute();
+
+        verify(getPaymentEventsService).getPaymentEventsFromLedger(mockAccountId, mockPaymentId);
+        verify(getPaymentEventsService, never()).getPaymentEventsFromConnector(mockAccountId, mockPaymentId);
     }
 }

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundStrategyTest.java
@@ -3,9 +3,12 @@ package uk.gov.pay.api.resources;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.GetRefundException;
@@ -20,6 +23,9 @@ import static org.mockito.Mockito.when;
 
 @RunWith(JUnitParamsRunner.class)
 public class GetPaymentRefundStrategyTest {
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
 
     @Mock
     private PublicApiConfig configuration;

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundStrategyTest.java
@@ -68,4 +68,13 @@ public class GetPaymentRefundStrategyTest {
         verify(mockGetPaymentRefundService, never()).getLedgerPaymentRefund(account, paymentId, refundId);
         verify(mockGetPaymentRefundService, never()).getPaymentRefund(account, paymentId, refundId);
     }
+
+    @Test
+    public void whenSwitchingToFutureStrategyUsesFutureBehaviourStrategy() {
+        when(configuration.getAlwaysUseFutureStrategy()).thenReturn(true);
+        getPaymentRefundStrategy = new GetPaymentRefundStrategy(configuration, null, account, paymentId, refundId, mockGetPaymentRefundService);
+        getPaymentRefundStrategy.validateAndExecute();
+
+        verify(mockGetPaymentRefundService).getPaymentRefund(account, paymentId, refundId);
+    }
 }

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundStrategyTest.java
@@ -5,6 +5,8 @@ import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.GetRefundException;
 import uk.gov.pay.api.model.TokenPaymentType;
@@ -19,17 +21,20 @@ import static org.mockito.Mockito.when;
 @RunWith(JUnitParamsRunner.class)
 public class GetPaymentRefundStrategyTest {
 
+    @Mock
+    private PublicApiConfig configuration;
+
     private GetPaymentRefundService mockGetPaymentRefundService = mock(GetPaymentRefundService.class);
     private GetPaymentRefundStrategy getPaymentRefundStrategy;
 
     private String paymentId = "payment-id";
     private String refundId = "refund-id";
     private Account account = new Account("account-id", TokenPaymentType.CARD);
-    
+
     @Test
     public void validateAndExecuteUsesLedgerOnlyStrategy() {
         String strategy = "ledger-only";
-        getPaymentRefundStrategy = new GetPaymentRefundStrategy(strategy, account, paymentId, refundId, mockGetPaymentRefundService);
+        getPaymentRefundStrategy = new GetPaymentRefundStrategy(configuration, strategy, account, paymentId, refundId, mockGetPaymentRefundService);
         getPaymentRefundStrategy.validateAndExecute();
 
         verify(mockGetPaymentRefundService).getLedgerPaymentRefund(account, paymentId, refundId);
@@ -40,7 +45,7 @@ public class GetPaymentRefundStrategyTest {
     @Test
     public void validateAndExecuteUsesFutureStrategyOnly() {
         String strategy = "future-behaviour";
-        getPaymentRefundStrategy = new GetPaymentRefundStrategy(strategy, account, paymentId, refundId, mockGetPaymentRefundService);
+        getPaymentRefundStrategy = new GetPaymentRefundStrategy(configuration, strategy, account, paymentId, refundId, mockGetPaymentRefundService);
         getPaymentRefundStrategy.validateAndExecute();
 
         verify(mockGetPaymentRefundService).getPaymentRefund(account, paymentId, refundId);
@@ -49,7 +54,7 @@ public class GetPaymentRefundStrategyTest {
     @Test
     @Parameters({"", "unknown"})
     public void validateAndExecuteShouldUseConnectorOnlyStrategy(String strategy) {
-        getPaymentRefundStrategy = new GetPaymentRefundStrategy(strategy, account, paymentId, refundId, mockGetPaymentRefundService);
+        getPaymentRefundStrategy = new GetPaymentRefundStrategy(configuration, strategy, account, paymentId, refundId, mockGetPaymentRefundService);
 
         getPaymentRefundStrategy.validateAndExecute();
 

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategyTest.java
@@ -2,9 +2,12 @@ package uk.gov.pay.api.resources;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
@@ -16,6 +19,9 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(JUnitParamsRunner.class)
 public class GetPaymentRefundsStrategyTest {
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
 
     @Mock
     private PublicApiConfig configuration;

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategyTest.java
@@ -4,6 +4,8 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.service.GetPaymentRefundsService;
@@ -15,6 +17,9 @@ import static org.mockito.Mockito.verify;
 @RunWith(JUnitParamsRunner.class)
 public class GetPaymentRefundsStrategyTest {
 
+    @Mock
+    private PublicApiConfig configuration;
+
     private GetPaymentRefundsService mockGetPaymentRefundsService = mock(GetPaymentRefundsService.class);
     private GetPaymentRefundsStrategy getPaymentRefundsStrategy;
 
@@ -24,7 +29,7 @@ public class GetPaymentRefundsStrategyTest {
     @Test
     @Parameters({"ledger-only", "future-behaviour"})
     public void validateAndExecuteShouldUseLedgerOnlyForListedStrategies(String strategy) {
-        getPaymentRefundsStrategy = new GetPaymentRefundsStrategy(strategy, account, paymentId, mockGetPaymentRefundsService);
+        getPaymentRefundsStrategy = new GetPaymentRefundsStrategy(configuration, strategy, account, paymentId, mockGetPaymentRefundsService);
         getPaymentRefundsStrategy.validateAndExecute();
 
         verify(mockGetPaymentRefundsService).getLedgerTransactionTransactions(account, paymentId);
@@ -34,7 +39,7 @@ public class GetPaymentRefundsStrategyTest {
     @Test
     @Parameters({"", "unknown"})
     public void validateAndExecuteShouldUseConnectorOnlyForDefaultOrUnknownStrategy(String strategy) {
-        getPaymentRefundsStrategy = new GetPaymentRefundsStrategy(strategy, account, paymentId, mockGetPaymentRefundsService);
+        getPaymentRefundsStrategy = new GetPaymentRefundsStrategy(configuration, strategy, account, paymentId, mockGetPaymentRefundsService);
 
         getPaymentRefundsStrategy.validateAndExecute();
 

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategyTest.java
@@ -16,6 +16,7 @@ import uk.gov.pay.api.service.GetPaymentRefundsService;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(JUnitParamsRunner.class)
 public class GetPaymentRefundsStrategyTest {
@@ -51,5 +52,15 @@ public class GetPaymentRefundsStrategyTest {
 
         verify(mockGetPaymentRefundsService).getConnectorPaymentRefunds(account, paymentId);
         verify(mockGetPaymentRefundsService, never()).getLedgerTransactionTransactions(account, paymentId);
+    }
+
+    @Test
+    public void whenSwitchingToFutureStrategyUsesFutureBehaviourStrategy() {
+        when(configuration.getAlwaysUseFutureStrategy()).thenReturn(true);
+        getPaymentRefundsStrategy = new GetPaymentRefundsStrategy(configuration, null, account, paymentId, mockGetPaymentRefundsService);
+        getPaymentRefundsStrategy.validateAndExecute();
+
+        verify(mockGetPaymentRefundsService).getLedgerTransactionTransactions(account, paymentId);
+        verify(mockGetPaymentRefundsService, never()).getConnectorPaymentRefunds(account, paymentId);
     }
 }

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -82,14 +82,6 @@ public class PaymentsResourceCreatePaymentTest {
 
     @Before
     public void setup() {
-        paymentsResource = new PaymentsResource(createPaymentService,
-                paymentSearchService,
-                publicApiUriGenerator,
-                getPaymentService,
-                capturePaymentService,
-                cancelPaymentService,
-                getPaymentEventsService,
-                configuration);
         when(publicApiUriGenerator.getPaymentURI(anyString())).thenReturn(URI.create(paymentUri));
     }
 

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -4,8 +4,10 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.Address;
 import uk.gov.pay.api.model.CardDetails;
@@ -40,6 +42,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class PaymentsResourceCreatePaymentTest {
 
+    @InjectMocks
     private PaymentsResource paymentsResource;
 
     @Mock
@@ -62,13 +65,15 @@ public class PaymentsResourceCreatePaymentTest {
 
     @Mock
     private CapturePaymentService capturePaymentService;
-    
+
     @Mock
     private CancelPaymentService cancelPaymentService;
 
     @Mock
     private GetPaymentEventsService getPaymentEventsService;
 
+    @Mock
+    private PublicApiConfig configuration;
 
     @Mock
     private GetDirectDebitPaymentService getDirectDebitPaymentService;
@@ -83,7 +88,8 @@ public class PaymentsResourceCreatePaymentTest {
                 getPaymentService,
                 capturePaymentService,
                 cancelPaymentService,
-                getPaymentEventsService);
+                getPaymentEventsService,
+                configuration);
         when(publicApiUriGenerator.getPaymentURI(anyString())).thenReturn(URI.create(paymentUri));
     }
 
@@ -134,7 +140,7 @@ public class PaymentsResourceCreatePaymentTest {
                 URI.create(paymentUri + "/capture"),
                 null,
                 null,
-                "providerId", 
+                "providerId",
                 null,
                 null, null);
     }

--- a/src/test/java/uk/gov/pay/api/resources/SearchPaymentsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/SearchPaymentsStrategyTest.java
@@ -17,6 +17,7 @@ import uk.gov.pay.api.service.PaymentSearchService;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(JUnitParamsRunner.class)
 public class SearchPaymentsStrategyTest {
@@ -52,5 +53,15 @@ public class SearchPaymentsStrategyTest {
 
         verify(mockPaymentSearchService).searchConnectorPayments(account, paymentSearchParams);
         verify(mockPaymentSearchService, never()).searchLedgerPayments(account, paymentSearchParams);
+    }
+
+    @Test
+    public void whenSwitchingToFutureStrategyUsesFutureBehaviourStrategy() {
+        when(configuration.getAlwaysUseFutureStrategy()).thenReturn(true);
+        searchPaymentsStrategy = new SearchPaymentsStrategy(configuration, null, account, paymentSearchParams, mockPaymentSearchService);
+        searchPaymentsStrategy.validateAndExecute();
+
+        verify(mockPaymentSearchService).searchLedgerPayments(account, paymentSearchParams);
+        verify(mockPaymentSearchService, never()).searchConnectorPayments(account, paymentSearchParams);
     }
 }

--- a/src/test/java/uk/gov/pay/api/resources/SearchPaymentsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/SearchPaymentsStrategyTest.java
@@ -2,9 +2,12 @@ package uk.gov.pay.api.resources;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
@@ -17,6 +20,10 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(JUnitParamsRunner.class)
 public class SearchPaymentsStrategyTest {
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
     @Mock
     private PublicApiConfig configuration;
 

--- a/src/test/java/uk/gov/pay/api/resources/SearchPaymentsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/SearchPaymentsStrategyTest.java
@@ -4,6 +4,8 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.service.PaymentSearchParams;
@@ -15,6 +17,9 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(JUnitParamsRunner.class)
 public class SearchPaymentsStrategyTest {
+    @Mock
+    private PublicApiConfig configuration;
+
     private PaymentSearchService mockPaymentSearchService = mock(PaymentSearchService.class);
     private SearchPaymentsStrategy searchPaymentsStrategy;
 
@@ -24,7 +29,7 @@ public class SearchPaymentsStrategyTest {
     @Test
     @Parameters({"ledger-only", "future-behaviour"})
     public void validateAndExecuteShouldUseLedgerOnlyForListedStrategies(String strategy) {
-        searchPaymentsStrategy = new SearchPaymentsStrategy(strategy, account, paymentSearchParams, mockPaymentSearchService);
+        searchPaymentsStrategy = new SearchPaymentsStrategy(configuration, strategy, account, paymentSearchParams, mockPaymentSearchService);
         searchPaymentsStrategy.validateAndExecute();
 
         verify(mockPaymentSearchService).searchLedgerPayments(account, paymentSearchParams);
@@ -34,7 +39,7 @@ public class SearchPaymentsStrategyTest {
     @Test
     @Parameters({"", "unknown"})
     public void validateAndExecuteShouldUseConnectorOnlyForDefaultOrUnknownStrategy(String strategy) {
-        searchPaymentsStrategy = new SearchPaymentsStrategy(strategy, account, paymentSearchParams, mockPaymentSearchService);
+        searchPaymentsStrategy = new SearchPaymentsStrategy(configuration, strategy, account, paymentSearchParams, mockPaymentSearchService);
 
         searchPaymentsStrategy.validateAndExecute();
 

--- a/src/test/java/uk/gov/pay/api/resources/SearchRefundsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/SearchRefundsStrategyTest.java
@@ -2,9 +2,12 @@ package uk.gov.pay.api.resources;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
@@ -17,6 +20,9 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(JUnitParamsRunner.class)
 public class SearchRefundsStrategyTest {
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
 
     @Mock
     private PublicApiConfig configuration;

--- a/src/test/java/uk/gov/pay/api/resources/SearchRefundsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/SearchRefundsStrategyTest.java
@@ -4,6 +4,8 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.service.RefundsParams;
@@ -16,6 +18,9 @@ import static org.mockito.Mockito.verify;
 @RunWith(JUnitParamsRunner.class)
 public class SearchRefundsStrategyTest {
 
+    @Mock
+    private PublicApiConfig configuration;
+
     private SearchRefundsService mockSearchRefundsService = mock(SearchRefundsService.class);
     private SearchRefundsStrategy searchRefundsStrategy;
 
@@ -25,7 +30,7 @@ public class SearchRefundsStrategyTest {
     @Test
     @Parameters({"ledger-only", "future-behaviour"})
     public void validateAndExecuteShouldUseLedgerOnlyForListedStrategies(String strategy) {
-        searchRefundsStrategy = new SearchRefundsStrategy(strategy, account, refundsParams, mockSearchRefundsService);
+        searchRefundsStrategy = new SearchRefundsStrategy(configuration, strategy, account, refundsParams, mockSearchRefundsService);
         searchRefundsStrategy.validateAndExecute();
 
         verify(mockSearchRefundsService).searchLedgerRefunds(account, refundsParams);
@@ -35,7 +40,7 @@ public class SearchRefundsStrategyTest {
     @Test
     @Parameters({"", "unknown"})
     public void validateAndExecuteShouldUseConnectorOnlyForDefaultOrUnknownStrategy(String strategy) {
-        searchRefundsStrategy = new SearchRefundsStrategy(strategy, account, refundsParams, mockSearchRefundsService);
+        searchRefundsStrategy = new SearchRefundsStrategy(configuration, strategy, account, refundsParams, mockSearchRefundsService);
 
         searchRefundsStrategy.validateAndExecute();
 

--- a/src/test/java/uk/gov/pay/api/resources/SearchRefundsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/SearchRefundsStrategyTest.java
@@ -17,6 +17,7 @@ import uk.gov.pay.api.service.SearchRefundsService;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(JUnitParamsRunner.class)
 public class SearchRefundsStrategyTest {
@@ -52,5 +53,15 @@ public class SearchRefundsStrategyTest {
 
         verify(mockSearchRefundsService).searchConnectorRefunds(account, refundsParams);
         verify(mockSearchRefundsService, never()).searchLedgerRefunds(account, refundsParams);
+    }
+
+    @Test
+    public void whenSwitchingToFutureStrategyUsesFutureBehaviourStrategy() {
+        when(configuration.getAlwaysUseFutureStrategy()).thenReturn(true);
+        searchRefundsStrategy = new SearchRefundsStrategy(configuration, null, account, refundsParams, mockSearchRefundsService);
+        searchRefundsStrategy.validateAndExecute();
+
+        verify(mockSearchRefundsService).searchLedgerRefunds(account, refundsParams);
+        verify(mockSearchRefundsService, never()).searchConnectorRefunds(account, refundsParams);
     }
 }

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -21,6 +21,8 @@ connectorDDUrl: http://connector_direct_debit.url/
 publicAuthUrl: http://publicauth.url/v1/auth
 ledgerUrl: http://ledger.url/
 
+alwaysUseFutureStrategy: false
+
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 


### PR DESCRIPTION
**Why**
There is a `X-Ledger` header that controls data source of  the charge endpoints. If it's not specified it uses connector. If it's `future-strategy` it simulates the behaviour when we switch ledger on in production (depending on the endpoint it can be always using ledger or connector falling back to ledger). `ledger-only` is for testing purposes - to be able to compare connector and ledger responses.

In order to switch to using ledger as a primary source of information (with a possibility to roll it back only with a configuration change) I introduced a feature flag (`FEATURE_ALWAYS_USE_FUTURE_LEDGER_CONNECTOR_STRATEGY`) that allows to switch to `future strategy`. By default the feature value is false so it would be using connector for all the requests (unless `X-Ledger` header says differently).

**What**
* add configuration property for feature toggle
* factor configuration in all the strategies and their usages
* change the order of choosing the strategy
* add mockito runner to parametrised strategy test  - there can be only one runner so in order for mock to work the rule needs to be added
* Update template strategy behaviour - future behaviour will be used when either header or feature flag is set