### PR TITLE
PP-5285 Swagger library and config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <docker-client.version>8.16.0</docker-client.version>
         <pay-java-commons.version>1.0.20191001125636</pay-java-commons.version>
         <pact.version>3.6.14</pact.version>
+        <swagger.lib.version>2.0.9</swagger.lib.version>
         <PACT_BROKER_URL/>
         <PACT_BROKER_USERNAME/>
         <PACT_BROKER_PASSWORD/>
@@ -220,6 +221,12 @@
                     <artifactId>jersey-container-servlet-core</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>${swagger.lib.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -508,6 +515,27 @@
                         <phase>compile</phase>
                         <goals>
                             <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-maven-plugin</artifactId>
+                <version>${swagger.lib.version}</version>
+                <configuration>
+                    <outputPath>swagger</outputPath>
+                    <outputFileName>swagger_v3_0_0</outputFileName>
+                    <outputFormat>JSON</outputFormat>
+                    <prettyPrint>true</prettyPrint>
+                    <configurationFilePath>${basedir}/src/main/resources/swagger-config.yaml
+                    </configurationFilePath>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>resolve</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/main/resources/swagger-config.yaml
+++ b/src/main/resources/swagger-config.yaml
@@ -1,0 +1,24 @@
+resourceClasses:
+    - uk.gov.pay.api.resources.PaymentRefundsResource
+    - uk.gov.pay.api.resources.SearchRefundsResource
+    - uk.gov.pay.api.resources.PaymentsResource
+    - uk.gov.pay.api.resources.MandatesResource
+    - uk.gov.pay.api.resources.directdebit.DirectDebitPaymentsResource
+openAPI:
+  info:
+    description: 'GOV.UK Pay API'
+    version: '1.0.3'
+    title: 'GOV.UK Pay API'
+  servers:
+    - url: 'https://publicapi.payments.service.gov.uk'
+  tags:
+    - name: Card payments
+    - name: Direct Debit
+    - name: Refunding card payments
+
+  components:
+    securitySchemes:
+      BearerAuth:
+        type: http
+        scheme: bearer
+        description: "<br> The Authorisation token needs to be specified in the 'Authorization' header as `Authorization: Bearer YOUR_API_KEY_HERE`"


### PR DESCRIPTION
## WHY
- To move from swagger v2.0 to Open API v3.0.0

## WHAT
- Adds swagger core library and plugin to generate swagger with openapi 3.0 specification
- Configuration for resource classes and basic info including auth

## How to test
- `mvn compile` will generate a swagger file `swagger_v3_0_0.json` ("openapi" : "3.0.1") with all the definitions for resource packages specified



Although swagger file is generated, it is not accurate with the definitions and examples. PRs to follow that defines required properties for schemas, descriptions, examples..