### PR TITLE
PP-5443-Fix to Connector Payload method

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/telephone/CreateTelephonePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/telephone/CreateTelephonePaymentRequest.java
@@ -216,8 +216,7 @@ public class CreateTelephonePaymentRequest {
     public String getFirstSixDigits() {
         return firstSixDigits;
     }
-
-    @JsonIgnore
+    
     public Optional<String> getTelephoneNumber() {
         return Optional.ofNullable(telephoneNumber);
     }

--- a/src/main/java/uk/gov/pay/api/model/telephone/CreateTelephonePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/telephone/CreateTelephonePaymentRequest.java
@@ -92,7 +92,6 @@ public class CreateTelephonePaymentRequest {
                 .add("description", this.getDescription())
                 .add("processor_id", this.getProcessorId())
                 .add("provider_id", this.getProviderId())
-                .add("auth_code", this.getAuthCode())
                 .add("card_type", this.getCardType())
                 .add("card_expiry", this.getCardExpiry())
                 .add("last_four_digits", this.getLastFourDigits())
@@ -100,8 +99,8 @@ public class CreateTelephonePaymentRequest {
                 .addToMap("payment_outcome", "status", this.getPaymentOutcome().getStatus());
         this.getPaymentOutcome().getCode().ifPresent(code -> request.addToMap("payment_outcome", "code", code));
         this.getPaymentOutcome().getSupplemental().ifPresent(supplemental -> {
-                    request.addToNestedMap("error_code", supplemental.getErrorCode(), "payment_outcome", "supplemental");
-                    request.addToNestedMap("error_message", supplemental.getErrorMessage(), "payment_outcome", "supplemental");
+                    supplemental.getErrorCode().ifPresent(errorCode -> request.addToNestedMap("error_code", errorCode, "payment_outcome", "supplemental"));
+                    supplemental.getErrorCode().ifPresent(errorMessage -> request.addToNestedMap("error_message", errorMessage, "payment_outcome", "supplemental"));
                 }
         );
 


### PR DESCRIPTION
This PR fixes an error in the toConnectorPayload() method of CreateTelephonePaymentRequest. The problem occurs as 'this.getAuthCode' returns an Optional which isn't unwrapped. Similarly with 'getErrorCode' and 'getErrorMessage' both return Optionals which aren't unwrapped. This causes an error in Connector as it is unable to deserialize into a String as an Optional<String> is sent across instead of a String.

This PR unwraps the Optionals and returns them as Strings.

