### PR TITLE
PP-5759 Only log error on error from connector

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -43,10 +43,10 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
             paymentError = aPaymentError(CREATE_PAYMENT_MANDATE_STATE_INVALID);
         } else {
             paymentError = aPaymentError(CREATE_PAYMENT_CONNECTOR_ERROR);
+            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}",
+                    exception.getMessage(), INTERNAL_SERVER_ERROR, paymentError);
         }
 
-        LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}", 
-                exception.getMessage(), INTERNAL_SERVER_ERROR, paymentError);
 
         return Response
                 .status(statusCode)

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapper.java
@@ -38,7 +38,7 @@ public class CreateRefundExceptionMapper implements ExceptionMapper<CreateRefund
             status = INTERNAL_SERVER_ERROR;
         }
 
-        if (status != NOT_FOUND) {
+        if (status == INTERNAL_SERVER_ERROR) {
             LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {} {}", exception.getMessage(), status, paymentError);
         }
 


### PR DESCRIPTION
We should only log an error at this point if connector has done something weird. Validation errors etc should just be passed on to user - no log necessary.
