### PR TITLE
PP-5632: add configuration for rate-limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ values:
 | ---------------------------------- | ------------ | ------------------------------------------ |
 | `RATE_LIMITER_VALUE`               | Default 75   | Number of non-`POST` requests allowed per `RATE_LIMITER_PER_MILLIS` milliseconds |
 | `RATE_LIMITER_VALUE_POST`          | Default 15   | Number of `POST` requests allowed per `RATE_LIMITER_PER_MILLIS` milliseconds |
+| `RATE_LIMITER_ELEVATED_ACCOUNTS`   | N/A          | Comma-separated list of accounts to which `..._ELEVATED_...` limits apply (example: `1,2,3`) |
+| `RATE_LIMITER_ELEVATED_VALUE_GET`  | Default 100  | Number of non-`POST` requests allowed per `RATE_LIMITER_PER_MILLIS` milliseconds (for `RATE_LIMITER_ELEVATED_ACCOUNTS`) |
+| `RATE_LIMITER_ELEVATED_VALUE_POST` | Default 40   | Number of `POST` requests allowed per `RATE_LIMITER_PER_MILLIS` milliseconds (for `RATE_LIMITER_ELEVATED_ACCOUNTS`) |
 | `RATE_LIMITER_VALUE_PER_NODE`      | Default 25   | Number of non-`POST` requests allowed per `RATE_LIMITER_PER_MILLIS` milliseconds for a given client |
 | `RATE_LIMITER_VALUE_PER_NODE_POST` | Default 5    | Number of `POST` requests allowed per `RATE_LIMITER_PER_MILLIS` milliseconds for a given client |
 | `RATE_LIMITER_PER_MILLIS`          | Default 1000 | Rate limiter time window |

--- a/src/main/java/uk/gov/pay/api/app/config/RateLimiterConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/RateLimiterConfig.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.api.app.config;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.dropwizard.Configuration;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import java.util.List;
 
 public class RateLimiterConfig extends Configuration {
 
@@ -14,10 +16,19 @@ public class RateLimiterConfig extends Configuration {
     private int noOfReqForPost;
 
     @Min(1)
+    private int noOfReqForElevatedAccounts;
+
+    @Min(1)
+    private int noOfPostReqForElevatedAccounts;
+
+    @Min(1)
     private int noOfReqPerNode;
 
     @Min(1)
     private int noOfReqForPostPerNode;
+
+    @JsonDeserialize(converter = StringToListConverter.class)
+    private List<String> elevatedAccounts;
 
     @Min(500)
     @Max(60000)
@@ -35,7 +46,23 @@ public class RateLimiterConfig extends Configuration {
         return noOfReqForPost;
     }
 
-    public int getNoOfReqPerNode() { return noOfReqPerNode; }
+    public int getNoOfReqPerNode() {
+        return noOfReqPerNode;
+    }
 
-    public int getNoOfReqForPostPerNode() { return noOfReqForPostPerNode; }
+    public int getNoOfReqForPostPerNode() {
+        return noOfReqForPostPerNode;
+    }
+
+    public int getNoOfReqForElevatedAccounts() {
+        return noOfReqForElevatedAccounts;
+    }
+
+    public int getNoOfPostReqForElevatedAccounts() {
+        return noOfPostReqForElevatedAccounts;
+    }
+
+    public List<String> getElevatedAccounts() {
+        return elevatedAccounts;
+    }
 }

--- a/src/main/java/uk/gov/pay/api/app/config/StringToListConverter.java
+++ b/src/main/java/uk/gov/pay/api/app/config/StringToListConverter.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.api.app.config;
+
+import com.fasterxml.jackson.databind.util.StdConverter;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StringToListConverter extends StdConverter<String, List<String>> {
+
+    @Override
+    public List<String> convert(String value) {
+        if (StringUtils.isBlank(value)) {
+            return Collections.emptyList();
+        }
+
+        return Arrays.stream(value.split(",")).map(String::trim).collect(Collectors.toList());
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -37,6 +37,9 @@ jerseyClientConfig:
 rateLimiter:  # rate = noOfReq per perMillis
   noOfReq: ${RATE_LIMITER_VALUE:-75}  # for requests except POST and across all publicapi instances.
   noOfReqForPost: ${RATE_LIMITER_VALUE_POST:-15} # for POST requests across all publicapi instances.
+  elevatedAccounts: ${RATE_LIMITER_ELEVATED_ACCOUNTS}
+  noOfReqForElevatedAccounts: ${RATE_LIMITER_ELEVATED_VALUE_GET:-100}
+  noOfPostReqForElevatedAccounts: ${RATE_LIMITER_ELEVATED_VALUE_POST:-40}
   noOfReqPerNode: ${RATE_LIMITER_VALUE_PER_NODE:-25}  # per public api instance, if Redis is unavailable
   noOfReqForPostPerNode: ${RATE_LIMITER_VALUE_PER_NODE_POST:-5}  # per public api instance, if Redis is unavailable
   perMillis: ${RATE_LIMITER_PER_MILLIS:-1000}

--- a/src/test/java/uk/gov/pay/api/app/config/StringToListConverterTest.java
+++ b/src/test/java/uk/gov/pay/api/app/config/StringToListConverterTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.api.app.config;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(JUnitParamsRunner.class)
+public class StringToListConverterTest {
+
+    private StringToListConverter converter;
+
+    @Before
+    public void setUp() {
+        converter = new StringToListConverter();
+    }
+
+    @Test
+    @Parameters
+    public void convertsStringInputToListOfStrings(String input, List<String> expectedOutput) {
+        assertThat(converter.convert(input), is(expectedOutput));
+    }
+
+    public Object[] parametersForConvertsStringInputToListOfStrings() {
+        return new Object[]{
+                new Object[]{null, Collections.emptyList()},
+                new Object[]{"", Collections.emptyList()},
+                new Object[]{"a", List.of("a")},
+                new Object[]{"a, b, b", List.of("a", "b", "b")}
+        };
+    }
+}

--- a/src/test/java/uk/gov/pay/api/it/validation/PublicApiConfigIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PublicApiConfigIT.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.api.it.validation;
+
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.pay.api.app.PublicApi;
+import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.app.config.RateLimiterConfig;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class PublicApiConfigIT {
+
+    @Rule
+    public final DropwizardAppRule<PublicApiConfig> RULE =
+            new DropwizardAppRule<>(PublicApi.class, ResourceHelpers.resourceFilePath("config/test-config.yaml"));
+
+    @Test
+    public void shouldParseConfiguration() {
+        RateLimiterConfig rateLimiterConfig = RULE.getConfiguration().getRateLimiterConfig();
+        assertThat(rateLimiterConfig.getNoOfReq(), is(1000));
+        assertThat(rateLimiterConfig.getPerMillis(), is(1000));
+        assertThat(rateLimiterConfig.getNoOfReqForPost(), is(1000));
+        assertThat(rateLimiterConfig.getNoOfReqPerNode(), is(1));
+        assertThat(rateLimiterConfig.getNoOfReqForPostPerNode(), is(1));
+        assertThat(rateLimiterConfig.getNoOfReqForElevatedAccounts(), is(1000));
+        assertThat(rateLimiterConfig.getNoOfPostReqForElevatedAccounts(), is(1000));
+        assertThat(rateLimiterConfig.getElevatedAccounts(), is(List.of("1", "2", "3")));
+    }
+}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -35,6 +35,9 @@ rateLimiter:
   noOfReqForPost: 1000
   noOfReqPerNode: 1
   noOfReqForPostPerNode: 1
+  elevatedAccounts: 1, 2, 3
+  noOfReqForElevatedAccounts: 1000
+  noOfPostReqForElevatedAccounts: 1000
 
 redis:
   endpoint: localhost:6379


### PR DESCRIPTION
## Why
In order to support extended limits for chosen accounts we need to extend configuration.

## What
* add additional parameter values for rate-limitting
* introduce converter to transform string into list of strings
* cover changes with tests
* update README
