### PR TITLE
PP-5761: Log X-Request-Id temporarily

### DIFF
--- a/src/main/java/uk/gov/pay/api/clients/ExternalServiceClient.java
+++ b/src/main/java/uk/gov/pay/api/clients/ExternalServiceClient.java
@@ -1,6 +1,9 @@
 package uk.gov.pay.api.clients;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import uk.gov.pay.api.resources.PaymentRefundsResource;
 
 import javax.inject.Inject;
 import javax.ws.rs.client.Client;
@@ -9,10 +12,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 
 public class ExternalServiceClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(ExternalServiceClient.class);
 
     private final Client client;
 
@@ -26,10 +33,23 @@ public class ExternalServiceClient {
     }
 
     private MultivaluedMap<String, Object> getHeaders() {
-        return Optional.ofNullable(MDC.get("x_request_id"))
-                    .filter(s -> !s.isBlank())
-                    .map(s -> new MultivaluedHashMap<String, Object>(Map.of("X-Request-Id", s)))
-                    .orElse(new MultivaluedHashMap<>());
+        StringBuilder log = new StringBuilder();
+        log.append("x_request_id in MDC: " + MDC.get("x_request_id") + "\n");
+        
+        MultivaluedHashMap<String, Object> headers = Optional.ofNullable(MDC.get("x_request_id"))
+                .filter(s -> !s.isBlank())
+                .map(s -> new MultivaluedHashMap<String, Object>(Map.of("X-Request-Id", s)))
+                .orElse(new MultivaluedHashMap<>());
+        
+        log.append("Headers:\n");
+        headers.forEach((s, objects) -> {
+            log.append("Header name: " + s + "\n");
+            objects.forEach(o -> log.append("Header value: " + o + "\n"));
+        });
+        
+        logger.info(log.toString());
+        
+        return headers;
     }
 
     public Response post(String url) {


### PR DESCRIPTION
It seems when the x-request-id gets into connector, it's appended with a comma.
Search `atlkbga69vtvp2kk64lnm2v7ae` in the test environment in splunk to see
what I mean. As this doesn't happen for calls from frontend to connector, and
https://github.com/alphagov/pay-publicapi/pull/779 was the only thing that was
deployed, log the headers to see if anything is actually happening here.
