### PR TITLE
PP-5648 make expiry date an optional field

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/telephone/CreateTelephonePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/telephone/CreateTelephonePaymentRequest.java
@@ -70,7 +70,6 @@ public class CreateTelephonePaymentRequest {
     @JsonProperty("email_address")
     private String emailAddress;
 
-    @NotNull(message = "Field [card_expiry] cannot be null")
     @ValidCardExpiryDate(message = "Field [card_expiry] must have valid MM/YY")
     private String cardExpiry;
     
@@ -93,17 +92,17 @@ public class CreateTelephonePaymentRequest {
                 .add("processor_id", this.getProcessorId())
                 .add("provider_id", this.getProviderId())
                 .add("card_type", this.getCardType())
-                .add("card_expiry", this.getCardExpiry())
                 .add("last_four_digits", this.getLastFourDigits())
                 .add("first_six_digits", this.getFirstSixDigits())
                 .addToMap("payment_outcome", "status", this.getPaymentOutcome().getStatus());
         this.getPaymentOutcome().getCode().ifPresent(code -> request.addToMap("payment_outcome", "code", code));
         this.getPaymentOutcome().getSupplemental().ifPresent(supplemental -> {
-                    supplemental.getErrorCode().ifPresent(errorCode -> request.addToNestedMap("error_code", errorCode, "payment_outcome", "supplemental"));
-                    supplemental.getErrorMessage().ifPresent(errorMessage -> request.addToNestedMap("error_message", errorMessage, "payment_outcome", "supplemental"));
+            supplemental.getErrorCode().ifPresent(errorCode -> request.addToNestedMap("error_code", errorCode, "payment_outcome", "supplemental"));
+            supplemental.getErrorMessage().ifPresent(errorMessage -> request.addToNestedMap("error_message", errorMessage, "payment_outcome", "supplemental"));
                 }
         );
 
+        this.getCardExpiry().ifPresent(cardExpiry -> request.add("card_expiry", cardExpiry));
         this.getCreatedDate().ifPresent(createdDate -> request.add("created_date", createdDate));
         this.getAuthorisedDate().ifPresent(authorisedDate -> request.add("authorised_date", authorisedDate));
         this.getAuthCode().ifPresent(authCode -> request.add("auth_code", authCode));
@@ -205,8 +204,8 @@ public class CreateTelephonePaymentRequest {
         return Optional.ofNullable(emailAddress);
     }
 
-    public String getCardExpiry() {
-        return cardExpiry;
+    public Optional<String> getCardExpiry() {
+        return Optional.ofNullable(cardExpiry);
     }
 
     public String getLastFourDigits() {

--- a/src/test/java/uk/gov/pay/api/it/telephone/CardExpiryValidationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/telephone/CardExpiryValidationIT.java
@@ -37,10 +37,4 @@ public class CardExpiryValidationIT extends TelephonePaymentResourceITBase {
         postPaymentResponse(toJson(requestBody))
                 .statusCode(422);
     }
-
-    @Test
-    public void respondWith422_whenCardExpiryisMissing() {
-        postPaymentResponse(toJson(requestBody))
-                .statusCode(422);
-    }
 }

--- a/src/test/java/uk/gov/pay/api/it/telephone/CreateTelephonePaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/telephone/CreateTelephonePaymentIT.java
@@ -10,6 +10,7 @@ import uk.gov.pay.api.utils.mocks.ConnectorMockClient;
 
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static io.restassured.http.ContentType.JSON;
 
@@ -29,7 +30,6 @@ public class CreateTelephonePaymentIT extends TelephonePaymentResourceITBase {
         requestBody.put("provider_id", "1PROV");
         requestBody.put("payment_outcome", Map.of("status", "success"));
         requestBody.put("card_type", "visa");
-        requestBody.put("card_expiry", "01/08");
         requestBody.put("last_four_digits", "1234");
         requestBody.put("first_six_digits", "123456");
 
@@ -41,7 +41,6 @@ public class CreateTelephonePaymentIT extends TelephonePaymentResourceITBase {
                 .withProviderId("1PROV")
                 .withPaymentOutcome(new PaymentOutcome("success"))
                 .withCardType("visa")
-                .withCardExpiry("01/08")
                 .withLastFourDigits("1234")
                 .withFirstSixDigits("123456");
     }
@@ -55,7 +54,8 @@ public class CreateTelephonePaymentIT extends TelephonePaymentResourceITBase {
                 .withAuthorisedDate(null)
                 .withNameOnCard(null)
                 .withEmailAddress(null)
-                .withTelephoneNumber(null);
+                .withTelephoneNumber(null)
+                .withCardExpiry(null);
     }
 
     @Test
@@ -66,6 +66,7 @@ public class CreateTelephonePaymentIT extends TelephonePaymentResourceITBase {
         requestBody.put("name_on_card", "Jane Doe");
         requestBody.put("email_address", "jane_doe@example.com");
         requestBody.put("telephone_number", "+447700900796");
+        requestBody.put("card_expiry", "01/08");
 
         createTelephonePaymentRequest
                 .withAuthCode("666")
@@ -73,7 +74,8 @@ public class CreateTelephonePaymentIT extends TelephonePaymentResourceITBase {
                 .withAuthorisedDate("2018-02-21T16:05:33Z")
                 .withNameOnCard("Jane Doe")
                 .withEmailAddress("jane_doe@example.com")
-                .withTelephoneNumber("+447700900796");
+                .withTelephoneNumber("+447700900796")
+                .withCardExpiry("01/08");
         
         connectorMockClient.respondCreated_whenCreateTelephoneCharge(GATEWAY_ACCOUNT_ID, createTelephonePaymentRequest
                 .build());
@@ -116,7 +118,6 @@ public class CreateTelephonePaymentIT extends TelephonePaymentResourceITBase {
                 .body("processor_id", is("1PROC"))
                 .body("payment_outcome.status", is("success"))
                 .body("card_type", is("visa"))
-                .body("card_expiry", is("01/08"))
                 .body("last_four_digits", is("1234"))
                 .body("first_six_digits", is("123456"))
                 .body("payment_id", is("dummypaymentid123notpersisted"))
@@ -138,7 +139,7 @@ public class CreateTelephonePaymentIT extends TelephonePaymentResourceITBase {
                 .body("processor_id", is("1PROC"))
                 .body("payment_outcome.status", is("success"))
                 .body("card_type", is("visa"))
-                .body("card_expiry", is("01/08"))
+                .body("card_expiry", is(nullValue()))
                 .body("last_four_digits", is("1234"))
                 .body("first_six_digits", is("123456"))
                 .body("payment_id", is("dummypaymentid123notpersisted"))

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -181,7 +181,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                                 requestParams.getLastFourDigits(),
                                 requestParams.getFirstSixDigits(),
                                 requestParams.getNameOnCard().orElse(null),
-                                requestParams.getCardExpiry(),
+                                requestParams.getCardExpiry().orElse(null),
                                 null,
                                 requestParams.getCardType()
                         )
@@ -216,7 +216,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                                 requestParams.getLastFourDigits(),
                                 requestParams.getFirstSixDigits(),
                                 requestParams.getNameOnCard().orElse(null),
-                                requestParams.getCardExpiry(),
+                                requestParams.getCardExpiry().orElse(null),
                                 null,
                                 requestParams.getCardType()
                         )

--- a/src/test/java/uk/gov/pay/api/validation/CardExpiryValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/CardExpiryValidatorTest.java
@@ -84,7 +84,6 @@ public class CardExpiryValidatorTest {
 
         Set<ConstraintViolation<CreateTelephonePaymentRequest>> constraintViolations = validator.validate(telephonePaymentRequest);
 
-        assertThat(constraintViolations.size(), is(1));
-        assertThat(constraintViolations.iterator().next().getMessage(),is("Field [card_expiry] cannot be null"));
+        assertThat(constraintViolations.isEmpty(), is(true));
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- as pointed out by our integrating partner, card_expiry field is not present when the transaction failed. We're removing the @NotNull annotation from CreateTelephonePaymentRequest
- update relevant tests
