### PR TITLE
PP-5285 Open API specs for `Card payment` endpoints

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/Address.java
+++ b/src/main/java/uk/gov/pay/api/model/Address.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import uk.gov.pay.api.validation.ExactLengthOrEmpty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import javax.validation.constraints.Size;
 import java.util.Objects;
@@ -15,6 +15,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(NON_NULL)
 @ApiModel(value = "Address", description = "A structure representing the billing address of a card")
+@Schema(name = "Address", description = "A structure representing the billing address of a card")
 public class Address {
 
     @Size(max = 255, message = "Must be less than or equal to {max} characters length")
@@ -44,26 +45,31 @@ public class Address {
     }
 
     @ApiModelProperty(example = "address line 1")
+    @Schema(example = "address line 1")
     public String getLine1() {
         return line1;
     }
 
     @ApiModelProperty(example = "address line 2")
+    @Schema(example = "address line 2")
     public String getLine2() {
         return line2;
     }
 
     @ApiModelProperty(example = "AB1 2CD")
+    @Schema(example = "AB1 2CD")
     public String getPostcode() {
         return postcode;
     }
 
     @ApiModelProperty(example = "address city")
+    @Schema(example = "address city")
     public String getCity() {
         return city;
     }
 
     @ApiModelProperty(example = "GB")
+    @Schema(example = "GB")
     public String getCountry() {
         return country;
     }

--- a/src/main/java/uk/gov/pay/api/model/CardDetails.java
+++ b/src/main/java/uk/gov/pay/api/model/CardDetails.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Optional;
 
@@ -11,6 +12,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.ALWAYS;
 
 @JsonInclude(ALWAYS)
 @ApiModel(value = "CardDetails", description = "A structure representing the payment card")
+@Schema(name = "CardDetails", description = "A structure representing the payment card")
 public class CardDetails {
 
     @JsonProperty("last_digits_card_number")
@@ -51,21 +53,25 @@ public class CardDetails {
     }
 
     @ApiModelProperty(example = "1234")
+    @Schema(example = "1234")
     public String getLastDigitsCardNumber() {
         return lastDigitsCardNumber;
     }
 
     @ApiModelProperty(example = "123456")
+    @Schema(example = "123456")
     public String getFirstDigitsCardNumber() {
         return firstDigitsCardNumber;
     }
 
     @ApiModelProperty(example = "Mr. Card holder")
+    @Schema(example = "Mr. Card holder")
     public String getCardHolderName() {
         return cardHolderName;
     }
 
     @ApiModelProperty(value = "The expiry date of the card in MM/yy format", example = "04/24")
+    @Schema(description = "The expiry date of the card in MM/yy format", example = "04/24")
     public String getExpiryDate() {
         return expiryDate;
     }
@@ -75,11 +81,13 @@ public class CardDetails {
     }
 
     @ApiModelProperty(example = "Visa")
+    @Schema(example = "Visa")
     public String getCardBrand() {
         return cardBrand;
     }
 
     @ApiModelProperty(value = "The card type, `debit` or `credit` or `null` if not able to determine", allowableValues = "debit,credit,null", example = "debit")
+    @Schema(description = "The card type, `debit` or `credit` or `null` if not able to determine", allowableValues = {"debit","credit","null"}, example = "debit")
     public String getCardType() {
         return cardType;
     }

--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -7,16 +7,19 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.commons.api.json.ExternalMetadataSerialiser;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 
 import java.util.Optional;
 
+import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
 
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 @ApiModel(value = "CardPayment")
+@Schema(name = "CardPayment")
 public class CardPayment extends Payment {
 
     @JsonProperty("refund_summary")
@@ -50,10 +53,12 @@ public class CardPayment extends Payment {
 
     @JsonProperty("provider_id")
     @ApiModelProperty(example = "reference-from-payment-gateway")
+    @Schema(example = "reference-from-payment-gateway", accessMode = READ_ONLY)
     private final String providerId;
 
     @JsonSerialize(using = ExternalMetadataSerialiser.class)
     @ApiModelProperty(name = "metadata", dataType = "Map[String,String]")
+    @Schema(name = "metadata", example = "{\"property1\": \"value1\", \"property2\": \"value2\"}\"")
     private final ExternalMetadata metadata;
 
     @JsonProperty("return_url")
@@ -98,6 +103,8 @@ public class CardPayment extends Payment {
      * @return
      */
     @ApiModelProperty(value = "Card Brand", example = "Visa", notes = "Deprecated. Please use card_details.card_brand instead")
+    @Schema(description = "Card Brand. Deprecated, please use card_details.card_brand instead", example = "Visa",
+            accessMode = READ_ONLY, deprecated = true)
     @JsonProperty("card_brand")
     @Deprecated
     public String getCardBrand() {
@@ -129,26 +136,34 @@ public class CardPayment extends Payment {
     }
 
     @ApiModelProperty(value = "delayed capture flag", example = "false")
+    @Schema(description = "delayed capture flag", example = "false", accessMode = READ_ONLY)
     public boolean getDelayedCapture() {
         return delayedCapture;
     }
 
     @ApiModelProperty(example = "250")
+    @Schema(example = "250", accessMode = READ_ONLY)
     public Optional<Long> getCorporateCardSurcharge() {
         return Optional.ofNullable(corporateCardSurcharge);
     }
 
     @ApiModelProperty(example = "5", value = "processing fee taken by the GOV.UK Pay platform, in pence. Only available depending on payment service provider")
+    @Schema(example = "5", description = "processing fee taken by the GOV.UK Pay platform, in pence. Only available depending on payment service provider",
+            accessMode = READ_ONLY)
     public Optional<Long> getFee() {
         return Optional.ofNullable(fee);
     }
 
     @ApiModelProperty(example = "1195", value = "amount including all surcharges and less all fees, in pence. Only available depending on payment service provider")
+    @Schema(example = "1195", 
+            description = "amount including all surcharges and less all fees, in pence. Only available depending on payment service provider",
+            accessMode = READ_ONLY)
     public Optional<Long> getNetAmount() {
         return Optional.ofNullable(netAmount);
     }
 
     @ApiModelProperty(example = "1450")
+    @Schema(example = "1450", accessMode = READ_ONLY)
     public Optional<Long> getTotalAmount() {
         return Optional.ofNullable(totalAmount);
     }
@@ -158,11 +173,13 @@ public class CardPayment extends Payment {
     }
 
     @ApiModelProperty(example = "http://your.service.domain/your-reference")
+    @Schema(example = "http://your.service.domain/your-reference", accessMode = READ_ONLY)
     public Optional<String> getReturnUrl() {
         return Optional.ofNullable(returnUrl);
     }
 
     @ApiModelProperty(example = "your email")
+    @Schema(example = "your email")
     public Optional<String> getEmail() {
         return Optional.ofNullable(email);
     }

--- a/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.hibernate.validator.constraints.Length;
 import uk.gov.pay.api.utils.JsonStringBuilder;
 import uk.gov.pay.api.validation.ValidReturnUrl;
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.StringJoiner;
 
 @ApiModel(description = "The Payment Request Payload")
+@Schema(description = "The Payment Request Payload")
 public class CreateCardPaymentRequest {
 
     public static final int EMAIL_MAX_LENGTH = 254;
@@ -75,6 +76,7 @@ public class CreateCardPaymentRequest {
     private final Boolean delayedCapture;
 
     @ApiModelProperty(name = "metadata", dataType = "Map[String,String]")
+    @Schema(name = "metadata", example = "{\"property1\": \"value1\", \"property2\": \"value2\"}\"")
     private final ExternalMetadata metadata;
 
     @Valid
@@ -93,44 +95,52 @@ public class CreateCardPaymentRequest {
     }
 
     @ApiModelProperty(value = "amount in pence", required = true, allowableValues = "range[1, 10000000]", example = "12000")
+    @Schema(description = "amount in pence", required = true, minimum = "1", maximum = "10000000", example = "12000")
     public int getAmount() {
         return amount;
     }
 
     @ApiModelProperty(value = "payment reference", required = true, example = "12345")
+    @Schema(description = "payment reference", required = true, example = "12345")
     public String getReference() {
         return reference;
     }
 
     @ApiModelProperty(value = "payment description", required = true, example = "New passport application")
+    @Schema(description = "payment description", required = true, example = "New passport application")
     public String getDescription() {
         return description;
     }
 
     @ApiModelProperty(value = "ISO-639-1 Alpha-2 code of a supported language to use on the payment pages", required = false, example = "en", allowableValues = "en,cy")
+    @Schema(description = "ISO-639-1 Alpha-2 code of a supported language to use on the payment pages", example = "en")
     @JsonProperty(LANGUAGE_FIELD_NAME)
     public Optional<SupportedLanguage> getLanguage() {
         return Optional.ofNullable(language);
     }
 
     @ApiModelProperty(value = "email", required = false, example = "Joe.Bogs@example.org")
+    @Schema(name = "email", example = "Joe.Bogs@example.org")
     @JsonProperty(EMAIL_FIELD_NAME)
     public Optional<String> getEmail() {
         return Optional.ofNullable(email);
     }
     
     @ApiModelProperty(value = "service return url", required = true, example = "https://service-name.gov.uk/transactions/12345")
+    @Schema(description = "service return url", required = true, example = "https://service-name.gov.uk/transactions/12345")
     public String getReturnUrl() {
         return returnUrl;
     }
 
     @ApiModelProperty(value = "prefilled_cardholder_details", required = false)
+    @Schema(description = "prefilled_cardholder_details")
     @JsonProperty(CreateCardPaymentRequest.PREFILLED_CARDHOLDER_DETAILS_FIELD_NAME)
     public Optional<PrefilledCardholderDetails> getPrefilledCardholderDetails() {
         return Optional.ofNullable(prefilledCardholderDetails);
     }
 
     @ApiModelProperty(value = "delayed capture flag", required = false, example = "false")
+    @Schema(description = "delayed capture flag", example = "false")
     @JsonProperty(DELAYED_CAPTURE_FIELD_NAME)
     public Optional<Boolean> getDelayedCapture() {
         return Optional.ofNullable(delayedCapture);
@@ -142,6 +152,11 @@ public class CreateCardPaymentRequest {
             "The value, if a string, must be no greater than 50 characters long. " +
             "Other permissible value types: boolean, number.",
             dataType = "java.util.Map", example = "{\"ledger_code\":\"123\", \"reconciled\": true}")
+    @Schema(description = "Additional metadata - up to 10 name/value pairs - on the payment. " +
+            "Each key must be between 1 and 30 characters long. " +
+            "The value, if a string, must be no greater than 50 characters long. " +
+            "Other permissible value types: boolean, number.",
+            example = "{\"ledger_code\":\"123\", \"reconciled\": true}")
     public Optional<ExternalMetadata> getMetadata() {
         return Optional.ofNullable(metadata);
     }

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentResult.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentResult.java
@@ -3,6 +3,7 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.PaymentLinks;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
@@ -17,6 +18,7 @@ public class CreatePaymentResult {
 
     @JsonProperty
     @ApiModelProperty(name = "amount", example = "1200")
+    @Schema(name = "amount", example = "1200")
     private long amount;
 
     @JsonProperty
@@ -25,34 +27,42 @@ public class CreatePaymentResult {
 
     @JsonProperty
     @ApiModelProperty(example = "Your Service Description")
+    @Schema(example = "Your Service Description")
     private String description;
 
     @JsonProperty
     @ApiModelProperty(example = "your-reference")
+    @Schema(example = "your-reference")
     private String reference;
 
     @JsonProperty
     @ApiModelProperty(name = "language", access = "language", example = "en", allowableValues = "en,cy")
+    @Schema(name = "language", example = "en")
     private SupportedLanguage language;
 
     @JsonProperty
     @ApiModelProperty(name = "payment_id", example = "hu20sqlact5260q2nanm0q8u93")
+    @Schema(name = "payment_id", example = "hu20sqlact5260q2nanm0q8u93")
     private String paymentId;
 
     @JsonProperty
     @ApiModelProperty(name = "payment_provider", example = "worldpay")
+    @Schema(name = "payment_provider", example = "worldpay")
     private String paymentProvider;
 
     @JsonProperty
     @ApiModelProperty(name = "return_url", example = "http://your.service.domain/your-reference")
+    @Schema(name = "return_url", example = "http://your.service.domain/your-reference")
     private String returnUrl;
 
     @JsonProperty
     @ApiModelProperty(name = "created_date", example = "2016-01-21T17:15:00Z")
+    @Schema(name = "created_date", example = "2016-01-21T17:15:00Z")
     private String createdDate;
 
     @JsonProperty
     @ApiModelProperty(name = "delayed_capture", access = "delayed_capture")
+    @Schema(name = "delayed_capture")
     private boolean delayedCapture;
 
     @JsonProperty("refund_summary")
@@ -63,21 +73,26 @@ public class CreatePaymentResult {
 
     @JsonProperty
     @ApiModelProperty(name = LINKS_JSON_ATTRIBUTE)
+    @Schema(name = LINKS_JSON_ATTRIBUTE)
     private PaymentLinks links;
 
     @JsonProperty
     @ApiModelProperty(name = "provider_id", example = "null")
+    @Schema(name = "provider_id", example = "null")
     private String providerId;
 
     @JsonProperty
     @ApiModelProperty(name = "metadata", dataType = "Map[String,String]")
+    @Schema(name = "metadata")
     private ExternalMetadata metadata;
 
     @JsonProperty
     @ApiModelProperty(name = "email", example = "citizen@example.org", required = false)
+    @Schema(name = "email", example = "citizen@example.org")
     private String email;
 
     @JsonProperty(value = "card_details")
-    @ApiModelProperty(name = "card_details", required = false)
+    @ApiModelProperty(name = "card_details")
+    @Schema(name = "card_details")
     private CardDetails cardDetails;
 }

--- a/src/main/java/uk/gov/pay/api/model/PaymentEventResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentEventResponse.java
@@ -4,9 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.PaymentEventLink;
 
+import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
+
 @ApiModel(value="PaymentEvent", description = "A List of Payment Events information")
+@Schema(name = "PaymentEvent", description = "A List of Payment Events information")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PaymentEventResponse {
     @JsonProperty("payment_id")
@@ -37,16 +41,19 @@ public class PaymentEventResponse {
     }
 
     @ApiModelProperty(example = "hu20sqlact5260q2nanm0q8u93")
+    @Schema(example = "hu20sqlact5260q2nanm0q8u93", accessMode = READ_ONLY)
     public String getPaymentId() {
         return paymentId;
     }
 
     @ApiModelProperty(value = "state", dataType = "uk.gov.pay.api.model.PaymentState")
+    @Schema(description = "state")
     public PaymentState getState() {
         return state;
     }
 
     @ApiModelProperty(value = "updated",example = "2017-01-10T16:44:48.646Z")
+    @Schema(description = "updated", example = "2017-01-10T16:44:48.646Z", accessMode = READ_ONLY)
     public String getUpdated() {
         return updated;
     }

--- a/src/main/java/uk/gov/pay/api/model/PaymentEventsResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentEventsResponse.java
@@ -3,13 +3,17 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.PaymentLinksForEvents;
 
 import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
+
 @ApiModel(value="PaymentEvents", description = "A List of Payment Events information")
+@Schema(name = "PaymentEvents", description = "A List of Payment Events information")
 public class PaymentEventsResponse {
     @JsonProperty("payment_id")
     private final String paymentId;
@@ -44,6 +48,7 @@ public class PaymentEventsResponse {
     }
 
     @ApiModelProperty(example = "hu20sqlact5260q2nanm0q8u93")
+    @Schema(example = "hu20sqlact5260q2nanm0q8u93", accessMode = READ_ONLY)
     public String getPaymentId() {
         return paymentId;
     }

--- a/src/main/java/uk/gov/pay/api/model/PaymentState.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentState.java
@@ -6,12 +6,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Objects;
+
+import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @ApiModel(value = "PaymentState", description = "A structure representing the current state of the payment in its lifecycle.")
+@Schema(name = "PaymentState", description = "A structure representing the current state of the payment in its lifecycle.")
 public class PaymentState {
     @JsonProperty("status")
     private String status;
@@ -50,21 +54,27 @@ public class PaymentState {
     }
 
     @ApiModelProperty(value = "Current progress of the payment in its lifecycle", example = "created")
+    @Schema(description = "Current progress of the payment in its lifecycle", example = "created", accessMode = READ_ONLY)
     public String getStatus() {
         return status;
     }
 
     @ApiModelProperty(value = "Whether the payment has finished")
+    @Schema(description = "Whether the payment has finished", accessMode = READ_ONLY)
     public boolean isFinished() {
         return finished;
     }
 
     @ApiModelProperty(value = "What went wrong with the Payment if it finished with an error - English message", example = "User cancelled the payment")
+    @Schema(description = "What went wrong with the Payment if it finished with an error - English message",
+            example = "User cancelled the payment", accessMode = READ_ONLY)
     public String getMessage() {
         return message;
     }
 
     @ApiModelProperty(value = "What went wrong with the Payment if it finished with an error - error code", example = "P010")
+    @Schema(description = "What went wrong with the Payment if it finished with an error - error code", example = "P010",
+            accessMode = READ_ONLY)
     public String getCode() {
         return code;
     }

--- a/src/main/java/uk/gov/pay/api/model/PrefilledCardholderDetails.java
+++ b/src/main/java/uk/gov/pay/api/model/PrefilledCardholderDetails.java
@@ -3,6 +3,7 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Size;
@@ -14,10 +15,12 @@ public class PrefilledCardholderDetails {
 
     @JsonProperty("cardholder_name")
     @ApiModelProperty(name = "cardholder_name", value = "prefilled cardholder name", required = false, example = "J. Bogs")
+    @Schema(name = "cardholder_name", description = "prefilled cardholder name", example = "J. Bogs")
     @Size(max = 255, message = "Must be less than or equal to {max} characters length")
     private String cardholderName;
 
     @ApiModelProperty(name = "billing_address", value = "prefilled billing address", required = false)
+    @Schema(name = "billing_address", description = "prefilled billing address")
     @JsonProperty("billing_address")
     @Valid
     private Address billingAddress;

--- a/src/main/java/uk/gov/pay/api/model/RefundSummary.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundSummary.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-@ApiModel(value="RefundSummary", description = "A structure representing the refunds availability")
+@ApiModel(value = "RefundSummary", description = "A structure representing the refunds availability")
+@Schema(name = "RefundSummary", description = "A structure representing the refunds availability")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RefundSummary {
 
@@ -26,16 +28,19 @@ public class RefundSummary {
     }
 
     @ApiModelProperty(value = "Availability status of the refund", example = "available")
+    @Schema(description = "Availability status of the refund", example = "available")
     public String getStatus() {
         return status;
     }
 
     @ApiModelProperty(value = "Amount available for refund in pence", example = "100")
+    @Schema(description = "Amount available for refund in pence", example = "100")
     public long getAmountAvailable() {
         return amountAvailable;
     }
 
     @ApiModelProperty(value = "Amount submitted for refunds on this Payment in pence")
+    @Schema(description = "Amount submitted for refunds on this Payment in pence")
     public long getAmountSubmitted() {
         return amountSubmitted;
     }

--- a/src/main/java/uk/gov/pay/api/model/SettlementSummary.java
+++ b/src/main/java/uk/gov/pay/api/model/SettlementSummary.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 @ApiModel(value="SettlementSummary", description = "A structure representing information about a settlement")
+@Schema(name = "SettlementSummary", description = "A structure representing information about a settlement")
 public class SettlementSummary {
 
     @JsonProperty("capture_submit_time")
@@ -23,11 +25,14 @@ public class SettlementSummary {
     }
 
     @ApiModelProperty(value = "Date and time capture request has been submitted (may be null if capture request was not immediately acknowledged by payment gateway)", example = "2016-01-21T17:15:000Z")
+    @Schema(description = "Date and time capture request has been submitted (may be null if capture request was not immediately acknowledged by payment gateway)", 
+            example = "2016-01-21T17:15:000Z")
     public String getCaptureSubmitTime() {
         return captureSubmitTime;
     }
 
     @ApiModelProperty(value = "Date of the capture event", example = "2016-01-21")
+    @Schema(description = "Date of the capture event", example = "2016-01-21")
     public String getCapturedDate() {
         return capturedDate;
     }

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentEventLink.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentEventLink.java
@@ -3,10 +3,12 @@ package uk.gov.pay.api.model.links;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import static javax.ws.rs.HttpMethod.GET;
 
 @ApiModel(value = "PaymentEventLink", description = "Resource link for a payment of a payment event")
+@Schema(name = "PaymentEventLink", description = "Resource link for a payment of a payment event")
 public class PaymentEventLink {
 
     public static final String PAYMENT_LINK = "payment_url";
@@ -20,6 +22,7 @@ public class PaymentEventLink {
     }
 
     @ApiModelProperty(value = PAYMENT_LINK, dataType = "uk.gov.pay.api.model.links.Link")
+    @Schema(name = PAYMENT_LINK)
     public Link getPaymentLink() {
         return paymentLink;
     }

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentLinksForEvents.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentLinksForEvents.java
@@ -3,10 +3,12 @@ package uk.gov.pay.api.model.links;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import static javax.ws.rs.HttpMethod.GET;
 
 @ApiModel(value = "PaymentLinksForEvents", description = "links for events resource")
+@Schema(name = "PaymentLinksForEvents", description = "links for events resource")
 public class PaymentLinksForEvents {
 
     public static final String SELF = "self";
@@ -15,6 +17,7 @@ public class PaymentLinksForEvents {
     private Link self;
 
     @ApiModelProperty(value = SELF, dataType = "uk.gov.pay.api.model.links.Link")
+    @Schema(description = SELF)
     public Link getSelf() {
         return self;
     }

--- a/src/main/java/uk/gov/pay/api/model/search/card/PaymentSearchResults.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/PaymentSearchResults.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.api.model.search.card;
 
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.SearchNavigationLinks;
 import uk.gov.pay.api.model.search.SearchPagination;
 
@@ -12,13 +13,17 @@ import java.util.List;
 public class PaymentSearchResults implements SearchPagination {
 
     @ApiModelProperty(name = "total", example = "100")
+    @Schema(name = "total", example = "100")
     private int total;
     @ApiModelProperty(name = "count", example = "20")
+    @Schema(name = "count", example = "20")
     private int count;
     @ApiModelProperty(name = "page", example = "1")
+    @Schema(name = "page", example = "1")
     private int page;
     private List<PaymentForSearchResult> results;
     @ApiModelProperty(name = "_links")
+    @Schema(name = "_links")
     SearchNavigationLinks links;
 
     @Override
@@ -38,6 +43,7 @@ public class PaymentSearchResults implements SearchPagination {
     }
 
     @ApiModelProperty(name = "results")
+    @Schema(name = "results")
     public List<PaymentForSearchResult> getPayments() {
         return results;
     }

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
@@ -2,6 +2,7 @@ package uk.gov.pay.api.model.search.directdebit;
 
 import io.swagger.annotations.ApiParam;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.commons.validation.ValidDate;
 
 import javax.validation.constraints.Max;
@@ -22,6 +23,7 @@ public class DirectDebitSearchMandatesParams {
     @QueryParam("state")
     @Pattern(regexp = "created|started|pending|active|inactive|cancelled|failed|abandoned|error",
             message = "Must be one of created, started, pending, active, inactive, cancelled, failed, abandoned or error")
+    @Parameter(name = "state", schema = @Schema(allowableValues = {"created","started","pending","active","inactive","cancelled","failed","abandoned","error"}))
     private String state;
 
     @QueryParam("bank_statement_reference")
@@ -47,14 +49,15 @@ public class DirectDebitSearchMandatesParams {
 
     @QueryParam("page")
     @ApiParam(value = "Page number requested for the search, should be a positive integer (optional, defaults to 1)")
-    @Parameter(description = "Page number requested for the search, should be a positive integer (optional, defaults to 1)")
+    @Parameter(description = "Page number requested for the search, should be a positive integer (optional, defaults to 1)", schema = @Schema(minimum = "1"))
     @DefaultValue("1")
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     private int page;
 
     @QueryParam("display_size")
     @ApiParam(value = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)")
-    @Parameter(description = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)")
+    @Parameter(description = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)",
+     schema = @Schema(minimum = "1", maximum = "500"))
     @DefaultValue("500")
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     @Max(value = 500, message = "Must be less than or equal to {value}")

--- a/src/main/java/uk/gov/pay/api/resources/MandatesResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/MandatesResource.java
@@ -168,7 +168,7 @@ public class MandatesResource {
                     "The Authorisation token needs to be specified in the 'Authorization' header " +
                     "as 'Authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Created",
                             content = @Content(schema = @Schema(implementation = MandateResponse.class))),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Bad Request",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -203,8 +203,9 @@ public class PaymentRefundsResource {
             summary = "Return issued refund information. " +
                     "The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "202", description = "ACCEPTED",
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "successful operation",
                             content = @Content(schema = @Schema(implementation = RefundResult.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "202", description = "ACCEPTED"),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Credentials are required to access this resource"),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -8,6 +8,12 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +56,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/")
 @Api(tags = "Card payments", value = "/")
+@Tag(name = "Card payments")
 @Produces({"application/json"})
 public class PaymentsResource {
 
@@ -87,6 +94,25 @@ public class PaymentsResource {
     @Timed
     @Path("/v1/payments/{paymentId}")
     @Produces(APPLICATION_JSON)
+    @Operation(security = {@SecurityRequirement(name = "BearerAuth")},
+            operationId = "Get a payment",
+            summary = "Find payment by ID",
+            description = "Return information about the payment " +
+                    "The Authorisation token needs to be specified in the 'authorization' header " +
+                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+                            content = @Content(schema = @Schema(implementation = GetPaymentResult.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                            description = "Credentials are required to access this resource"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                            content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class)))
+            }
+    )
     @ApiOperation(
             nickname = "Get a payment",
             value = "Find payment by ID",
@@ -101,11 +127,12 @@ public class PaymentsResource {
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
             @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
-    public Response getPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
+    public Response getPayment(@ApiParam(value = "accountId", hidden = true) @Parameter(hidden = true) @Auth Account account,
                                @PathParam("paymentId")
                                @ApiParam(name = "paymentId", value = "Payment identifier", example = "hu20sqlact5260q2nanm0q8u93")
+                               @Parameter(name = "paymentId", description = "Payment identifier", example = "hu20sqlact5260q2nanm0q8u93")
                                        String paymentId,
-                               @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
+                               @ApiParam(hidden = true) @Parameter(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
 
         logger.info("Payment request - paymentId={}", paymentId);
 
@@ -120,6 +147,25 @@ public class PaymentsResource {
     @Timed
     @Path("/v1/payments/{paymentId}/events")
     @Produces(APPLICATION_JSON)
+    @Operation(security = {@SecurityRequirement(name = "BearerAuth")},
+            operationId = "Get events for a payment",
+            summary = "Return payment events by ID",
+            description = "Return payment events information about a certain payment " +
+                    "The Authorisation token needs to be specified in the 'authorization' header " +
+                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+                            content = @Content(schema = @Schema(implementation = PaymentEventsResponse.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                            description = "Credentials are required to access this resource"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                            content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class)))
+            }
+    )
     @ApiOperation(
             nickname = "Get events for a payment",
             value = "Return payment events by ID",
@@ -134,11 +180,13 @@ public class PaymentsResource {
             @ApiResponse(code = 404, message = "Not found", response = PaymentError.class),
             @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
-    public PaymentEventsResponse getPaymentEvents(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
+    public PaymentEventsResponse getPaymentEvents(@ApiParam(value = "accountId", hidden = true) 
+                                                  @Parameter(hidden = true) @Auth Account account,
                                                   @PathParam("paymentId")
                                                   @ApiParam(name = "paymentId", value = "Payment identifier", example = "hu20sqlact5260q2nanm0q8u93")
+                                                  @Parameter(name = "paymentId", description = "Payment identifier", example = "hu20sqlact5260q2nanm0q8u93")
                                                           String paymentId,
-                                                  @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
+                                                  @ApiParam(hidden = true) @Parameter(hidden = true)  @HeaderParam("X-Ledger") String strategyName) {
 
         logger.info("Payment events request - payment_id={}", paymentId);
 
@@ -154,6 +202,26 @@ public class PaymentsResource {
     @Timed
     @Path("/v1/payments")
     @Produces(APPLICATION_JSON)
+    @Operation(security = {@SecurityRequirement(name = "BearerAuth")},
+            operationId = "Search payments",
+            summary = "Search payments",
+            description = "Search payments by reference, state, 'from' and 'to' date. " +
+                    "The Authorisation token needs to be specified in the 'authorization' header " +
+                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+                            content = @Content(schema = @Schema(implementation = PaymentSearchResults.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                            description = "Credentials are required to access this resource"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422",
+                            description = "Invalid parameters: from_date, to_date, status, display_size. See Public API documentation for the correct data formats",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                            content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class)))
+            }
+    )
     @ApiOperation(
             nickname = "Search payments",
             value = "Search payments",
@@ -170,35 +238,48 @@ public class PaymentsResource {
             @ApiResponse(code = 422, message = "Invalid parameters: from_date, to_date, status, display_size. See Public API documentation for the correct data formats", response = PaymentError.class),
             @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
-    public Response searchPayments(@ApiParam(value = "accountId", hidden = true)
+    public Response searchPayments(@ApiParam(value = "accountId", hidden = true) @Parameter(hidden = true)
                                    @Auth Account account,
                                    @ApiParam(value = "Your payment reference to search (exact match, case insensitive)", hidden = false)
+                                   @Parameter(description = "Your payment reference to search (exact match, case insensitive)")
                                    @QueryParam("reference") String reference,
                                    @ApiParam(value = "The user email used in the payment to be searched", hidden = false)
+                                   @Parameter(description = "The user email used in the payment to be searched")
                                    @QueryParam("email") String email,
                                    @ApiParam(value = "State of payments to be searched. Example=success", hidden = false, allowableValues = "created,started,submitted,success,failed,cancelled,error")
+                                   @Parameter(description = "State of payments to be searched. Example=success", example = "success",
+                                           schema = @Schema(allowableValues = {"created","started","submitted","success","failed","cancelled","error"}))
                                    @QueryParam("state") String state,
                                    @ApiParam(value = "Card brand used for payment. Example=master-card", hidden = false)
+                                   @Parameter(description = "Card brand used for payment. Example=master-card")
                                    @QueryParam("card_brand") String cardBrand,
                                    @ApiParam(value = "From date of payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z", hidden = false)
+                                   @Parameter(description = "From date of payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z")
                                    @QueryParam("from_date") String fromDate,
                                    @ApiParam(value = "To date of payments to be searched (this date is exclusive). Example=2015-08-14T12:35:00Z", hidden = false)
+                                   @Parameter(description = "To date of payments to be searched (this date is exclusive). Example=2015-08-14T12:35:00Z")
                                    @QueryParam("to_date") String toDate,
                                    @ApiParam(value = "Page number requested for the search, should be a positive integer (optional, defaults to 1)", hidden = false)
+                                   @Parameter(description = "Page number requested for the search, should be a positive integer (optional, defaults to 1)")
                                    @QueryParam("page") String pageNumber,
                                    @ApiParam(value = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)", hidden = false)
+                                   @Parameter(description = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)")
                                    @QueryParam("display_size") String displaySize,
                                    @ApiParam(value = "Direct Debit Agreement Id", hidden = true)
+                                   @Parameter(hidden = true)
                                    @QueryParam("agreement_id") String agreementId,
                                    @ApiParam(value = "Name on card used to make payment", hidden = false)
+                                   @Parameter(description = "Name on card used to make payment")
                                    @QueryParam("cardholder_name") String cardHolderName,
-                                   @ApiParam(value = "First six digits of the card used to make payment", hidden = false)
+                                   @ApiParam(value = "First six digits of the card used to make payment")
+                                   @Parameter(description = "First six digits of the card used to make payment")
 
                                    @QueryParam("first_digits_card_number") String firstDigitsCardNumber,
                                    @ApiParam(value = "Last four digits of the card used to make payment", hidden = false)
+                                   @Parameter(description = "Last four digits of the card used to make payment", hidden = false)
 
                                    @QueryParam("last_digits_card_number") String lastDigitsCardNumber,
-                                   @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName,
+                                   @Parameter(hidden = true) @ApiParam(hidden = true) @HeaderParam("X-Ledger") String strategyName,
                                    @Context UriInfo uriInfo) {
 
         logger.info("Payments search request - [ {} ]",
@@ -229,6 +310,28 @@ public class PaymentsResource {
     @Path("/v1/payments")
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
+    @Operation(security = {@SecurityRequirement(name = "BearerAuth")},
+            operationId = "Create a payment",
+            summary = "Create a payment",
+            description = "Create a new payment for the account associated to the Authorisation token. " +
+                    "The Authorisation token needs to be specified in the 'authorization' header " +
+                    "as 'authorization: Bearer YOUR_API_KEY_HERE'",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Created",
+                            content = @Content(schema = @Schema(implementation = CreatePaymentResult.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Bad request",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                            description = "Credentials are required to access this resource"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422",
+                            description = "Invalid attribute value: description. Must be less than or equal to 255 characters length",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                            content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class)))
+            }
+    )
     @ApiOperation(
             nickname = "Create a payment",
             value = "Create new payment",
@@ -244,8 +347,9 @@ public class PaymentsResource {
             @ApiResponse(code = 422, message = "Invalid attribute value: description. Must be less than or equal to 255 characters length", response = PaymentError.class),
             @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)})
-    public Response createNewPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
-                                     @ApiParam(value = "requestPayload", required = true) @Valid CreateCardPaymentRequest createCardPaymentRequest) {
+    public Response createNewPayment(@ApiParam(value = "accountId", hidden = true) @Parameter(hidden = true) @Auth Account account,
+                                     @ApiParam(value = "requestPayload", required = true) @Parameter(required = true, name = "requestPayload")
+                                     @Valid CreateCardPaymentRequest createCardPaymentRequest) {
         logger.info("Payment create request parsed to {}", createCardPaymentRequest);
 
         PaymentWithAllLinks createdPayment = createPaymentService.create(account, createCardPaymentRequest);
@@ -263,6 +367,29 @@ public class PaymentsResource {
     @Timed
     @Path("/v1/payments/{paymentId}/cancel")
     @Produces(APPLICATION_JSON)
+    @Operation(security = {@SecurityRequirement(name = "BearerAuth")},
+            operationId = "Cancel a payment",
+            summary = "Cancel payment",
+            description = "Cancel a payment based on the provided payment ID and the Authorisation token. " +
+                    "The Authorisation token needs to be specified in the 'authorization' header " +
+                    "as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be cancelled if it's in " +
+                    "a state that isn't finished.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "No Content"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Cancellation of payment failed",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                            description = "Credentials are required to access this resource"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not Found",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Conflict",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                            content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class)))
+            }
+    )
     @ApiOperation(
             nickname = "Cancel a payment",
             value = "Cancel payment",
@@ -281,9 +408,10 @@ public class PaymentsResource {
             @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)
     })
-    public Response cancelPayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
+    public Response cancelPayment(@Parameter(hidden = true) @ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                   @PathParam("paymentId")
                                   @ApiParam(name = "paymentId", value = "Payment identifier", example = "hu20sqlact5260q2nanm0q8u93")
+                                  @Parameter(name = "paymentId", description = "Payment identifier", example = "hu20sqlact5260q2nanm0q8u93")
                                           String paymentId) {
 
         logger.info("Payment cancel request - payment_id=[{}]", paymentId);
@@ -295,6 +423,29 @@ public class PaymentsResource {
     @Timed
     @Path("/v1/payments/{paymentId}/capture")
     @Produces(APPLICATION_JSON)
+    @Operation(security = {@SecurityRequirement(name = "BearerAuth")},
+            operationId = "Capture a payment",
+            summary = "Capture payment",
+            description = "Capture a payment based on the provided payment ID and the Authorisation token. " +
+                    "The Authorisation token needs to be specified in the 'authorization' header " +
+                    "as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be captured if it's in " +
+                    "'submitted' state",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "No Content"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Capture of payment failed",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                            description = "Credentials are required to access this resource"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Conflict",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                            content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                            content = @Content(schema = @Schema(implementation = PaymentError.class)))
+            }
+    )
     @ApiOperation(
             nickname = "Capture a payment",
             value = "Capture payment",
@@ -313,9 +464,10 @@ public class PaymentsResource {
             @ApiResponse(code = 429, message = "Too many requests", response = ApiErrorResponse.class),
             @ApiResponse(code = 500, message = "Downstream system error", response = PaymentError.class)
     })
-    public Response capturePayment(@ApiParam(value = "accountId", hidden = true) @Auth Account account,
+    public Response capturePayment(@Parameter(hidden = true) @ApiParam(value = "accountId", hidden = true) @Auth Account account,
                                    @PathParam("paymentId")
                                    @ApiParam(name = "paymentId", value = "Payment identifier", example = "hu20sqlact5260q2nanm0q8u93")
+                                   @Parameter(name = "paymentId", description = "Payment identifier", example = "hu20sqlact5260q2nanm0q8u93")
                                            String paymentId) {
         logger.info("Payment capture request - payment_id=[{}]", paymentId);
 


### PR DESCRIPTION
## WHAT YOU DID
- Swagger definitions for Card payment endpoints (for openapi v3.0.0)

## HOW TO TEST
- `mvn compile` should now generate swagger (with openapi v3.0.0) with correct definitions for card payment endpoints including examples