### PR TITLE
PP-5868 Pact ensures null searches have pagination

### DIFF
--- a/src/test/java/uk/gov/pay/api/service/SearchRefundsServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/SearchRefundsServiceTest.java
@@ -191,6 +191,18 @@ public class SearchRefundsServiceTest {
     }
 
     @Test
+    @PactVerification({"ledger"})
+    @Pacts(pacts = {"publicapi-ledger-search-refunds-with-page-and-display-when-no-refunds-exist"})
+    public void getAllRefundsShouldReturnNoRefundsFromLedgerWhenThereAreNone() {
+        Account account = new Account(ACCOUNT_ID, TokenPaymentType.CARD);
+        RefundsParams params = new RefundsParams(null, null, "1", "1");
+        SearchRefundsResults results = searchRefundsService.searchLedgerRefunds(account, params);
+        assertThat(results.getCount(), is(0));
+        assertThat(results.getTotal(), is(0));
+        assertThat(results.getPage(), is(1));
+    }
+
+    @Test
     public void getSearchResponseFromLedger_shouldThrowRefundsValidationExceptionWhenParamsAreInvalid() {
         Account account = new Account(ACCOUNT_ID, TokenPaymentType.CARD);
         String invalid = "invalid_param";

--- a/src/test/resources/pacts/publicapi-ledger-search-refunds-with-page-and-display-when-no-refunds-exist.json
+++ b/src/test/resources/pacts/publicapi-ledger-search-refunds-with-page-and-display-when-no-refunds-exist.json
@@ -1,0 +1,83 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "ledger"
+  },
+  "interactions": [
+    {
+      "description": "Return no refunds when no refunds exist",
+      "providerStates": [
+        {
+          "name": "refund transactions exists for a gateway account",
+          "params": {
+            "account_id": "888"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/transaction",
+        "query": {
+          "account_id": [
+            "888"
+          ],
+          "status_version": ["1"],
+          "transaction_type": ["REFUND"],
+          "page": [
+            "1"
+          ],
+          "display_size": [
+            "1"
+          ]
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "total": 0,
+          "count": 0,
+          "page": 1,
+          "results": []
+        },
+        "matchingRules": {
+          "body": {
+            "$.total": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.count": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.page": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
- Adds a pact test to ensure that searchs with 'null' (but still valid)
responses still have pagination when they are returned from ledger.