### PR TITLE
PP-5725 Add Sentry config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,11 @@
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.dhatim</groupId>
+            <artifactId>dropwizard-sentry</artifactId>
+            <version>1.3.9-1</version>
+        </dependency>
         <!-- testing -->
         <dependency>
             <groupId>uk.gov.pay</groupId>

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -19,6 +19,10 @@ logging:
       target: stdout
       customFields:
         container: "publicapi"
+    - type: sentry
+      threshold: ERROR
+      dsn: ${SENTRY_DSN:-https://example.com@dummy/1}
+      environment: ${ENVIRONMENT}
 
 baseUrl: ${PUBLICAPI_BASE}
 connectorUrl: ${CONNECTOR_URL}


### PR DESCRIPTION
Add Sentry logging appender so that logs at `ERROR` level and uncaught
exceptions are reported to Sentry. Same implementations as per
https://github.com/alphagov/pay-direct-debit-connector/pull/745

There is a default value for the dsn so that the app will start if the
`SENTRY_DSN` env variable has not been set.

## WHAT YOU DID
Same implementation that is already successfully working for DD-Connector and Classic Connector
https://github.com/alphagov/pay-connector/pull/1824/commits/d3834e14cb8d88dbab9fdc78c523770937d69bc6