### PR TITLE
PP-5285 Open API specs for `DirectDebit` endpoints

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CreateDirectDebitPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateDirectDebitPaymentRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.hibernate.validator.constraints.NotBlank;
 
 import javax.validation.constraints.Max;
@@ -12,6 +13,7 @@ import javax.validation.constraints.Size;
 import java.util.StringJoiner;
 
 @ApiModel(description = "The Direct Debit Payment Request Payload")
+@Schema(description = "The Direct Debit Payment Request Payload")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CreateDirectDebitPaymentRequest {
 
@@ -45,21 +47,25 @@ public class CreateDirectDebitPaymentRequest {
     }
     
     @ApiModelProperty(value = "amount in pence", required = true, allowableValues = "range[1, 10000000]", example = "12000")
+    @Schema(description = "amount in pence", required = true, example = "12000", minimum = "1", maximum = "10000000")
     public int getAmount() {
         return amount;
     }
 
     @ApiModelProperty(value = "payment reference", required = true, example = "12345")
+    @Schema(description = "payment reference", required = true, example = "12345")
     public String getReference() {
         return reference;
     }
 
     @ApiModelProperty(value = "payment description", required = true, example = "New passport application")
+    @Schema(description = "payment description", required = true, example = "New passport application")
     public String getDescription() {
         return description;
     }
 
     @ApiModelProperty(value = "ID of the mandates being used to collect the payment", required = false, example = "33890b55-b9ea-4e2f-90fd-77ae0e9009e2")
+    @Schema(description = "ID of the mandates being used to collect the payment", required = false, example = "33890b55-b9ea-4e2f-90fd-77ae0e9009e2")
     public String getMandateId() {
         return mandateId;
     }

--- a/src/main/java/uk/gov/pay/api/model/Payment.java
+++ b/src/main/java/uk/gov/pay/api/model/Payment.java
@@ -4,12 +4,16 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.directdebit.mandates.DirectDebitPayment;
+
+import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
 
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 @ApiModel(value = "Payment", discriminator = "paymentType", subTypes = {
         CardPayment.class, DirectDebitPayment.class})
+@Schema(name = "Payment", subTypes = {CardPayment.class, DirectDebitPayment.class})
 public abstract class Payment {
     public static final String LINKS_JSON_ATTRIBUTE = "_links";
 
@@ -46,31 +50,37 @@ public abstract class Payment {
     }
 
     @ApiModelProperty(example = "2016-01-21T17:15:000Z")
+    @Schema(example = "2016-01-21T17:15:000Z", accessMode = READ_ONLY)
     public String getCreatedDate() {
         return createdDate;
     }
 
     @ApiModelProperty(example = "hu20sqlact5260q2nanm0q8u93")
+    @Schema(example = "hu20sqlact5260q2nanm0q8u93", accessMode = READ_ONLY)
     public String getPaymentId() {
         return paymentId;
     }
 
     @ApiModelProperty(example = "1200")
+    @Schema(example = "1200")
     public long getAmount() {
         return amount;
     }
 
     @ApiModelProperty(example = "Your Service Description")
+    @Schema(example = "Your Service Description")
     public String getDescription() {
         return description;
     }
 
     @ApiModelProperty(example = "your-reference")
+    @Schema(example = "your-reference")
     public String getReference() {
         return reference;
     }
 
     @ApiModelProperty(example = "worldpay")
+    @Schema(example = "worldpay", accessMode = READ_ONLY)
     public String getPaymentProvider() {
         return paymentProvider;
     }

--- a/src/main/java/uk/gov/pay/api/model/directdebit/DirectDebitConnectorPaymentResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/DirectDebitConnectorPaymentResponse.java
@@ -2,38 +2,48 @@ package uk.gov.pay.api.model.directdebit;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.DirectDebitPaymentState;
 
 import java.util.Objects;
 
+import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DirectDebitConnectorPaymentResponse {
     @JsonProperty
+    @Schema(example = "1200", accessMode = READ_ONLY)
     private Long amount;
     
     @JsonProperty
     private DirectDebitPaymentState state;
     
     @JsonProperty("mandate_id")
+    @Schema(example = "33890b55-b9ea-4e2f-90fd-77ae0e9009e2", accessMode = READ_ONLY)
     private String mandateId;
     
     @JsonProperty
+    @Schema(example = "Your Service Description", accessMode = READ_ONLY)
     private String description;
 
     @JsonProperty
+    @Schema(example = "your-reference", accessMode = READ_ONLY)
     private String reference;
     
     @JsonProperty("payment_id")
+    @Schema(example = "payment id", accessMode = READ_ONLY)
     private String paymentExternalId;
 
     @JsonProperty("payment_provider")
+    @Schema(example = "worldpay", accessMode = READ_ONLY)
     private String paymentProvider;
 
-
+    @Schema(example = "2016-01-21T17:15:000Z", accessMode = READ_ONLY)
     @JsonProperty("created_date")
     private String createdDate;
 
     @JsonProperty("provider_id")
+    @Schema(example = "provider id", accessMode = READ_ONLY)
     private String providerId;
 
     public String getPaymentProvider() {

--- a/src/main/java/uk/gov/pay/api/model/directdebit/DirectDebitPaymentLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/DirectDebitPaymentLinks.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.Link;
 
 import java.net.URI;
@@ -12,6 +13,7 @@ import static javax.ws.rs.HttpMethod.GET;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 @ApiModel(value = "DirectDebitPaymentLinks", description = "links for payment")
+@Schema(name = "DirectDebitPaymentLinks", description = "links for payment")
 public class DirectDebitPaymentLinks {
     
     @JsonProperty("self")
@@ -19,6 +21,7 @@ public class DirectDebitPaymentLinks {
 
     //Hidden because it is currently unused
     @ApiModelProperty(hidden = true)
+    @Schema(hidden = true)
     @JsonProperty("events")
     private Link events;
 

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/CreateMandateRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/CreateMandateRequest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.hibernate.validator.constraints.NotBlank;
 import uk.gov.pay.api.validation.ValidReturnUrl;
 
@@ -14,6 +15,7 @@ import javax.validation.constraints.Size;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @ApiModel(description = "The Payload to create a new Mandate")
+@Schema(description = "The Payload to create a new Mandate")
 public class CreateMandateRequest {
 
     @NotNull
@@ -33,16 +35,19 @@ public class CreateMandateRequest {
     private String description;
 
     @ApiModelProperty(value = "mandate description")
+    @Schema(description = "mandate description")
     public String getDescription() {
         return description;
     }
 
     @ApiModelProperty(value = "mandate return url", required = true, example = "https://service-name.gov.uk/transactions/12345")
+    @Schema(description = "mandate return url", required = true, example = "https://service-name.gov.uk/transactions/12345")
     public String getReturnUrl() {
         return returnUrl;
     }
 
     @ApiModelProperty(value = "mandate reference", example = "test_service_reference")
+    @Schema(description = "mandate reference", example = "test_service_reference")
     public String getReference() {
         return reference;
     }

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/DirectDebitPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/DirectDebitPayment.java
@@ -3,6 +3,7 @@ package uk.gov.pay.api.model.directdebit.mandates;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.DirectDebitPaymentState;
 import uk.gov.pay.api.model.Payment;
 import uk.gov.pay.api.model.PaymentState;
@@ -13,21 +14,26 @@ import uk.gov.pay.api.service.PublicApiUriGenerator;
 import java.net.URI;
 import java.util.Objects;
 
+import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 import static uk.gov.pay.api.model.directdebit.DirectDebitPaymentLinks.DirectDebitPaymentLinksBuilder.aDirectDebitPaymentLinks;
 import static uk.gov.pay.api.model.directdebit.mandates.DirectDebitPayment.DirectDebitPaymentBuilder.aDirectDebitPayment;
 
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 @ApiModel(value = "DirectDebitPayment")
+@Schema(description = "DirectDebitPayment")
 public class DirectDebitPayment extends Payment {
 
     @JsonProperty("mandate_id")
+    @Schema(example = "33890b55-b9ea-4e2f-90fd-77ae0e9009e2", accessMode = READ_ONLY)
     private String mandateId;
     
     @JsonProperty("provider_id")
+    @Schema(example = "provider id", accessMode = READ_ONLY)
     private String providerId;
     
     @JsonProperty("_links")
+    @Schema(name = "_links")
     private DirectDebitPaymentLinks links;
 
     @JsonProperty("state")

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateError.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateError.java
@@ -3,12 +3,14 @@ package uk.gov.pay.api.model.directdebit.mandates;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static com.google.common.collect.ObjectArrays.concat;
 import static java.lang.String.format;
 
 @ApiModel(value = "MandateError", description = "A Mandate Error response")
+@Schema(name = "MandateError", description = "A Mandate Error response")
 @JsonInclude(NON_NULL)
 public class MandateError {
 
@@ -65,16 +67,19 @@ public class MandateError {
     }
 
     @ApiModelProperty(example = "return_url")
+    @Schema(example = "return_url")
     public String getField() {
         return field;
     }
 
     @ApiModelProperty(example = "P0102")
+    @Schema(example = "P0102")
     public String getCode() {
         return code.value();
     }
 
     @ApiModelProperty(example = "Invalid attribute value: return_url. Must be a valid url.")
+    @Schema(example = "Invalid attribute value: return_url. Must be a valid url.")
     public String getDescription() {
         return description;
     }

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateResponse.java
@@ -3,12 +3,15 @@ package uk.gov.pay.api.model.directdebit.mandates;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.directdebit.MandateLinks;
 import uk.gov.pay.api.service.PublicApiUriGenerator;
 
+import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 import static uk.gov.pay.api.model.links.directdebit.MandateLinks.MandateLinksBuilder.aMandateLinks;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema
 public class MandateResponse {
 
     private final String mandateId;
@@ -45,62 +48,73 @@ public class MandateResponse {
     }
 
     @ApiModelProperty(value = "payer")
+    @Schema(description = "payer")
     @JsonProperty(value = "payer")
     public Payer getPayer() {
         return payer;
     }
 
     @ApiModelProperty(value = "description")
+    @Schema(description = "description", accessMode = READ_ONLY)
     @JsonProperty(value = "description")
     public String getDescription() {
         return description;
     }
 
     @ApiModelProperty(value = "payment_provider")
+    @Schema(description = "payment_provider", accessMode = READ_ONLY)
     @JsonProperty(value = "payment_provider")
     public String getPaymentProvider() {
         return paymentProvider;
     }
     
     @ApiModelProperty(value = "mandate created date")
+    @Schema(description = "mandate created date", accessMode = READ_ONLY)
     @JsonProperty("created_date")
     public String getCreatedDate() {
         return createdDate;
     }
 
     @ApiModelProperty(value = "mandate id", example = "jhjcvaiqlediuhh23d89hd3")
+    @Schema(description = "mandate id", example = "jhjcvaiqlediuhh23d89hd3", accessMode = READ_ONLY)
     @JsonProperty(value = "mandate_id")
     public String getMandateId() {
         return this.mandateId;
     }
 
     @ApiModelProperty(value = "provider id", example = "jhjcvaiqlediuhh23d89hd3")
+    @Schema(description = "provider id", example = "jhjcvaiqlediuhh23d89hd3", accessMode = READ_ONLY)
     @JsonProperty(value = "provider_id")
     public String getProviderId() { return providerId; }
 
     @ApiModelProperty(value = "service return url", example = "https://service-name.gov.uk/transactions/12345")
+    @Schema(description = "service return url", example = "https://service-name.gov.uk/transactions/12345", accessMode = READ_ONLY)
     @JsonProperty("return_url")
     public String getReturnUrl() {
         return returnUrl;
     }
 
     @ApiModelProperty(value = "mandate state", example = "CREATED")
+    @Schema(description = "mandate state")
     @JsonProperty(value = "state")
     public MandateStatus getState() {
         return state;
     }
 
-    @ApiModelProperty(value = "links") 
+    @ApiModelProperty(value = "links")
+    @Schema(name = "_links", description = "payment, events, self and next links of a Mandate")
     @JsonProperty(value = "_links")
     public MandateLinks getLinks() {
         return links;
     }
 
     @ApiModelProperty(value = "service reference", example = "jhjcvaiqlediuhh23d89hd3")
+    @Schema(description = "service reference", example = "jhjcvaiqlediuhh23d89hd3", accessMode = READ_ONLY)
     @JsonProperty(value = "reference")
     public String getReference() { return reference; }
 
     @ApiModelProperty(value = "This value comes from GoCardless when a mandate has been created.")
+    @Schema(description = "This value comes from GoCardless when a mandate has been created.", accessMode = READ_ONLY)
     @JsonProperty(value = "bank_statement_reference")
     public String getMandateReference() {
         return mandateReference;

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateStatus.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateStatus.java
@@ -2,8 +2,10 @@ package uk.gov.pay.api.model.directdebit.mandates;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "mandate state")
 public class MandateStatus {
 
     @JsonProperty("status")

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/Payer.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/Payer.java
@@ -1,13 +1,19 @@
 package uk.gov.pay.api.model.directdebit.mandates;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
+
+@Schema(name = "Payer")
 public class Payer {
-    
+
     @JsonProperty("name")
+    @Schema(accessMode = READ_ONLY)
     private String name;
-    
+
     @JsonProperty("email")
+    @Schema(accessMode = READ_ONLY)
     private String email;
 
     public Payer() {

--- a/src/main/java/uk/gov/pay/api/model/links/PostLink.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PostLink.java
@@ -3,6 +3,7 @@ package uk.gov.pay.api.model.links;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Map;
 import java.util.Objects;
@@ -10,6 +11,7 @@ import java.util.Objects;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 @ApiModel(value = "PostLink", description = "A POST link related to a payment")
+@Schema(name = "PostLink", description = "A POST link related to a payment")
 @JsonInclude(Include.NON_NULL)
 public class PostLink extends Link {
 
@@ -27,16 +29,19 @@ public class PostLink extends Link {
     }
 
     @ApiModelProperty(example = "POST")
+    @Schema(example = "POST")
     public String getMethod() {
         return super.getMethod();
     }
 
     @ApiModelProperty(example = "application/x-www-form-urlencoded")
+    @Schema(example = "application/x-www-form-urlencoded")
     public String getType() {
         return type;
     }
 
     @ApiModelProperty(example = "\"description\":\"This is a value for a parameter called description\"")
+    @Schema(example = "{\"description\": \"This is a value for a parameter called description\"}")
     public Map<String, Object> getParams() {
         return params;
     }

--- a/src/main/java/uk/gov/pay/api/model/links/directdebit/MandateLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/directdebit/MandateLinks.java
@@ -3,6 +3,7 @@ package uk.gov.pay.api.model.links.directdebit;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 import uk.gov.pay.api.model.links.Link;
 import uk.gov.pay.api.model.links.PostLink;
@@ -13,6 +14,7 @@ import java.util.List;
 import static javax.ws.rs.HttpMethod.GET;
 
 @ApiModel(value = "MandateLinks", description = "payment, events, self and next links of a Mandate")
+@Schema(name = "MandateLinks", description = "payment, events, self and next links of a Mandate")
 public class MandateLinks {
 
     private static final String SELF = "self";
@@ -34,15 +36,18 @@ public class MandateLinks {
     private final Link payments;
     
     @ApiModelProperty(hidden = true)
+    @Schema(hidden = true)
     @JsonProperty(EVENTS)
     private final Link events;
 
     @ApiModelProperty(value = SELF, dataType = "uk.gov.pay.api.model.links.Link")
+    @Schema(name = SELF, description = "A link related to mandate")
     public Link getSelf() {
         return self;
     }
 
     @ApiModelProperty(value = NEXT_URL, dataType = "uk.gov.pay.api.model.links.Link")
+    @Schema(name = NEXT_URL, description = "A link related to mandate")
     public Link getNextUrl() {
         return nextUrl;
     }
@@ -53,11 +58,13 @@ public class MandateLinks {
     }
 
     @ApiModelProperty(value = PAYMENTS, dataType = "uk.gov.pay.api.model.links.Link")
+    @Schema(name = PAYMENTS, description = "A link related to payments")
     public Link getPayments() {
         return payments;
     }
 
     @ApiModelProperty(value = EVENTS, dataType = "uk.gov.pay.api.model.links.Link", hidden = true)
+    @Schema(hidden = true)
     public Link getEvents() {
         return events;
     }

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.api.model.search.directdebit;
 
 import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Parameter;
 import uk.gov.pay.commons.validation.ValidDate;
 
 import javax.validation.constraints.Max;
@@ -33,23 +34,27 @@ public class DirectDebitSearchMandatesParams {
     private String name;
 
     @ApiParam(value = "From date of mandates to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z")
+    @Parameter(description = "From date of mandates to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z")
     @QueryParam("from_date")
     @ValidDate()
     private String fromDate;
 
     @QueryParam("to_date")
     @ApiParam(value = "To date of mandates to be searched (this date is exclusive). Example=2015-08-13T12:35:00Z")
+    @Parameter(description = "To date of mandates to be searched (this date is exclusive). Example=2015-08-13T12:35:00Z")
     @ValidDate()
     private String toDate;
 
     @QueryParam("page")
     @ApiParam(value = "Page number requested for the search, should be a positive integer (optional, defaults to 1)")
+    @Parameter(description = "Page number requested for the search, should be a positive integer (optional, defaults to 1)")
     @DefaultValue("1")
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     private int page;
 
     @QueryParam("display_size")
     @ApiParam(value = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)")
+    @Parameter(description = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)")
     @DefaultValue("500")
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     @Max(value = 500, message = "Must be less than or equal to {value}")

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
@@ -1,15 +1,14 @@
 package uk.gov.pay.api.model.search.directdebit;
 
 import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Parameter;
 import uk.gov.pay.commons.validation.ValidDate;
 
-import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import javax.ws.rs.QueryParam;
-
 import java.util.Optional;
 
 import static uk.gov.pay.api.model.CreateDirectDebitPaymentRequest.MANDATE_ID_MAX_LENGTH;
@@ -19,37 +18,44 @@ public class DirectDebitSearchPaymentsParams {
     
     @QueryParam("reference")
     @ApiParam(value = "Your payment reference to search")
+    @Parameter(description = "Your payment reference to search")
     @Size(min = 1, max = REFERENCE_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     private String reference;
     
     @QueryParam("state")
     @ApiParam(value = "State of payments to be searched. Example=success")
+    @Parameter(description = "State of payments to be searched. Example=success")
     @Pattern(regexp = "created|pending|success|failed|cancelled|paidout|indemnityclaim|error",
             message = "Must be one of created, pending, success, failed, cancelled, paidout, indemnityclaim or error")
     private String state;
     
     @QueryParam("mandate_id")
     @ApiParam(value = "The GOV.UK Pay identifier for the mandate")
+    @Parameter(description = "The GOV.UK Pay identifier for the mandate")
     @Size(min = 1, max = MANDATE_ID_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     private String mandateId;
     
     @QueryParam("from_date")
     @ApiParam(value = "From date of Direct Debit payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z")
+    @Parameter(description = "From date of Direct Debit payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z")
     @ValidDate
     private String fromDate;
     
     @QueryParam("to_date")
     @ApiParam(value = "To date of Direct Debit payments to be searched (this date is exclusive). Example=2015-08-13T12:35:00Z")
+    @Parameter(description = "To date of Direct Debit payments to be searched (this date is exclusive). Example=2015-08-13T12:35:00Z")
     @ValidDate
     private String toDate;
     
     @QueryParam("page")
     @ApiParam(value = "Page number requested for the search, should be a positive integer (optional, defaults to 1)")
+    @Parameter(description = "Page number requested for the search, should be a positive integer (optional, defaults to 1)")
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     private Integer page;
     
     @QueryParam("display_size")
     @ApiParam(value = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)")
+    @Parameter(description = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)")
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     @Max(value = 500, message = "Must be less than or equal to {value}")
     private Integer displaySize;

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchResponse.java
@@ -3,23 +3,30 @@ package uk.gov.pay.api.model.search.directdebit;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.directdebit.DirectDebitConnectorPaymentResponse;
 import uk.gov.pay.api.model.links.SearchNavigationLinks;
 import uk.gov.pay.api.model.search.SearchPagination;
 
 import java.util.List;
 
+import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DirectDebitSearchResponse implements SearchPagination {
 
     @JsonProperty("total")
+    @Schema(example = "100", accessMode = READ_ONLY)
     private int total;
     @JsonProperty("count")
+    @Schema(example = "20", accessMode = READ_ONLY)
     private int count;
     @JsonProperty("page")
+    @Schema(example = "1", accessMode = READ_ONLY)
     private int page;
     @JsonProperty("results")
+    @Schema(name = "results", accessMode = READ_ONLY)
     private List<DirectDebitConnectorPaymentResponse> payments;
     @JsonProperty("_links")
     private SearchNavigationLinks links = new SearchNavigationLinks();

--- a/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
@@ -8,14 +8,18 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.CreateDirectDebitPaymentRequest;
 import uk.gov.pay.api.model.PaymentError;
 import uk.gov.pay.api.model.directdebit.mandates.DirectDebitPayment;
-import uk.gov.pay.api.model.directdebit.mandates.MandateError;
-import uk.gov.pay.api.model.directdebit.mandates.MandateResponse;
 import uk.gov.pay.api.model.search.directdebit.DirectDebitSearchPaymentsParams;
 import uk.gov.pay.api.model.search.directdebit.DirectDebitSearchResponse;
 import uk.gov.pay.api.resources.error.ApiErrorResponse;
@@ -41,6 +45,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/v1/directdebit/payments/")
 @Api(tags = "Direct Debit", value = "/v1/directdebit/payments")
+@Tag(name = "Direct Debit")
 @Produces({"application/json"})
 public class DirectDebitPaymentsResource {
 
@@ -66,6 +71,28 @@ public class DirectDebitPaymentsResource {
     @Timed
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
+    @Operation(security = {@SecurityRequirement(name = "BearerAuth")},
+            operationId = "Collect a Direct Debit payment",
+            summary = "Create new Direct Debit payment",
+            description = "Create a new Direct Debit payment for the account associated to the Authorisation token. " +
+                    "The Authorisation token needs to be specified in the 'authorization' header " +
+                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Created",
+                            content = @Content(schema = @Schema(implementation = DirectDebitPayment.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Bad request",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", 
+                            description = "Credentials are required to access this resource"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422", 
+                            description = "Invalid parameters: amount, reference, description, mandate id. See Public API documentation for the correct data formats",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                            content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class)))
+            }
+    )
     @ApiOperation(
             nickname = "Collect a Direct Debit payment",
             value = "Create new Direct Debit payment",
@@ -81,8 +108,9 @@ public class DirectDebitPaymentsResource {
             @ApiResponse(code = 422, message = "Invalid parameters: amount, reference, description, mandate id. See Public API documentation for the correct data formats", response = PaymentError.class),
             @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
-    public Response createPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
-                                  @ApiParam(value = "requestPayload", required = true) @Valid CreateDirectDebitPaymentRequest request) {
+    public Response createPayment(@Parameter(hidden = true) @ApiParam(value = "accountId", hidden = true) @Auth Account account,
+                                  @Parameter(required = true, description = "requestPayload") @ApiParam(value = "requestPayload", required = true) 
+                                  @Valid CreateDirectDebitPaymentRequest request) {
         DirectDebitPayment payment = createDirectDebitPaymentsService.create(account, request);
         return Response.created(publicApiUriGenerator.getDirectDebitPaymentURI(payment.getPaymentId()))
                 .entity(payment).build();
@@ -92,6 +120,26 @@ public class DirectDebitPaymentsResource {
     @GET
     @Timed
     @Produces(APPLICATION_JSON)
+    @Operation(security = {@SecurityRequirement(name = "BearerAuth")},
+            operationId = "Search Direct Debit payments",
+            summary = "Search Direct Debit payments",
+            description = "Search Direct Debit payments by reference, state, mandate id, and 'from' and 'to' dates. " +
+                    "The Authorisation token needs to be specified in the 'Authorization' header " +
+                    "as 'Authorization: Bearer YOUR_API_KEY_HERE'",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+                            content = @Content(schema = @Schema(implementation = DirectDebitSearchResponse.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                            description = "Credentials are required to access this resource"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422",
+                            description = "Invalid parameter. See Public API documentation for the correct data formats",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                            content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class)))
+            }
+    )
     @ApiOperation(
             nickname = "Search Direct Debit payments",
             value = "Search Direct Debit payments",
@@ -107,10 +155,10 @@ public class DirectDebitPaymentsResource {
             @ApiResponse(code = 422, message = "Invalid parameter. See Public API documentation for the correct data formats", response = PaymentError.class),
             @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
-    public Response searchPayments(@ApiParam(value = "accountId", hidden = true)
+    public Response searchPayments(@Parameter(hidden = true) @ApiParam(value = "accountId", hidden = true)
                                    @Auth Account account,
                                    @Valid @BeanParam DirectDebitSearchPaymentsParams searchPaymentsParams,
-                                   @Context UriInfo uriInfo) {
+                                   @Parameter(hidden = true) @Context UriInfo uriInfo) {
 
         LOGGER.info("Payments search request - {}", searchPaymentsParams);
         return directDebitPaymentSearchService.doSearch(account, searchPaymentsParams);
@@ -120,6 +168,25 @@ public class DirectDebitPaymentsResource {
     @Timed
     @Path("{paymentId}")
     @Produces(APPLICATION_JSON)
+    @Operation(security = {@SecurityRequirement(name = "BearerAuth")},
+            operationId = "Get a Direct Debit payment",
+            summary = "Find Direct Debit payment by ID",
+            description = "Return information about the Direct Debit payment. " +
+                    "The Authorisation token needs to be specified in the 'Authorization' header " +
+                    "as 'Authorization: Bearer YOUR_API_KEY_HERE'",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+                            content = @Content(schema = @Schema(implementation = DirectDebitPayment.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                            description = "Credentials are required to access this resource"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                            content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class)))
+            }
+    )
     @ApiOperation(
             nickname = "Get a Direct Debit payment",
             value = "Find Direct Debit payment by ID",
@@ -134,8 +201,9 @@ public class DirectDebitPaymentsResource {
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
             @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
-    public Response getPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
-                               @PathParam("paymentId") @ApiParam(value = "Payment identifier") String paymentId) {
+    public Response getPayment(@Parameter(hidden = true) @ApiParam(value = "accountId", hidden = true) @Auth Account account,
+                               @PathParam("paymentId") @Parameter(required = true, description = "Payment identifier") 
+                               @ApiParam(value = "Payment identifier") String paymentId) {
 
         LOGGER.info("Direct Debit Payment request - paymentId={}", paymentId);
         DirectDebitPayment payment = getDirectDebitPaymentService.getDirectDebitPayment(account, paymentId);


### PR DESCRIPTION
## WHAT YOU DID
Follows on from https://github.com/alphagov/pay-publicapi/pull/722 and now includes definitions for DirectDebit endpoints (for openapi v3.0.0)

## HOW TO TEST
- `mvn compile` should now generate swagger (with openapi v3.0.0) with correct definitions for direct debit endpoints including examples