### PR TITLE
PP-5742 Payment events use Connector if payment exists

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/GetPaymentEventsStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/GetPaymentEventsStrategy.java
@@ -25,7 +25,7 @@ public class GetPaymentEventsStrategy extends LedgerOrConnectorStrategyTemplate<
 
     @Override
     protected PaymentEventsResponse executeFutureBehaviourStrategy() {
-        return executeLedgerOnlyStrategy();
+        return getPaymentEventsService.getPaymentEvents(account, paymentId);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/api/service/GetPaymentEventsService.java
+++ b/src/main/java/uk/gov/pay/api/service/GetPaymentEventsService.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.api.service;
 
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.exception.GetEventsException;
 import uk.gov.pay.api.model.PaymentEvents;
 import uk.gov.pay.api.model.PaymentEventsResponse;
 import uk.gov.pay.api.model.TransactionEvents;
@@ -39,5 +40,13 @@ public class GetPaymentEventsService {
         URI paymentLink = publicApiUriGenerator.getPaymentURI(paymentId);
 
         return PaymentEventsResponse.from(transactionEvents, paymentLink, paymentEventsLink);
+    }
+
+    public PaymentEventsResponse getPaymentEvents(Account account, String paymentId) {
+        try {
+            return getPaymentEventsFromConnector(account, paymentId);
+        } catch (GetEventsException ex) {
+            return getPaymentEventsFromLedger(account, paymentId);
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentEventsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentEventsStrategyTest.java
@@ -88,8 +88,7 @@ public class GetPaymentEventsStrategyTest {
 
         getPaymentEventsStrategy.validateAndExecute();
 
-        verify(getPaymentEventsService).getPaymentEventsFromLedger(mockAccountId, mockPaymentId);
-        verify(getPaymentEventsService, never()).getPaymentEventsFromConnector(mockAccountId, mockPaymentId);
+        verify(getPaymentEventsService).getPaymentEvents(mockAccountId, mockPaymentId);
     }
 
     @Test
@@ -115,7 +114,6 @@ public class GetPaymentEventsStrategyTest {
 
         getPaymentEventsStrategy.validateAndExecute();
 
-        verify(getPaymentEventsService).getPaymentEventsFromLedger(mockAccountId, mockPaymentId);
-        verify(getPaymentEventsService, never()).getPaymentEventsFromConnector(mockAccountId, mockPaymentId);
+        verify(getPaymentEventsService).getPaymentEvents(mockAccountId, mockPaymentId);
     }
 }


### PR DESCRIPTION
Update get payment events strategy to check Connector before fetching
events from Ledger. This is our "get one" strategy and will make sure
asking for events has no delay when processing a payment in real time.