### PR TITLE
PP-5647: add exact_reference_match query param to ledger search call

### DIFF
--- a/src/main/java/uk/gov/pay/api/service/LedgerService.java
+++ b/src/main/java/uk/gov/pay/api/service/LedgerService.java
@@ -29,6 +29,7 @@ import static org.apache.http.HttpStatus.SC_OK;
 public class LedgerService {
     private static final String PARAM_ACCOUNT_ID = "account_id";
     private static final String PARAM_TRANSACTION_TYPE = "transaction_type";
+    private static final String PARAM_EXACT_REFERENCE_MATCH = "exact_reference_match";
     private static final String PAYMENT_TRANSACTION_TYPE = "PAYMENT";
     private static final String REFUND_TRANSACTION_TYPE = "REFUND";
 
@@ -118,6 +119,7 @@ public class LedgerService {
 
         paramsAsMap.put(PARAM_ACCOUNT_ID, account.getAccountId());
         paramsAsMap.put(PARAM_TRANSACTION_TYPE, PAYMENT_TRANSACTION_TYPE);
+        paramsAsMap.put(PARAM_EXACT_REFERENCE_MATCH, "true");
 
         Response response = client
                 .target(ledgerUriGenerator.transactionsURIWithParams(paramsAsMap))

--- a/src/test/resources/pacts/publicapi-ledger-search-payments.json
+++ b/src/test/resources/pacts/publicapi-ledger-search-payments.json
@@ -26,7 +26,8 @@
           ],
           "status_version": ["1"],
           "cardholder_name": ["j.doe@example.org"],
-          "transaction_type": ["PAYMENT"]
+          "transaction_type": ["PAYMENT"],
+          "exact_reference_match": ["true"]
         }
       },
       "response": {


### PR DESCRIPTION
Context:
Connector endpoint used by public api does the exact match search.
In order to do the same through ledger the exact_reference_match query param
needs to be added to the search call (https://github.com/alphagov/pay-ledger/pull/305)


Changes:
* add exact_reference_match query param to payments search endpoint (LedgerService)
* update pact to include exact_reference_match query param for payments search