### PR TITLE
PP-5632: fix to config causing null pointer exception

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/config/RateLimiterConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/RateLimiterConfig.java
@@ -5,7 +5,9 @@ import io.dropwizard.Configuration;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 public class RateLimiterConfig extends Configuration {
 
@@ -63,6 +65,6 @@ public class RateLimiterConfig extends Configuration {
     }
 
     public List<String> getElevatedAccounts() {
-        return elevatedAccounts;
+        return Optional.ofNullable(elevatedAccounts).orElse(Collections.emptyList());
     }
 }


### PR DESCRIPTION
It seems the dropwizard uses converter only when there is a value;
When there is none it returns null;
The fix is to wrap the value in optional nullable and return empty list if
value doesn't exist.