### PR TITLE
[PP-5869] second part of ledger integration tests for payment resource

### DIFF
--- a/src/test/java/uk/gov/pay/api/utils/mocks/TransactionEventFixture.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/TransactionEventFixture.java
@@ -1,0 +1,47 @@
+package uk.gov.pay.api.utils.mocks;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import uk.gov.pay.api.model.PaymentState;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class TransactionEventFixture {
+    private PaymentState state;
+    private String timestamp;
+
+    public PaymentState getState() {
+        return state;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public TransactionEventFixture(TransactionEventFixtureBuilder builder) {
+        this.state = builder.state;
+        this.timestamp = builder.timestamp;
+    }
+
+    public static final class TransactionEventFixtureBuilder {
+        private PaymentState state;
+        private String timestamp;
+        
+        public TransactionEventFixtureBuilder withState(PaymentState state) {
+            this.state = state;
+            return this;
+        }
+        
+        public TransactionEventFixtureBuilder withTimestamp(String timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+        
+        public static TransactionEventFixtureBuilder aTransactionEventFixture() {
+            return new TransactionEventFixtureBuilder();
+        }
+        
+        public TransactionEventFixture build() {
+            return new TransactionEventFixture(this);
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/api/utils/mocks/TransactionFromLedgerFixture.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/TransactionFromLedgerFixture.java
@@ -117,7 +117,7 @@ public class TransactionFromLedgerFixture {
         this.settlementSummary = builder.settlementSummary;
         this.cardDetails = builder.cardDetails;
         this.description = builder.description;
-        this.reference = builder.description;
+        this.reference = builder.reference;
         this.email = builder.email;
         this.language = builder.language;
         this.delayedCapture = builder.delayedCapture;


### PR DESCRIPTION
Why?
In order to make sure both paths (connector and ledger) are properly covered with tests.

Changes:
* add ledger equivalent of tests for get payment and payment events (part two)