### PR TITLE
PP-5628: update ledger requests to use old status version

### DIFF
--- a/src/main/java/uk/gov/pay/api/ledger/service/LedgerUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/ledger/service/LedgerUriGenerator.java
@@ -34,7 +34,8 @@ public class LedgerUriGenerator {
         String path = format("/v1/transaction/%s", paymentId);
         return buildLedgerUri(path, Map.of(
                 "account_id", gatewayAccountId.getAccountId(),
-                "transaction_type", transactionType
+                "transaction_type", transactionType,
+                "status_version", "1"
         ));
     }
 
@@ -43,13 +44,17 @@ public class LedgerUriGenerator {
         return buildLedgerUri(path, Map.of(
                 "account_id", gatewayAccountId.getAccountId(),
                 "transaction_type", transactionType,
-                "parent_external_id", paymentId)
+                "parent_external_id", paymentId,
+                "status_version", "1")
         );
     }
 
     public String transactionEventsURI(Account gatewayAccountId, String paymentId) {
         String path = format("/v1/transaction/%s/event", paymentId);
-        return buildLedgerUri(path, Map.of("gateway_account_id", gatewayAccountId.getAccountId()));
+        return buildLedgerUri(path, Map.of(
+                "gateway_account_id", gatewayAccountId.getAccountId(),
+                "status_version", "1")
+        );
     }
 
     public String transactionsForTransactionURI(String gatewayAccountId, String paymentId) {

--- a/src/test/resources/pacts/publicapi-ledger-get-payment-events.json
+++ b/src/test/resources/pacts/publicapi-ledger-get-payment-events.json
@@ -21,7 +21,8 @@
         "method": "GET",
         "path": "/v1/transaction/abc123/event",
         "query": {
-          "gateway_account_id": ["42"]
+          "gateway_account_id": ["42"],
+          "status_version": ["1"]
         }
       },
       "response": {
@@ -55,21 +56,21 @@
             "$.transaction_id": {
               "matchers": [
                 {
-                  "match": "type"
+                  "match": "value"
                 }
               ]
             },
             "$.events[0].state.status": {
               "matchers": [
                 {
-                  "match": "type"
+                  "match": "value"
                 }
               ]
             },
             "$.events[0].state.finished": {
               "matchers": [
                 {
-                  "match": "type"
+                  "match": "value"
                 }
               ]
             },
@@ -84,28 +85,28 @@
             "$.events[1].state.status": {
               "matchers": [
                 {
-                  "match": "type"
+                  "match": "value"
                 }
               ]
             },
             "$.events[1].state.finished": {
               "matchers": [
                 {
-                  "match": "type"
+                  "match": "value"
                 }
               ]
             },
             "$.events[1].state.code": {
               "matchers": [
                 {
-                  "match": "type"
+                  "match": "value"
                 }
               ]
             },
             "$.events[1].state.message": {
               "matchers": [
                 {
-                  "match": "type"
+                  "match": "value"
                 }
               ]
             },

--- a/src/test/resources/pacts/publicapi-ledger-get-payment-refund.json
+++ b/src/test/resources/pacts/publicapi-ledger-get-payment-refund.json
@@ -24,7 +24,8 @@
         "query": {
           "account_id": ["123456"],
           "parent_external_id" :["123456789"],
-          "transaction_type":["REFUND"]
+          "transaction_type":["REFUND"],
+          "status_version": ["1"]
         }
       },
       "response": {

--- a/src/test/resources/pacts/publicapi-ledger-get-payment-with-corporate-surcharge.json
+++ b/src/test/resources/pacts/publicapi-ledger-get-payment-with-corporate-surcharge.json
@@ -22,7 +22,8 @@
         "path": "/v1/transaction/ch_123abc456xyz",
         "query": {
           "account_id": ["123456"],
-          "transaction_type": ["PAYMENT"]
+          "transaction_type": ["PAYMENT"],
+          "status_version": ["1"]
         }
       },
       "response": {

--- a/src/test/resources/pacts/publicapi-ledger-get-payment-with-delayed-capture-true.json
+++ b/src/test/resources/pacts/publicapi-ledger-get-payment-with-delayed-capture-true.json
@@ -22,7 +22,8 @@
         "path": "/v1/transaction/ch_123abc456xyz",
         "query": {
           "account_id": ["123456"],
-          "transaction_type": ["PAYMENT"]
+          "transaction_type": ["PAYMENT"],
+          "status_version": ["1"]
         }
       },
       "response": {

--- a/src/test/resources/pacts/publicapi-ledger-get-payment-with-fee-and-net-amount.json
+++ b/src/test/resources/pacts/publicapi-ledger-get-payment-with-fee-and-net-amount.json
@@ -22,7 +22,8 @@
         "path": "/v1/transaction/ch_123abc456xyz",
         "query": {
           "account_id": ["123456"],
-          "transaction_type": ["PAYMENT"]
+          "transaction_type": ["PAYMENT"],
+          "status_version": ["1"]
         }
       },
       "response": {

--- a/src/test/resources/pacts/publicapi-ledger-get-payment-with-gateway-transaction-id.json
+++ b/src/test/resources/pacts/publicapi-ledger-get-payment-with-gateway-transaction-id.json
@@ -23,7 +23,8 @@
         "path": "/v1/transaction/ch_123abc456xyz",
         "query": {
           "account_id": ["123456"],
-          "transaction_type": ["PAYMENT"]
+          "transaction_type": ["PAYMENT"],
+          "status_version": ["1"]
         }
       },
       "response": {

--- a/src/test/resources/pacts/publicapi-ledger-get-payment-with-metadata.json
+++ b/src/test/resources/pacts/publicapi-ledger-get-payment-with-metadata.json
@@ -23,7 +23,8 @@
         "path": "/v1/transaction/ch_123abc456xyz",
         "query": {
           "account_id": ["123456"],
-          "transaction_type": ["PAYMENT"]
+          "transaction_type": ["PAYMENT"],
+          "status_version": ["1"]
         }
       },
       "response": {


### PR DESCRIPTION
In order to for ledger to be compatible with connector
the returned status needs to be the old version ("status_version", "1")
Updated pact test to match value (to prevent regression)

ledger changes to support status_version
https://github.com/alphagov/pay-ledger/pull/295