### PR TITLE
PP-5809: Log things at info

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapper.java
@@ -29,7 +29,7 @@ public class CreateAgreementExceptionMapper implements ExceptionMapper<CreateMan
             mandateError = MandateError.aMandateError(MandateError.Code.CREATE_MANDATE_CONNECTOR_ERROR);
         }
 
-        LOGGER.error("Direct Debit connector invalid response was {}.\n Returning http status {} with error body {}",
+        LOGGER.info("Direct Debit connector invalid response was {}.\n Returning http status {} with error body {}",
                 exception.getMessage(), INTERNAL_SERVER_ERROR, mandateError);
 
         return Response

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -43,7 +43,7 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
             paymentError = aPaymentError(CREATE_PAYMENT_MANDATE_STATE_INVALID);
         } else {
             paymentError = aPaymentError(CREATE_PAYMENT_CONNECTOR_ERROR);
-            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}",
+            LOGGER.info("Connector invalid response was {}.\n Returning http status {} with error body {}",
                     exception.getMessage(), INTERNAL_SERVER_ERROR, paymentError);
         }
 

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapper.java
@@ -39,7 +39,7 @@ public class CreateRefundExceptionMapper implements ExceptionMapper<CreateRefund
         }
 
         if (status == INTERNAL_SERVER_ERROR) {
-            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {} {}", exception.getMessage(), status, paymentError);
+            LOGGER.info("Connector invalid response was {}.\n Returning http status {} with error body {} {}", exception.getMessage(), status, paymentError);
         }
 
         return Response

--- a/src/main/java/uk/gov/pay/api/exception/mapper/SearchRefundsExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/SearchRefundsExceptionMapper.java
@@ -27,7 +27,7 @@ public class SearchRefundsExceptionMapper implements ExceptionMapper<SearchRefun
 
     private Response buildResponse(SearchRefundsException exception, RefundError.Code connectorError, Response.Status status) {
         RefundError refundError = aRefundError(connectorError);
-        LOGGER.error("Connector response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, refundError);
+        LOGGER.info("Connector response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, refundError);
         return Response
                 .status(status)
                 .entity(refundError)


### PR DESCRIPTION
From Sentry, these things are logged at error when they should be at info:

GO_CARDLESS_ACCOUNT_NOT_LINKED
CREATE_MANDATE_ACCOUNT_ERROR - There is an error with this account. Please contact support
CREATE_PAYMENT_REFUND_CONNECTOR_ERROR - Stripe refund response (error code: charge_already_refunded
CREATE_PAYMENT_VALIDATION_ERROR - Invalid attribute value: amount. Must be greater than or equal to 1
