### PR TITLE
PP-5758 Return 404 if charge not found when refunding

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CreateRefundException;
-import uk.gov.pay.api.model.ChargeFromResponse;
+import uk.gov.pay.api.model.Charge;
 import uk.gov.pay.api.model.CreatePaymentRefundRequest;
 import uk.gov.pay.api.model.PaymentError;
 import uk.gov.pay.api.model.RefundFromConnector;
@@ -31,6 +31,7 @@ import uk.gov.pay.api.model.RefundsResponse;
 import uk.gov.pay.api.model.search.card.RefundForSearchResult;
 import uk.gov.pay.api.model.search.card.RefundResult;
 import uk.gov.pay.api.resources.error.ApiErrorResponse;
+import uk.gov.pay.api.service.ConnectorService;
 import uk.gov.pay.api.service.GetPaymentRefundService;
 import uk.gov.pay.api.service.GetPaymentRefundsService;
 
@@ -76,7 +77,6 @@ public class PaymentRefundsResource {
     private static final String CONNECTOR_CHARGE_RESOURCE = CONNECTOR_CHARGES_RESOURCE + "/%s";
 
     private static final String CONNECTOR_CHARGE_REFUNDS_RESOURCE = CONNECTOR_CHARGE_RESOURCE + "/refunds";
-    private static final String CONNECTOR_CHARGE_REFUND_BY_ID_RESOURCE = CONNECTOR_CHARGE_REFUNDS_RESOURCE + "/%s";
 
     private final String baseUrl;
     private final Client client;
@@ -84,17 +84,19 @@ public class PaymentRefundsResource {
     private PublicApiConfig configuration;
     private GetPaymentRefundsService getPaymentRefundsService;
     private GetPaymentRefundService getPaymentRefundService;
+    private ConnectorService connectorService;
 
     @Inject
     public PaymentRefundsResource(Client client, PublicApiConfig configuration,
                                   GetPaymentRefundsService getPaymentRefundsService,
-                                  GetPaymentRefundService getPaymentRefundService) {
+                                  GetPaymentRefundService getPaymentRefundService, ConnectorService connectorService) {
         this.client = client;
         this.baseUrl = configuration.getBaseUrl();
         this.connectorUrl = configuration.getConnectorUrl();
         this.configuration = configuration;
         this.getPaymentRefundsService = getPaymentRefundsService;
         this.getPaymentRefundService = getPaymentRefundService;
+        this.connectorService = connectorService;
     }
 
     @GET
@@ -244,13 +246,8 @@ public class PaymentRefundsResource {
 
         Integer refundAmountAvailable = requestPayload.getRefundAmountAvailable()
                 .orElseGet(() -> {
-                    Response getChargeResponse = client
-                            .target(getConnectorUrl(format(CONNECTOR_CHARGE_RESOURCE, account.getAccountId(), paymentId)))
-                            .request()
-                            .get();
-
-                    ChargeFromResponse chargeFromResponse = getChargeResponse.readEntity(ChargeFromResponse.class);
-                    return Long.valueOf(chargeFromResponse.getRefundSummary().getAmountAvailable()).intValue();
+                    Charge charge = connectorService.getCharge(account, paymentId);
+                    return Long.valueOf(charge.getRefundSummary().getAmountAvailable()).intValue();
                 });
 
         ImmutableMap<String, Object> payloadMap = ImmutableMap.of("amount", requestPayload.getAmount(), "refund_amount_available", refundAmountAvailable);

--- a/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceIT.java
@@ -27,6 +27,7 @@ import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.ACCEPTED;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.api.utils.Urls.paymentLocationFor;
@@ -202,6 +203,18 @@ public class PaymentRefundsResourceIT extends PaymentResourceITestBase {
                         .build());
 
         postRefundRequest(payload);
+    }
+    
+    @Test
+    public void createRefundWhenChargeNotFound_shouldReturn404() {
+        String payload = new GsonBuilder().create().toJson(Map.of("amount", AMOUNT));
+
+        connectorMockClient.respondChargeNotFound(CHARGE_ID, GATEWAY_ACCOUNT_ID, "Not found");
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+
+        postRefunds(payload)
+                .then()
+                .statusCode(NOT_FOUND.getStatusCode());
     }
 
     @Test


### PR DESCRIPTION
Previously if charge not found when trying to retrieve charge,
we got a NPE. Instead use Connector Service to get charge which
handles errors and deserialisation etc, meaning a 404 will be thrown
if refund attempted for non-existent charge.

It is possible for the refund summary on a charge not to be
present when fetching a charge in process of refund. In that
case assume the amount available to refund is 0. This does mean
an extra call will be made to connector before the refund fails, but
has the advantage of keeping the logic contained in connector.
