### PR TITLE
PP-5632: Implementation for rate-limiting

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
@@ -12,6 +12,7 @@ import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.filter.ratelimit.LocalRateLimiter;
 import uk.gov.pay.api.filter.ratelimit.RateLimiter;
 import uk.gov.pay.api.filter.ratelimit.RedisRateLimiter;
+import uk.gov.pay.api.filter.ratelimit.RateLimitManager;
 import uk.gov.pay.api.json.CreatePaymentRefundRequestDeserializer;
 import uk.gov.pay.api.json.CreateCardPaymentRequestDeserializer;
 import uk.gov.pay.api.json.StringDeserializer;
@@ -86,8 +87,8 @@ public class PublicApiModule extends AbstractModule {
     }
 
     private RedisRateLimiter getRedisRateLimiter() {
-        return new RedisRateLimiter(configuration.getRateLimiterConfig().getNoOfReq(),
-                configuration.getRateLimiterConfig().getNoOfReqForPost(),
+        var rateLimitManager = new RateLimitManager(configuration.getRateLimiterConfig());
+        return new RedisRateLimiter(rateLimitManager,
                 configuration.getRateLimiterConfig().getPerMillis(),
                 configuration.getJedisFactory().build(environment));
     }

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
@@ -62,12 +62,12 @@ public class RateLimiterFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
-        final String authorization = requestContext.getHeaderString("Authorization");
         final String method = requestContext.getMethod();
 
         String accountId = getAccountId(requestContext);
+        RateLimiterKey key = RateLimiterKey.from(requestContext);
         try {
-            rateLimiter.checkRateOf(accountId, method + "-" + authorization, method);
+            rateLimiter.checkRateOf(accountId, key, method);
         } catch (RateLimitException e) {
             LOGGER.info("Rate limit reached for current service [account - {}, method - {}]. Sending response '429 Too Many Requests'", accountId, method);
             setTooManyRequestsError();

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
@@ -65,9 +65,9 @@ public class RateLimiterFilter implements ContainerRequestFilter {
         final String method = requestContext.getMethod();
 
         String accountId = getAccountId(requestContext);
-        RateLimiterKey key = RateLimiterKey.from(requestContext);
+        RateLimiterKey key = RateLimiterKey.from(requestContext, accountId);
         try {
-            rateLimiter.checkRateOf(accountId, key, method);
+            rateLimiter.checkRateOf(accountId, key);
         } catch (RateLimitException e) {
             LOGGER.info("Rate limit reached for current service [account - {}, method - {}]. Sending response '429 Too Many Requests'", accountId, method);
             setTooManyRequestsError();

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterKey.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterKey.java
@@ -1,0 +1,46 @@
+package uk.gov.pay.api.filter;
+
+import uk.gov.pay.api.utils.PathHelper;
+
+import javax.ws.rs.container.ContainerRequestContext;
+
+public class RateLimiterKey {
+    
+    private String method;
+    private String key;
+    private String keyType;
+
+    public RateLimiterKey(String key, String keyType, String method) {
+        this.key = key;
+        this.keyType = keyType;
+        this.method = method;
+    }
+
+    public static RateLimiterKey from(ContainerRequestContext requestContext) {
+        final String method = requestContext.getMethod();
+
+        StringBuilder builder = new StringBuilder(method);
+
+        final String pathType = PathHelper.getPathType(requestContext.getUriInfo().getPath(), method);
+        if (!pathType.isBlank()) {
+            builder.append("-" + pathType);
+        }
+
+        final String keyType = builder.toString();
+        builder.append("-" + requestContext.getHeaderString("Authorization"));
+
+        return new RateLimiterKey(builder.toString(), keyType, method);
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getKeyType() {
+        return keyType;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+}

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterKey.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterKey.java
@@ -1,8 +1,11 @@
 package uk.gov.pay.api.filter;
 
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.utils.PathHelper;
 
 import javax.ws.rs.container.ContainerRequestContext;
+import java.util.Optional;
 
 public class RateLimiterKey {
     
@@ -16,7 +19,7 @@ public class RateLimiterKey {
         this.method = method;
     }
 
-    public static RateLimiterKey from(ContainerRequestContext requestContext) {
+    public static RateLimiterKey from(ContainerRequestContext requestContext, String accountId) {
         final String method = requestContext.getMethod();
 
         StringBuilder builder = new StringBuilder(method);
@@ -27,7 +30,7 @@ public class RateLimiterKey {
         }
 
         final String keyType = builder.toString();
-        builder.append("-" + requestContext.getHeaderString("Authorization"));
+        builder.append("-" + accountId);
 
         return new RateLimiterKey(builder.toString(), keyType, method);
     }

--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimitManager.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimitManager.java
@@ -1,0 +1,29 @@
+package uk.gov.pay.api.filter.ratelimit;
+
+import uk.gov.pay.api.app.config.RateLimiterConfig;
+import uk.gov.pay.api.filter.RateLimiterKey;
+
+public class RateLimitManager {
+   
+    private RateLimiterConfig configuration;
+
+    public RateLimitManager(RateLimiterConfig config) {
+        configuration = config;
+    }
+
+    public int getAllowedNumberOfRequests(RateLimiterKey rateLimiterKey, String account) {
+        if(configuration.getElevatedAccounts().contains(account)) {
+            if("POST".equals(rateLimiterKey.getMethod())) {
+                return configuration.getNoOfPostReqForElevatedAccounts();
+            }
+
+            return configuration.getNoOfReqForElevatedAccounts();
+        }
+
+        if("POST".equals(rateLimiterKey.getMethod())) {
+            return configuration.getNoOfReqForPost();
+        }
+        
+        return configuration.getNoOfReq();
+    }
+}

--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimiter.java
@@ -18,13 +18,13 @@ public class RateLimiter {
         this.redisRateLimiter = redisRateLimiter;
     }
 
-    public void checkRateOf(String accountId, RateLimiterKey key, String method) throws RateLimitException {
+    public void checkRateOf(String accountId, RateLimiterKey key) throws RateLimitException {
         try {
             redisRateLimiter.checkRateOf(accountId, key);
         } catch (RedisException e) {
             LOGGER.warn("Exception occurred checking rate limits using RedisRateLimiter, falling back to LocalRateLimiter");
 
-            localRateLimiter.checkRateOf(accountId, key.getKey(), method);
+            localRateLimiter.checkRateOf(accountId, key.getKey(), key.getMethod());
         }
     }
 }

--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimiter.java
@@ -3,6 +3,7 @@ package uk.gov.pay.api.filter.ratelimit;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.api.filter.RateLimiterKey;
 
 public class RateLimiter {
 
@@ -17,13 +18,13 @@ public class RateLimiter {
         this.redisRateLimiter = redisRateLimiter;
     }
 
-    public void checkRateOf(String accountId, String key, String method) throws RateLimitException {
+    public void checkRateOf(String accountId, RateLimiterKey key, String method) throws RateLimitException {
         try {
-            redisRateLimiter.checkRateOf(accountId, key, method);
+            redisRateLimiter.checkRateOf(accountId, key);
         } catch (RedisException e) {
             LOGGER.warn("Exception occurred checking rate limits using RedisRateLimiter, falling back to LocalRateLimiter");
 
-            localRateLimiter.checkRateOf(accountId, key, method);
+            localRateLimiter.checkRateOf(accountId, key.getKey(), method);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/api/utils/PathHelper.java
+++ b/src/main/java/uk/gov/pay/api/utils/PathHelper.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.api.utils;
+
+public class PathHelper {
+
+    public static String getPathType(String pathValue, String method) {
+        String path = pathValue;
+        if (path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+
+        if (path.endsWith("/capture")) {
+            return "capture_payment";
+        }
+
+        if (path.endsWith("/payments") && method.equals("POST")) {
+            return "create_payment";
+        }
+
+        return "";
+    }
+}

--- a/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
@@ -17,8 +17,11 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -35,6 +38,10 @@ public class RateLimiterFilterTest {
     private RateLimiter rateLimiter;
     @Mock
     private ContainerRequestContext mockContainerRequestContext;
+    @Mock
+    private UriInfo uriInfo;
+    @Mock
+    private RateLimiterKey rateLimiterKey;
 
     @Before
     public void setup() {
@@ -49,6 +56,8 @@ public class RateLimiterFilterTest {
 
         when(mockContainerRequestContext.getHeaderString("Authorization")).thenReturn(authorization);
         when(mockContainerRequestContext.getMethod()).thenReturn("GET");
+        when(mockContainerRequestContext.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("");
     }
 
     @Test
@@ -58,12 +67,12 @@ public class RateLimiterFilterTest {
         
         rateLimiterFilter.filter(mockContainerRequestContext);
         
-        verify(rateLimiter).checkRateOf(ACCOUNT_ID, "POST-apiKey", "POST");
+        verify(rateLimiter).checkRateOf(eq(ACCOUNT_ID), any(), eq("POST"));
     }
 
     @Test
     public void shouldSendErrorResponse_whenRateLimitExceeded() throws Exception {
-        doThrow(RateLimitException.class).when(rateLimiter).checkRateOf("account-id", "GET-" + authorization, "GET");
+        doThrow(RateLimitException.class).when(rateLimiter).checkRateOf(eq("account-id"), any(), eq("GET"));
 
         try {
             rateLimiterFilter.filter(mockContainerRequestContext);

--- a/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
@@ -54,7 +54,6 @@ public class RateLimiterFilterTest {
 
         when(mockContainerRequestContext.getSecurityContext()).thenReturn(mockSecurityContext);
 
-        when(mockContainerRequestContext.getHeaderString("Authorization")).thenReturn(authorization);
         when(mockContainerRequestContext.getMethod()).thenReturn("GET");
         when(mockContainerRequestContext.getUriInfo()).thenReturn(uriInfo);
         when(uriInfo.getPath()).thenReturn("");
@@ -62,17 +61,16 @@ public class RateLimiterFilterTest {
 
     @Test
     public void shouldCheckRateLimitsWhenFilterIsInvoked() throws Exception {
-        when(mockContainerRequestContext.getHeaderString("Authorization")).thenReturn("apiKey");
         when(mockContainerRequestContext.getMethod()).thenReturn("POST");
         
         rateLimiterFilter.filter(mockContainerRequestContext);
         
-        verify(rateLimiter).checkRateOf(eq(ACCOUNT_ID), any(), eq("POST"));
+        verify(rateLimiter).checkRateOf(eq(ACCOUNT_ID), any());
     }
 
     @Test
     public void shouldSendErrorResponse_whenRateLimitExceeded() throws Exception {
-        doThrow(RateLimitException.class).when(rateLimiter).checkRateOf(eq("account-id"), any(), eq("GET"));
+        doThrow(RateLimitException.class).when(rateLimiter).checkRateOf(eq("account-id"), any());
 
         try {
             rateLimiterFilter.filter(mockContainerRequestContext);

--- a/src/test/java/uk/gov/pay/api/filter/RateLimiterKeyTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/RateLimiterKeyTest.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.api.filter;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.UriInfo;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(JUnitParamsRunner.class)
+public class RateLimiterKeyTest {
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+    
+    @Mock
+    private ContainerRequestContext containerRequestContext;
+    
+    @Mock
+    private UriInfo uriInfo;
+
+    @Before
+    public void setUp() {
+        when(containerRequestContext.getUriInfo()).thenReturn(uriInfo);
+        when(containerRequestContext.getHeaderString("Authorization")).thenReturn("headerValue");
+    }
+    
+    @Test
+    @Parameters({
+            "/v1/payments,POST,POST-create_payment,POST-create_payment-headerValue",
+            "/v1/payments/paymentId/capture,POST,POST-capture_payment,POST-capture_payment-headerValue",
+            "/v1/payments/paymentId/cancel,POST,POST,POST-headerValue",
+            "/v1/payments,GET,GET,GET-headerValue"
+    })
+    public void returnsRateLimiterKey(String path, String method, String expectedKeyType, String expectedKey) {
+        when(uriInfo.getPath()).thenReturn(path);
+        when(containerRequestContext.getMethod()).thenReturn(method);
+
+        var rateLimiterKey = RateLimiterKey.from(containerRequestContext);
+        assertThat(rateLimiterKey.getKey(), is(expectedKey));
+        assertThat(rateLimiterKey.getKeyType(), is(expectedKeyType));
+    }
+}

--- a/src/test/java/uk/gov/pay/api/filter/RateLimiterKeyTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/RateLimiterKeyTest.java
@@ -32,21 +32,20 @@ public class RateLimiterKeyTest {
     @Before
     public void setUp() {
         when(containerRequestContext.getUriInfo()).thenReturn(uriInfo);
-        when(containerRequestContext.getHeaderString("Authorization")).thenReturn("headerValue");
     }
     
     @Test
     @Parameters({
-            "/v1/payments,POST,POST-create_payment,POST-create_payment-headerValue",
-            "/v1/payments/paymentId/capture,POST,POST-capture_payment,POST-capture_payment-headerValue",
-            "/v1/payments/paymentId/cancel,POST,POST,POST-headerValue",
-            "/v1/payments,GET,GET,GET-headerValue"
+            "/v1/payments,POST,POST-create_payment,POST-create_payment-account_id",
+            "/v1/payments/paymentId/capture,POST,POST-capture_payment,POST-capture_payment-account_id",
+            "/v1/payments/paymentId/cancel,POST,POST,POST-account_id",
+            "/v1/payments,GET,GET,GET-account_id"
     })
     public void returnsRateLimiterKey(String path, String method, String expectedKeyType, String expectedKey) {
         when(uriInfo.getPath()).thenReturn(path);
         when(containerRequestContext.getMethod()).thenReturn(method);
 
-        var rateLimiterKey = RateLimiterKey.from(containerRequestContext);
+        var rateLimiterKey = RateLimiterKey.from(containerRequestContext, "account_id");
         assertThat(rateLimiterKey.getKey(), is(expectedKey));
         assertThat(rateLimiterKey.getKeyType(), is(expectedKeyType));
     }

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimitManagerTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimitManagerTest.java
@@ -28,8 +28,6 @@ public class RateLimitManagerTest {
     @Mock
     private RateLimiterConfig rateLimiterConfig;
 
-    @Mock
-    private RateLimiterKey rateLimiterKey;
     
     private RateLimitManager rateLimitManager;
     
@@ -53,7 +51,7 @@ public class RateLimitManagerTest {
             ",PUT,1"
     })
     public void returnsNumberOfAllowedRequests(String account, String method, int expectedNumberOfAllowedRequests) {
-        when(rateLimiterKey.getMethod()).thenReturn(method);
+        var rateLimiterKey = new RateLimiterKey("path", "key-type", method);
         
         assertThat(rateLimitManager.getAllowedNumberOfRequests(rateLimiterKey, account), is(expectedNumberOfAllowedRequests));
     }

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimitManagerTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimitManagerTest.java
@@ -1,0 +1,60 @@
+package uk.gov.pay.api.filter.ratelimit;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import uk.gov.pay.api.app.config.RateLimiterConfig;
+import uk.gov.pay.api.filter.RateLimiterKey;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(JUnitParamsRunner.class)
+public class RateLimitManagerTest {
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+    
+    @Mock
+    private RateLimiterConfig rateLimiterConfig;
+
+    @Mock
+    private RateLimiterKey rateLimiterKey;
+    
+    private RateLimitManager rateLimitManager;
+    
+    @Before
+    public void setUp() {
+        when(rateLimiterConfig.getElevatedAccounts()).thenReturn(List.of("1"));
+        when(rateLimiterConfig.getNoOfReq()).thenReturn(1);
+        when(rateLimiterConfig.getNoOfReqForPost()).thenReturn(2);
+        when(rateLimiterConfig.getNoOfReqForElevatedAccounts()).thenReturn(3);
+        when(rateLimiterConfig.getNoOfPostReqForElevatedAccounts()).thenReturn(4);
+        
+        rateLimitManager = new RateLimitManager(rateLimiterConfig);
+    }
+
+    @Test
+    @Parameters({
+            "1,POST,4",
+            "1,GET,3",
+            "2,POST,2",
+            "2,GET,1",
+            ",PUT,1"
+    })
+    public void returnsNumberOfAllowedRequests(String account, String method, int expectedNumberOfAllowedRequests) {
+        when(rateLimiterKey.getMethod()).thenReturn(method);
+        
+        assertThat(rateLimitManager.getAllowedNumberOfRequests(rateLimiterKey, account), is(expectedNumberOfAllowedRequests));
+    }
+}

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimiterTest.java
@@ -5,10 +5,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.api.filter.RateLimiterKey;
 
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RateLimiterTest {
@@ -19,6 +21,8 @@ public class RateLimiterTest {
     LocalRateLimiter localRateLimiter;
     @Mock
     RedisRateLimiter redisRateLimiter;
+    @Mock
+    private RateLimiterKey rateLimiterKey;
     RateLimiter rateLimiter;
 
     @Before
@@ -28,22 +32,21 @@ public class RateLimiterTest {
 
     @Test
     public void shouldInvokeRedisRateLimiter_whenRedisDbIsAvaiable() throws Exception {
-        String key = "key1";
+        rateLimiter.checkRateOf(accountId, rateLimiterKey, POST);
+        rateLimiter.checkRateOf(accountId, rateLimiterKey, POST);
 
-        rateLimiter.checkRateOf(accountId, key, POST);
-        rateLimiter.checkRateOf(accountId, key, POST);
-
-        verify(redisRateLimiter, times(2)).checkRateOf(accountId, key, "POST");
+        verify(redisRateLimiter, times(2)).checkRateOf(accountId, rateLimiterKey);
     }
 
     @Test
     public void shouldInvokeLocalRateLimiter_whenRedisIsNotAvaiable() throws Exception {
         String key = "key2";
+        when(rateLimiterKey.getKey()).thenReturn(key);
 
-        doThrow(new RedisException()).when(redisRateLimiter).checkRateOf(accountId, key, POST);
+        doThrow(new RedisException()).when(redisRateLimiter).checkRateOf(accountId, rateLimiterKey);
 
-        rateLimiter.checkRateOf(accountId, key, POST);
-        rateLimiter.checkRateOf(accountId, key, POST);
+        rateLimiter.checkRateOf(accountId, rateLimiterKey, POST);
+        rateLimiter.checkRateOf(accountId, rateLimiterKey, POST);
 
         verify(localRateLimiter, times(2)).checkRateOf(accountId, key, POST);
     }

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimiterTest.java
@@ -32,8 +32,8 @@ public class RateLimiterTest {
 
     @Test
     public void shouldInvokeRedisRateLimiter_whenRedisDbIsAvaiable() throws Exception {
-        rateLimiter.checkRateOf(accountId, rateLimiterKey, POST);
-        rateLimiter.checkRateOf(accountId, rateLimiterKey, POST);
+        rateLimiter.checkRateOf(accountId, rateLimiterKey);
+        rateLimiter.checkRateOf(accountId, rateLimiterKey);
 
         verify(redisRateLimiter, times(2)).checkRateOf(accountId, rateLimiterKey);
     }
@@ -42,11 +42,12 @@ public class RateLimiterTest {
     public void shouldInvokeLocalRateLimiter_whenRedisIsNotAvaiable() throws Exception {
         String key = "key2";
         when(rateLimiterKey.getKey()).thenReturn(key);
+        when(rateLimiterKey.getMethod()).thenReturn("POST");
 
         doThrow(new RedisException()).when(redisRateLimiter).checkRateOf(accountId, rateLimiterKey);
 
-        rateLimiter.checkRateOf(accountId, rateLimiterKey, POST);
-        rateLimiter.checkRateOf(accountId, rateLimiterKey, POST);
+        rateLimiter.checkRateOf(accountId, rateLimiterKey);
+        rateLimiter.checkRateOf(accountId, rateLimiterKey);
 
         verify(localRateLimiter, times(2)).checkRateOf(accountId, key, POST);
     }

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiterTest.java
@@ -17,10 +17,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
+import uk.gov.pay.api.filter.RateLimiterKey;
 
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -35,9 +37,13 @@ public class RedisRateLimiterTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
     @Mock
+    private RateLimitManager rateLimitManager;
+    @Mock
     JedisPool jedisPool;
     @Mock
     Jedis jedis;
+    @Mock
+    private RateLimiterKey rateLimiterKey;
     @Captor
     ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
     private RedisRateLimiter redisRateLimiter;
@@ -55,39 +61,44 @@ public class RedisRateLimiterTest {
 
     @Test
     public void rateLimiterSetTo_1CallPerSecond_shouldAllowSingleCall() throws Exception {
-        redisRateLimiter = new RedisRateLimiter(1, 1, 1000, jedisPool);
+        when(rateLimiterKey.getKey()).thenReturn("Key1");
+        when(rateLimitManager.getAllowedNumberOfRequests(any(), any())).thenReturn(1);
+        redisRateLimiter = new RedisRateLimiter(rateLimitManager, 1000, jedisPool);
 
         when(jedis.incr(anyString())).thenReturn(1L, 2L);
-        redisRateLimiter.checkRateOf(accountId, "Key1", POST);
+        redisRateLimiter.checkRateOf(accountId, rateLimiterKey);
     }
 
     @Test
     public void rateLimiterSetTo_2CallsPerSecond_shouldAllow2ConsecutiveCallsWithSameKeys() throws Exception {
-        String key = "Key2";
-        redisRateLimiter = new RedisRateLimiter(2, 2, 1000, jedisPool);
+        when(rateLimiterKey.getKey()).thenReturn("Key2");
+        when(rateLimitManager.getAllowedNumberOfRequests(any(), any())).thenReturn(2);
+        redisRateLimiter = new RedisRateLimiter(rateLimitManager, 1000, jedisPool);
 
         when(jedis.incr(anyString())).thenReturn(1L, 2L, 3L);
 
-        redisRateLimiter.checkRateOf(accountId, key, POST);
-        redisRateLimiter.checkRateOf(accountId, key, POST);
+        redisRateLimiter.checkRateOf(accountId, rateLimiterKey);
+        redisRateLimiter.checkRateOf(accountId, rateLimiterKey);
 
     }
 
     @Test(expected = RateLimitException.class)
     public void rateLimiterSetTo_2CallsPerSecond_shouldFailWhen3ConsecutiveCallsWithSameKeysAreMade() throws Exception {
-        String key = "Key3";
-        redisRateLimiter = new RedisRateLimiter(2, 2, 1000, jedisPool);
+        when(rateLimiterKey.getKey()).thenReturn("Key3");
+        when(rateLimiterKey.getKeyType()).thenReturn("POST");
+        when(rateLimitManager.getAllowedNumberOfRequests(any(), any())).thenReturn(2);
+        redisRateLimiter = new RedisRateLimiter(rateLimitManager, 1000, jedisPool);
 
         when(jedis.incr(anyString())).thenReturn(1L, 2L, 3L);
 
         try {
-            redisRateLimiter.checkRateOf(accountId, key, POST);
-            redisRateLimiter.checkRateOf(accountId, key, POST);
-            redisRateLimiter.checkRateOf(accountId, key, POST);
+            redisRateLimiter.checkRateOf(accountId, rateLimiterKey);
+            redisRateLimiter.checkRateOf(accountId, rateLimiterKey);
+            redisRateLimiter.checkRateOf(accountId, rateLimiterKey);
         } catch (RedisException | RateLimitException e) {
             verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
             List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-            assertEquals("RedisRateLimiter - Rate limit exceeded for account [account-id] and method [POST] - count: 3, rate allowed: 2",
+            assertEquals("RedisRateLimiter - Rate limit exceeded for account [account-id] and type [POST] - count: 3, rate allowed: 2",
                     loggingEvents.get(0).getFormattedMessage());
             
             throw e;

--- a/src/test/java/uk/gov/pay/api/utils/PathHelperTest.java
+++ b/src/test/java/uk/gov/pay/api/utils/PathHelperTest.java
@@ -1,0 +1,26 @@
+package uk.gov.pay.api.utils;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(JUnitParamsRunner.class)
+public class PathHelperTest {
+
+    @Test
+    @Parameters({
+            "/v1/payments,POST,create_payment",
+            "/v1/payments/,POST,create_payment",
+            "/v1/payments/paymentId/capture,POST,capture_payment",
+            "/v1/payments/paymentId/capture/,POST,capture_payment",
+            "/v1/payments/paymentId/cancel,POST,",
+            "/v1/payments,GET,"
+    })
+    public void returnsPathType(String path, String method, String pathType) {
+        assertThat(PathHelper.getPathType(path, method), is(pathType));
+    }
+}


### PR DESCRIPTION
Context:
At the moment rate limiting works on per method basis [GET/POST].
It is required to introduce separate buckets (each bucket will have separate limit counter):
* [POST] create payment
* [POST] capture payment
* remaining [POST] requests
* all [GET] requests

In order to do that the RateLimiterKey has been introduces. It determines the bucket
based on the method and path (taken from ContainerRequestContext).
On top of splitting endpoints into separate buckets the logic to have two types of limits
has been introduced. Certain accounts (defined in configuration #697) will have different limits
than by default. In the implementation RateLimitManager is used to determine the limit based on
account id and RateLimiterKey (although at the moment only method from the object is used for the limit).

The changes affect both limiters (redis and local one) although local one is affected only by bucketing.

Changes:
* introduce PathHelper that returns path type depending on path and method
* introduce RateLimiterKey that based on ContainerRequestContext constructs itself (key, keyType, method)
  it extends the previous way of generating the request key
* introduce RateLimitManager which returns the allowed number of requests for
given rateLimiterKey and account