### PR TITLE
[PP-5771] remove alwaysUseFutureStrategy feature flag

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
@@ -33,9 +33,6 @@ public class PublicApiConfig extends Configuration {
     @NotNull
     private Boolean allowHttpForReturnUrl;
 
-    @NotNull
-    private Boolean alwaysUseFutureStrategy;
-
     private String apiKeyHmacSecret;
 
     @NotNull
@@ -107,7 +104,4 @@ public class PublicApiConfig extends Configuration {
         return redis;
     }
 
-    public Boolean getAlwaysUseFutureStrategy() {
-        return alwaysUseFutureStrategy;
-    }
 }

--- a/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
@@ -32,7 +32,7 @@ public class RefundForSearchRefundsResult {
     private Long amount;
 
     private RefundLinksForSearch links = new RefundLinksForSearch();
-    
+
     @JsonProperty("status")
     @ApiModelProperty(example = "success", allowableValues = "submitted,success,error")
     @Schema(example = "success", allowableValues = {"submitted", "success", "error"}, accessMode = READ_ONLY)
@@ -47,8 +47,8 @@ public class RefundForSearchRefundsResult {
         this.status = status;
         this.chargeId = chargeId;
         this.amount = amount;
-        this.links.addSelf(refundsURI.toString()); 
-        this.links.addPayment(paymentURI.toString()); 
+        this.links.addSelf(refundsURI.toString());
+        this.links.addPayment(paymentURI.toString());
     }
 
     public String getRefundId() {
@@ -81,29 +81,18 @@ public class RefundForSearchRefundsResult {
     public void setAmount(Long amount) {
         this.amount = amount;
     }
-    
+
     @JsonProperty("amount")
     @ApiModelProperty(example = "120")
     @Schema(example = "120", accessMode = READ_ONLY)
     public Long getAmount() {
         return amount;
     }
-    
+
     @ApiModelProperty(dataType = "uk.gov.pay.api.model.links.RefundLinksForSearch")
     @JsonProperty("_links")
     public RefundLinksForSearch getLinks() {
         return links;
-    }
-
-    public static RefundForSearchRefundsResult valueOf(RefundForSearchRefundsResult refundResult, URI paymentURI, URI refundsURI) {
-        return new RefundForSearchRefundsResult(
-                refundResult.getRefundId(),
-                refundResult.getCreatedDate(),
-                refundResult.getStatus(),
-                refundResult.getChargeId(),
-                refundResult.getAmount(),
-                paymentURI,
-                refundsURI);
     }
 
     public static RefundForSearchRefundsResult valueOf(RefundTransactionFromLedger refundResult, URI paymentURI, URI refundsURI) {

--- a/src/main/java/uk/gov/pay/api/resources/GetOnePaymentStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/GetOnePaymentStrategy.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.api.resources;
 
-import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 import uk.gov.pay.api.service.GetPaymentService;
@@ -11,8 +10,8 @@ public class GetOnePaymentStrategy extends LedgerOrConnectorStrategyTemplate<Pay
     private final String paymentId;
     private final GetPaymentService getPaymentService;
 
-    public GetOnePaymentStrategy(PublicApiConfig configuration, String strategy, Account account, String paymentId, GetPaymentService getPaymentService) {
-        super(configuration, strategy);
+    public GetOnePaymentStrategy(String strategy, Account account, String paymentId, GetPaymentService getPaymentService) {
+        super(strategy);
         this.account = account;
         this.paymentId = paymentId;
         this.getPaymentService = getPaymentService;

--- a/src/main/java/uk/gov/pay/api/resources/GetPaymentEventsStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/GetPaymentEventsStrategy.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.api.resources;
 
-import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.PaymentEventsResponse;
 import uk.gov.pay.api.service.GetPaymentEventsService;
@@ -10,9 +9,9 @@ public class GetPaymentEventsStrategy extends LedgerOrConnectorStrategyTemplate<
     private final String paymentId;
     private final GetPaymentEventsService getPaymentEventsService;
 
-    public GetPaymentEventsStrategy(PublicApiConfig configuration, String strategyName, Account account, String paymentId,
+    public GetPaymentEventsStrategy(String strategyName, Account account, String paymentId,
                                     GetPaymentEventsService getPaymentEventsService) {
-        super(configuration, strategyName);
+        super(strategyName);
         this.account = account;
         this.paymentId = paymentId;
         this.getPaymentEventsService = getPaymentEventsService;

--- a/src/main/java/uk/gov/pay/api/resources/GetPaymentRefundStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/GetPaymentRefundStrategy.java
@@ -1,7 +1,5 @@
 package uk.gov.pay.api.resources;
 
-
-import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.RefundResponse;
 import uk.gov.pay.api.service.GetPaymentRefundService;
@@ -13,9 +11,9 @@ public class GetPaymentRefundStrategy extends LedgerOrConnectorStrategyTemplate<
     private final String refundId;
     private final GetPaymentRefundService getPaymentRefundsService;
 
-    public GetPaymentRefundStrategy(PublicApiConfig configuration, String strategy, Account account, String paymentId, String refundId,
+    public GetPaymentRefundStrategy(String strategy, Account account, String paymentId, String refundId,
                                     GetPaymentRefundService getPaymentRefundsService) {
-        super(configuration, strategy);
+        super(strategy);
         this.account = account;
         this.paymentId = paymentId;
         this.refundId = refundId;

--- a/src/main/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategy.java
@@ -1,7 +1,5 @@
 package uk.gov.pay.api.resources;
 
-
-import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.RefundsResponse;
 import uk.gov.pay.api.service.GetPaymentRefundsService;
@@ -12,9 +10,9 @@ public class GetPaymentRefundsStrategy extends LedgerOrConnectorStrategyTemplate
     private final String paymentId;
     private final GetPaymentRefundsService getPaymentRefundsService;
 
-    public GetPaymentRefundsStrategy(PublicApiConfig configuration, String strategy, Account account, String paymentId,
+    public GetPaymentRefundsStrategy(String strategy, Account account, String paymentId,
                                      GetPaymentRefundsService getPaymentRefundsService) {
-        super(configuration, strategy);
+        super(strategy);
         this.account = account;
         this.paymentId = paymentId;
         this.getPaymentRefundsService = getPaymentRefundsService;

--- a/src/main/java/uk/gov/pay/api/resources/LedgerOrConnectorStrategyTemplate.java
+++ b/src/main/java/uk/gov/pay/api/resources/LedgerOrConnectorStrategyTemplate.java
@@ -11,12 +11,10 @@ import java.util.List;
 public abstract class LedgerOrConnectorStrategyTemplate<T> {
 
     private static final Logger logger = LoggerFactory.getLogger(LedgerOrConnectorStrategyTemplate.class);
-    private final Boolean shouldAlwaysUseFutureStrategy;
     private String strategy;
     private List<String> VALID_STRATEGIES = ImmutableList.of("ledger-only", "future-behaviour");
 
-    public LedgerOrConnectorStrategyTemplate(PublicApiConfig configuration, String strategy) {
-        this.shouldAlwaysUseFutureStrategy = configuration.getAlwaysUseFutureStrategy();
+    public LedgerOrConnectorStrategyTemplate(String strategy) {
         this.strategy = strategy;
     }
 
@@ -30,7 +28,7 @@ public abstract class LedgerOrConnectorStrategyTemplate<T> {
     public T validateAndExecute() {
         validate();
 
-        if (shouldAlwaysUseFutureStrategy || "future-behaviour".equals(strategy)) {
+        if ("future-behaviour".equals(strategy)) {
             return executeFutureBehaviourStrategy();
         } else if ("ledger-only".equals(strategy)) {
             return executeLedgerOnlyStrategy();

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -83,7 +83,6 @@ public class PaymentRefundsResource {
     private final String baseUrl;
     private final Client client;
     private final String connectorUrl;
-    private PublicApiConfig configuration;
     private GetPaymentRefundsService getPaymentRefundsService;
     private GetPaymentRefundService getPaymentRefundService;
     private ConnectorService connectorService;
@@ -95,7 +94,6 @@ public class PaymentRefundsResource {
         this.client = client;
         this.baseUrl = configuration.getBaseUrl();
         this.connectorUrl = configuration.getConnectorUrl();
-        this.configuration = configuration;
         this.getPaymentRefundsService = getPaymentRefundsService;
         this.getPaymentRefundService = getPaymentRefundService;
         this.connectorService = connectorService;
@@ -141,7 +139,7 @@ public class PaymentRefundsResource {
 
         logger.info("Get refunds for payment request - paymentId={} using strategy={}", paymentId, strategyName);
 
-        GetPaymentRefundsStrategy strategy = new GetPaymentRefundsStrategy(configuration, strategyName, account, paymentId, getPaymentRefundsService);
+        GetPaymentRefundsStrategy strategy = new GetPaymentRefundsStrategy(strategyName, account, paymentId, getPaymentRefundsService);
         RefundsResponse refundsResponse = strategy.validateAndExecute();
 
         logger.debug("refund returned - [ {} ]", refundsResponse);
@@ -192,7 +190,7 @@ public class PaymentRefundsResource {
 
         logger.info("Payment refund request - paymentId={}, refundId={}", paymentId, refundId);
 
-        var strategy = new GetPaymentRefundStrategy(configuration, strategyName, account, paymentId, refundId, getPaymentRefundService);
+        var strategy = new GetPaymentRefundStrategy(strategyName, account, paymentId, refundId, getPaymentRefundService);
         RefundResponse refundResponse = strategy.validateAndExecute();
 
         logger.info("refund returned - [ {} ]", refundResponse);

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -17,7 +17,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CaptureChargeException;
 import uk.gov.pay.api.model.CreateCardPaymentRequest;
@@ -69,7 +68,6 @@ public class PaymentsResource {
     private final CapturePaymentService capturePaymentService;
     private final CancelPaymentService cancelPaymentService;
     private final GetPaymentEventsService getPaymentEventsService;
-    private PublicApiConfig configuration;
 
     @Inject
     public PaymentsResource(CreatePaymentService createPaymentService,
@@ -78,8 +76,7 @@ public class PaymentsResource {
                             GetPaymentService getPaymentService,
                             CapturePaymentService capturePaymentService,
                             CancelPaymentService cancelPaymentService,
-                            GetPaymentEventsService getPaymentEventsService,
-                            PublicApiConfig configuration) {
+                            GetPaymentEventsService getPaymentEventsService) {
         this.createPaymentService = createPaymentService;
         this.publicApiUriGenerator = publicApiUriGenerator;
         this.paymentSearchService = paymentSearchService;
@@ -87,7 +84,6 @@ public class PaymentsResource {
         this.capturePaymentService = capturePaymentService;
         this.cancelPaymentService = cancelPaymentService;
         this.getPaymentEventsService = getPaymentEventsService;
-        this.configuration = configuration;
     }
 
     @GET
@@ -136,7 +132,7 @@ public class PaymentsResource {
 
         logger.info("Payment request - paymentId={}", paymentId);
 
-        var strategy = new GetOnePaymentStrategy(configuration, strategyName, account, paymentId, getPaymentService);
+        var strategy = new GetOnePaymentStrategy(strategyName, account, paymentId, getPaymentService);
         PaymentWithAllLinks payment = strategy.validateAndExecute();
 
         logger.info("Payment returned - [ {} ]", payment);
@@ -190,7 +186,7 @@ public class PaymentsResource {
 
         logger.info("Payment events request - payment_id={}", paymentId);
 
-        var strategy = new GetPaymentEventsStrategy(configuration, strategyName, account, paymentId, getPaymentEventsService);
+        var strategy = new GetPaymentEventsStrategy(strategyName, account, paymentId, getPaymentEventsService);
         PaymentEventsResponse paymentEventsResponse = strategy.validateAndExecute();
 
         logger.info("Payment events returned - [ {} ]", paymentEventsResponse);

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -34,8 +34,6 @@ connectorDDUrl: ${CONNECTOR_DD_URL}
 publicAuthUrl: ${PUBLIC_AUTH_URL}
 ledgerUrl: ${LEDGER_URL}
 
-alwaysUseFutureStrategy: ${FEATURE_ALWAYS_USE_FUTURE_LEDGER_CONNECTOR_STRATEGY:-false}
-
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterITestBase.java
@@ -91,7 +91,6 @@ abstract public class ResourcesFilterITestBase {
             config("publicAuthUrl", "http://localhost:" + PUBLIC_AUTH_PORT + "/v1/auth"),
             config("redis.endpoint", redisDockerRule.getRedisUrl()),
             config("ledgerUrl", "http://localhost:" + LEDGER_PORT),
-            config("alwaysUseFutureStrategy", "true"),
             config("rateLimiter.noOfReq", "1"),
             config("rateLimiter.noOfReqForPost", "1")
     );

--- a/src/test/java/uk/gov/pay/api/resources/GetOnePaymentStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetOnePaymentStrategyTest.java
@@ -12,7 +12,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.service.GetPaymentService;
@@ -24,14 +23,10 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GetOnePaymentStrategyTest {
-
-    @Mock
-    private PublicApiConfig configuration;
 
     @Mock
     private GetPaymentService mockGetPaymentService;
@@ -54,7 +49,7 @@ public class GetOnePaymentStrategyTest {
 
     @Test
     public void whenNoStrategyProvidedUsesDefaultStrategy() {
-        getOnePaymentStrategy = new GetOnePaymentStrategy(configuration, null, mockAccountId, mockPaymentId, mockGetPaymentService);
+        getOnePaymentStrategy = new GetOnePaymentStrategy(null, mockAccountId, mockPaymentId, mockGetPaymentService);
 
         getOnePaymentStrategy.validateAndExecute();
 
@@ -64,7 +59,7 @@ public class GetOnePaymentStrategyTest {
 
     @Test
     public void whenEmptyStrategyProvidedUsesDefaultStrategy() {
-        getOnePaymentStrategy = new GetOnePaymentStrategy(configuration, "", mockAccountId, mockPaymentId, mockGetPaymentService);
+        getOnePaymentStrategy = new GetOnePaymentStrategy("", mockAccountId, mockPaymentId, mockGetPaymentService);
 
         getOnePaymentStrategy.validateAndExecute();
 
@@ -74,7 +69,7 @@ public class GetOnePaymentStrategyTest {
 
     @Test
     public void whenLedgerOnlyStrategyProvidedUsesLedgerStrategy() {
-        getOnePaymentStrategy = new GetOnePaymentStrategy(configuration, "ledger-only", mockAccountId, mockPaymentId, mockGetPaymentService);
+        getOnePaymentStrategy = new GetOnePaymentStrategy("ledger-only", mockAccountId, mockPaymentId, mockGetPaymentService);
 
         getOnePaymentStrategy.validateAndExecute();
 
@@ -84,7 +79,7 @@ public class GetOnePaymentStrategyTest {
 
     @Test
     public void whenFutureBehaviourStrategyProvidedUsesFutureBehaviourStrategy() {
-        getOnePaymentStrategy = new GetOnePaymentStrategy(configuration, "future-behaviour", mockAccountId, mockPaymentId, mockGetPaymentService);
+        getOnePaymentStrategy = new GetOnePaymentStrategy("future-behaviour", mockAccountId, mockPaymentId, mockGetPaymentService);
 
         getOnePaymentStrategy.validateAndExecute();
 
@@ -93,7 +88,7 @@ public class GetOnePaymentStrategyTest {
 
     @Test
     public void whenNotValidStrategyProvidedUsesDefaultStrategy() {
-        getOnePaymentStrategy = new GetOnePaymentStrategy(configuration, "not-valid-strategy-name", mockAccountId, mockPaymentId, mockGetPaymentService);
+        getOnePaymentStrategy = new GetOnePaymentStrategy("not-valid-strategy-name", mockAccountId, mockPaymentId, mockGetPaymentService);
 
         getOnePaymentStrategy.validateAndExecute();
 
@@ -105,15 +100,5 @@ public class GetOnePaymentStrategyTest {
 
         verify(mockGetPaymentService, never()).getPayment(mockAccountId, mockPaymentId);
         verify(mockGetPaymentService).getConnectorCharge(mockAccountId, mockPaymentId);
-    }
-
-    @Test
-    public void whenSwitchingToFutureStrategyUsesFutureBehaviourStrategy() {
-        when(configuration.getAlwaysUseFutureStrategy()).thenReturn(true);
-        getOnePaymentStrategy = new GetOnePaymentStrategy(configuration, "ledger-only", mockAccountId, mockPaymentId, mockGetPaymentService);
-
-        getOnePaymentStrategy.validateAndExecute();
-
-        verify(mockGetPaymentService).getPayment(mockAccountId, mockPaymentId);
     }
 }

--- a/src/test/java/uk/gov/pay/api/resources/GetOnePaymentStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetOnePaymentStrategyTest.java
@@ -1,104 +1,62 @@
 package uk.gov.pay.api.resources;
 
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.spi.LoggingEvent;
-import ch.qos.logback.core.Appender;
-import org.junit.Before;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.slf4j.LoggerFactory;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.service.GetPaymentService;
 
-import java.util.List;
-
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(JUnitParamsRunner.class)
 public class GetOnePaymentStrategyTest {
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
 
     @Mock
     private GetPaymentService mockGetPaymentService;
-
-    @Captor
-    ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
-
-    private Appender<ILoggingEvent> mockAppender;
 
     private GetOnePaymentStrategy getOnePaymentStrategy;
     private String mockPaymentId = "some-payment-id";
     private Account mockAccountId = new Account("some-account-id", TokenPaymentType.CARD);
 
-    @Before
-    public void setUp() {
-        ch.qos.logback.classic.Logger root = (Logger) LoggerFactory.getLogger(LedgerOrConnectorStrategyTemplate.class);
-        mockAppender = mock(Appender.class);
-        root.addAppender(mockAppender);
-    }
-
     @Test
-    public void whenNoStrategyProvidedUsesDefaultStrategy() {
-        getOnePaymentStrategy = new GetOnePaymentStrategy(null, mockAccountId, mockPaymentId, mockGetPaymentService);
-
+    public void validateAndExecuteUsesLedgerOnlyStrategy() {
+        String strategy = "ledger-only";
+        getOnePaymentStrategy = new GetOnePaymentStrategy(strategy, mockAccountId, mockPaymentId, mockGetPaymentService);
         getOnePaymentStrategy.validateAndExecute();
 
-        verify(mockGetPaymentService, never()).getPayment(mockAccountId, mockPaymentId);
-        verify(mockGetPaymentService).getConnectorCharge(mockAccountId, mockPaymentId);
-    }
-
-    @Test
-    public void whenEmptyStrategyProvidedUsesDefaultStrategy() {
-        getOnePaymentStrategy = new GetOnePaymentStrategy("", mockAccountId, mockPaymentId, mockGetPaymentService);
-
-        getOnePaymentStrategy.validateAndExecute();
-
-        verify(mockGetPaymentService, never()).getPayment(mockAccountId, mockPaymentId);
-        verify(mockGetPaymentService).getConnectorCharge(mockAccountId, mockPaymentId);
-    }
-
-    @Test
-    public void whenLedgerOnlyStrategyProvidedUsesLedgerStrategy() {
-        getOnePaymentStrategy = new GetOnePaymentStrategy("ledger-only", mockAccountId, mockPaymentId, mockGetPaymentService);
-
-        getOnePaymentStrategy.validateAndExecute();
-
-        verify(mockGetPaymentService, never()).getPayment(mockAccountId, mockPaymentId);
         verify(mockGetPaymentService).getLedgerTransaction(mockAccountId, mockPaymentId);
+        verify(mockGetPaymentService, never()).getConnectorCharge(mockAccountId, mockPaymentId);
+        verify(mockGetPaymentService, never()).getPayment(mockAccountId, mockPaymentId);
     }
 
     @Test
-    public void whenFutureBehaviourStrategyProvidedUsesFutureBehaviourStrategy() {
-        getOnePaymentStrategy = new GetOnePaymentStrategy("future-behaviour", mockAccountId, mockPaymentId, mockGetPaymentService);
-
+    public void validateAndExecuteUsesFutureStrategyOnly() {
+        String strategy = "future-behaviour";
+        getOnePaymentStrategy = new GetOnePaymentStrategy(strategy, mockAccountId, mockPaymentId, mockGetPaymentService);
         getOnePaymentStrategy.validateAndExecute();
 
         verify(mockGetPaymentService).getPayment(mockAccountId, mockPaymentId);
     }
 
     @Test
-    public void whenNotValidStrategyProvidedUsesDefaultStrategy() {
-        getOnePaymentStrategy = new GetOnePaymentStrategy("not-valid-strategy-name", mockAccountId, mockPaymentId, mockGetPaymentService);
+    @Parameters({"", "unknown"})
+    public void validateAndExecuteShouldUseConnectorOnlyStrategy(String strategy) {
+        getOnePaymentStrategy = new GetOnePaymentStrategy(strategy, mockAccountId, mockPaymentId, mockGetPaymentService);
 
         getOnePaymentStrategy.validateAndExecute();
 
-        verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
-        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-
-        assertThat(loggingEvents.get(0).getFormattedMessage(),
-                is("Not valid strategy (valid values are \"ledger-only\", \"future-behaviour\" or empty); using the default strategy"));
-
-        verify(mockGetPaymentService, never()).getPayment(mockAccountId, mockPaymentId);
         verify(mockGetPaymentService).getConnectorCharge(mockAccountId, mockPaymentId);
+        verify(mockGetPaymentService, never()).getLedgerTransaction(mockAccountId, mockPaymentId);
+        verify(mockGetPaymentService, never()).getPayment(mockAccountId, mockPaymentId);
     }
 }

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentEventsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentEventsStrategyTest.java
@@ -12,7 +12,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.service.GetPaymentEventsService;
@@ -25,13 +24,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GetPaymentEventsStrategyTest {
-
-    @Mock
-    private PublicApiConfig configuration;
 
     @Mock
     private GetPaymentEventsService getPaymentEventsService;
@@ -54,7 +49,7 @@ public class GetPaymentEventsStrategyTest {
 
     @Test
     public void whenNoStrategyProvidedUsesDefaultStrategy() {
-        getPaymentEventsStrategy = new GetPaymentEventsStrategy(configuration, null, mockAccountId, mockPaymentId, getPaymentEventsService);
+        getPaymentEventsStrategy = new GetPaymentEventsStrategy(null, mockAccountId, mockPaymentId, getPaymentEventsService);
 
         getPaymentEventsStrategy.validateAndExecute();
 
@@ -64,7 +59,7 @@ public class GetPaymentEventsStrategyTest {
 
     @Test
     public void whenEmptyStrategyProvidedUsesDefaultStrategy() {
-        getPaymentEventsStrategy = new GetPaymentEventsStrategy(configuration, "", mockAccountId, mockPaymentId, getPaymentEventsService);
+        getPaymentEventsStrategy = new GetPaymentEventsStrategy("", mockAccountId, mockPaymentId, getPaymentEventsService);
 
         getPaymentEventsStrategy.validateAndExecute();
 
@@ -74,7 +69,7 @@ public class GetPaymentEventsStrategyTest {
 
     @Test
     public void whenLedgerOnlyStrategyProvidedUsesLedgerStrategy() {
-        getPaymentEventsStrategy = new GetPaymentEventsStrategy(configuration, "ledger-only", mockAccountId, mockPaymentId, getPaymentEventsService);
+        getPaymentEventsStrategy = new GetPaymentEventsStrategy("ledger-only", mockAccountId, mockPaymentId, getPaymentEventsService);
 
         getPaymentEventsStrategy.validateAndExecute();
 
@@ -84,7 +79,7 @@ public class GetPaymentEventsStrategyTest {
 
     @Test
     public void whenFutureBehaviourStrategyProvidedUsesFutureBehaviourStrategy() {
-        getPaymentEventsStrategy = new GetPaymentEventsStrategy(configuration, "future-behaviour", mockAccountId, mockPaymentId, getPaymentEventsService);
+        getPaymentEventsStrategy = new GetPaymentEventsStrategy("future-behaviour", mockAccountId, mockPaymentId, getPaymentEventsService);
 
         getPaymentEventsStrategy.validateAndExecute();
 
@@ -93,7 +88,7 @@ public class GetPaymentEventsStrategyTest {
 
     @Test
     public void whenNotValidStrategyProvidedUsesDefaultStrategy() {
-        getPaymentEventsStrategy = new GetPaymentEventsStrategy(configuration, "not-valid-strategy-name", mockAccountId, mockPaymentId, getPaymentEventsService);
+        getPaymentEventsStrategy = new GetPaymentEventsStrategy("not-valid-strategy-name", mockAccountId, mockPaymentId, getPaymentEventsService);
 
         getPaymentEventsStrategy.validateAndExecute();
 
@@ -105,15 +100,5 @@ public class GetPaymentEventsStrategyTest {
 
         verify(getPaymentEventsService, never()).getPaymentEventsFromLedger(mockAccountId, mockPaymentId);
         verify(getPaymentEventsService).getPaymentEventsFromConnector(mockAccountId, mockPaymentId);
-    }
-
-    @Test
-    public void whenSwitchingToFutureStrategyUsesFutureBehaviourStrategy() {
-        when(configuration.getAlwaysUseFutureStrategy()).thenReturn(true);
-        getPaymentEventsStrategy = new GetPaymentEventsStrategy(configuration, null, mockAccountId, mockPaymentId, getPaymentEventsService);
-
-        getPaymentEventsStrategy.validateAndExecute();
-
-        verify(getPaymentEventsService).getPaymentEvents(mockAccountId, mockPaymentId);
     }
 }

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentEventsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentEventsStrategyTest.java
@@ -1,104 +1,62 @@
 package uk.gov.pay.api.resources;
 
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.spi.LoggingEvent;
-import ch.qos.logback.core.Appender;
-import org.junit.Before;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.slf4j.LoggerFactory;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.service.GetPaymentEventsService;
 
-import java.util.List;
-
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(JUnitParamsRunner.class)
 public class GetPaymentEventsStrategyTest {
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
 
     @Mock
     private GetPaymentEventsService getPaymentEventsService;
-
-    @Captor
-    ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
-
-    private Appender<ILoggingEvent> mockAppender;
 
     private GetPaymentEventsStrategy getPaymentEventsStrategy;
     private String mockPaymentId = "some-payment-id";
     private Account mockAccountId = new Account("some-account-id", TokenPaymentType.CARD);
 
-    @Before
-    public void setUp() {
-        Logger root = (Logger) LoggerFactory.getLogger(LedgerOrConnectorStrategyTemplate.class);
-        mockAppender = mock(Appender.class);
-        root.addAppender(mockAppender);
-    }
-
     @Test
-    public void whenNoStrategyProvidedUsesDefaultStrategy() {
-        getPaymentEventsStrategy = new GetPaymentEventsStrategy(null, mockAccountId, mockPaymentId, getPaymentEventsService);
-
-        getPaymentEventsStrategy.validateAndExecute();
-
-        verify(getPaymentEventsService, never()).getPaymentEventsFromLedger(mockAccountId, mockPaymentId);
-        verify(getPaymentEventsService).getPaymentEventsFromConnector(mockAccountId, mockPaymentId);
-    }
-
-    @Test
-    public void whenEmptyStrategyProvidedUsesDefaultStrategy() {
-        getPaymentEventsStrategy = new GetPaymentEventsStrategy("", mockAccountId, mockPaymentId, getPaymentEventsService);
-
-        getPaymentEventsStrategy.validateAndExecute();
-
-        verify(getPaymentEventsService, never()).getPaymentEventsFromLedger(mockAccountId, mockPaymentId);
-        verify(getPaymentEventsService).getPaymentEventsFromConnector(mockAccountId, mockPaymentId);
-    }
-
-    @Test
-    public void whenLedgerOnlyStrategyProvidedUsesLedgerStrategy() {
-        getPaymentEventsStrategy = new GetPaymentEventsStrategy("ledger-only", mockAccountId, mockPaymentId, getPaymentEventsService);
-
+    public void validateAndExecuteUsesLedgerOnlyStrategy() {
+        String strategy = "ledger-only";
+        getPaymentEventsStrategy = new GetPaymentEventsStrategy(strategy, mockAccountId, mockPaymentId, getPaymentEventsService);
         getPaymentEventsStrategy.validateAndExecute();
 
         verify(getPaymentEventsService).getPaymentEventsFromLedger(mockAccountId, mockPaymentId);
         verify(getPaymentEventsService, never()).getPaymentEventsFromConnector(mockAccountId, mockPaymentId);
+        verify(getPaymentEventsService, never()).getPaymentEvents(mockAccountId, mockPaymentId);
     }
 
     @Test
-    public void whenFutureBehaviourStrategyProvidedUsesFutureBehaviourStrategy() {
-        getPaymentEventsStrategy = new GetPaymentEventsStrategy("future-behaviour", mockAccountId, mockPaymentId, getPaymentEventsService);
-
+    public void validateAndExecuteUsesFutureStrategyOnly() {
+        String strategy = "future-behaviour";
+        getPaymentEventsStrategy = new GetPaymentEventsStrategy(strategy, mockAccountId, mockPaymentId, getPaymentEventsService);
         getPaymentEventsStrategy.validateAndExecute();
 
         verify(getPaymentEventsService).getPaymentEvents(mockAccountId, mockPaymentId);
     }
 
     @Test
-    public void whenNotValidStrategyProvidedUsesDefaultStrategy() {
-        getPaymentEventsStrategy = new GetPaymentEventsStrategy("not-valid-strategy-name", mockAccountId, mockPaymentId, getPaymentEventsService);
+    @Parameters({"", "unknown"})
+    public void validateAndExecuteShouldUseConnectorOnlyStrategy(String strategy) {
+        getPaymentEventsStrategy = new GetPaymentEventsStrategy(strategy, mockAccountId, mockPaymentId, getPaymentEventsService);
 
         getPaymentEventsStrategy.validateAndExecute();
 
-        verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
-        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
-
-        assertThat(loggingEvents.get(0).getFormattedMessage(),
-                is("Not valid strategy (valid values are \"ledger-only\", \"future-behaviour\" or empty); using the default strategy"));
-
-        verify(getPaymentEventsService, never()).getPaymentEventsFromLedger(mockAccountId, mockPaymentId);
         verify(getPaymentEventsService).getPaymentEventsFromConnector(mockAccountId, mockPaymentId);
+        verify(getPaymentEventsService, never()).getPaymentEventsFromLedger(mockAccountId, mockPaymentId);
+        verify(getPaymentEventsService, never()).getPaymentEvents(mockAccountId, mockPaymentId);
     }
 }

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundStrategyTest.java
@@ -2,33 +2,24 @@ package uk.gov.pay.api.resources;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
-import uk.gov.pay.api.exception.GetRefundException;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.service.GetPaymentRefundService;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(JUnitParamsRunner.class)
 public class GetPaymentRefundStrategyTest {
 
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
-
-    @Mock
-    private PublicApiConfig configuration;
 
     private GetPaymentRefundService mockGetPaymentRefundService = mock(GetPaymentRefundService.class);
     private GetPaymentRefundStrategy getPaymentRefundStrategy;
@@ -40,7 +31,7 @@ public class GetPaymentRefundStrategyTest {
     @Test
     public void validateAndExecuteUsesLedgerOnlyStrategy() {
         String strategy = "ledger-only";
-        getPaymentRefundStrategy = new GetPaymentRefundStrategy(configuration, strategy, account, paymentId, refundId, mockGetPaymentRefundService);
+        getPaymentRefundStrategy = new GetPaymentRefundStrategy(strategy, account, paymentId, refundId, mockGetPaymentRefundService);
         getPaymentRefundStrategy.validateAndExecute();
 
         verify(mockGetPaymentRefundService).getLedgerPaymentRefund(account, paymentId, refundId);
@@ -51,7 +42,7 @@ public class GetPaymentRefundStrategyTest {
     @Test
     public void validateAndExecuteUsesFutureStrategyOnly() {
         String strategy = "future-behaviour";
-        getPaymentRefundStrategy = new GetPaymentRefundStrategy(configuration, strategy, account, paymentId, refundId, mockGetPaymentRefundService);
+        getPaymentRefundStrategy = new GetPaymentRefundStrategy(strategy, account, paymentId, refundId, mockGetPaymentRefundService);
         getPaymentRefundStrategy.validateAndExecute();
 
         verify(mockGetPaymentRefundService).getPaymentRefund(account, paymentId, refundId);
@@ -60,21 +51,12 @@ public class GetPaymentRefundStrategyTest {
     @Test
     @Parameters({"", "unknown"})
     public void validateAndExecuteShouldUseConnectorOnlyStrategy(String strategy) {
-        getPaymentRefundStrategy = new GetPaymentRefundStrategy(configuration, strategy, account, paymentId, refundId, mockGetPaymentRefundService);
+        getPaymentRefundStrategy = new GetPaymentRefundStrategy(strategy, account, paymentId, refundId, mockGetPaymentRefundService);
 
         getPaymentRefundStrategy.validateAndExecute();
 
         verify(mockGetPaymentRefundService).getConnectorPaymentRefund(account, paymentId, refundId);
         verify(mockGetPaymentRefundService, never()).getLedgerPaymentRefund(account, paymentId, refundId);
         verify(mockGetPaymentRefundService, never()).getPaymentRefund(account, paymentId, refundId);
-    }
-
-    @Test
-    public void whenSwitchingToFutureStrategyUsesFutureBehaviourStrategy() {
-        when(configuration.getAlwaysUseFutureStrategy()).thenReturn(true);
-        getPaymentRefundStrategy = new GetPaymentRefundStrategy(configuration, null, account, paymentId, refundId, mockGetPaymentRefundService);
-        getPaymentRefundStrategy.validateAndExecute();
-
-        verify(mockGetPaymentRefundService).getPaymentRefund(account, paymentId, refundId);
     }
 }

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategyTest.java
@@ -5,10 +5,8 @@ import junitparams.Parameters;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.service.GetPaymentRefundsService;
@@ -16,16 +14,12 @@ import uk.gov.pay.api.service.GetPaymentRefundsService;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(JUnitParamsRunner.class)
 public class GetPaymentRefundsStrategyTest {
 
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
-
-    @Mock
-    private PublicApiConfig configuration;
 
     private GetPaymentRefundsService mockGetPaymentRefundsService = mock(GetPaymentRefundsService.class);
     private GetPaymentRefundsStrategy getPaymentRefundsStrategy;
@@ -36,7 +30,7 @@ public class GetPaymentRefundsStrategyTest {
     @Test
     @Parameters({"ledger-only", "future-behaviour"})
     public void validateAndExecuteShouldUseLedgerOnlyForListedStrategies(String strategy) {
-        getPaymentRefundsStrategy = new GetPaymentRefundsStrategy(configuration, strategy, account, paymentId, mockGetPaymentRefundsService);
+        getPaymentRefundsStrategy = new GetPaymentRefundsStrategy(strategy, account, paymentId, mockGetPaymentRefundsService);
         getPaymentRefundsStrategy.validateAndExecute();
 
         verify(mockGetPaymentRefundsService).getLedgerTransactionTransactions(account, paymentId);
@@ -46,21 +40,11 @@ public class GetPaymentRefundsStrategyTest {
     @Test
     @Parameters({"", "unknown"})
     public void validateAndExecuteShouldUseConnectorOnlyForDefaultOrUnknownStrategy(String strategy) {
-        getPaymentRefundsStrategy = new GetPaymentRefundsStrategy(configuration, strategy, account, paymentId, mockGetPaymentRefundsService);
+        getPaymentRefundsStrategy = new GetPaymentRefundsStrategy(strategy, account, paymentId, mockGetPaymentRefundsService);
 
         getPaymentRefundsStrategy.validateAndExecute();
 
         verify(mockGetPaymentRefundsService).getConnectorPaymentRefunds(account, paymentId);
         verify(mockGetPaymentRefundsService, never()).getLedgerTransactionTransactions(account, paymentId);
-    }
-
-    @Test
-    public void whenSwitchingToFutureStrategyUsesFutureBehaviourStrategy() {
-        when(configuration.getAlwaysUseFutureStrategy()).thenReturn(true);
-        getPaymentRefundsStrategy = new GetPaymentRefundsStrategy(configuration, null, account, paymentId, mockGetPaymentRefundsService);
-        getPaymentRefundsStrategy.validateAndExecute();
-
-        verify(mockGetPaymentRefundsService).getLedgerTransactionTransactions(account, paymentId);
-        verify(mockGetPaymentRefundsService, never()).getConnectorPaymentRefunds(account, paymentId);
     }
 }

--- a/src/test/resources/config/empty-elevated-accounts-test-config.yaml
+++ b/src/test/resources/config/empty-elevated-accounts-test-config.yaml
@@ -21,8 +21,6 @@ connectorDDUrl: http://connector_direct_debit.url/
 publicAuthUrl: http://publicauth.url/v1/auth
 ledgerUrl: http://ledger.url/
 
-alwaysUseFutureStrategy: false
-
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -21,8 +21,6 @@ connectorDDUrl: http://connector_direct_debit.url/
 publicAuthUrl: http://publicauth.url/v1/auth
 ledgerUrl: http://ledger.url/
 
-alwaysUseFutureStrategy: false
-
 graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 


### PR DESCRIPTION
Why? The flag has been used to switch public api to use ledger. Given the
changes have been there for a while, now it's time to remove the feature
flag. It's been decided to leave the `X-Ledger` header to allow ad-hoc
change to public api behaviour (local curl-ing for testing)

Changes:
* remove feature flag
* remove usage of the feature flag from the LedgerOrConnectorStrategyTemplate
* clean up the tests (for feature flag behaviour)
* clean up dependencies in remaining strategies
* parametrize strategy unit tests