### PR TITLE
Remove support for custom CA certificates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -156,11 +156,11 @@ pipeline {
        parallel {
          stage('Card Smoke Test') {
            when { branch 'master' }
-           steps { runCardSmokeTest() }
+           steps { runSmokeTest('smoke-card') }
          }
          stage('Direct Debit Smoke Test') {
            when { branch 'master' }
-           steps { runDirectDebitSmokeTest() }
+           steps { runSmokeTest("smoke-directdebit") }
          }
        }
      }

--- a/README.md
+++ b/README.md
@@ -21,18 +21,6 @@ Configuration of the application is performed via environment variables, some of
 | `REDIS_URL`                 | No        | localhost:6379 | The location of the redis endpoint to store rate-limiter information in                                    |
 | `TOKEN_API_HMAC_SECRET`     | Yes       | N/A            | Hmac secret to be used to validate that the given token is genuine (Api Key = Token + Hmac (Token, Secret) |
 
-## Custom CA certificates
-
-By default, the application will use the default Java truststore for validating
-TLS connections. The docker startup script will add any PEM-format certificates
-in `CERTS_PATH` to the default truststore prior to starting the application.
-
-If `CERTS_PATH` is not specified, the default truststore will be used as-is.
-
-| Variable     | Description                               |
-| -------------| ----------------------------------------- |
-| `CERTS_PATH` | A directory within the container containing CA certificates to add to the default Java truststore |
-
 ## Rate limiting
 
 The application will rate-limit incoming API requests, recording the current

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -2,14 +2,4 @@
 
 set -eu
 
-if [ -n "${CERTS_PATH:-}" ]; then
-  i=0
-  truststore_pass=changeit
-  for cert in "$CERTS_PATH"/*; do
-    [ -f "$cert" ] || continue
-    echo "Adding $cert to default truststore"
-    keytool -importcert -noprompt -cacerts -storepass "$truststore_pass" -file "$cert" -alias custom$((i++))
-  done
-fi
-
 exec java ${JAVA_OPTS} -jar *-allinone.jar server *.yaml

--- a/env.sh
+++ b/env.sh
@@ -7,6 +7,4 @@ then
   set +a  
 fi
 
-export CERTS_PATH=$WORKSPACE/pay-scripts/services/ssl/certs
-
 eval "$@"


### PR DESCRIPTION
This was only used for testing environments, but they no longer run with TLS
enabled. Remove support for adding additional CA certificates to the Java
truststore.

Also, sneak in a change to how we call smoketests from the `Jenkinsfile`