### PR TITLE
[PP-5869] first part of ledger integration tests for payment resource

### DIFF
--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
@@ -30,6 +30,8 @@ public abstract class PaymentResourceITestBase {
     protected static final String API_KEY = ApiKeyGenerator.apiKeyValueOf("TEST_BEARER_TOKEN", "qwer9yuhgf");
     protected static final String GATEWAY_ACCOUNT_ID = "GATEWAY_ACCOUNT_ID";
     protected static final String PAYMENTS_PATH = "/v1/payments/";
+    protected static final String LEDGER_ONLY_STRATEGY = "ledger-only";
+    protected static final String CONNECTOR_STRATEGY = "";
 
     @ClassRule
     public static RedisDockerRule redisDockerRule;

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchIT.java
@@ -62,8 +62,6 @@ public class PaymentResourceSearchIT extends PaymentResourceITestBase {
     private static final String SEARCH_PATH = "/v1/payments";
     private static final Address BILLING_ADDRESS = new Address("line1", "line2", "NR2 5 6EG", "city", "UK");
     private static final CardDetails CARD_DETAILS = new CardDetails(TEST_LAST_DIGITS_CARD_NUMBER, TEST_FIRST_DIGITS_CARD_NUMBER, TEST_CARDHOLDER_NAME, "12/19", BILLING_ADDRESS, TEST_CARD_BRAND_LABEL, TEST_CARD_TYPE);
-    private static final String LEDGER_ONLY_STRATEGY = "ledger-only";
-    private static final String CONNECTOR_STRATEGY = "";
 
     private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
     private ConnectorMockClient connectorMockClient = new ConnectorMockClient(connectorMock);


### PR DESCRIPTION
Why?
In order to make sure both paths (connector and ledger) are properly covered with tests.

Changes:
* add and refactor methods to mock ledger client
* add ledger equivalent of tests for get payment and payment events (part one)