### PR TITLE
PP-5670: Specify consumer when running provider test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,9 +100,9 @@ pipeline {
                 env.PACT_TAG = gitBranchName()
             }
             ws('contract-tests-wp') {
-                runPactProviderTests("pay-direct-debit-connector", "${env.PACT_TAG}")
-                runPactProviderTests("pay-connector", "${env.PACT_TAG}")
-                runPactProviderTests("pay-ledger", "${env.PACT_TAG}")
+                runPactProviderTests("pay-direct-debit-connector", "${env.PACT_TAG}", "publicapi")
+                runPactProviderTests("pay-connector", "${env.PACT_TAG}", "publicapi")
+                runPactProviderTests("pay-ledger", "${env.PACT_TAG}", "publicapi")
             }
         }
         post {


### PR DESCRIPTION
This will cause only the publicapi->{connector,direct-debit-connector,ledger}
test to run on a publicapi build during the provider test runs.

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition