### PR TITLE
PP-5632: rate-limiting follow-up changes

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/config/RateLimiterConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/RateLimiterConfig.java
@@ -3,6 +3,7 @@ package uk.gov.pay.api.app.config;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.dropwizard.Configuration;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import java.util.Collections;
@@ -29,6 +30,7 @@ public class RateLimiterConfig extends Configuration {
     @Min(1)
     private int noOfReqForPostPerNode;
 
+    @Valid
     @JsonDeserialize(converter = StringToListConverter.class)
     private List<String> elevatedAccounts;
 

--- a/src/main/java/uk/gov/pay/api/app/config/StringToListConverter.java
+++ b/src/main/java/uk/gov/pay/api/app/config/StringToListConverter.java
@@ -16,6 +16,9 @@ public class StringToListConverter extends StdConverter<String, List<String>> {
             return Collections.emptyList();
         }
 
-        return Arrays.stream(value.split(",")).map(String::trim).collect(Collectors.toList());
+        return Arrays.stream(value.split(","))
+                .filter(StringUtils::isNotBlank)
+                .map(String::trim)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
@@ -62,14 +62,13 @@ public class RateLimiterFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
-        final String method = requestContext.getMethod();
-
         String accountId = getAccountId(requestContext);
         RateLimiterKey key = RateLimiterKey.from(requestContext, accountId);
         try {
             rateLimiter.checkRateOf(accountId, key);
         } catch (RateLimitException e) {
-            LOGGER.info("Rate limit reached for current service [account - {}, method - {}]. Sending response '429 Too Many Requests'", accountId, method);
+            LOGGER.info("Rate limit reached for current service [account - {}, method - {}]. Sending response '429 Too Many Requests'",
+                    accountId, key.getMethod());
             setTooManyRequestsError();
         }
     }

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterKey.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterKey.java
@@ -1,14 +1,11 @@
 package uk.gov.pay.api.filter;
 
-import org.apache.commons.lang3.StringUtils;
-import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.utils.PathHelper;
 
 import javax.ws.rs.container.ContainerRequestContext;
-import java.util.Optional;
 
 public class RateLimiterKey {
-    
+
     private String method;
     private String key;
     private String keyType;

--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimitManager.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimitManager.java
@@ -3,6 +3,8 @@ package uk.gov.pay.api.filter.ratelimit;
 import uk.gov.pay.api.app.config.RateLimiterConfig;
 import uk.gov.pay.api.filter.RateLimiterKey;
 
+import javax.ws.rs.HttpMethod;
+
 public class RateLimitManager {
    
     private RateLimiterConfig configuration;
@@ -13,14 +15,14 @@ public class RateLimitManager {
 
     public int getAllowedNumberOfRequests(RateLimiterKey rateLimiterKey, String account) {
         if(configuration.getElevatedAccounts().contains(account)) {
-            if("POST".equals(rateLimiterKey.getMethod())) {
+            if(HttpMethod.POST.equals(rateLimiterKey.getMethod())) {
                 return configuration.getNoOfPostReqForElevatedAccounts();
             }
 
             return configuration.getNoOfReqForElevatedAccounts();
         }
 
-        if("POST".equals(rateLimiterKey.getMethod())) {
+        if(HttpMethod.POST.equals(rateLimiterKey.getMethod())) {
             return configuration.getNoOfReqForPost();
         }
         

--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimiter.java
@@ -24,7 +24,7 @@ public class RateLimiter {
         } catch (RedisException e) {
             LOGGER.warn("Exception occurred checking rate limits using RedisRateLimiter, falling back to LocalRateLimiter");
 
-            localRateLimiter.checkRateOf(accountId, key.getKey(), key.getMethod());
+            localRateLimiter.checkRateOf(accountId, key);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
@@ -8,7 +8,6 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import uk.gov.pay.api.filter.RateLimiterKey;
 
-import javax.ws.rs.HttpMethod;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoField;
 
@@ -44,7 +43,8 @@ public class RedisRateLimiter {
         if (count != null) {
             int allowedNumberOfRequests = rateLimitManager.getAllowedNumberOfRequests(key, accountId);
             if (count > allowedNumberOfRequests) {
-                LOGGER.info(String.format("RedisRateLimiter - Rate limit exceeded for account [%s] and type [%s] - count: %d, rate allowed: %d", accountId, key.getKeyType(), count, allowedNumberOfRequests));
+                LOGGER.info(String.format("RedisRateLimiter - Rate limit exceeded for account [%s] and method [%s] - count: %d, rate allowed: %d",
+                        accountId, key.getKeyType(), count, allowedNumberOfRequests));
                 throw new RateLimitException();
             }
         }

--- a/src/main/java/uk/gov/pay/api/utils/PathHelper.java
+++ b/src/main/java/uk/gov/pay/api/utils/PathHelper.java
@@ -1,12 +1,11 @@
 package uk.gov.pay.api.utils;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class PathHelper {
 
     public static String getPathType(String pathValue, String method) {
-        String path = pathValue;
-        if (path.endsWith("/")) {
-            path = path.substring(0, path.length() - 1);
-        }
+        String path = StringUtils.removeEnd(pathValue, "/");
 
         if (path.endsWith("/capture")) {
             return "capture_payment";

--- a/src/test/java/uk/gov/pay/api/app/config/StringToListConverterTest.java
+++ b/src/test/java/uk/gov/pay/api/app/config/StringToListConverterTest.java
@@ -32,8 +32,10 @@ public class StringToListConverterTest {
         return new Object[]{
                 new Object[]{null, Collections.emptyList()},
                 new Object[]{"", Collections.emptyList()},
+                new Object[]{", ,   ,", Collections.emptyList()},
                 new Object[]{"a", List.of("a")},
-                new Object[]{"a, b, b", List.of("a", "b", "b")}
+                new Object[]{"a, b, b", List.of("a", "b", "b")},
+                new Object[]{"a, , b", List.of("a", "b")}
         };
     }
 }

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/LocalRateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/LocalRateLimiterTest.java
@@ -15,6 +15,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.api.filter.RateLimiterKey;
 
 import java.util.Arrays;
 import java.util.List;
@@ -56,23 +57,23 @@ public class LocalRateLimiterTest {
 
     @Test
     public void rateLimiterSetTo_2CallsPerSecond_shouldAllow2ConsecutiveCallsWithSameKeys() throws Exception {
-
         String key = "key1";
+        var rateLimiterKey = new RateLimiterKey(key, "key-type", POST);
         localRateLimiter = new LocalRateLimiter(2, 2, 1000);
 
-        localRateLimiter.checkRateOf(accountId, key, POST);
-        localRateLimiter.checkRateOf(accountId, key, POST);
+        localRateLimiter.checkRateOf(accountId, rateLimiterKey);
+        localRateLimiter.checkRateOf(accountId, rateLimiterKey);
     }
 
     @Test(expected = RateLimitException.class)
     public void rateLimiterSetTo_1CallPer300Millis_shouldAFailWhen2ConsecutiveCallsWithSameKeysAreMade() throws RateLimitException {
-
         String key = "key2";
+        var rateLimiterKey = new RateLimiterKey(key, "key-type", POST);
         localRateLimiter = new LocalRateLimiter(1, 1, 300);
 
         try {
-            localRateLimiter.checkRateOf(accountId, key, POST);
-            localRateLimiter.checkRateOf(accountId, key, POST);
+            localRateLimiter.checkRateOf(accountId, rateLimiterKey);
+            localRateLimiter.checkRateOf(accountId, rateLimiterKey);
         } catch (RateLimitException e) {
             verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
             List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
@@ -85,27 +86,27 @@ public class LocalRateLimiterTest {
 
     @Test
     public void rateLimiterSetTo_3CallsPerSecond_shouldAllowMakingOnly3CallsWithSameKey() throws Exception {
-
         String key = "key3";
+        var rateLimiterKey = new RateLimiterKey(key, "key-type", POST);
         localRateLimiter = new LocalRateLimiter(3, 3, 1000);
 
         ExecutorService executor = Executors.newFixedThreadPool(3);
 
         List<Callable<String>> tasks = Arrays.asList(
                 () -> {
-                    localRateLimiter.checkRateOf(accountId, key, POST);
+                    localRateLimiter.checkRateOf(accountId, rateLimiterKey);
                     return "task1";
                 },
                 () -> {
-                    localRateLimiter.checkRateOf(accountId, key, POST);
+                    localRateLimiter.checkRateOf(accountId, rateLimiterKey);
                     return "task2";
                 },
                 () -> {
-                    localRateLimiter.checkRateOf(accountId, key, POST);
+                    localRateLimiter.checkRateOf(accountId, rateLimiterKey);
                     return "task3";
                 },
                 () -> {
-                    localRateLimiter.checkRateOf(accountId, key, POST);
+                    localRateLimiter.checkRateOf(accountId, rateLimiterKey);
                     return "task4";
                 }
         );

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimiterTest.java
@@ -18,15 +18,16 @@ public class RateLimiterTest {
     private static final String POST = "POST";
     private static final String accountId = "account-id";
     @Mock
-    LocalRateLimiter localRateLimiter;
+    private LocalRateLimiter localRateLimiter;
     @Mock
-    RedisRateLimiter redisRateLimiter;
-    @Mock
+    private RedisRateLimiter redisRateLimiter;
+
     private RateLimiterKey rateLimiterKey;
-    RateLimiter rateLimiter;
+    private RateLimiter rateLimiter;
 
     @Before
     public void setup() {
+        rateLimiterKey = new RateLimiterKey("key2", "key-type", POST);
         rateLimiter = new RateLimiter(localRateLimiter, redisRateLimiter);
     }
 
@@ -40,15 +41,11 @@ public class RateLimiterTest {
 
     @Test
     public void shouldInvokeLocalRateLimiter_whenRedisIsNotAvaiable() throws Exception {
-        String key = "key2";
-        when(rateLimiterKey.getKey()).thenReturn(key);
-        when(rateLimiterKey.getMethod()).thenReturn("POST");
-
         doThrow(new RedisException()).when(redisRateLimiter).checkRateOf(accountId, rateLimiterKey);
 
         rateLimiter.checkRateOf(accountId, rateLimiterKey);
         rateLimiter.checkRateOf(accountId, rateLimiterKey);
 
-        verify(localRateLimiter, times(2)).checkRateOf(accountId, key, POST);
+        verify(localRateLimiter, times(2)).checkRateOf(accountId, rateLimiterKey);
     }
 }

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiterTest.java
@@ -98,7 +98,7 @@ public class RedisRateLimiterTest {
         } catch (RedisException | RateLimitException e) {
             verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
             List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-            assertEquals("RedisRateLimiter - Rate limit exceeded for account [account-id] and type [POST] - count: 3, rate allowed: 2",
+            assertEquals("RedisRateLimiter - Rate limit exceeded for account [account-id] and method [POST] - count: 3, rate allowed: 2",
                     loggingEvents.get(0).getFormattedMessage());
             
             throw e;

--- a/src/test/java/uk/gov/pay/api/it/validation/PublicApiConfigIT/EmptyElevatedAccountsPublicApiConfigIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PublicApiConfigIT/EmptyElevatedAccountsPublicApiConfigIT.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.api.it.validation.PublicApiConfigIT;
+
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.pay.api.app.PublicApi;
+import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.app.config.RateLimiterConfig;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class EmptyElevatedAccountsPublicApiConfigIT {
+
+    @Rule
+    public final DropwizardAppRule<PublicApiConfig> RULE =
+            new DropwizardAppRule<>(PublicApi.class, ResourceHelpers.resourceFilePath("config/empty-elevated-accounts-test-config.yaml"));
+
+    @Test
+    public void shouldParseConfiguration() {
+        RateLimiterConfig rateLimiterConfig = RULE.getConfiguration().getRateLimiterConfig();
+        assertThat(rateLimiterConfig.getNoOfReq(), is(1000));
+        assertThat(rateLimiterConfig.getPerMillis(), is(1000));
+        assertThat(rateLimiterConfig.getNoOfReqForPost(), is(1000));
+        assertThat(rateLimiterConfig.getNoOfReqPerNode(), is(1));
+        assertThat(rateLimiterConfig.getNoOfReqForPostPerNode(), is(1));
+        assertThat(rateLimiterConfig.getNoOfReqForElevatedAccounts(), is(1000));
+        assertThat(rateLimiterConfig.getNoOfPostReqForElevatedAccounts(), is(1000));
+        assertThat(rateLimiterConfig.getElevatedAccounts(), is(Collections.emptyList()));
+    }
+}

--- a/src/test/java/uk/gov/pay/api/it/validation/PublicApiConfigIT/PublicApiConfigIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PublicApiConfigIT/PublicApiConfigIT.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.api.it.validation;
+package uk.gov.pay.api.it.validation.PublicApiConfigIT;
 
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;

--- a/src/test/resources/config/empty-elevated-accounts-test-config.yaml
+++ b/src/test/resources/config/empty-elevated-accounts-test-config.yaml
@@ -1,0 +1,52 @@
+server:
+  applicationConnectors:
+    - type: http
+      port: 0
+  adminConnectors:
+    - type: http
+      port: 0
+
+logging:
+  level: INFO
+  appenders:
+    - type: console
+      threshold: ALL
+      timeZone: UTC
+      target: stdout
+      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] [gateway_account_id=%X{gateway_account_id:-(none)}] - %msg%n"
+
+baseUrl: http://publicapi.url/
+connectorUrl: http://connector_card.url/
+connectorDDUrl: http://connector_direct_debit.url/
+publicAuthUrl: http://publicauth.url/v1/auth
+ledgerUrl: http://ledger.url/
+
+alwaysUseFutureStrategy: false
+
+graphiteHost: ${METRICS_HOST:-localhost}
+graphitePort: ${METRICS_PORT:-8092}
+
+jerseyClientConfig:
+  disabledSecureConnection: "true"
+
+rateLimiter:
+  noOfReq: 1000
+  perMillis: 1000
+  noOfReqForPost: 1000
+  noOfReqPerNode: 1
+  noOfReqForPostPerNode: 1
+  elevatedAccounts:
+  noOfReqForElevatedAccounts: 1000
+  noOfPostReqForElevatedAccounts: 1000
+
+redis:
+  endpoint: localhost:6379
+  ssl: false
+  timeout: 100
+
+allowHttpForReturnUrl: false
+
+apiKeyHmacSecret: qwer9yuhgf
+
+# Caching authenticator.
+authenticationCachePolicy: expireAfterWrite=3s


### PR DESCRIPTION
Addressing review comments (https://github.com/alphagov/pay-publicapi/pull/701 and https://github.com/alphagov/pay-publicapi/pull/697):
* filtering empty values in StringToListConverter
* using method from rateLimiterKey in RateLimiterFilter
* removing unused imports from RateLimiterKey
* using HttpMethod.POST instead of string in RateLimitManager
* using removeEnd to remove trailing slash in PathHelper
* refactor LocalRateLimiter to use RateLimiterKey