### PR TITLE
PP-5761: Send X-Request-Id properly to downstream calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <jackson.version>2.10.1</jackson.version>
         <logback.version>1.2.3</logback.version>
         <docker-client.version>8.16.0</docker-client.version>
-        <pay-java-commons.version>1.0.20191127134754</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20191129092421</pay-java-commons.version>
         <pact.version>3.6.14</pact.version>
         <swagger.lib.version>2.1.0</swagger.lib.version>
         <PACT_BROKER_URL/>

--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -56,8 +56,8 @@ import uk.gov.pay.api.resources.SearchRefundsResource;
 import uk.gov.pay.api.resources.directdebit.DirectDebitPaymentsResource;
 import uk.gov.pay.api.resources.telephone.TelephonePaymentNotificationResource;
 import uk.gov.pay.api.validation.InjectingValidationFeature;
-import uk.gov.pay.commons.utils.logging.LoggingFilter;
 import uk.gov.pay.logging.GovUkPayDropwizardRequestJsonLogLayoutFactory;
+import uk.gov.pay.logging.LoggingFilter;
 import uk.gov.pay.logging.LogstashConsoleAppenderFactory;
 
 import javax.net.ssl.HttpsURLConnection;

--- a/src/main/java/uk/gov/pay/api/filter/RestClientLoggingFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RestClientLoggingFilter.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import uk.gov.pay.logging.LoggingKeys;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
@@ -17,14 +18,14 @@ import static java.lang.String.format;
 public class RestClientLoggingFilter implements ClientRequestFilter, ClientResponseFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(RestClientLoggingFilter.class);
-    static final String HEADER_REQUEST_ID = "X-Request-Id";
+    private static final String HEADER_REQUEST_ID = "X-Request-Id";
     private static ThreadLocal<String> requestId = new ThreadLocal<>();
     private static ThreadLocal<Stopwatch> timer = new ThreadLocal<>();
 
     @Override
     public void filter(ClientRequestContext requestContext) {
         timer.set(Stopwatch.createStarted());
-        requestId.set(StringUtils.defaultString(MDC.get(HEADER_REQUEST_ID)));
+        requestId.set(StringUtils.defaultString(MDC.get(LoggingKeys.MDC_REQUEST_ID_KEY)));
 
         requestContext.getHeaders().add(HEADER_REQUEST_ID, requestId.get());
         logger.info(format("[%s] - %s to %s began",

--- a/src/test/java/uk/gov/pay/api/filter/RestClientLoggingFilterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/RestClientLoggingFilterTest.java
@@ -15,12 +15,12 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import uk.gov.pay.logging.LoggingKeys;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientResponseContext;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
-
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
@@ -28,9 +28,12 @@ import java.util.UUID;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import static uk.gov.pay.api.filter.RestClientLoggingFilter.HEADER_REQUEST_ID;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RestClientLoggingFilterTest {
@@ -67,7 +70,7 @@ public class RestClientLoggingFilterTest {
         when(clientRequestContext.getUri()).thenReturn(requestUrl);
         when(clientRequestContext.getMethod()).thenReturn(requestMethod);
         when(clientRequestContext.getHeaders()).thenReturn(mockHeaders);
-        MDC.put(HEADER_REQUEST_ID,requestId);
+        MDC.put(LoggingKeys.MDC_REQUEST_ID_KEY, requestId);
 
         loggingFilter.filter(clientRequestContext);
 
@@ -92,7 +95,7 @@ public class RestClientLoggingFilterTest {
 
         when(clientRequestContext.getHeaders()).thenReturn(mockHeaders);
         when(clientResponseContext.getHeaders()).thenReturn(mockHeaders2);
-        MDC.put(HEADER_REQUEST_ID,requestId);
+        MDC.put(LoggingKeys.MDC_REQUEST_ID_KEY, requestId);
         loggingFilter.filter(clientRequestContext);
 
         loggingFilter.filter(clientRequestContext,clientResponseContext);


### PR DESCRIPTION
The MDC value is actually "x_request_id" which is set in
https://github.com/alphagov/pay-java-commons/blob/master/utils/src/main/java/uk/gov/pay/commons/utils/logging/LoggingFilter.java.
