### PR TITLE
PP-5869: add integration test for refunds search

### DIFF
--- a/src/test/java/uk/gov/pay/api/utils/mocks/LedgerMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/LedgerMockClient.java
@@ -2,9 +2,12 @@ package uk.gov.pay.api.utils.mocks;
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
+import uk.gov.pay.api.model.links.Link;
 import uk.gov.pay.api.utils.JsonStringBuilder;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,6 +64,28 @@ public class LedgerMockClient {
                 .add("transactions", refunds);
 
         ledgerMock.stubFor(get(urlPathEqualTo(format("/v1/transaction/%s/transaction", transactionId)))
+                .willReturn(aResponse()
+                        .withStatus(OK_200)
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                        .withBody(jsonStringBuilder.build())));
+    }
+
+    public void respondWithSearchRefunds(RefundTransactionFromLedgerFixture... refunds) {
+
+        Map<String, Link> links = (ImmutableMap.of("first_page", new Link("http://server:port/first-link?page=1"),
+                "prev_page", new Link("http://server:port/prev-link?page=2"),
+                "self", new Link("http://server:port/self-link?page=3"),
+                "last_page", new Link("http://server:port/last-link?page=5"),
+                "next_page", new Link("http://server:port/next-link?page=4")));
+
+        JsonStringBuilder jsonStringBuilder = new JsonStringBuilder()
+                .add("total", 1)
+                .add("count", 1)
+                .add("page", 1)
+                .add("results", Arrays.asList(refunds))
+                .add("_links", links);
+
+        ledgerMock.stubFor(get(urlPathEqualTo("/v1/transaction"))
                 .willReturn(aResponse()
                         .withStatus(OK_200)
                         .withHeader(CONTENT_TYPE, APPLICATION_JSON)

--- a/src/test/java/uk/gov/pay/api/utils/mocks/RefundTransactionFromLedgerFixture.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/RefundTransactionFromLedgerFixture.java
@@ -10,12 +10,14 @@ public class RefundTransactionFromLedgerFixture {
     private final TransactionState state;
     private final String createdDate;
     private final String transactionId;
+    private final String parentTransactionId;
 
     public RefundTransactionFromLedgerFixture(RefundTransactionFromLedgerBuilder builder) {
         this.amount = builder.amount;
         this.state = builder.state;
         this.createdDate = builder.createdDate;
         this.transactionId = builder.transactionId;
+        this.parentTransactionId = builder.parentTransactionId;
     }
 
     public Long getAmount() {
@@ -34,11 +36,16 @@ public class RefundTransactionFromLedgerFixture {
         return transactionId;
     }
 
+    public String getParentTransactionId() {
+        return parentTransactionId;
+    }
+
     public static final class RefundTransactionFromLedgerBuilder {
         private Long amount;
         private TransactionState state;
         private String createdDate;
         private String transactionId;
+        private String parentTransactionId;
 
         private RefundTransactionFromLedgerBuilder() {
         }
@@ -64,6 +71,11 @@ public class RefundTransactionFromLedgerFixture {
 
         public RefundTransactionFromLedgerBuilder withTransactionId(String transactionId) {
             this.transactionId = transactionId;
+            return this;
+        }
+
+        public RefundTransactionFromLedgerBuilder withParentTransactionId(String parentTransactionId) {
+            this.parentTransactionId = parentTransactionId;
             return this;
         }
 


### PR DESCRIPTION
Why?
To make sure the code path executed in production is properly tested.

What?
Introduce integreation test for refunds search that makes sure the mapping between
dto from Ledger maps properly to public api response for searching refunds.