### PR TITLE
PP-5285 OpenAPI specs for refund endpoints

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRefundRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRefundRequest.java
@@ -3,17 +3,25 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Optional;
 
+import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
+
 @ApiModel(value = "PaymentRefundRequest", description = "The Payment Refund Request Payload")
+@Schema(name = "PaymentRefundRequest", description = "The Payment Refund Request Payload")
 public class CreatePaymentRefundRequest {
 
     public static final String REFUND_AMOUNT_AVAILABLE = "refund_amount_available";
     public static final int REFUND_MIN_VALUE = 1;
 
+    @Schema(description = "Amount in pence. Can't be more than the available amount for refunds", required = true,
+            example = "150000")
     private int amount;
     @JsonProperty("refund_amount_available")
+    @Schema(description = "Amount in pence. Total amount still available before issuing the refund", required = false,
+            example = "200000", accessMode = READ_ONLY)
     private Integer refundAmountAvailable;
 
     public CreatePaymentRefundRequest() {

--- a/src/main/java/uk/gov/pay/api/model/PaymentError.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentError.java
@@ -3,12 +3,14 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static com.google.common.collect.ObjectArrays.concat;
 import static java.lang.String.format;
 
 @ApiModel(value = "PaymentError", description = "A Payment Error response")
+@Schema(name = "PaymentError", description = "A Payment Error response")
 @JsonInclude(NON_NULL)
 public class PaymentError {
 
@@ -104,16 +106,19 @@ public class PaymentError {
     }
 
     @ApiModelProperty(example = "amount")
+    @Schema(example = "amount")
     public String getField() {
         return field;
     }
 
     @ApiModelProperty(example = "P0102")
+    @Schema(example = "P0102")
     public String getCode() {
         return code.value();
     }
 
     @ApiModelProperty(example = "Invalid attribute value: amount. Must be less than or equal to 10000000")
+    @Schema(example = "Invalid attribute value: amount. Must be less than or equal to 10000000")
     public String getDescription() {
         return description;
     }

--- a/src/main/java/uk/gov/pay/api/model/RefundError.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundError.java
@@ -3,12 +3,14 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static com.google.common.collect.ObjectArrays.concat;
 import static java.lang.String.format;
 
 @ApiModel(value = "RefundError", description = "A Refund Error response")
+@Schema(name = "RefundError", description = "A Refund Error response")
 @JsonInclude(NON_NULL)
 public class RefundError {
 
@@ -60,16 +62,19 @@ public class RefundError {
     }
 
     @ApiModelProperty(example = "amount_submitted")
+    @Schema(example = "amount_submitted")
     public String getField() {
         return field;
     }
 
     @ApiModelProperty(example = "P0102")
+    @Schema(example = "P0102")
     public String getCode() {
         return code.value();
     }
 
     @ApiModelProperty(example = "Invalid attribute value: amountSubmitted. Must be less than or equal to 10000000")
+    @Schema(example = "Invalid attribute value: amountSubmitted. Must be less than or equal to 10000000")
     public String getDescription() {
         return description;
     }

--- a/src/main/java/uk/gov/pay/api/model/RefundResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundResponse.java
@@ -3,23 +3,30 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.ledger.RefundTransactionFromLedger;
 import uk.gov.pay.api.model.links.RefundLinksForSearch;
 
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 
+import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 import static uk.gov.pay.api.resources.PaymentRefundsResource.PAYMENT_BY_ID_PATH;
 import static uk.gov.pay.api.resources.PaymentRefundsResource.PAYMENT_REFUND_BY_ID_PATH;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@Schema(name = "Refund")
 public class RefundResponse {
 
+    @Schema(example = "act4c33g40j3edfmi8jknab84x", accessMode = READ_ONLY)
     private String refundId;
+    @Schema(example = "2017-01-10T16:52:07.855Z", accessMode = READ_ONLY)
     private String createdDate;
+    @Schema(example = "120", accessMode = READ_ONLY)
     private Long amount;
     @JsonProperty("_links")
     private RefundLinksForSearch links;
+    @Schema(example = "success", allowableValues = {"submitted", "success", "error"}, accessMode = READ_ONLY)
     private String status;
 
     private RefundResponse(RefundFromConnector refund, URI selfLink, URI paymentLink) {
@@ -63,7 +70,7 @@ public class RefundResponse {
     public static RefundResponse from(RefundTransactionFromLedger refund, URI selfLink, URI paymentLink) {
         return new RefundResponse(refund, selfLink, paymentLink);
     }
-    
+
     //todo: remove after full refactoring of PaymentRefundsResource (to use service layer) 
     public static RefundResponse valueOf(RefundFromConnector refundEntity, String paymentId, String baseUrl) {
         URI selfLink = UriBuilder.fromUri(baseUrl)

--- a/src/main/java/uk/gov/pay/api/model/RefundsResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundsResponse.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.RefundLinksForSearch;
 
 import java.util.List;
@@ -8,10 +9,12 @@ import java.util.List;
 public class RefundsResponse {
 
     @JsonProperty("payment_id")
+    @Schema(example = "hu20sqlact5260q2nanm0q8u93")
     private String paymentId;
     @JsonProperty("_links")
     private RefundLinksForSearch links;
     @JsonProperty("_embedded")
+    @Schema(name = "_embedded")
     private EmbeddedRefunds embedded;
 
     private RefundsResponse(String paymentId, List<RefundResponse> refundsForPayment, String selfLink, String paymentLink) {
@@ -40,10 +43,12 @@ public class RefundsResponse {
         return links;
     }
 
+    @Schema(hidden = true)
     public EmbeddedRefunds getEmbedded() {
         return embedded;
     }
 
+    @Schema(hidden = true)
     public class EmbeddedRefunds {
         private List<RefundResponse> refunds;
 

--- a/src/main/java/uk/gov/pay/api/model/links/Link.java
+++ b/src/main/java/uk/gov/pay/api/model/links/Link.java
@@ -4,18 +4,23 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Objects;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
 @ApiModel(value = "Link", description = "A link related to a payment")
+@Schema(name = "Link", description = "A link related to a payment")
 @JsonInclude(Include.NON_NULL)
 public class Link {
 
     @JsonProperty(value = "href")
+    @Schema(example = "https://an.example.link/from/payment/platform", accessMode = READ_ONLY)
     private String href;
     @JsonProperty(value = "method")
+    @Schema(example = "GET", accessMode = READ_ONLY)
     private String method;
 
     public Link(String href, String method) {

--- a/src/main/java/uk/gov/pay/api/model/links/RefundLinksForSearch.java
+++ b/src/main/java/uk/gov/pay/api/model/links/RefundLinksForSearch.java
@@ -3,10 +3,12 @@ package uk.gov.pay.api.model.links;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import static javax.ws.rs.HttpMethod.GET;
 
 @ApiModel(value = "RefundLinksForSearch", description = "links for search refunds resource")
+@Schema(name = "RefundLinksForSearch", description = "links for search refunds resource")
 public class RefundLinksForSearch {
 
     private static final String SELF = "self";

--- a/src/main/java/uk/gov/pay/api/model/links/RefundLinksForSearch.java
+++ b/src/main/java/uk/gov/pay/api/model/links/RefundLinksForSearch.java
@@ -18,12 +18,14 @@ public class RefundLinksForSearch {
     private Link payment;
 
     @ApiModelProperty(value = SELF, dataType = "uk.gov.pay.api.model.links.Link")
+    @Schema(description = "self")
     @JsonProperty(value = SELF)
     public Link getSelf() {
         return self;
     }
-    
+
     @ApiModelProperty(value = PAYMENT, dataType = "uk.gov.pay.api.model.links.Link")
+    @Schema(description = "payment")
     @JsonProperty(value = PAYMENT)
     public Link getPayment() {
         return payment;

--- a/src/main/java/uk/gov/pay/api/model/links/SearchNavigationLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/SearchNavigationLinks.java
@@ -2,8 +2,10 @@ package uk.gov.pay.api.model.links;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @ApiModel(value = "SearchNavigationLinks", description = "Links to navigate through pages")
+@Schema(name = "SearchNavigationLinks", description = "Links to navigate through pages")
 public class SearchNavigationLinks {
 
     @JsonProperty(value = "self")

--- a/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
@@ -4,21 +4,27 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.ledger.RefundTransactionFromLedger;
 import uk.gov.pay.api.model.links.RefundLinksForSearch;
 
 import java.net.URI;
 
+import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 @ApiModel(value = "RefundDetailForSearch")
+@Schema(name = "RefundDetailForSearch")
 public class RefundForSearchRefundsResult {
 
     @JsonProperty("refund_id")
     @ApiModelProperty(example = "act4c33g40j3edfmi8jknab84x")
+    @Schema(example = "act4c33g40j3edfmi8jknab84x", accessMode = READ_ONLY)
     private String refundId;
 
     @JsonProperty("created_date")
     @ApiModelProperty(example = "2017-01-10T16:52:07.855Z")
+    @Schema(example = "2017-01-10T16:52:07.855Z", accessMode = READ_ONLY)
     private String createdDate;
 
     private String chargeId;
@@ -29,6 +35,7 @@ public class RefundForSearchRefundsResult {
     
     @JsonProperty("status")
     @ApiModelProperty(example = "success", allowableValues = "submitted,success,error")
+    @Schema(example = "success", allowableValues = {"submitted", "success", "error"}, accessMode = READ_ONLY)
     private String status;
 
     public RefundForSearchRefundsResult() {
@@ -58,22 +65,26 @@ public class RefundForSearchRefundsResult {
 
     @JsonProperty("payment_id")
     @ApiModelProperty(example = "2q1r18djndhsrm3closjqr81fx", hidden = true)
+    @Schema(hidden = true)
     public String getChargeId() {
         return chargeId;
     }
 
     @JsonProperty("charge_id")
+    @Schema(hidden = true)
     public void setChargeId(String chargeId) {
         this.chargeId = chargeId;
     }
 
     @JsonProperty("amount_submitted")
+    @Schema(hidden = true)
     public void setAmount(Long amount) {
         this.amount = amount;
     }
     
     @JsonProperty("amount")
     @ApiModelProperty(example = "120")
+    @Schema(example = "120", accessMode = READ_ONLY)
     public Long getAmount() {
         return amount;
     }

--- a/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchResult.java
@@ -3,6 +3,7 @@ package uk.gov.pay.api.model.search.card;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.RefundLinksForSearch;
 
 import java.util.List;
@@ -11,13 +12,17 @@ import java.util.List;
 public class RefundForSearchResult {
 
     @ApiModelProperty(name = "payment_id", example = "hu20sqlact5260q2nanm0q8u93")
+    @Schema(name = "payment_id", example = "hu20sqlact5260q2nanm0q8u93")
     private String paymentId;
     @ApiModelProperty(name = "_links")
+    @Schema(name = "_links")
     private RefundLinksForSearch links;
     @JsonProperty(value = "_embedded")
+    @Schema(name = "_embedded")
     private Embedded embedded;
 
     @ApiModel(value = "EmbeddedRefunds")
+    @Schema(name = "EmbeddedRefunds")
     public class Embedded {
         @ApiModelProperty
         private List<RefundResult> refunds;

--- a/src/main/java/uk/gov/pay/api/model/search/card/RefundResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/RefundResult.java
@@ -3,15 +3,18 @@ package uk.gov.pay.api.model.search.card;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.RefundLinksForSearch;
 
 @ApiModel(value = "Refund")
+@Schema(name = "Refund")
 public class RefundResult {
 
     @ApiModelProperty
     @JsonUnwrapped
     private RefundForSearchRefundsResult refunds;
     @ApiModelProperty(name = "_links")
+    @Schema(name = "_links")
     private RefundLinksForSearch links;
 
     public RefundForSearchRefundsResult getRefunds() {

--- a/src/main/java/uk/gov/pay/api/model/search/card/SearchRefundsResults.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/SearchRefundsResults.java
@@ -5,20 +5,25 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.SearchNavigationLinks;
 import uk.gov.pay.api.model.search.SearchPagination;
 
 import java.util.List;
 
 @ApiModel(value = "RefundSearchResults")
+@Schema(name = "RefundSearchResults")
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class SearchRefundsResults implements SearchPagination {
 
     @ApiModelProperty(name = "total", example = "100")
+    @Schema(example = "100")
     private int total;
     @ApiModelProperty(name = "count", example = "20")
+    @Schema(example = "20")
     private int count;
     @ApiModelProperty(name = "page", example = "1")
+    @Schema(example = "1")
     private int page;
     @ApiModelProperty(name = "results")
     private List<RefundForSearchRefundsResult> results;

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -10,6 +10,12 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +56,7 @@ import static javax.ws.rs.core.UriBuilder.fromPath;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @Path(PaymentRefundsResource.PAYMENT_REFUNDS_PATH)
+@Tag(name = "Refunding card payments")
 @Api(tags = "Refunding card payments", value = "/refunds")
 @Produces({"application/json"})
 public class PaymentRefundsResource {
@@ -93,6 +100,22 @@ public class PaymentRefundsResource {
     @GET
     @Timed
     @Produces(APPLICATION_JSON)
+    @Operation(security = {@SecurityRequirement(name = "BearerAuth")},
+            operationId = "Get all refunds for a payment",
+            summary = "Return refunds for a payment. " +
+                    "The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+                            content = @Content(schema = @Schema(implementation = RefundForSearchResult.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Credentials are required to access this resource"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                            content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class)))
+            }
+    )
     @ApiOperation(
             response = RefundForSearchResult.class,
             nickname = "Get all refunds for a payment",
@@ -107,9 +130,9 @@ public class PaymentRefundsResource {
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
             @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
-    public RefundsResponse getRefunds(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
+    public RefundsResponse getRefunds(@Parameter(hidden = true) @ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                       @PathParam(PATH_PAYMENT_KEY) String paymentId,
-                                      @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
+                                      @Parameter(hidden = true) @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
 
         logger.info("Get refunds for payment request - paymentId={} using strategy={}", paymentId, strategyName);
 
@@ -123,9 +146,25 @@ public class PaymentRefundsResource {
     @GET
     @Timed
     @Path("/{refundId}")
+    @Operation(security = {@SecurityRequirement(name = "BearerAuth")},
+            operationId = "Get a payment refund",
+            summary = "Return payment refund information by Refund ID " +
+                    "The Authorisation token needs to be specified in the 'authorization' header " +
+                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+                            content = @Content(schema = @Schema(implementation = RefundResult.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Credentials are required to access this resource"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                            content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class)))
+            }
+    )
     @Produces(APPLICATION_JSON)
-    @ApiOperation(
-            response = RefundResult.class,
+    @ApiOperation(response = RefundResult.class,
             nickname = "Get a payment refund",
             value = "Find payment refund by ID",
             notes = "Return payment refund information by Refund ID " +
@@ -139,10 +178,11 @@ public class PaymentRefundsResource {
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
             @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
-    public RefundResponse getRefundById(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
+    public RefundResponse getRefundById(@Parameter(hidden = true) @ApiParam(value = "accountId", hidden = true) 
+                                            @Auth Account account,
                                         @PathParam(PATH_PAYMENT_KEY) String paymentId,
                                         @PathParam(PATH_REFUND_KEY) String refundId,
-                                        @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
+                                        @Parameter(hidden = true) @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
 
         logger.info("Payment refund request - paymentId={}, refundId={}", paymentId, refundId);
 
@@ -158,6 +198,23 @@ public class PaymentRefundsResource {
     @Timed
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
+    @Operation(security = {@SecurityRequirement(name = "BearerAuth")},
+            operationId = "Submit a refund for a payment",
+            summary = "Return issued refund information. " +
+                    "The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "202", description = "ACCEPTED",
+                            content = @Content(schema = @Schema(implementation = RefundResult.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Credentials are required to access this resource"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "412", description = "Refund amount available mismatch"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                            content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class)))
+            }
+    )
     @ApiOperation(
             response = RefundResult.class,
             nickname = "Submit a refund for a payment",
@@ -174,8 +231,9 @@ public class PaymentRefundsResource {
             @ApiResponse(code = 412, message = "Refund amount available mismatch"),
             @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
-    public Response submitRefund(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
+    public Response submitRefund(@Parameter(hidden = true) @ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                  @ApiParam(value = "paymentId", required = true) @PathParam(PATH_PAYMENT_KEY) String paymentId,
+                                 @Parameter(required = true, description = "requestPayload")
                                  @ApiParam(value = "requestPayload", required = true) CreatePaymentRefundRequest requestPayload) {
 
         logger.info("Create a refund for payment request - paymentId={}", paymentId);

--- a/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
@@ -8,6 +8,12 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
@@ -29,6 +35,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/")
 @Api(tags = "Refunding card payments", value = "/")
+@Tag(name = "Refunding card payments")
 @Produces({"application/json"})
 public class SearchRefundsResource {
 
@@ -47,6 +54,21 @@ public class SearchRefundsResource {
     @Timed
     @Path("/v1/refunds")
     @Produces(APPLICATION_JSON)
+    @Operation(
+            security = {@SecurityRequirement(name = "BearerAuth")},
+            operationId = "Search refunds",
+            summary = "Search refunds by 'from' and 'to' date. " +
+                    "The Authorisation token needs to be specified in the 'authorization' header " +
+                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SearchRefundsResults.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Credentials are required to access this resource"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422", description = "Invalid parameters. See Public API documentation for the correct data formats",
+                            content = @Content(schema = @Schema(implementation = RefundError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                            content = @Content(schema = @Schema(implementation = RefundError.class))),
+            }
+    )
     @ApiOperation(
             nickname = "Search refunds",
             value = "Search refunds",
@@ -62,17 +84,21 @@ public class SearchRefundsResource {
             @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
             @ApiResponse(code = 422, message = "Invalid parameters. See Public API documentation for the correct data formats", response = RefundError.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = RefundError.class)})
-    public SearchRefundsResults searchRefunds(@ApiParam(value = "accountId", hidden = true)
+    public SearchRefundsResults searchRefunds(@Parameter(hidden = true) @ApiParam(value = "accountId", hidden = true)
                                   @Auth Account account,
+                                  @Parameter(description = "From date of refunds to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z")
                                   @ApiParam(value = "From date of refunds to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z", hidden = false)
                                   @QueryParam("from_date") String fromDate,
+                                  @Parameter(description = "To date of refunds to be searched (this date is exclusive). Example=2015-08-14T12:35:00Z")
                                   @ApiParam(value = "To date of refunds to be searched (this date is exclusive). Example=2015-08-14T12:35:00Z", hidden = false)
                                   @QueryParam("to_date") String toDate,
+                                  @Parameter(description = "Page number requested for the search, should be a positive integer (optional, defaults to 1)")
                                   @ApiParam(value = "Page number requested for the search, should be a positive integer (optional, defaults to 1)", hidden = false)
                                   @QueryParam("page") String pageNumber,
+                                  @Parameter(description = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)", hidden = false)
                                   @ApiParam(value = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)", hidden = false)
-                                  @QueryParam("display_size") String displaySize, 
-                                  @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
+                                  @QueryParam("display_size") String displaySize,
+                                  @Parameter(hidden = true) @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
 
         logger.info("Refunds search request with strategy [{}]- [ {} ]", strategyName,
                 format("from_date: %s, to_date: %s, page: %s, display_size: %s",

--- a/src/main/java/uk/gov/pay/api/resources/error/ApiErrorResponse.java
+++ b/src/main/java/uk/gov/pay/api/resources/error/ApiErrorResponse.java
@@ -3,11 +3,13 @@ package uk.gov.pay.api.resources.error;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static java.lang.String.format;
 
 @ApiModel(value = "ErrorResponse", description = "An error response")
+@Schema(name = "ErrorResponse", description = "An error response")
 @JsonInclude(NON_NULL)
 public class ApiErrorResponse {
 
@@ -45,11 +47,13 @@ public class ApiErrorResponse {
     }
 
     @ApiModelProperty(example = "P0900")
+    @Schema(example = "P0900")
     public String getCode() {
         return code.value();
     }
 
     @ApiModelProperty(example = "Too many requests")
+    @Schema(example = "Too many requests")
     public String getDescription() {
         return description;
     }


### PR DESCRIPTION
## WHAT YOU DID
Prep to convert swagger to openAPI v3.0

- Adds annotations for refund endpoints defining parameters required, examples for related schemas

## HOW TO TEST
- `mvn compile` should now generate swagger (with openapi v3.0.0) with correct definitions for refund endpoints including examples