### PR TITLE
PP-5758 Downgrade violation exception log level

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/ViolationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/ViolationExceptionMapper.java
@@ -24,7 +24,7 @@ public class ViolationExceptionMapper implements ExceptionMapper<JerseyViolation
 
     @Override
     public Response toResponse(JerseyViolationException exception) {
-        LOGGER.error(exception.getMessage());
+        LOGGER.info(exception.getMessage());
         ConstraintViolation<?> firstException = exception.getConstraintViolations().iterator().next();
         String fieldName = getApiFieldName(firstException.getPropertyPath());
         


### PR DESCRIPTION
The ViolationExceptionMapper maps all validation exceptions. In
general a validation exception is a client error, and of no concern
from an operational perspective. This commit downgrades the log level to
info - the log may still be useful for debugging purposes