### PR TITLE
Improve comments used for generating OpenAPI/Swagger file

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/Address.java
+++ b/src/main/java/uk/gov/pay/api/model/Address.java
@@ -14,7 +14,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(NON_NULL)
-@ApiModel(value = "Address", description = "A structure representing the billing address of a card")
+@ApiModel(value = "Address", description = "The billing address for a payment card.")
 public class Address {
 
     @Size(max = 255, message = "Must be less than or equal to {max} characters length")

--- a/src/main/java/uk/gov/pay/api/model/Address.java
+++ b/src/main/java/uk/gov/pay/api/model/Address.java
@@ -14,7 +14,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(NON_NULL)
-@ApiModel(value = "Address", description = "The billing address for a payment card.")
+@ApiModel(value = "Address", description = "Information about the billing address of a payment card.")
 public class Address {
 
     @Size(max = 255, message = "Must be less than or equal to {max} characters length")

--- a/src/main/java/uk/gov/pay/api/model/CardDetails.java
+++ b/src/main/java/uk/gov/pay/api/model/CardDetails.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.ALWAYS;
 
 @JsonInclude(ALWAYS)
-@ApiModel(value = "CardDetails", description = "A structure representing the payment card")
+@ApiModel(value = "CardDetails", description = "Information about a payment card.")
 public class CardDetails {
 
     @JsonProperty("last_digits_card_number")
@@ -30,7 +30,7 @@ public class CardDetails {
 
     @JsonProperty("card_brand")
     private final String cardBrand;
-    
+
     @JsonProperty("card_type")
     private final String cardType;
 
@@ -65,7 +65,7 @@ public class CardDetails {
         return cardHolderName;
     }
 
-    @ApiModelProperty(value = "The expiry date of the card in MM/yy format", example = "04/24")
+    @ApiModelProperty(value = "The expiry date of the card in the format MM/YY.", example = "04/24")
     public String getExpiryDate() {
         return expiryDate;
     }
@@ -79,7 +79,7 @@ public class CardDetails {
         return cardBrand;
     }
 
-    @ApiModelProperty(value = "The card type, `debit` or `credit` or `null` if not able to determine", allowableValues = "debit,credit,null", example = "debit")
+    @ApiModelProperty(value = "Whether the card is `debit` or `credit`. This is `null` if we did not recognise which type of card your user made the payment with.", allowableValues = "debit,credit,null", example = "debit")
     public String getCardType() {
         return cardType;
     }

--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -128,7 +128,7 @@ public class CardPayment extends Payment {
         return language;
     }
 
-    @ApiModelProperty(value = "Whether to [delay capture](https://docs.payments.service.gov.uk/optional_features/delayed_capture/) of this payment.", example = "false")
+    @ApiModelProperty(value = "Whether to [delay capturing](https://docs.payments.service.gov.uk/optional_features/delayed_capture/) this payment.", example = "false")
     public boolean getDelayedCapture() {
         return delayedCapture;
     }

--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -58,7 +58,7 @@ public class CardPayment extends Payment {
 
     @JsonProperty("return_url")
     protected String returnUrl;
-    
+
     protected String email;
 
     protected PaymentState state;
@@ -97,7 +97,7 @@ public class CardPayment extends Payment {
      *
      * @return
      */
-    @ApiModelProperty(value = "Card Brand", example = "Visa", notes = "Deprecated. Please use card_details.card_brand instead")
+    @ApiModelProperty(value = "The brand of the payment card, for example `master-card`.", example = "Visa", notes = "Deprecated. Please use card_details.card_brand instead")
     @JsonProperty("card_brand")
     @Deprecated
     public String getCardBrand() {
@@ -128,7 +128,7 @@ public class CardPayment extends Payment {
         return language;
     }
 
-    @ApiModelProperty(value = "delayed capture flag", example = "false")
+    @ApiModelProperty(value = "Whether to [delay capture](https://docs.payments.service.gov.uk/optional_features/delayed_capture/) of this payment.", example = "false")
     public boolean getDelayedCapture() {
         return delayedCapture;
     }
@@ -138,12 +138,12 @@ public class CardPayment extends Payment {
         return Optional.ofNullable(corporateCardSurcharge);
     }
 
-    @ApiModelProperty(example = "5", value = "processing fee taken by the GOV.UK Pay platform, in pence. Only available depending on payment service provider")
+    @ApiModelProperty(example = "5", value = "The Payment Service Provider (PSP) transaction fee that we took from the amount your user paid, in pence. This is only included in the API response if you use GOV.UK’s PSP.")
     public Optional<Long> getFee() {
         return Optional.ofNullable(fee);
     }
 
-    @ApiModelProperty(example = "1195", value = "amount including all surcharges and less all fees, in pence. Only available depending on payment service provider")
+    @ApiModelProperty(example = "1195", value = "The amount that will be paid into your account, in pence. This is only included in the API response if you use GOV.UK’s PSP.")
     public Optional<Long> getNetAmount() {
         return Optional.ofNullable(netAmount);
     }

--- a/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
@@ -66,7 +66,7 @@ public class CreateCardPaymentRequest {
     @JsonProperty("email")
     @Length(max = EMAIL_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     private String email;
-    
+
     @ValidReturnUrl
     @Size(max = URL_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     @JsonProperty("return_url")
@@ -79,7 +79,7 @@ public class CreateCardPaymentRequest {
 
     @Valid
     private final PrefilledCardholderDetails prefilledCardholderDetails;
-    
+
     public CreateCardPaymentRequest(CreateCardPaymentRequestBuilder builder) {
         this.amount = builder.getAmount();
         this.reference = builder.getReference();
@@ -92,55 +92,52 @@ public class CreateCardPaymentRequest {
         this.prefilledCardholderDetails = builder.getPrefilledCardholderDetails();
     }
 
-    @ApiModelProperty(value = "amount in pence", required = true, allowableValues = "range[1, 10000000]", example = "12000")
+    @ApiModelProperty(value = "The amount in pence.", required = true, allowableValues = "range[1, 10000000]", example = "12000")
     public int getAmount() {
         return amount;
     }
 
-    @ApiModelProperty(value = "payment reference", required = true, example = "12345")
+    @ApiModelProperty(value = "The reference number you want to associate with this payment.", required = true, example = "12345")
     public String getReference() {
         return reference;
     }
 
-    @ApiModelProperty(value = "payment description", required = true, example = "New passport application")
+    @ApiModelProperty(value = "A human-readable description of the payment.", required = true, example = "New passport application")
     public String getDescription() {
         return description;
     }
 
-    @ApiModelProperty(value = "ISO-639-1 Alpha-2 code of a supported language to use on the payment pages", required = false, example = "en", allowableValues = "en,cy")
+    @ApiModelProperty(value = "Which language your users will see on the payment pages when they make a payment.", required = false, example = "en", allowableValues = "en,cy")
     @JsonProperty(LANGUAGE_FIELD_NAME)
     public Optional<SupportedLanguage> getLanguage() {
         return Optional.ofNullable(language);
     }
 
-    @ApiModelProperty(value = "email", required = false, example = "Joe.Bogs@example.org")
+    @ApiModelProperty(value = "The email address of your user.", required = false, example = "Joe.Bogs@example.org")
     @JsonProperty(EMAIL_FIELD_NAME)
     public Optional<String> getEmail() {
         return Optional.ofNullable(email);
     }
-    
-    @ApiModelProperty(value = "service return url", required = true, example = "https://service-name.gov.uk/transactions/12345")
+
+    @ApiModelProperty(value = "An HTTPS URL on your site that your user will be sent back to once they have completed their payment attempt on GOV.UK Pay.", required = true, example = "https://service-name.gov.uk/transactions/12345")
     public String getReturnUrl() {
         return returnUrl;
     }
 
-    @ApiModelProperty(value = "prefilled_cardholder_details", required = false)
+    @ApiModelProperty(value = "End user details that you've collected in your service, which the API will use to [prefill fields]( https://docs.payments.service.gov.uk/optional_features/prefill_user_details/) on the payment pages.", required = false)
     @JsonProperty(CreateCardPaymentRequest.PREFILLED_CARDHOLDER_DETAILS_FIELD_NAME)
     public Optional<PrefilledCardholderDetails> getPrefilledCardholderDetails() {
         return Optional.ofNullable(prefilledCardholderDetails);
     }
 
-    @ApiModelProperty(value = "delayed capture flag", required = false, example = "false")
+    @ApiModelProperty(value = "Whether to [delay capture](https://docs.payments.service.gov.uk/optional_features/delayed_capture/) of this payment.", required = false, example = "false")
     @JsonProperty(DELAYED_CAPTURE_FIELD_NAME)
     public Optional<Boolean> getDelayedCapture() {
         return Optional.ofNullable(delayedCapture);
     }
 
     @JsonProperty("metadata")
-    @ApiModelProperty(value = "Additional metadata - up to 10 name/value pairs - on the payment. " +
-            "Each key must be between 1 and 30 characters long. " +
-            "The value, if a string, must be no greater than 50 characters long. " +
-            "Other permissible value types: boolean, number.",
+    @ApiModelProperty(value = "Custom metadata to add to the payment.",
             dataType = "java.util.Map", example = "{\"ledger_code\":\"123\", \"reconciled\": true}")
     public Optional<ExternalMetadata> getMetadata() {
         return Optional.ofNullable(metadata);
@@ -156,7 +153,7 @@ public class CreateCardPaymentRequest {
         getDelayedCapture().ifPresent(delayedCapture -> request.add("delayed_capture", delayedCapture));
         getMetadata().ifPresent(metadata -> request.add("metadata", metadata.getMetadata()));
         getEmail().ifPresent(email -> request.add("email", email));
-        
+
         getPrefilledCardholderDetails().ifPresent(prefilledDetails -> {
             prefilledDetails.getCardholderName().ifPresent(name -> request.addToMap(PREFILLED_CARDHOLDER_DETAILS, "cardholder_name", name));
             prefilledDetails.getBillingAddress().ifPresent(address -> {
@@ -167,7 +164,7 @@ public class CreateCardPaymentRequest {
                 request.addToNestedMap("country", address.getCountry(), PREFILLED_CARDHOLDER_DETAILS, BILLING_ADDRESS);
             });
         });
-        
+
         return request.build();
     }
 

--- a/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
@@ -130,7 +130,7 @@ public class CreateCardPaymentRequest {
         return Optional.ofNullable(prefilledCardholderDetails);
     }
 
-    @ApiModelProperty(value = "Whether to [delay capture](https://docs.payments.service.gov.uk/optional_features/delayed_capture/) of this payment.", required = false, example = "false")
+    @ApiModelProperty(value = "Whether to [delay capturing](https://docs.payments.service.gov.uk/optional_features/delayed_capture/) this payment.", required = false, example = "false")
     @JsonProperty(DELAYED_CAPTURE_FIELD_NAME)
     public Optional<Boolean> getDelayedCapture() {
         return Optional.ofNullable(delayedCapture);

--- a/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
@@ -137,7 +137,7 @@ public class CreateCardPaymentRequest {
     }
 
     @JsonProperty("metadata")
-    @ApiModelProperty(value = "Custom metadata to add to the payment.",
+    @ApiModelProperty(value = "[Custom metadata](https://docs.payments.service.gov.uk/optional_features/custom_metadata/) to add to the payment.",
             dataType = "java.util.Map", example = "{\"ledger_code\":\"123\", \"reconciled\": true}")
     public Optional<ExternalMetadata> getMetadata() {
         return Optional.ofNullable(metadata);

--- a/src/main/java/uk/gov/pay/api/model/CreateDirectDebitPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateDirectDebitPaymentRequest.java
@@ -59,7 +59,7 @@ public class CreateDirectDebitPaymentRequest {
         return description;
     }
 
-    @ApiModelProperty(value = "The ID of the mandate you want to collect the payment against.", required = false, example = "33890b55-b9ea-4e2f-90fd-77ae0e9009e2")
+    @ApiModelProperty(value = "The identifier of the mandate you want to collect the payment against.", required = false, example = "33890b55-b9ea-4e2f-90fd-77ae0e9009e2")
     public String getMandateId() {
         return mandateId;
     }

--- a/src/main/java/uk/gov/pay/api/model/CreateDirectDebitPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateDirectDebitPaymentRequest.java
@@ -11,7 +11,7 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
 import java.util.StringJoiner;
 
-@ApiModel(description = "The Direct Debit Payment Request Payload")
+@ApiModel(description = "The structure of your request to the API when you collect a payment against a Direct Debit mandate.")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CreateDirectDebitPaymentRequest {
 
@@ -39,27 +39,27 @@ public class CreateDirectDebitPaymentRequest {
     @Size(max = MANDATE_ID_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     @NotBlank
     private String mandateId;
-    
+
     public CreateDirectDebitPaymentRequest() {
         //To enable Jackson serialisation we need a default constructor
     }
-    
-    @ApiModelProperty(value = "amount in pence", required = true, allowableValues = "range[1, 10000000]", example = "12000")
+
+    @ApiModelProperty(value = "The amount in pence.", required = true, allowableValues = "range[1, 10000000]", example = "12000")
     public int getAmount() {
         return amount;
     }
 
-    @ApiModelProperty(value = "payment reference", required = true, example = "12345")
+    @ApiModelProperty(value = "The reference number you want to associate with this payment.", required = true, example = "12345")
     public String getReference() {
         return reference;
     }
 
-    @ApiModelProperty(value = "payment description", required = true, example = "New passport application")
+    @ApiModelProperty(value = "A human-readable description of the payment.", required = true, example = "New passport application")
     public String getDescription() {
         return description;
     }
 
-    @ApiModelProperty(value = "ID of the mandates being used to collect the payment", required = false, example = "33890b55-b9ea-4e2f-90fd-77ae0e9009e2")
+    @ApiModelProperty(value = "The ID of the mandate you want to collect the payment against.", required = false, example = "33890b55-b9ea-4e2f-90fd-77ae0e9009e2")
     public String getMandateId() {
         return mandateId;
     }

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRefundRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRefundRequest.java
@@ -6,7 +6,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 import java.util.Optional;
 
-@ApiModel(value = "PaymentRefundRequest", description = "The Payment Refund Request Payload")
+@ApiModel(value = "PaymentRefundRequest", description = "The structure of your request to the API when you create a refund.")
 public class CreatePaymentRefundRequest {
 
     public static final String REFUND_AMOUNT_AVAILABLE = "refund_amount_available";
@@ -24,7 +24,7 @@ public class CreatePaymentRefundRequest {
         this.refundAmountAvailable = refundAmountAvailable;
     }
 
-    @ApiModelProperty(value = "Amount in pence. Can't be more than the available amount for refunds", required = true, allowableValues = "range[1, 10000000]", example = "150000")
+    @ApiModelProperty(value = "How much to refund in pence.", required = true, allowableValues = "range[1, 10000000]", example = "150000")
     public int getAmount() {
         return amount;
     }
@@ -34,7 +34,7 @@ public class CreatePaymentRefundRequest {
      *
      * @return
      */
-    @ApiModelProperty(value = "Amount in pence. Total amount still available before issuing the refund", required = false, allowableValues = "range[1, 10000000]", example = "200000")
+    @ApiModelProperty(value = "The `amount_available` you received when you got information about the payment.", required = false, allowableValues = "range[1, 10000000]", example = "200000")
     public Optional<Integer> getRefundAmountAvailable() {
         return Optional.ofNullable(refundAmountAvailable);
     }

--- a/src/main/java/uk/gov/pay/api/model/PaymentState.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentState.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@ApiModel(value = "PaymentState", description = "The status of a payment.")
+@ApiModel(value = "PaymentState", description = "Information about the status of a payment.")
 public class PaymentState {
     @JsonProperty("status")
     private String status;
@@ -49,22 +49,22 @@ public class PaymentState {
         this.code = code;
     }
 
-    @ApiModelProperty(value = "The current stage of the user's payment journey.", example = "created")
+    @ApiModelProperty(value = "The current stage of your user's payment journey.", example = "created")
     public String getStatus() {
         return status;
     }
 
-    @ApiModelProperty(value = "Whether the user's payment journey is complete.")
+    @ApiModelProperty(value = "Whether your user's payment journey is complete.")
     public boolean isFinished() {
         return finished;
     }
 
-    @ApiModelProperty(value = "What went wrong if the payment did not complete successfully.", example = "User cancelled the payment")
+    @ApiModelProperty(value = "What went wrong if your user did not successfully complete their payment.", example = "User cancelled the payment")
     public String getMessage() {
         return message;
     }
 
-    @ApiModelProperty(value = "Which error code was generated if the payment did not complete successfully.", example = "P010")
+    @ApiModelProperty(value = "Which error code was generated if your user did not successfully complete their payment.", example = "P010")
     public String getCode() {
         return code;
     }

--- a/src/main/java/uk/gov/pay/api/model/PaymentState.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentState.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@ApiModel(value = "PaymentState", description = "A structure representing the current state of the payment in its lifecycle.")
+@ApiModel(value = "PaymentState", description = "The status of a payment.")
 public class PaymentState {
     @JsonProperty("status")
     private String status;
@@ -24,7 +24,7 @@ public class PaymentState {
 
     @JsonProperty("code")
     private String code;
-    
+
 
     public static PaymentState createPaymentState(JsonNode node) {
         return new PaymentState(
@@ -49,26 +49,26 @@ public class PaymentState {
         this.code = code;
     }
 
-    @ApiModelProperty(value = "Current progress of the payment in its lifecycle", example = "created")
+    @ApiModelProperty(value = "The current stage of the user's payment journey.", example = "created")
     public String getStatus() {
         return status;
     }
 
-    @ApiModelProperty(value = "Whether the payment has finished")
+    @ApiModelProperty(value = "Whether the user's payment journey is complete.")
     public boolean isFinished() {
         return finished;
     }
 
-    @ApiModelProperty(value = "What went wrong with the Payment if it finished with an error - English message", example = "User cancelled the payment")
+    @ApiModelProperty(value = "What went wrong if the payment did not complete successfully.", example = "User cancelled the payment")
     public String getMessage() {
         return message;
     }
 
-    @ApiModelProperty(value = "What went wrong with the Payment if it finished with an error - error code", example = "P010")
+    @ApiModelProperty(value = "Which error code was generated if the payment did not complete successfully.", example = "P010")
     public String getCode() {
         return code;
     }
-    
+
     @Override
     public String toString() {
         return "PaymentState{" +

--- a/src/main/java/uk/gov/pay/api/model/PrefilledCardholderDetails.java
+++ b/src/main/java/uk/gov/pay/api/model/PrefilledCardholderDetails.java
@@ -13,11 +13,11 @@ import java.util.Optional;
 public class PrefilledCardholderDetails {
 
     @JsonProperty("cardholder_name")
-    @ApiModelProperty(name = "cardholder_name", value = "The name to prefill the **Cardholder name** field with on the payment pages.", required = false, example = "J. Bogs")
+    @ApiModelProperty(name = "cardholder_name", value = "The name to prefill in the **Cardholder name** field on the payment pages.", required = false, example = "J. Bogs")
     @Size(max = 255, message = "Must be less than or equal to {max} characters length")
     private String cardholderName;
 
-    @ApiModelProperty(name = "billing_address", value = "The address to prefill the **Billing address** field with on the payment pages.", required = false)
+    @ApiModelProperty(name = "billing_address", value = "The address to prefill in the **Billing address** field on the payment pages.", required = false)
     @JsonProperty("billing_address")
     @Valid
     private Address billingAddress;

--- a/src/main/java/uk/gov/pay/api/model/PrefilledCardholderDetails.java
+++ b/src/main/java/uk/gov/pay/api/model/PrefilledCardholderDetails.java
@@ -13,11 +13,11 @@ import java.util.Optional;
 public class PrefilledCardholderDetails {
 
     @JsonProperty("cardholder_name")
-    @ApiModelProperty(name = "cardholder_name", value = "prefilled cardholder name", required = false, example = "J. Bogs")
+    @ApiModelProperty(name = "cardholder_name", value = "The name to prefill the **Cardholder name** field with on the payment pages.", required = false, example = "J. Bogs")
     @Size(max = 255, message = "Must be less than or equal to {max} characters length")
     private String cardholderName;
 
-    @ApiModelProperty(name = "billing_address", value = "prefilled billing address", required = false)
+    @ApiModelProperty(name = "billing_address", value = "The address to prefill the **Billing address** field with on the payment pages.", required = false)
     @JsonProperty("billing_address")
     @Valid
     private Address billingAddress;
@@ -25,7 +25,7 @@ public class PrefilledCardholderDetails {
     public Optional<Address> getBillingAddress() {
         return Optional.ofNullable(billingAddress);
     }
-    
+
     public Optional<String> getCardholderName() {
         return Optional.ofNullable(cardholderName);
     }
@@ -33,7 +33,7 @@ public class PrefilledCardholderDetails {
     public void setCardholderName(String cardholderName) {
         this.cardholderName = cardholderName;
     }
-    
+
     public void setAddress(String addressLine1, String addressLine2, String postcode, String city, String country) {
         this.billingAddress = new Address(addressLine1, addressLine2, postcode, city, country);
     }

--- a/src/main/java/uk/gov/pay/api/model/RefundSummary.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundSummary.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
-@ApiModel(value="RefundSummary", description = "A structure representing the refunds availability")
+@ApiModel(value="RefundSummary", description = "Information about a refund.")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RefundSummary {
 
@@ -25,17 +25,17 @@ public class RefundSummary {
         this.amountSubmitted = amountSubmitted;
     }
 
-    @ApiModelProperty(value = "Availability status of the refund", example = "available")
+    @ApiModelProperty(value = "The status of the refund.", example = "available")
     public String getStatus() {
         return status;
     }
 
-    @ApiModelProperty(value = "Amount available for refund in pence", example = "100")
+    @ApiModelProperty(value = "How much you can refund in pence.", example = "100")
     public long getAmountAvailable() {
         return amountAvailable;
     }
 
-    @ApiModelProperty(value = "Amount submitted for refunds on this Payment in pence")
+    @ApiModelProperty(value = "How much you've already refunded.")
     public long getAmountSubmitted() {
         return amountSubmitted;
     }

--- a/src/main/java/uk/gov/pay/api/model/SettlementSummary.java
+++ b/src/main/java/uk/gov/pay/api/model/SettlementSummary.java
@@ -6,7 +6,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
-@ApiModel(value="SettlementSummary", description = "Information about when your PSP took a payment.")
+@ApiModel(value="SettlementSummary", description = "Information about when your Payment Service Provider (PSP) took a payment.")
 public class SettlementSummary {
 
     @JsonProperty("capture_submit_time")
@@ -27,7 +27,7 @@ public class SettlementSummary {
         return captureSubmitTime;
     }
 
-    @ApiModelProperty(value = "When the PSP took the payment from your user's bank account.", example = "2016-01-21")
+    @ApiModelProperty(value = "When your PSP took the payment from your user's bank account.", example = "2016-01-21")
     public String getCapturedDate() {
         return capturedDate;
     }

--- a/src/main/java/uk/gov/pay/api/model/SettlementSummary.java
+++ b/src/main/java/uk/gov/pay/api/model/SettlementSummary.java
@@ -6,7 +6,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
-@ApiModel(value="SettlementSummary", description = "A structure representing information about a settlement")
+@ApiModel(value="SettlementSummary", description = "Information about when your PSP took a payment.")
 public class SettlementSummary {
 
     @JsonProperty("capture_submit_time")
@@ -22,12 +22,12 @@ public class SettlementSummary {
         this.capturedDate = capturedDate;
     }
 
-    @ApiModelProperty(value = "Date and time capture request has been submitted (may be null if capture request was not immediately acknowledged by payment gateway)", example = "2016-01-21T17:15:000Z")
+    @ApiModelProperty(value = "When we sent a request to your PSP to take the payment from your user's bank account.", example = "2016-01-21T17:15:000Z")
     public String getCaptureSubmitTime() {
         return captureSubmitTime;
     }
 
-    @ApiModelProperty(value = "Date of the capture event", example = "2016-01-21")
+    @ApiModelProperty(value = "When the PSP took the payment from your user's bank account.", example = "2016-01-21")
     public String getCapturedDate() {
         return capturedDate;
     }

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/CreateMandateRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/CreateMandateRequest.java
@@ -13,22 +13,22 @@ import javax.validation.constraints.Size;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@ApiModel(description = "The Payload to create a new Mandate")
+@ApiModel(description = "The structure of your request to the API when you create a Direct Debit mandate.")
 public class CreateMandateRequest {
 
     @NotNull
     @ValidReturnUrl
     @Size(max = 2000, message = "Must be less than or equal to {max} characters length")
-    @JsonProperty(value = "return_url")
+    @JsonProperty(value = "An HTTPS URL on your site that your user will be sent back to once they have confirmed the mandate on GOV.UK Pay.")
     private String returnUrl;
 
     @NotNull
     @NotBlank
     @Size(max = 255, message = "Must be less than or equal to {max} characters length")
-    @JsonProperty(value = "reference")
+    @JsonProperty(value = "The reference number you want to associate with this mandate.")
     private String reference;
-    
-    @JsonProperty(value = "description")
+
+    @JsonProperty(value = "A human-readable description of the mandate.")
     @Size(min = 1, max = 255, message = "Must have a size between {min} and {max}")
     private String description;
 

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/CreateMandateRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/CreateMandateRequest.java
@@ -13,7 +13,7 @@ import javax.validation.constraints.Size;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@ApiModel(description = "The structure of your request to the API when you create a Direct Debit mandate.")
+@ApiModel(description = "The structure of your request to the API when you set up a Direct Debit mandate.")
 public class CreateMandateRequest {
 
     @NotNull

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/CreateMandateRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/CreateMandateRequest.java
@@ -25,7 +25,7 @@ public class CreateMandateRequest {
     @NotNull
     @NotBlank
     @Size(max = 255, message = "Must be less than or equal to {max} characters length")
-    @JsonProperty(value = "The reference number you want to associate with this mandate.")
+    @JsonProperty(value = "The reference number you want to associate with the mandate.")
     private String reference;
 
     @JsonProperty(value = "A human-readable description of the mandate.")

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateResponse.java
@@ -30,7 +30,7 @@ public class MandateResponse {
                 .withNextUrl(mandate.getLinks())
                 .withNextUrlPost(mandate.getLinks())
                 .build();
-        
+
         this.mandateId = mandate.getMandateId();
         this.providerId = mandate.getProviderId();
         this.reference = mandate.getServiceReference();
@@ -44,63 +44,63 @@ public class MandateResponse {
         this.payer = mandate.getPayer();
     }
 
-    @ApiModelProperty(value = "payer")
+    @ApiModelProperty(value = "Your user's name and email address.")
     @JsonProperty(value = "payer")
     public Payer getPayer() {
         return payer;
     }
 
-    @ApiModelProperty(value = "description")
+    @ApiModelProperty(value = "The human-readable description of the mandate.")
     @JsonProperty(value = "description")
     public String getDescription() {
         return description;
     }
 
-    @ApiModelProperty(value = "payment_provider")
+    @ApiModelProperty(value = "This is `GoCardless`.")
     @JsonProperty(value = "payment_provider")
     public String getPaymentProvider() {
         return paymentProvider;
     }
-    
-    @ApiModelProperty(value = "mandate created date")
+
+    @ApiModelProperty(value = "The date you requested the mandate.")
     @JsonProperty("created_date")
     public String getCreatedDate() {
         return createdDate;
     }
 
-    @ApiModelProperty(value = "mandate id", example = "jhjcvaiqlediuhh23d89hd3")
+    @ApiModelProperty(value = "The reference number of the mandate.", example = "jhjcvaiqlediuhh23d89hd3")
     @JsonProperty(value = "mandate_id")
     public String getMandateId() {
         return this.mandateId;
     }
 
-    @ApiModelProperty(value = "provider id", example = "jhjcvaiqlediuhh23d89hd3")
+    @ApiModelProperty(value = "The reference number GoCardless associated with the mandate.", example = "jhjcvaiqlediuhh23d89hd3")
     @JsonProperty(value = "provider_id")
     public String getProviderId() { return providerId; }
 
-    @ApiModelProperty(value = "service return url", example = "https://service-name.gov.uk/transactions/12345")
+    @ApiModelProperty(value = "An HTTPS URL on your site that your user will be sent back to once they have confirmed the mandate on GOV.UK Pay.", example = "https://service-name.gov.uk/transactions/12345")
     @JsonProperty("return_url")
     public String getReturnUrl() {
         return returnUrl;
     }
 
-    @ApiModelProperty(value = "mandate state", example = "CREATED")
+    @ApiModelProperty(value = "The `status` of the mandate, and the reason for the status.", example = "CREATED")
     @JsonProperty(value = "state")
     public MandateStatus getState() {
         return state;
     }
 
-    @ApiModelProperty(value = "links") 
+    @ApiModelProperty(value = "API endpoints related to this mandate.")
     @JsonProperty(value = "_links")
     public MandateLinks getLinks() {
         return links;
     }
 
-    @ApiModelProperty(value = "service reference", example = "jhjcvaiqlediuhh23d89hd3")
+    @ApiModelProperty(value = "The reference number you associated with this mandate.", example = "jhjcvaiqlediuhh23d89hd3")
     @JsonProperty(value = "reference")
     public String getReference() { return reference; }
 
-    @ApiModelProperty(value = "This value comes from GoCardless when a mandate has been created.")
+    @ApiModelProperty(value = "The description that may appear on your user's bank statement. Your user may not see the full description.")
     @JsonProperty(value = "bank_statement_reference")
     public String getMandateReference() {
         return mandateReference;

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateResponse.java
@@ -50,7 +50,7 @@ public class MandateResponse {
         return payer;
     }
 
-    @ApiModelProperty(value = "The human-readable description of the mandate.")
+    @ApiModelProperty(value = "The human-readable description you gave the mandate.")
     @JsonProperty(value = "description")
     public String getDescription() {
         return description;
@@ -90,13 +90,13 @@ public class MandateResponse {
         return state;
     }
 
-    @ApiModelProperty(value = "API endpoints related to this mandate.")
+    @ApiModelProperty(value = "API endpoints related to the mandate.")
     @JsonProperty(value = "_links")
     public MandateLinks getLinks() {
         return links;
     }
 
-    @ApiModelProperty(value = "The reference number you associated with this mandate.", example = "jhjcvaiqlediuhh23d89hd3")
+    @ApiModelProperty(value = "The reference number you associated with the mandate.", example = "jhjcvaiqlediuhh23d89hd3")
     @JsonProperty(value = "reference")
     public String getReference() { return reference; }
 

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateResponse.java
@@ -68,7 +68,7 @@ public class MandateResponse {
         return createdDate;
     }
 
-    @ApiModelProperty(value = "The reference number of the mandate.", example = "jhjcvaiqlediuhh23d89hd3")
+    @ApiModelProperty(value = "The unique identifier of the mandate.", example = "jhjcvaiqlediuhh23d89hd3")
     @JsonProperty(value = "mandate_id")
     public String getMandateId() {
         return this.mandateId;

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
@@ -32,24 +32,24 @@ public class DirectDebitSearchMandatesParams {
     @QueryParam("name")
     private String name;
 
-    @ApiParam(value = "The start date for mandates to be searched, inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.")
+    @ApiParam(value = "The start date for mandates to be searched - inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.")
     @QueryParam("from_date")
     @ValidDate()
     private String fromDate;
 
     @QueryParam("to_date")
-    @ApiParam(value = "The end date for mandates to be searched, inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.")
+    @ApiParam(value = "The end date for mandates to be searched - exclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.")
     @ValidDate()
     private String toDate;
 
     @QueryParam("page")
-    @ApiParam(value = "Which page number of results to return. The default is 1.")
+    @ApiParam(value = "Which page number of results to return.")
     @DefaultValue("1")
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     private int page;
 
     @QueryParam("display_size")
-    @ApiParam(value = "The number of results per page. This must be between 1 and 500. The default is 500.")
+    @ApiParam(value = "The number of results per page.")
     @DefaultValue("500")
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     @Max(value = 500, message = "Must be less than or equal to {value}")

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
@@ -43,7 +43,7 @@ public class DirectDebitSearchMandatesParams {
     private String toDate;
 
     @QueryParam("page")
-    @ApiParam(value = "Which page number of results to return.")
+    @ApiParam(value = "The page number of results to return.")
     @DefaultValue("1")
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     private int page;

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
@@ -32,24 +32,24 @@ public class DirectDebitSearchMandatesParams {
     @QueryParam("name")
     private String name;
 
-    @ApiParam(value = "From date of mandates to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z")
+    @ApiParam(value = "The start date for mandates to be searched, inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.")
     @QueryParam("from_date")
     @ValidDate()
     private String fromDate;
 
     @QueryParam("to_date")
-    @ApiParam(value = "To date of mandates to be searched (this date is exclusive). Example=2015-08-13T12:35:00Z")
+    @ApiParam(value = "The end date for mandates to be searched, inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.")
     @ValidDate()
     private String toDate;
 
     @QueryParam("page")
-    @ApiParam(value = "Page number requested for the search, should be a positive integer (optional, defaults to 1)")
+    @ApiParam(value = "Which page number of results to return. The default is 1.")
     @DefaultValue("1")
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     private int page;
 
     @QueryParam("display_size")
-    @ApiParam(value = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)")
+    @ApiParam(value = "The number of results per page. This must be between 1 and 500. The default is 500.")
     @DefaultValue("500")
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     @Max(value = 500, message = "Must be less than or equal to {value}")

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
@@ -18,38 +18,38 @@ import static uk.gov.pay.api.model.CreateDirectDebitPaymentRequest.REFERENCE_MAX
 public class DirectDebitSearchPaymentsParams {
 
     @QueryParam("reference")
-    @ApiParam(value = "The payment reference to search for (case insensitive).")
+    @ApiParam(value = "The payment reference to search for - case insensitive.")
     @Size(min = 1, max = REFERENCE_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     private String reference;
 
     @QueryParam("state")
-    @ApiParam(value = "The payment state to search for (case sensitive).")
+    @ApiParam(value = "The payment state to search for - case sensitive.")
     @Pattern(regexp = "created|pending|success|failed|cancelled|paidout|indemnityclaim|error",
             message = "Must be one of created, pending, success, failed, cancelled, paidout, indemnityclaim or error")
     private String state;
 
     @QueryParam("mandate_id")
-    @ApiParam(value = "The mandate reference to search for (case insensitive).")
+    @ApiParam(value = "The mandate ID to search for - case insensitive.")
     @Size(min = 1, max = MANDATE_ID_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     private String mandateId;
 
     @QueryParam("from_date")
-    @ApiParam(value = "The start date for payments to be searched, inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.")
+    @ApiParam(value = "The start date for payments to be searched - inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.")
     @ValidDate
     private String fromDate;
 
     @QueryParam("to_date")
-    @ApiParam(value = "The end date for payments to be searched, inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.")
+    @ApiParam(value = "The end date for payments to be searched - exclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.")
     @ValidDate
     private String toDate;
 
     @QueryParam("page")
-    @ApiParam(value = "Which page number of results to return. The default is 1.")
+    @ApiParam(value = "Which page number of results to return.")
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     private Integer page;
 
     @QueryParam("display_size")
-    @ApiParam(value = "The number of results per page. This must be between 1 and 500. The default is 500.")
+    @ApiParam(value = "The number of results per page.")
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     @Max(value = 500, message = "Must be less than or equal to {value}")
     private Integer displaySize;

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
@@ -29,7 +29,7 @@ public class DirectDebitSearchPaymentsParams {
     private String state;
 
     @QueryParam("mandate_id")
-    @ApiParam(value = "The mandate ID to search for - case insensitive.")
+    @ApiParam(value = "The mandate identifier to search for - case insensitive.")
     @Size(min = 1, max = MANDATE_ID_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     private String mandateId;
 

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
@@ -44,7 +44,7 @@ public class DirectDebitSearchPaymentsParams {
     private String toDate;
 
     @QueryParam("page")
-    @ApiParam(value = "Which page number of results to return.")
+    @ApiParam(value = "The page number of results to return.")
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     private Integer page;
 

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
@@ -16,44 +16,44 @@ import static uk.gov.pay.api.model.CreateDirectDebitPaymentRequest.MANDATE_ID_MA
 import static uk.gov.pay.api.model.CreateDirectDebitPaymentRequest.REFERENCE_MAX_LENGTH;
 
 public class DirectDebitSearchPaymentsParams {
-    
+
     @QueryParam("reference")
-    @ApiParam(value = "Your payment reference to search")
+    @ApiParam(value = "The payment reference to search for (case insensitive).")
     @Size(min = 1, max = REFERENCE_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     private String reference;
-    
+
     @QueryParam("state")
-    @ApiParam(value = "State of payments to be searched. Example=success")
+    @ApiParam(value = "The payment state to search for (case sensitive).")
     @Pattern(regexp = "created|pending|success|failed|cancelled|paidout|indemnityclaim|error",
             message = "Must be one of created, pending, success, failed, cancelled, paidout, indemnityclaim or error")
     private String state;
-    
+
     @QueryParam("mandate_id")
-    @ApiParam(value = "The GOV.UK Pay identifier for the mandate")
+    @ApiParam(value = "The mandate reference to search for (case insensitive).")
     @Size(min = 1, max = MANDATE_ID_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     private String mandateId;
-    
+
     @QueryParam("from_date")
-    @ApiParam(value = "From date of Direct Debit payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z")
+    @ApiParam(value = "The start date for payments to be searched, inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.")
     @ValidDate
     private String fromDate;
-    
+
     @QueryParam("to_date")
-    @ApiParam(value = "To date of Direct Debit payments to be searched (this date is exclusive). Example=2015-08-13T12:35:00Z")
+    @ApiParam(value = "The end date for payments to be searched, inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.")
     @ValidDate
     private String toDate;
-    
+
     @QueryParam("page")
-    @ApiParam(value = "Page number requested for the search, should be a positive integer (optional, defaults to 1)")
+    @ApiParam(value = "Which page number of results to return. The default is 1.")
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     private Integer page;
-    
+
     @QueryParam("display_size")
-    @ApiParam(value = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)")
+    @ApiParam(value = "The number of results per page. This must be between 1 and 500. The default is 500.")
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     @Max(value = 500, message = "Must be less than or equal to {value}")
     private Integer displaySize;
-    
+
     public String getReference() {
         return reference;
     }

--- a/src/main/java/uk/gov/pay/api/resources/MandatesResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/MandatesResource.java
@@ -62,16 +62,14 @@ public class MandatesResource {
     @ApiOperation(
             nickname = "Get a mandate",
             value = "Find mandate by ID",
-            notes = "Return information about the mandate. " +
-                    "The Authorisation token needs to be specified in the 'Authorization' header " +
-                    "as 'Authorization: Bearer YOUR_API_KEY_HERE'",
+            notes = "Get information about a single mandate. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`.",
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = MandateResponse.class),
-            @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 404, message = "Not found", response = MandateError.class),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
-            @ApiResponse(code = 500, message = "Downstream system error", response = MandateError.class)})
+            @ApiResponse(code = 200, message = "Your request succeeded.", response = MandateResponse.class),
+            @ApiResponse(code = 401, message = "You did not include your API key in the 'Authorization' HTTP header, or the key was invalid."),
+            @ApiResponse(code = 404, message = "No mandate matched the `mandateId` you provided.", response = MandateError.class),
+            @ApiResponse(code = 429, message = "You exceeded a [rate limit](https://docs.payments.service.gov.uk/api_reference/#rate-limits) for requests to the API.", response = ApiErrorResponse.class),
+            @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = MandateError.class)})
     public Response getMandate(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                @PathParam("mandateId") String mandateId) {
         LOGGER.info("Mandate get request - [ {} ]", mandateId);
@@ -87,26 +85,24 @@ public class MandatesResource {
     @ApiOperation(
             nickname = "Search mandates",
             value = "Search mandates",
-            notes = "Searches for mandates with the parameters provided. " +
-                    "The Authorisation token needs to be specified in the 'Authorization' header " +
-                    "as 'Authorization: Bearer YOUR_API_KEY_HERE'",
+            notes = "Search Direct Debit mandates. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`",
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = SearchMandateResponse.class),
-            @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 404, message = "Not found", response = MandateError.class),
-            @ApiResponse(code = 422, message = "Invalid parameters: from_date, to_date, state, page, display_size. See Public API documentation for the correct data formats", response = PaymentError.class),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
-            @ApiResponse(code = 500, message = "Downstream system error", response = MandateError.class)})
+            @ApiResponse(code = 200, message = "Your request succeeded.", response = SearchMandateResponse.class),
+            @ApiResponse(code = 401, message = "You did not include your API key in the 'Authorization' HTTP header, or the key was invalid."),
+            @ApiResponse(code = 404, message = "There are no results that match your search.", response = MandateError.class),
+            @ApiResponse(code = 422, message = "There were invalid parameters in your request.", response = PaymentError.class),
+            @ApiResponse(code = 429, message = "You exceeded a [rate limit](https://docs.payments.service.gov.uk/api_reference/#rate-limits) for requests to the API.", response = ApiErrorResponse.class),
+            @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = MandateError.class)})
     public Response searchMandates(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                    @Valid @BeanParam DirectDebitSearchMandatesParams mandateSearchParams) {
         LOGGER.info("Mandate search request - [ {} ]", mandateSearchParams.toString());
         SearchMandateResponse searchMandatesResponse = mandateSearchService.search(account, mandateSearchParams);
-        
+
         LOGGER.info("Mandate search returned: [ {} ]", searchMandatesResponse);
         return Response.ok().entity(searchMandatesResponse).build();
     }
-    
+
     @POST
     @Timed
     @Path("/v1/directdebit/mandates")
@@ -115,19 +111,17 @@ public class MandatesResource {
     @ApiOperation(
             nickname = "Create a mandate",
             value = "Create a new mandate",
-            notes = "Create a new mandate for the account associated to the Authorisation token. " +
-                    "The Authorisation token needs to be specified in the 'Authorization' header " +
-                    "as 'Authorization: Bearer YOUR_API_KEY_HERE'",
+            notes = "Set up a Direct Debit mandate. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`. The API will create a mandate in the account linked to the API key you provide.",
             code = 201,
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "Created", response = MandateResponse.class),
-            @ApiResponse(code = 400, message = "Bad request", response = PaymentError.class),
-            @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
-            @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
+            @ApiResponse(code = 201, message = "The mandate was successfully set up.", response = MandateResponse.class),
+            @ApiResponse(code = 400, message = "The API could not process your request, for example because you did not include a required parameter.", response = PaymentError.class),
+            @ApiResponse(code = 401, message = "You did not include your API key in the 'Authorization' HTTP header, or the key was invalid."),
+            @ApiResponse(code = 429, message = "You exceeded a [rate limit](https://docs.payments.service.gov.uk/api_reference/#rate-limits) for requests to the API.", response = ApiErrorResponse.class),
+            @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = PaymentError.class)})
     public Response createMandate(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
-                                  @ApiParam(value = "requestPayload", required = true) @Valid CreateMandateRequest createMandateRequest) {
+                                  @ApiParam(value = "The structure of your request to the API when you set up a Direct Debit mandate.", required = true) @Valid CreateMandateRequest createMandateRequest) {
         LOGGER.info("Mandate create request - [ {} ]", createMandateRequest);
         MandateResponse createMandateResponse = mandateService.create(account, createMandateRequest);
         URI mandateUri = UriBuilder.fromUri(baseUrl)

--- a/src/main/java/uk/gov/pay/api/resources/MandatesResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/MandatesResource.java
@@ -62,7 +62,7 @@ public class MandatesResource {
     @ApiOperation(
             nickname = "Get a mandate",
             value = "Find mandate by ID",
-            notes = "Get information about a single mandate. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`.",
+            notes = "Get information about a single Direct Debit mandate. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`.",
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Your request succeeded.", response = MandateResponse.class),

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -97,16 +97,15 @@ public class PaymentRefundsResource {
             response = RefundForSearchResult.class,
             nickname = "Get all refunds for a payment",
             value = "Get all refunds for a payment",
-            notes = "Return refunds for a payment. " +
-                    "The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            notes = "Get all refunds for a payment. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`.",
             code = 200,
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK"),
-            @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
-            @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
+            @ApiResponse(code = 200, message = "Your request succeeded."),
+            @ApiResponse(code = 401, message = "You did not include your API key in the 'Authorization' HTTP header, or the key was invalid."),
+            @ApiResponse(code = 404, message = "No payment matched the `paymentId` you provided.", response = PaymentError.class),
+            @ApiResponse(code = 429, message = "You exceeded a [rate limit](https://docs.payments.service.gov.uk/api_reference/#rate-limits) for requests to the API.", response = ApiErrorResponse.class),
+            @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = PaymentError.class)})
     public RefundsResponse getRefunds(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                       @PathParam(PATH_PAYMENT_KEY) String paymentId,
                                       @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
@@ -128,17 +127,15 @@ public class PaymentRefundsResource {
             response = RefundResult.class,
             nickname = "Get a payment refund",
             value = "Find payment refund by ID",
-            notes = "Return payment refund information by Refund ID " +
-                    "The Authorisation token needs to be specified in the 'authorization' header " +
-                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            notes = "Check the status of a refund. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`.",
             code = 200,
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK"),
-            @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
-            @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
+            @ApiResponse(code = 200, message = "Your request succeeded."),
+            @ApiResponse(code = 401, message = "You did not include your API key in the 'Authorization' HTTP header, or the key was invalid."),
+            @ApiResponse(code = 404, message = "No refund matched the `refundId` you provided.", response = PaymentError.class),
+            @ApiResponse(code = 429, message = "You exceeded a [rate limit](https://docs.payments.service.gov.uk/api_reference/#rate-limits) for requests to the API.", response = ApiErrorResponse.class),
+            @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = PaymentError.class)})
     public RefundResponse getRefundById(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                         @PathParam(PATH_PAYMENT_KEY) String paymentId,
                                         @PathParam(PATH_REFUND_KEY) String refundId,
@@ -162,18 +159,17 @@ public class PaymentRefundsResource {
             response = RefundResult.class,
             nickname = "Submit a refund for a payment",
             value = "Submit a refund for a payment",
-            notes = "Return issued refund information. " +
-                    "The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            notes = "Create a refund. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`.",
             code = 202,
             authorizations = {@Authorization("Authorization")}
     )
     @ApiResponses(value = {
-            @ApiResponse(code = 202, message = "ACCEPTED"),
-            @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
-            @ApiResponse(code = 412, message = "Refund amount available mismatch"),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
-            @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
+            @ApiResponse(code = 202, message = "Your request succeeded, but the refund is still being processed."),
+            @ApiResponse(code = 401, message = "You did not include your API key in the 'Authorization' HTTP header, or the key was invalid."),
+            @ApiResponse(code = 404, message = "No payment matched the `paymentId` you provided.", response = PaymentError.class),
+            @ApiResponse(code = 412, message = "The `refund_amount_available` you provided did not match the amount that's available to refund."),
+            @ApiResponse(code = 429, message = "You exceeded a [rate limit](https://docs.payments.service.gov.uk/api_reference/#rate-limits) for requests to the API.", response = ApiErrorResponse.class),
+            @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = PaymentError.class)})
     public Response submitRefund(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                  @ApiParam(value = "paymentId", required = true) @PathParam(PATH_PAYMENT_KEY) String paymentId,
                                  @ApiParam(value = "requestPayload", required = true) CreatePaymentRefundRequest requestPayload) {

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -90,20 +90,18 @@ public class PaymentsResource {
     @ApiOperation(
             nickname = "Get a payment",
             value = "Find payment by ID",
-            notes = "Return information about the payment " +
-                    "The Authorisation token needs to be specified in the 'authorization' header " +
-                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            notes = "Get information about a single payment. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`.",
             code = 200,
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = GetPaymentResult.class),
-            @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
-            @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
+            @ApiResponse(code = 200, message = "Your request succeeded.", response = GetPaymentResult.class),
+            @ApiResponse(code = 401, message = "You did not include your API key in the 'Authorization' HTTP header, or the key was invalid."),
+            @ApiResponse(code = 404, message = "No payment matched the `paymentId` you provided.", response = PaymentError.class),
+            @ApiResponse(code = 429, message = "You exceeded a [rate limit](https://docs.payments.service.gov.uk/api_reference/#rate-limits) for requests to the API.", response = ApiErrorResponse.class),
+            @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = PaymentError.class)})
     public Response getPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                @PathParam("paymentId")
-                               @ApiParam(name = "paymentId", value = "Payment identifier", example = "hu20sqlact5260q2nanm0q8u93")
+                               @ApiParam(name = "paymentId", value = "The payment to get information about.", example = "hu20sqlact5260q2nanm0q8u93")
                                        String paymentId,
                                @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
 
@@ -123,20 +121,18 @@ public class PaymentsResource {
     @ApiOperation(
             nickname = "Get events for a payment",
             value = "Return payment events by ID",
-            notes = "Return payment events information about a certain payment " +
-                    "The Authorisation token needs to be specified in the 'authorization' header " +
-                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            notes = "Get events from a single payment. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`.",
             code = 200,
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = PaymentEventsResponse.class),
-            @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
-            @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
+            @ApiResponse(code = 200, message = "Your request succeeded.", response = PaymentEventsResponse.class),
+            @ApiResponse(code = 401, message = "You did not include your API key in the 'Authorization' HTTP header, or the key was invalid."),
+            @ApiResponse(code = 404, message = "No payment matched the `paymentId` you provided.", response = PaymentError.class),
+            @ApiResponse(code = 429, message = "You exceeded a [rate limit](https://docs.payments.service.gov.uk/api_reference/#rate-limits) for requests to the API.", response = ApiErrorResponse.class),
+            @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = PaymentError.class)})
     public PaymentEventsResponse getPaymentEvents(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                                   @PathParam("paymentId")
-                                                  @ApiParam(name = "paymentId", value = "Payment identifier", example = "hu20sqlact5260q2nanm0q8u93")
+                                                  @ApiParam(name = "paymentId", value = "The payment to get events from.", example = "hu20sqlact5260q2nanm0q8u93")
                                                           String paymentId,
                                                   @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
 
@@ -157,45 +153,43 @@ public class PaymentsResource {
     @ApiOperation(
             nickname = "Search payments",
             value = "Search payments",
-            notes = "Search payments by reference, state, 'from' and 'to' date. " +
-                    "The Authorisation token needs to be specified in the 'authorization' header " +
-                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            notes = "Search payments. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`.",
             responseContainer = "List",
             code = 200,
             authorizations = {@Authorization("Authorization")})
 
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = PaymentSearchResults.class),
-            @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 422, message = "Invalid parameters: from_date, to_date, status, display_size. See Public API documentation for the correct data formats", response = PaymentError.class),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
-            @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
+            @ApiResponse(code = 200, message = "Your request succeeded.", response = PaymentSearchResults.class),
+            @ApiResponse(code = 401, message = "You did not include your API key in the 'Authorization' HTTP header, or the key was invalid."),
+            @ApiResponse(code = 422, message = "There were invalid parameters in your request.", response = PaymentError.class),
+            @ApiResponse(code = 429, message = "You exceeded a [rate limit](https://docs.payments.service.gov.uk/api_reference/#rate-limits) for requests to the API.", response = ApiErrorResponse.class),
+            @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = PaymentError.class)})
     public Response searchPayments(@ApiParam(value = "accountId", hidden = true)
                                    @Auth Account account,
-                                   @ApiParam(value = "Your payment reference to search (exact match, case insensitive)", hidden = false)
+                                   @ApiParam(value = "The payment reference to search for (case insensitive, exact match only).", hidden = false)
                                    @QueryParam("reference") String reference,
-                                   @ApiParam(value = "The user email used in the payment to be searched", hidden = false)
+                                   @ApiParam(value = "The user email address to search for (case insensitive).", hidden = false)
                                    @QueryParam("email") String email,
-                                   @ApiParam(value = "State of payments to be searched. Example=success", hidden = false, allowableValues = "created,started,submitted,success,failed,cancelled,error")
+                                   @ApiParam(value = "The payment state to search for (case sensitive, exact match only).", hidden = false, allowableValues = "created,started,submitted,success,failed,cancelled,error")
                                    @QueryParam("state") String state,
-                                   @ApiParam(value = "Card brand used for payment. Example=master-card", hidden = false)
+                                   @ApiParam(value = "The card brand to search for (case sensitive).", hidden = false)
                                    @QueryParam("card_brand") String cardBrand,
-                                   @ApiParam(value = "From date of payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z", hidden = false)
+                                   @ApiParam(value = "The start date for payments to be searched, inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.", hidden = false)
                                    @QueryParam("from_date") String fromDate,
-                                   @ApiParam(value = "To date of payments to be searched (this date is exclusive). Example=2015-08-14T12:35:00Z", hidden = false)
+                                   @ApiParam(value = "The end date for payments to be searched, inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.", hidden = false)
                                    @QueryParam("to_date") String toDate,
-                                   @ApiParam(value = "Page number requested for the search, should be a positive integer (optional, defaults to 1)", hidden = false)
+                                   @ApiParam(value = "Which page number of results to return. The default is 1.", hidden = false)
                                    @QueryParam("page") String pageNumber,
-                                   @ApiParam(value = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)", hidden = false)
+                                   @ApiParam(value = "The number of results per page. This must be between 1 and 500. The default is 500.", hidden = false)
                                    @QueryParam("display_size") String displaySize,
                                    @ApiParam(value = "Direct Debit Agreement Id", hidden = true)
                                    @QueryParam("agreement_id") String agreementId,
-                                   @ApiParam(value = "Name on card used to make payment", hidden = false)
+                                   @ApiParam(value = "The end user name to search for (case insensitive).", hidden = false)
                                    @QueryParam("cardholder_name") String cardHolderName,
-                                   @ApiParam(value = "First six digits of the card used to make payment", hidden = false)
+                                   @ApiParam(value = "The first 6 digits of a payment card to search for (exact match only).", hidden = false)
 
                                    @QueryParam("first_digits_card_number") String firstDigitsCardNumber,
-                                   @ApiParam(value = "Last four digits of the card used to make payment", hidden = false)
+                                   @ApiParam(value = "The last 4 digits of a payment card to search for (exact match only).", hidden = false)
 
                                    @QueryParam("last_digits_card_number") String lastDigitsCardNumber,
                                    @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName,
@@ -232,18 +226,16 @@ public class PaymentsResource {
     @ApiOperation(
             nickname = "Create a payment",
             value = "Create new payment",
-            notes = "Create a new payment for the account associated to the Authorisation token. " +
-                    "The Authorisation token needs to be specified in the 'authorization' header " +
-                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            notes = "Create a payment. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`. The API will create a payment in the account linked to the API key you provide.",
             code = 201,
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "Created", response = CreatePaymentResult.class),
-            @ApiResponse(code = 400, message = "Bad request", response = PaymentError.class),
-            @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 422, message = "Invalid attribute value: description. Must be less than or equal to 255 characters length", response = PaymentError.class),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
-            @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
+            @ApiResponse(code = 201, message = "The payment was successfully created.", response = CreatePaymentResult.class),
+            @ApiResponse(code = 400, message = "The API could not process your request, for example because you did not include a required parameter.", response = PaymentError.class),
+            @ApiResponse(code = 401, message = "You did not include your API key in the 'Authorization' HTTP header, or the key was invalid."),
+            @ApiResponse(code = 422, message = "The `description` you provided was longer than the maximum of 255 characters.", response = PaymentError.class),
+            @ApiResponse(code = 429, message = "You exceeded a [rate limit](https://docs.payments.service.gov.uk/api_reference/#rate-limits) for requests to the API.", response = ApiErrorResponse.class),
+            @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = PaymentError.class)})
     public Response createNewPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                      @ApiParam(value = "requestPayload", required = true) @Valid CreateCardPaymentRequest createCardPaymentRequest) {
         logger.info("Payment create request parsed to {}", createCardPaymentRequest);
@@ -266,24 +258,21 @@ public class PaymentsResource {
     @ApiOperation(
             nickname = "Cancel a payment",
             value = "Cancel payment",
-            notes = "Cancel a payment based on the provided payment ID and the Authorisation token. " +
-                    "The Authorisation token needs to be specified in the 'authorization' header " +
-                    "as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be cancelled if it's in " +
-                    "a state that isn't finished.",
+            notes = "Cancel a payment, if the value of `finished` is `false`. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`.",
             code = 204,
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {
-            @ApiResponse(code = 204, message = "No Content"),
-            @ApiResponse(code = 400, message = "Cancellation of payment failed", response = PaymentError.class),
-            @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
+            @ApiResponse(code = 204, message = "The payment was successfully cancelled."),
+            @ApiResponse(code = 400, message = "The cancellation request failed.", response = PaymentError.class),
+            @ApiResponse(code = 401, message = "You did not include your API key in the 'Authorization' HTTP header, or the key was invalid."),
+            @ApiResponse(code = 404, message = "No payment matched the `paymentId` you provided.", response = PaymentError.class),
             @ApiResponse(code = 409, message = "Conflict", response = PaymentError.class),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
-            @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)
+            @ApiResponse(code = 429, message = "You exceeded a [rate limit](https://docs.payments.service.gov.uk/api_reference/#rate-limits) for requests to the API.", response = ApiErrorResponse.class),
+            @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = PaymentError.class)
     })
     public Response cancelPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                   @PathParam("paymentId")
-                                  @ApiParam(name = "paymentId", value = "Payment identifier", example = "hu20sqlact5260q2nanm0q8u93")
+                                  @ApiParam(name = "paymentId", value = "The payment to cancel.", example = "hu20sqlact5260q2nanm0q8u93")
                                           String paymentId) {
 
         logger.info("Payment cancel request - payment_id=[{}]", paymentId);
@@ -298,24 +287,21 @@ public class PaymentsResource {
     @ApiOperation(
             nickname = "Capture a payment",
             value = "Capture payment",
-            notes = "Capture a payment based on the provided payment ID and the Authorisation token. " +
-                    "The Authorisation token needs to be specified in the 'authorization' header " +
-                    "as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be captured if it's in " +
-                    "'submitted' state",
+            notes = "Capture a delayed payment. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`.",
             code = 204,
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {
-            @ApiResponse(code = 204, message = "No Content"),
-            @ApiResponse(code = 400, message = "Capture of payment failed", response = PaymentError.class),
-            @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
+            @ApiResponse(code = 204, message = "The payment was successfully captured."),
+            @ApiResponse(code = 400, message = "The capture request failed.", response = PaymentError.class),
+            @ApiResponse(code = 401, message = "You did not include your API key in the 'Authorization' HTTP header, or the key was invalid."),
+            @ApiResponse(code = 404, message = "No payment matched the `paymentId` you provided.", response = PaymentError.class),
             @ApiResponse(code = 409, message = "Conflict", response = PaymentError.class),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
-            @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)
+            @ApiResponse(code = 429, message = "You exceeded a [rate limit](https://docs.payments.service.gov.uk/api_reference/#rate-limits) for requests to the API.", response = ApiErrorResponse.class),
+            @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = PaymentError.class)
     })
     public Response capturePayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                    @PathParam("paymentId")
-                                   @ApiParam(name = "paymentId", value = "Payment identifier", example = "hu20sqlact5260q2nanm0q8u93")
+                                   @ApiParam(name = "paymentId", value = "The payment to capture.", example = "hu20sqlact5260q2nanm0q8u93")
                                            String paymentId) {
         logger.info("Payment capture request - payment_id=[{}]", paymentId);
 

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -166,30 +166,30 @@ public class PaymentsResource {
             @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = PaymentError.class)})
     public Response searchPayments(@ApiParam(value = "accountId", hidden = true)
                                    @Auth Account account,
-                                   @ApiParam(value = "The payment reference to search for (case insensitive, exact match only).", hidden = false)
+                                   @ApiParam(value = "The payment reference to search for - case insensitive, exact match only.", hidden = false)
                                    @QueryParam("reference") String reference,
-                                   @ApiParam(value = "The user email address to search for (case insensitive).", hidden = false)
+                                   @ApiParam(value = "The user email address to search for - case insensitive.", hidden = false)
                                    @QueryParam("email") String email,
-                                   @ApiParam(value = "The payment state to search for (case sensitive, exact match only).", hidden = false, allowableValues = "created,started,submitted,success,failed,cancelled,error")
+                                   @ApiParam(value = "The payment state to search for - case sensitive, exact match only.", hidden = false, allowableValues = "created,started,submitted,success,failed,cancelled,error")
                                    @QueryParam("state") String state,
-                                   @ApiParam(value = "The card brand to search for (case sensitive).", hidden = false)
+                                   @ApiParam(value = "The card brand to search for - case sensitive.", hidden = false)
                                    @QueryParam("card_brand") String cardBrand,
-                                   @ApiParam(value = "The start date for payments to be searched, inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.", hidden = false)
+                                   @ApiParam(value = "The start date for payments to be searched - inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.", hidden = false)
                                    @QueryParam("from_date") String fromDate,
-                                   @ApiParam(value = "The end date for payments to be searched, inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.", hidden = false)
+                                   @ApiParam(value = "The end date for payments to be searched - exclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.", hidden = false)
                                    @QueryParam("to_date") String toDate,
-                                   @ApiParam(value = "Which page number of results to return. The default is 1.", hidden = false)
+                                   @ApiParam(value = "Which page number of results to return.", hidden = false)
                                    @QueryParam("page") String pageNumber,
-                                   @ApiParam(value = "The number of results per page. This must be between 1 and 500. The default is 500.", hidden = false)
+                                   @ApiParam(value = "The number of results per page.", hidden = false)
                                    @QueryParam("display_size") String displaySize,
                                    @ApiParam(value = "Direct Debit Agreement Id", hidden = true)
                                    @QueryParam("agreement_id") String agreementId,
-                                   @ApiParam(value = "The end user name to search for (case insensitive).", hidden = false)
+                                   @ApiParam(value = "The end user name to search for - case insensitive.", hidden = false)
                                    @QueryParam("cardholder_name") String cardHolderName,
-                                   @ApiParam(value = "The first 6 digits of a payment card to search for (exact match only).", hidden = false)
+                                   @ApiParam(value = "The first 6 digits of a payment card to search for - exact match only.", hidden = false)
 
                                    @QueryParam("first_digits_card_number") String firstDigitsCardNumber,
-                                   @ApiParam(value = "The last 4 digits of a payment card to search for (exact match only).", hidden = false)
+                                   @ApiParam(value = "The first 6 digits of a payment card to search for - exact match only.", hidden = false)
 
                                    @QueryParam("last_digits_card_number") String lastDigitsCardNumber,
                                    @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName,

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -178,7 +178,7 @@ public class PaymentsResource {
                                    @QueryParam("from_date") String fromDate,
                                    @ApiParam(value = "The end date for payments to be searched - exclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.", hidden = false)
                                    @QueryParam("to_date") String toDate,
-                                   @ApiParam(value = "Which page number of results to return.", hidden = false)
+                                   @ApiParam(value = "The page number of results to return.", hidden = false)
                                    @QueryParam("page") String pageNumber,
                                    @ApiParam(value = "The number of results per page.", hidden = false)
                                    @QueryParam("display_size") String displaySize,

--- a/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
@@ -66,7 +66,7 @@ public class SearchRefundsResource {
                                   @QueryParam("from_date") String fromDate,
                                   @ApiParam(value = "The end date for refunds to be searched, exclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.", hidden = false)
                                   @QueryParam("to_date") String toDate,
-                                  @ApiParam(value = "Which page number of results to return.", hidden = false)
+                                  @ApiParam(value = "The page number of results to return.", hidden = false)
                                   @QueryParam("page") String pageNumber,
                                   @ApiParam(value = "The number of results per page.", hidden = false)
                                   @QueryParam("display_size") String displaySize,

--- a/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
@@ -50,28 +50,26 @@ public class SearchRefundsResource {
     @ApiOperation(
             nickname = "Search refunds",
             value = "Search refunds",
-            notes = "Search refunds by 'from' and 'to' date. " +
-                    "The Authorisation token needs to be specified in the 'authorization' header " +
-                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            notes = "Search refunds. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`.",
             responseContainer = "List",
             authorizations = {@Authorization("Authorization")},
             code = 200)
 
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = SearchRefundsResults.class),
-            @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 422, message = "Invalid parameters. See Public API documentation for the correct data formats", response = RefundError.class),
-            @ApiResponse(code = 500, message = "Downstream system error", response = RefundError.class)})
+            @ApiResponse(code = 200, message = "Your request succeeded.", response = SearchRefundsResults.class),
+            @ApiResponse(code = 401, message = "You did not include your API key in the 'Authorization' HTTP header, or the key was invalid."),
+            @ApiResponse(code = 422, message = "You exceeded a [rate limit](https://docs.payments.service.gov.uk/api_reference/#rate-limits) for requests to the API.", response = RefundError.class),
+            @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = RefundError.class)})
     public SearchRefundsResults searchRefunds(@ApiParam(value = "accountId", hidden = true)
                                   @Auth Account account,
-                                  @ApiParam(value = "From date of refunds to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z", hidden = false)
+                                  @ApiParam(value = "The start date for refunds to be searched, inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.", hidden = false)
                                   @QueryParam("from_date") String fromDate,
-                                  @ApiParam(value = "To date of refunds to be searched (this date is exclusive). Example=2015-08-14T12:35:00Z", hidden = false)
+                                  @ApiParam(value = "The end date for refunds to be searched, inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.", hidden = false)
                                   @QueryParam("to_date") String toDate,
-                                  @ApiParam(value = "Page number requested for the search, should be a positive integer (optional, defaults to 1)", hidden = false)
+                                  @ApiParam(value = "Which page number of results to return. The default is 1.", hidden = false)
                                   @QueryParam("page") String pageNumber,
-                                  @ApiParam(value = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)", hidden = false)
-                                  @QueryParam("display_size") String displaySize, 
+                                  @ApiParam(value = "The number of results per page. This must be between 1 and 500. The default is 500.", hidden = false)
+                                  @QueryParam("display_size") String displaySize,
                                   @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
 
         logger.info("Refunds search request with strategy [{}]- [ {} ]", strategyName,

--- a/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
@@ -58,17 +58,17 @@ public class SearchRefundsResource {
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Your request succeeded.", response = SearchRefundsResults.class),
             @ApiResponse(code = 401, message = "You did not include your API key in the 'Authorization' HTTP header, or the key was invalid."),
-            @ApiResponse(code = 422, message = "You exceeded a [rate limit](https://docs.payments.service.gov.uk/api_reference/#rate-limits) for requests to the API.", response = RefundError.class),
+            @ApiResponse(code = 422, message = "There were invalid parameters in your request.", response = RefundError.class),
             @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = RefundError.class)})
     public SearchRefundsResults searchRefunds(@ApiParam(value = "accountId", hidden = true)
                                   @Auth Account account,
                                   @ApiParam(value = "The start date for refunds to be searched, inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.", hidden = false)
                                   @QueryParam("from_date") String fromDate,
-                                  @ApiParam(value = "The end date for refunds to be searched, inclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.", hidden = false)
+                                  @ApiParam(value = "The end date for refunds to be searched, exclusive. Dates must be in ISO 8601 format. For example 2015-08-13T12:35:00Z.", hidden = false)
                                   @QueryParam("to_date") String toDate,
-                                  @ApiParam(value = "Which page number of results to return. The default is 1.", hidden = false)
+                                  @ApiParam(value = "Which page number of results to return.", hidden = false)
                                   @QueryParam("page") String pageNumber,
-                                  @ApiParam(value = "The number of results per page. This must be between 1 and 500. The default is 500.", hidden = false)
+                                  @ApiParam(value = "The number of results per page.", hidden = false)
                                   @QueryParam("display_size") String displaySize,
                                   @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
 

--- a/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
@@ -69,18 +69,16 @@ public class DirectDebitPaymentsResource {
     @ApiOperation(
             nickname = "Collect a Direct Debit payment",
             value = "Create new Direct Debit payment",
-            notes = "Create a new Direct Debit payment for the account associated to the Authorisation token. " +
-                    "The Authorisation token needs to be specified in the 'authorization' header " +
-                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            notes = "Create a new Direct Debit payment. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`. The API will create a mandate in the account linked to the API key you provide.",
             code = 201,
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "Created", response = DirectDebitPayment.class),
-            @ApiResponse(code = 400, message = "Bad request", response = PaymentError.class),
-            @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 422, message = "Invalid parameters: amount, reference, description, mandate id. See Public API documentation for the correct data formats", response = PaymentError.class),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
-            @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
+            @ApiResponse(code = 201, message = "The payment was successfully created.", response = DirectDebitPayment.class),
+            @ApiResponse(code = 400, message = "The API could not process your request, for example because you did not include a required parameter.", response = PaymentError.class),
+            @ApiResponse(code = 401, message = "You did not include your API key in the 'Authorization' HTTP header, or the key was invalid."),
+            @ApiResponse(code = 422, message = "There were invalid parameters in your request.", response = PaymentError.class),
+            @ApiResponse(code = 429, message = "You exceeded a [rate limit](https://docs.payments.service.gov.uk/api_reference/#rate-limits) for requests to the API.", response = ApiErrorResponse.class),
+            @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = PaymentError.class)})
     public Response createPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                   @ApiParam(value = "requestPayload", required = true) @Valid CreateDirectDebitPaymentRequest request) {
         DirectDebitPayment payment = createDirectDebitPaymentsService.create(account, request);
@@ -95,18 +93,16 @@ public class DirectDebitPaymentsResource {
     @ApiOperation(
             nickname = "Search Direct Debit payments",
             value = "Search Direct Debit payments",
-            notes = "Search Direct Debit payments by reference, state, mandate id, and 'from' and 'to' dates. " +
-                    "The Authorisation token needs to be specified in the 'Authorization' header " +
-                    "as 'Authorization: Bearer YOUR_API_KEY_HERE'",
+            notes = "Search Direct Debit payments. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`.",
             responseContainer = "List",
             code = 200,
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = DirectDebitSearchResponse.class),
-            @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 422, message = "Invalid parameter. See Public API documentation for the correct data formats", response = PaymentError.class),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
-            @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
+            @ApiResponse(code = 200, message = "Your request succeeded.", response = DirectDebitSearchResponse.class),
+            @ApiResponse(code = 401, message = "You did not include your API key in the 'Authorization' HTTP header, or the key was invalid."),
+            @ApiResponse(code = 422, message = "There were invalid parameters in your request.", response = PaymentError.class),
+            @ApiResponse(code = 429, message = "You exceeded a [rate limit](https://docs.payments.service.gov.uk/api_reference/#rate-limits) for requests to the API.", response = ApiErrorResponse.class),
+            @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = PaymentError.class)})
     public Response searchPayments(@ApiParam(value = "accountId", hidden = true)
                                    @Auth Account account,
                                    @Valid @BeanParam DirectDebitSearchPaymentsParams searchPaymentsParams,
@@ -123,19 +119,17 @@ public class DirectDebitPaymentsResource {
     @ApiOperation(
             nickname = "Get a Direct Debit payment",
             value = "Find Direct Debit payment by ID",
-            notes = "Return information about the Direct Debit payment. " +
-                    "The Authorisation token needs to be specified in the 'Authorization' header " +
-                    "as 'Authorization: Bearer YOUR_API_KEY_HERE'",
+            notes = "Get information about a single Direct Debit payment. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`.",
             code = 200,
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = DirectDebitPayment.class),
-            @ApiResponse(code = 401, message = "Credentials are required to access this resource"),
-            @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
-            @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
-            @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
+            @ApiResponse(code = 200, message = "Your request succeeded.", response = DirectDebitPayment.class),
+            @ApiResponse(code = 401, message = "You did not include your API key in the 'Authorization' HTTP header, or the key was invalid."),
+            @ApiResponse(code = 404, message = "No payment matched the `paymentId` you provided.", response = PaymentError.class),
+            @ApiResponse(code = 429, message = "You exceeded a [rate limit](https://docs.payments.service.gov.uk/api_reference/#rate-limits) for requests to the API.", response = ApiErrorResponse.class),
+            @ApiResponse(code = 500, message = "Something's wrong with GOV.UK Pay. [Contact us](https://docs.payments.service.gov.uk/support_contact_and_more_information/#contact-us) for help.", response = PaymentError.class)})
     public Response getPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
-                               @PathParam("paymentId") @ApiParam(value = "Payment identifier") String paymentId) {
+                               @PathParam("paymentId") @ApiParam(value = "The payment to get information about.") String paymentId) {
 
         LOGGER.info("Direct Debit Payment request - paymentId={}", paymentId);
         DirectDebitPayment payment = getDirectDebitPaymentService.getDirectDebitPayment(account, paymentId);

--- a/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
@@ -69,7 +69,7 @@ public class DirectDebitPaymentsResource {
     @ApiOperation(
             nickname = "Collect a Direct Debit payment",
             value = "Create new Direct Debit payment",
-            notes = "Create a new Direct Debit payment. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`. The API will create a mandate in the account linked to the API key you provide.",
+            notes = "Collect a payment against a Direct Debit mandate. You must include your API key in the 'Authorization' HTTP header: `Authorization: Bearer YOUR-API-KEY`. The API will create a mandate in the account linked to the API key you provide.",
             code = 201,
             authorizations = {@Authorization("Authorization")})
     @ApiResponses(value = {


### PR DESCRIPTION
## What you did
This pull request updates the `values` and `descriptions` in comments that are used to generate our OpenAPI/Swagger file. The updates bring descriptions of the API in line with our public tech docs at https://docs.payments.service.gov.uk/#gov-uk-pay-documentation, so they're clearer and more consistent.

(While doing this work, I also identified areas of the OpenAPI file where we can make future improvements. For example where descriptions are missing, other OpenAPI fields such as `example` need updating, and links definitions need updating. But to keep this PR in scope, we should look at those in a future iteration.)

## How to test
Please check if factually accurate.

Please bear in mind that:

- Style and tone is mostly copied or based on existing live content in https://docs.payments.service.gov.uk/#gov-uk-pay-documentation, so if a description needs major improvement it's best to save that for a future iteration (so we can update the tech docs to match) 
- I've intentionally removed min/max and default information from `description` fields so we don't duplicate what's already in the Swgger `min`, `max` and `default` objects