### PR TITLE
[PP-5869] update search integration tests to cover ledger paths

### DIFF
--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
@@ -79,6 +79,7 @@ public abstract class PaymentResourceITestBase {
         connectorMock.resetAll();
         connectorDDMock.resetAll();
         publicAuthMock.resetAll();
+        ledgerMock.resetAll();
     }
 
     String frontendUrlFor(TokenPaymentType paymentType) {


### PR DESCRIPTION
Why?
In order to make sure both paths (connector and ledger) are properly covered with tests.

Changes:
* add ledger equivalent tests for all the payment search scenarios (that make sense)
* add missing mock reset for ledger