### PR TITLE
PP-5623 Check for null metadata value

### DIFF
--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
@@ -2,6 +2,7 @@ package uk.gov.pay.api.it;
 
 import com.jayway.jsonassert.JsonAssert;
 import io.restassured.response.ValidatableResponse;
+import org.json.JSONObject;
 import org.junit.Test;
 import uk.gov.pay.api.model.Address;
 import uk.gov.pay.api.model.CardDetails;
@@ -106,6 +107,26 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
                 .body("metadata.fuh", is("fuh you"));
 
         connectorMockClient.verifyCreateChargeConnectorRequest(GATEWAY_ACCOUNT_ID, createChargeRequestParams);
+    }
+
+    @Test
+    public void createCardPaymentWithMetadataAsNull_shouldReturn422() {
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, CARD);
+
+        var payload = new JSONObject()
+                .put("amount", 100)
+                .put("reference", "my reference")
+                .put("description", "my description")
+                .put("metadata", JSONObject.NULL)
+                .put("return_url", "https://test.test")
+                .toString();
+
+        postPaymentResponse(payload)
+                .statusCode(422)
+                .contentType(JSON)
+                .body("field", is("metadata"))
+                .body("code", is("P0102"))
+                .body("description", is("Invalid attribute value: metadata. Value must not be null"));
     }
 
     @Test


### PR DESCRIPTION
If the `metadata` key is supplied in a create payment request and the
value is `null` then return a 422 status code and a helpful message.
Previously this was causing a `NullPointerException` when passing `null`
to the `ExternalMetadata` constructor.