### PR TITLE
PP-5757 Only log error if connector 500s

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CancelChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CancelChargeExceptionMapper.java
@@ -37,7 +37,7 @@ public class CancelChargeExceptionMapper implements ExceptionMapper<CancelCharge
             status = INTERNAL_SERVER_ERROR;
         }
 
-        if (status != NOT_FOUND) {
+        if (status == INTERNAL_SERVER_ERROR) {
             LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, paymentError);
         }
         return Response

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CaptureChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CaptureChargeExceptionMapper.java
@@ -42,7 +42,7 @@ public class CaptureChargeExceptionMapper implements ExceptionMapper<CaptureChar
             status = INTERNAL_SERVER_ERROR;
         }
 
-        if (status != NOT_FOUND) {
+        if (status == INTERNAL_SERVER_ERROR) {
             LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, paymentError);
         }
         return Response


### PR DESCRIPTION
We should not log an error if e.g. connector responds with a
400 - this can happen for all sorts of normal reasons. Seems
useful to keep log in case of connector 500, but don't log anything
otherwise.
