### PR TITLE
BAU-Fix-Refund-Doc-to-include-payment-id - DO NOT MERGE YET

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
@@ -57,7 +57,7 @@ public class RefundForSearchRefundsResult {
     }
 
     @JsonProperty("payment_id")
-    @ApiModelProperty(example = "2q1r18djndhsrm3closjqr81fx", hidden = true)
+    @ApiModelProperty(example = "2q1r18djndhsrm3closjqr81fx")
     public String getChargeId() {
         return chargeId;
     }

--- a/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
@@ -20,7 +20,7 @@ public class RefundForSearchRefundsResult {
     @JsonProperty("created_date")
     @ApiModelProperty(example = "2017-01-10T16:52:07.855Z")
     private String createdDate;
-
+    
     private String chargeId;
 
     private Long amount;

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -2161,6 +2161,11 @@
           "example" : "2017-01-10T16:52:07.855Z",
           "readOnly" : true
         },
+        "payment_id" : {
+          "type" : "string",
+          "example" : "2q1r18djndhsrm3closjqr81fx",
+          "readOnly" : true
+        },
         "amount" : {
           "type" : "integer",
           "format" : "int64",
@@ -2189,6 +2194,11 @@
         "created_date" : {
           "type" : "string",
           "example" : "2017-01-10T16:52:07.855Z",
+          "readOnly" : true
+        },
+        "payment_id" : {
+          "type" : "string",
+          "example" : "2q1r18djndhsrm3closjqr81fx",
           "readOnly" : true
         },
         "amount" : {


### PR DESCRIPTION
This PR removes the 'hidden = true' from the '@ApiModelDefinition' for payment_id. This is because GET /v1/refunds does return the payment_id yet this field is not present in the [API browser](https://govukpay-api-browser.cloudapps.digital/#search-refunds).

