### PR TITLE
PP-5761: Add X-Request-Id header to requests

### DIFF
--- a/src/main/java/uk/gov/pay/api/clients/ExternalServiceClient.java
+++ b/src/main/java/uk/gov/pay/api/clients/ExternalServiceClient.java
@@ -10,6 +10,7 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import java.util.Map;
+import java.util.Optional;
 
 public class ExternalServiceClient {
 
@@ -25,7 +26,10 @@ public class ExternalServiceClient {
     }
 
     private MultivaluedMap<String, Object> getHeaders() {
-        return new MultivaluedHashMap<>(Map.of("X-Request-Id", MDC.get("x_request_id")));
+        return Optional.ofNullable(MDC.get("x_request_id"))
+                    .filter(s -> !s.isBlank())
+                    .map(s -> new MultivaluedHashMap<String, Object>(Map.of("X-Request-Id", s)))
+                    .orElse(new MultivaluedHashMap<>());
     }
 
     public Response post(String url) {

--- a/src/main/java/uk/gov/pay/api/clients/ExternalServiceClient.java
+++ b/src/main/java/uk/gov/pay/api/clients/ExternalServiceClient.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.api.clients;
+
+import org.slf4j.MDC;
+
+import javax.inject.Inject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+public class ExternalServiceClient {
+
+    private final Client client;
+
+    @Inject
+    public ExternalServiceClient(Client client) {
+        this.client = client;
+    }
+
+    public Response get(String url) {
+        return client.target(url).request().headers(getHeaders()).accept(MediaType.APPLICATION_JSON).get();
+    }
+
+    private MultivaluedMap<String, Object> getHeaders() {
+        return new MultivaluedHashMap<>(Map.of("X-Request-Id", MDC.get("x_request_id")));
+    }
+
+    public Response post(String url) {
+        return post(url, null);
+    }
+
+    public Response post(String url, Entity entity) {
+        return client.target(url).request().headers(getHeaders()).accept(MediaType.APPLICATION_JSON).post(entity);
+    }
+}

--- a/src/main/java/uk/gov/pay/api/service/CancelPaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CancelPaymentService.java
@@ -2,28 +2,25 @@ package uk.gov.pay.api.service;
 
 import org.apache.http.HttpStatus;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.clients.ExternalServiceClient;
 import uk.gov.pay.api.exception.CancelChargeException;
 
 import javax.inject.Inject;
-import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
 
 public class CancelPaymentService {
 
-    private final Client client;
+    private final ExternalServiceClient client;
     private final ConnectorUriGenerator connectorUriGenerator;
 
     @Inject
-    public CancelPaymentService(Client client, ConnectorUriGenerator connectorUriGenerator) {
+    public CancelPaymentService(ExternalServiceClient client, ConnectorUriGenerator connectorUriGenerator) {
         this.client = client;
         this.connectorUriGenerator = connectorUriGenerator;
     }
 
     public Response cancel(Account account, String chargeId) {
-        Response connectorResponse = client
-                .target(connectorUriGenerator.cancelURI(account, chargeId))
-                .request()
-                .post(null);
+        Response connectorResponse = client.post(connectorUriGenerator.cancelURI(account, chargeId));
 
         if (connectorResponse.getStatus() == HttpStatus.SC_NO_CONTENT) {
             connectorResponse.close();

--- a/src/main/java/uk/gov/pay/api/service/CapturePaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CapturePaymentService.java
@@ -1,28 +1,25 @@
 package uk.gov.pay.api.service;
 
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.clients.ExternalServiceClient;
 
 import javax.inject.Inject;
-import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 
 public class CapturePaymentService {
 
-    private final Client client;
+    private final ExternalServiceClient client;
     private final ConnectorUriGenerator connectorUriGenerator;
 
     @Inject
-    public CapturePaymentService(Client client, ConnectorUriGenerator connectorUriGenerator) {
+    public CapturePaymentService(ExternalServiceClient client, ConnectorUriGenerator connectorUriGenerator) {
         this.client = client;
         this.connectorUriGenerator = connectorUriGenerator;
     }
 
     public Response capture(Account account, String chargeId) {
-        return client
-                .target(connectorUriGenerator.captureURI(account, chargeId))
-                .request()
-                .post(Entity.json("{}"));
+        return client.post(connectorUriGenerator.captureURI(account, chargeId), Entity.json("{}"));
     }
 
 }

--- a/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
@@ -2,6 +2,7 @@ package uk.gov.pay.api.service;
 
 import org.apache.http.HttpStatus;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.clients.ExternalServiceClient;
 import uk.gov.pay.api.exception.CreateChargeException;
 import uk.gov.pay.api.model.Charge;
 import uk.gov.pay.api.model.ChargeFromResponse;
@@ -9,21 +10,19 @@ import uk.gov.pay.api.model.CreateCardPaymentRequest;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 
 import javax.inject.Inject;
-import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import static javax.ws.rs.client.Entity.json;
 
 public class CreatePaymentService {
 
-    private final Client client;
+    private final ExternalServiceClient client;
     private final PublicApiUriGenerator publicApiUriGenerator;
     private final ConnectorUriGenerator connectorUriGenerator;
 
     @Inject
-    public CreatePaymentService(Client client, PublicApiUriGenerator publicApiUriGenerator, ConnectorUriGenerator connectorUriGenerator) {
+    public CreatePaymentService(ExternalServiceClient client, PublicApiUriGenerator publicApiUriGenerator, ConnectorUriGenerator connectorUriGenerator) {
         this.client = client;
         this.publicApiUriGenerator = publicApiUriGenerator;
         this.connectorUriGenerator = connectorUriGenerator;
@@ -56,11 +55,7 @@ public class CreatePaymentService {
     }
 
     private Response createCharge(Account account, CreateCardPaymentRequest createCardPaymentRequest) {
-        return client
-                .target(connectorUriGenerator.chargesURI(account))
-                .request()
-                .accept(MediaType.APPLICATION_JSON)
-                .post(buildChargeRequestPayload(createCardPaymentRequest));
+        return client.post(connectorUriGenerator.chargesURI(account), buildChargeRequestPayload(createCardPaymentRequest));
     }
 
     private Entity buildChargeRequestPayload(CreateCardPaymentRequest requestPayload) {

--- a/src/test/java/uk/gov/pay/api/clients/ExternalServiceClientTest.java
+++ b/src/test/java/uk/gov/pay/api/clients/ExternalServiceClientTest.java
@@ -13,6 +13,7 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
@@ -60,5 +61,23 @@ public class ExternalServiceClientTest {
 
         verify(builder).headers(builderArgumentCaptor.capture());
         assertThat(builderArgumentCaptor.getValue().getFirst("X-Request-Id")).isEqualTo("123-easy-as-abc");
+    }
+    
+    @Test
+    public void assert_empty_headers_in_post_request_when_mdc_is_empty() {
+        MDC.clear();
+        externalServiceClient.post("http://example123.com");
+
+        verify(builder).headers(builderArgumentCaptor.capture());
+        assertThat(builderArgumentCaptor.getAllValues()).containsExactly(new MultivaluedHashMap<>());
+    }
+
+    @Test
+    public void assert_empty_headers_in_get_request_when_mdc_is_empty() {
+        MDC.clear();
+        externalServiceClient.get("http://example123.com");
+
+        verify(builder).headers(builderArgumentCaptor.capture());
+        assertThat(builderArgumentCaptor.getAllValues()).containsExactly(new MultivaluedHashMap<>());
     }
 }

--- a/src/test/java/uk/gov/pay/api/clients/ExternalServiceClientTest.java
+++ b/src/test/java/uk/gov/pay/api/clients/ExternalServiceClientTest.java
@@ -1,0 +1,64 @@
+package uk.gov.pay.api.clients;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.MDC;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExternalServiceClientTest {
+
+    private ExternalServiceClient externalServiceClient;
+
+    @Mock
+    private Client client;
+    @Mock
+    private WebTarget webTarget;
+    @Mock
+    private Invocation.Builder builder;
+    @Captor
+    private ArgumentCaptor<MultivaluedMap<String, Object>> builderArgumentCaptor;
+
+    @Before
+    public void setup() {
+        externalServiceClient = new ExternalServiceClient(client);
+        when(client.target(anyString())).thenReturn(webTarget);
+        when(webTarget.request()).thenReturn(builder);
+        when(builder.headers(any(MultivaluedMap.class))).thenReturn(builder);
+        when(builder.accept(MediaType.APPLICATION_JSON)).thenReturn(builder);
+    }
+    
+    @Test
+    public void assert_x_request_id_in_request_header_for_get() {
+        MDC.put("x_request_id", "abc");
+        externalServiceClient.get("http://example123.com");
+        
+        verify(builder).headers(builderArgumentCaptor.capture());
+        assertThat(builderArgumentCaptor.getValue().getFirst("X-Request-Id")).isEqualTo("abc");
+    }
+    
+    @Test
+    public void assert_x_request_id_in_request_header_for_post() {
+        MDC.put("x_request_id", "123-easy-as-abc");
+        externalServiceClient.post("http://example123.com");
+
+        verify(builder).headers(builderArgumentCaptor.capture());
+        assertThat(builderArgumentCaptor.getValue().getFirst("X-Request-Id")).isEqualTo("123-easy-as-abc");
+    }
+}

--- a/src/test/java/uk/gov/pay/api/clients/ExternalServiceClientTest.java
+++ b/src/test/java/uk/gov/pay/api/clients/ExternalServiceClientTest.java
@@ -36,7 +36,7 @@ public class ExternalServiceClientTest {
     private ArgumentCaptor<MultivaluedMap<String, Object>> builderArgumentCaptor;
 
     @Before
-    public void setup() {
+    public void setUp() {
         externalServiceClient = new ExternalServiceClient(client);
         when(client.target(anyString())).thenReturn(webTarget);
         when(webTarget.request()).thenReturn(builder);

--- a/src/test/java/uk/gov/pay/api/service/CancelPaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CancelPaymentServiceTest.java
@@ -11,6 +11,7 @@ import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.clients.ExternalServiceClient;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.pay.commons.testing.pact.consumers.Pacts;
@@ -40,7 +41,7 @@ public class CancelPaymentServiceTest {
         when(mockConfiguration.getConnectorUrl()).thenReturn(connectorRule.getUrl());
         ConnectorUriGenerator connectorUriGenerator = new ConnectorUriGenerator(mockConfiguration);
         Client client = RestClientFactory.buildClient(new RestClientConfig(false));
-        cancelPaymentService = new CancelPaymentService(client, connectorUriGenerator);
+        cancelPaymentService = new CancelPaymentService(new ExternalServiceClient(client), connectorUriGenerator);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/service/CapturePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CapturePaymentServiceTest.java
@@ -11,11 +11,11 @@ import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.clients.ExternalServiceClient;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.pay.commons.testing.pact.consumers.Pacts;
 
-import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
 
 import static org.hamcrest.core.Is.is;
@@ -41,7 +41,7 @@ public class CapturePaymentServiceTest {
         when(mockConfiguration.getConnectorUrl()).thenReturn(connectorRule.getUrl());
 
         ConnectorUriGenerator connectorUriGenerator = new ConnectorUriGenerator(mockConfiguration);
-        Client client = RestClientFactory.buildClient(new RestClientConfig(false));
+        var client = new ExternalServiceClient(RestClientFactory.buildClient(new RestClientConfig(false)));
         capturePaymentService = new CapturePaymentService(client, connectorUriGenerator);
     }
 

--- a/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServiceTest.java
@@ -12,6 +12,7 @@ import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.clients.ExternalServiceClient;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.search.PaginationDecorator;
@@ -54,7 +55,7 @@ public class CardPaymentSearchServiceTest {
         paymentSearchService = new PaymentSearchService(
                 new PublicApiUriGenerator(configuration),
                 new PaginationDecorator(configuration),
-                new ConnectorService(client, connectorUriGenerator),
+                new ConnectorService(new ExternalServiceClient(client), connectorUriGenerator),
                 new LedgerService(client, ledgerUriGenerator));
     }
 

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -11,6 +11,7 @@ import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.clients.ExternalServiceClient;
 import uk.gov.pay.api.exception.CreateChargeException;
 import uk.gov.pay.api.model.Address;
 import uk.gov.pay.api.model.CardPayment;
@@ -26,7 +27,6 @@ import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.pay.commons.testing.pact.consumers.Pacts;
 
-import javax.ws.rs.client.Client;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -55,10 +55,9 @@ public class CreatePaymentServiceTest {
 
         PublicApiUriGenerator publicApiUriGenerator = new PublicApiUriGenerator(configuration);
         ConnectorUriGenerator connectorUriGenerator = new ConnectorUriGenerator(configuration);
-        Client client = RestClientFactory.buildClient(new RestClientConfig(false));
+        var client = new ExternalServiceClient(RestClientFactory.buildClient(new RestClientConfig(false)));
 
-        createPaymentService = new CreatePaymentService(client,
-                publicApiUriGenerator, connectorUriGenerator);
+        createPaymentService = new CreatePaymentService(client, publicApiUriGenerator, connectorUriGenerator);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/service/GetPaymentEventsServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentEventsServiceTest.java
@@ -11,6 +11,7 @@ import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.clients.ExternalServiceClient;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.PaymentEventsResponse;
 import uk.gov.pay.api.model.TokenPaymentType;
@@ -49,7 +50,7 @@ public class GetPaymentEventsServiceTest {
         LedgerUriGenerator ledgerUriGenerator = new LedgerUriGenerator(mockConfiguration);
         Client client = RestClientFactory.buildClient(new RestClientConfig(false));
         LedgerService ledgerService = new LedgerService(client, ledgerUriGenerator);
-        ConnectorService connectorService = new ConnectorService(client, connectorUriGenerator);
+        ConnectorService connectorService = new ConnectorService(new ExternalServiceClient(client), connectorUriGenerator);
 
         getPaymentEventsService = new GetPaymentEventsService(publicApiUriGenerator, connectorService, ledgerService);
     }

--- a/src/test/java/uk/gov/pay/api/service/GetPaymentRefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentRefundServiceTest.java
@@ -11,6 +11,7 @@ import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.clients.ExternalServiceClient;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.RefundResponse;
 import uk.gov.pay.api.model.TokenPaymentType;
@@ -51,7 +52,7 @@ public class GetPaymentRefundServiceTest {
         ConnectorUriGenerator connectorUriGenerator = new ConnectorUriGenerator(mockConfiguration);
         LedgerUriGenerator ledgerUriGenerator = new LedgerUriGenerator(mockConfiguration);
         Client client = RestClientFactory.buildClient(new RestClientConfig(false));
-        getPaymentService = new GetPaymentRefundService(new ConnectorService(client, connectorUriGenerator),
+        getPaymentService = new GetPaymentRefundService(new ConnectorService(new ExternalServiceClient(client), connectorUriGenerator),
                 new LedgerService(client, ledgerUriGenerator), publicApiUriGenerator);
     }
 

--- a/src/test/java/uk/gov/pay/api/service/GetPaymentRefundsServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentRefundsServiceTest.java
@@ -11,6 +11,7 @@ import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.clients.ExternalServiceClient;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.RefundResponse;
 import uk.gov.pay.api.model.RefundsResponse;
@@ -50,7 +51,7 @@ public class GetPaymentRefundsServiceTest {
         LedgerService ledgerService = new LedgerService(client, ledgerUriGenerator);
 
         ConnectorUriGenerator connectorUriGenerator = new ConnectorUriGenerator(mockConfiguration);
-        ConnectorService connectorService = new ConnectorService(client, connectorUriGenerator);
+        ConnectorService connectorService = new ConnectorService(new ExternalServiceClient(client), connectorUriGenerator);
 
         getPaymentRefundsService = new GetPaymentRefundsService(connectorService, ledgerService, publicApiUriGenerator);
     }

--- a/src/test/java/uk/gov/pay/api/service/GetPaymentServiceLedgerTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentServiceLedgerTest.java
@@ -13,6 +13,7 @@ import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.clients.ExternalServiceClient;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.CardPayment;
 import uk.gov.pay.api.model.PaymentState;
@@ -67,7 +68,7 @@ public class GetPaymentServiceLedgerTest {
         LedgerUriGenerator ledgerUriGenerator = new LedgerUriGenerator(mockConfiguration);
         Client client = RestClientFactory.buildClient(new RestClientConfig(false));
         getPaymentService = new GetPaymentService(publicApiUriGenerator,
-                new ConnectorService(client, connectorUriGenerator),
+                new ConnectorService(new ExternalServiceClient(client), connectorUriGenerator),
                 new LedgerService(client, ledgerUriGenerator));
     }
 

--- a/src/test/java/uk/gov/pay/api/service/GetPaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentServiceTest.java
@@ -11,6 +11,7 @@ import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.clients.ExternalServiceClient;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.CardPayment;
 import uk.gov.pay.api.model.PaymentState;
@@ -56,7 +57,7 @@ public class GetPaymentServiceTest {
         LedgerUriGenerator ledgerUriGenerator = new LedgerUriGenerator(mockConfiguration);
         Client client = RestClientFactory.buildClient(new RestClientConfig(false));
         getPaymentService = new GetPaymentService(publicApiUriGenerator,
-                new ConnectorService(client, connectorUriGenerator),
+                new ConnectorService(new ExternalServiceClient(client), connectorUriGenerator),
                 new LedgerService(client, ledgerUriGenerator));
     }
 

--- a/src/test/java/uk/gov/pay/api/service/SearchRefundsServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/SearchRefundsServiceTest.java
@@ -12,6 +12,7 @@ import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.clients.ExternalServiceClient;
 import uk.gov.pay.api.exception.RefundsValidationException;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.TokenPaymentType;
@@ -54,7 +55,7 @@ public class SearchRefundsServiceTest {
         LedgerUriGenerator ledgerUriGenerator = new LedgerUriGenerator(mockConfiguration);
 
         searchRefundsService = new SearchRefundsService(
-                new ConnectorService(client, connectorUriGenerator),
+                new ConnectorService(new ExternalServiceClient(client), connectorUriGenerator),
                 new LedgerService(client, ledgerUriGenerator),
                 new PublicApiUriGenerator(mockConfiguration),
                 new PaginationDecorator(mockConfiguration));


### PR DESCRIPTION
This is so we can trace requests from publicapi to calls to downstream services
such as connector in splunk.

Note PP-5761 only covers connector so i haven't done anything for calls to direct-debit-connector.