### PR TITLE
[PP-5869] replace connector mock with ledger when search in rate limit test

### DIFF
--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterITestBase.java
@@ -55,12 +55,13 @@ abstract public class ResourcesFilterITestBase {
     static final List<Map<String, String>> EVENTS = List.of(new ChargeEventBuilder(CREATED, CREATED_DATE).build());
     static final String GATEWAY_ACCOUNT_ID = "GATEWAY_ACCOUNT_ID";
     static final String PAYLOAD = paymentPayload();
-    
+
     private static final int CONNECTOR_PORT = findFreePort();
     private static final int PUBLIC_AUTH_PORT = findFreePort();
+    private static final int LEDGER_PORT = findFreePort();
 
     private ExecutorService executor = Executors.newFixedThreadPool(2);
-    
+
     @ClassRule
     public static RedisDockerRule redisDockerRule;
 
@@ -71,21 +72,26 @@ abstract public class ResourcesFilterITestBase {
             e.printStackTrace();
         }
     }
-    
+
     @ClassRule
     public static WireMockClassRule connectorMock = new WireMockClassRule(CONNECTOR_PORT);
+
+    @ClassRule
+    public static WireMockClassRule ledgerMock = new WireMockClassRule(LEDGER_PORT);
 
     @ClassRule
     public static WireMockClassRule publicAuthMock = new WireMockClassRule(PUBLIC_AUTH_PORT);
 
     @Rule
     public DropwizardAppRule<PublicApiConfig> app = new DropwizardAppRule<>(
-            PublicApi.class, 
-            resourceFilePath("config/test-config.yaml"), 
-            config("connectorUrl", "http://localhost:" + CONNECTOR_PORT), 
-            config("connectorDDUrl", "http://localhost"), 
-            config("publicAuthUrl", "http://localhost:" + PUBLIC_AUTH_PORT + "/v1/auth"), 
+            PublicApi.class,
+            resourceFilePath("config/test-config.yaml"),
+            config("connectorUrl", "http://localhost:" + CONNECTOR_PORT),
+            config("connectorDDUrl", "http://localhost"),
+            config("publicAuthUrl", "http://localhost:" + PUBLIC_AUTH_PORT + "/v1/auth"),
             config("redis.endpoint", redisDockerRule.getRedisUrl()),
+            config("ledgerUrl", "http://localhost:" + LEDGER_PORT),
+            config("alwaysUseFutureStrategy", "true"),
             config("rateLimiter.noOfReq", "1"),
             config("rateLimiter.noOfReqForPost", "1")
     );

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterIT.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterIT.java
@@ -5,6 +5,7 @@ import io.restassured.response.ValidatableResponse;
 import org.junit.Test;
 import uk.gov.pay.api.it.fixtures.PaymentNavigationLinksFixture;
 import uk.gov.pay.api.utils.mocks.ConnectorMockClient;
+import uk.gov.pay.api.utils.mocks.LedgerMockClient;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.util.Arrays;
@@ -13,13 +14,14 @@ import java.util.concurrent.Callable;
 
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.junit.Assert.assertThat;
-import static uk.gov.pay.api.it.fixtures.PaginatedPaymentSearchResultFixture.aPaginatedPaymentSearchResult;
+import static uk.gov.pay.api.it.fixtures.PaginatedTransactionSearchResultFixture.aPaginatedTransactionSearchResult;
 import static uk.gov.pay.api.it.fixtures.PaymentSearchResultBuilder.aSuccessfulSearchPayment;
 import static uk.gov.pay.api.utils.mocks.ChargeResponseFromConnector.ChargeResponseFromConnectorBuilder.aCreateOrGetChargeResponseFromConnector;
 
 public class ResourcesFilterRateLimiterIT extends ResourcesFilterITestBase {
 
     private ConnectorMockClient connectorMockClient = new ConnectorMockClient(connectorMock);
+    private LedgerMockClient ledgerMockClient = new LedgerMockClient(ledgerMock);
     
     @Test
     public void createPayment_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
@@ -100,7 +102,7 @@ public class ResourcesFilterRateLimiterIT extends ResourcesFilterITestBase {
 
     @Test
     public void searchPayments_whenRateLimitIsReached_shouldReturn429Response() throws Exception {
-        String payments = aPaginatedPaymentSearchResult()
+        String payments = aPaginatedTransactionSearchResult()
                 .withCount(10)
                 .withPage(2)
                 .withTotal(20)
@@ -111,7 +113,7 @@ public class ResourcesFilterRateLimiterIT extends ResourcesFilterITestBase {
                         .withNumberOfResults(1).getResults())
                 .build();
 
-        connectorMockClient.respondOk_whenSearchCharges(GATEWAY_ACCOUNT_ID, payments);
+        ledgerMockClient.respondOk_whenSearchCharges(payments);
 
         List<Callable<ValidatableResponse>> tasks = Arrays.asList(
                 () -> searchPayments(API_KEY, ImmutableMap.of("reference", REFERENCE)),


### PR DESCRIPTION
Why?
The search after the code cleanup will solely go through the ledger, so all the
references to the connector in this context should be removed.

Changes:
* replace connector mock with ledger one for rate limiting integration test of the
search endpoint