### PR TITLE
[PP-5771] update strategies to make future strategy the default one

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/GetOnePaymentStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/GetOnePaymentStrategy.java
@@ -23,12 +23,12 @@ public class GetOnePaymentStrategy extends LedgerOrConnectorStrategyTemplate<Pay
     }
 
     @Override
-    protected PaymentWithAllLinks executeFutureBehaviourStrategy() {
+    protected PaymentWithAllLinks executeDefaultStrategy() {
         return getPaymentService.getPayment(account, paymentId);
     }
 
     @Override
-    protected PaymentWithAllLinks executeDefaultStrategy() {
+    protected PaymentWithAllLinks executeConnectorOnlyStrategy() {
         return getPaymentService.getConnectorCharge(account, paymentId);
     }
 }

--- a/src/main/java/uk/gov/pay/api/resources/GetPaymentEventsStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/GetPaymentEventsStrategy.java
@@ -23,12 +23,12 @@ public class GetPaymentEventsStrategy extends LedgerOrConnectorStrategyTemplate<
     }
 
     @Override
-    protected PaymentEventsResponse executeFutureBehaviourStrategy() {
+    protected PaymentEventsResponse executeDefaultStrategy() {
         return getPaymentEventsService.getPaymentEvents(account, paymentId);
     }
 
     @Override
-    protected PaymentEventsResponse executeDefaultStrategy() {
+    protected PaymentEventsResponse executeConnectorOnlyStrategy() {
         return getPaymentEventsService.getPaymentEventsFromConnector(account, paymentId);
     }
 }

--- a/src/main/java/uk/gov/pay/api/resources/GetPaymentRefundStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/GetPaymentRefundStrategy.java
@@ -26,12 +26,12 @@ public class GetPaymentRefundStrategy extends LedgerOrConnectorStrategyTemplate<
     }
 
     @Override
-    protected RefundResponse executeFutureBehaviourStrategy() {
+    protected RefundResponse executeDefaultStrategy() {
         return getPaymentRefundsService.getPaymentRefund(account, paymentId, refundId);
     }
 
     @Override
-    protected RefundResponse executeDefaultStrategy() {
+    protected RefundResponse executeConnectorOnlyStrategy() {
         return getPaymentRefundsService.getConnectorPaymentRefund(account, paymentId, refundId);
     }
 }

--- a/src/main/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategy.java
@@ -24,12 +24,12 @@ public class GetPaymentRefundsStrategy extends LedgerOrConnectorStrategyTemplate
     }
 
     @Override
-    protected RefundsResponse executeFutureBehaviourStrategy() {
+    protected RefundsResponse executeDefaultStrategy() {
         return executeLedgerOnlyStrategy();
     }
 
     @Override
-    protected RefundsResponse executeDefaultStrategy() {
+    protected RefundsResponse executeConnectorOnlyStrategy() {
         return getPaymentRefundsService.getConnectorPaymentRefunds(account, paymentId);
     }
 }

--- a/src/main/java/uk/gov/pay/api/resources/LedgerOrConnectorStrategyTemplate.java
+++ b/src/main/java/uk/gov/pay/api/resources/LedgerOrConnectorStrategyTemplate.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.api.app.config.PublicApiConfig;
 
 import java.util.List;
 
@@ -12,7 +11,7 @@ public abstract class LedgerOrConnectorStrategyTemplate<T> {
 
     private static final Logger logger = LoggerFactory.getLogger(LedgerOrConnectorStrategyTemplate.class);
     private String strategy;
-    private List<String> VALID_STRATEGIES = ImmutableList.of("ledger-only", "future-behaviour");
+    private List<String> VALID_STRATEGIES = ImmutableList.of("ledger-only", "connector-only");
 
     public LedgerOrConnectorStrategyTemplate(String strategy) {
         this.strategy = strategy;
@@ -20,7 +19,7 @@ public abstract class LedgerOrConnectorStrategyTemplate<T> {
 
     private void validate() {
         if (!StringUtils.isBlank(strategy) && !VALID_STRATEGIES.contains(strategy)) {
-            logger.warn("Not valid strategy (valid values are \"ledger-only\", \"future-behaviour\" or empty); using the default strategy");
+            logger.warn("Not valid strategy (valid values are \"ledger-only\", \"connector-only\" or empty); using the default strategy");
             strategy = null;
         }
     }
@@ -28,8 +27,8 @@ public abstract class LedgerOrConnectorStrategyTemplate<T> {
     public T validateAndExecute() {
         validate();
 
-        if ("future-behaviour".equals(strategy)) {
-            return executeFutureBehaviourStrategy();
+        if ("connector-only".equals(strategy)) {
+            return executeConnectorOnlyStrategy();
         } else if ("ledger-only".equals(strategy)) {
             return executeLedgerOnlyStrategy();
         }
@@ -39,9 +38,9 @@ public abstract class LedgerOrConnectorStrategyTemplate<T> {
 
     protected abstract T executeLedgerOnlyStrategy();
 
-    protected abstract T executeFutureBehaviourStrategy();
-
     protected abstract T executeDefaultStrategy();
+
+    protected abstract T executeConnectorOnlyStrategy();
 }
 
 

--- a/src/test/java/uk/gov/pay/api/it/GetPaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/GetPaymentIT.java
@@ -289,7 +289,7 @@ public class GetPaymentIT extends PaymentResourceITestBase {
                         getConnectorCharge()
                                 .withCardDetails(cd)
                                 .build()),
-                CONNECTOR_STRATEGY);
+                CONNECTOR_ONLY_STRATEGY);
     }
 
     @Test
@@ -353,7 +353,7 @@ public class GetPaymentIT extends PaymentResourceITestBase {
         String errorMessage = "backend-error-message";
         connectorMockClient.respondWhenGetCharge(GATEWAY_ACCOUNT_ID, paymentId, errorMessage, SC_NOT_ACCEPTABLE);
 
-        assertErrorPaymentResponse(getPaymentResponse(paymentId));
+        assertErrorPaymentResponse(getPaymentResponse(paymentId, CONNECTOR_ONLY_STRATEGY));
     }
 
     @Test
@@ -449,7 +449,7 @@ public class GetPaymentIT extends PaymentResourceITestBase {
         String errorMessage = "backend-error-message";
         connectorMockClient.respondWhenGetChargeEvents(GATEWAY_ACCOUNT_ID, paymentId, errorMessage, SC_NOT_ACCEPTABLE);
 
-        assertErrorEventsResponse(getPaymentEventsResponse(paymentId));
+        assertErrorEventsResponse(getPaymentEventsResponse(paymentId, CONNECTOR_ONLY_STRATEGY));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentRefundsResourceIT.java
@@ -122,7 +122,7 @@ public class PaymentRefundsResourceIT extends PaymentResourceITestBase {
     public void getRefundById_returns500_whenConnectorRespondsWithResponseOtherThan200Or404() {
         connectorMockClient.respondRefundWithError(GATEWAY_ACCOUNT_ID, CHARGE_ID, REFUND_ID);
 
-        getPaymentRefundByIdResponse(CHARGE_ID, REFUND_ID)
+        getPaymentRefundByIdResponse(CHARGE_ID, REFUND_ID, CONNECTOR_ONLY_STRATEGY)
                 .statusCode(500)
                 .contentType(JSON)
                 .body("code", is("P0798"))
@@ -147,7 +147,7 @@ public class PaymentRefundsResourceIT extends PaymentResourceITestBase {
 
         connectorMockClient.respondWithGetAllRefunds(GATEWAY_ACCOUNT_ID, CHARGE_ID, refund1, refund2);
 
-        assertRefundsResponse(getPaymentRefundsResponse(CHARGE_ID));
+        assertRefundsResponse(getPaymentRefundsResponse(CHARGE_ID, CONNECTOR_ONLY_STRATEGY));
     }
 
     @Test
@@ -199,7 +199,7 @@ public class PaymentRefundsResourceIT extends PaymentResourceITestBase {
     public void getRefunds_shouldGetValidResponse_whenListReturnedIsEmpty() {
         connectorMockClient.respondWithGetAllRefunds(GATEWAY_ACCOUNT_ID, CHARGE_ID);
 
-        assertEmptyRefundsResponse(getPaymentRefundsResponse(CHARGE_ID));
+        assertEmptyRefundsResponse(getPaymentRefundsResponse(CHARGE_ID, CONNECTOR_ONLY_STRATEGY));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
@@ -31,7 +31,7 @@ public abstract class PaymentResourceITestBase {
     protected static final String GATEWAY_ACCOUNT_ID = "GATEWAY_ACCOUNT_ID";
     protected static final String PAYMENTS_PATH = "/v1/payments/";
     protected static final String LEDGER_ONLY_STRATEGY = "ledger-only";
-    protected static final String CONNECTOR_STRATEGY = "";
+    protected static final String CONNECTOR_ONLY_STRATEGY = "connector-only";
 
     @ClassRule
     public static RedisDockerRule redisDockerRule;

--- a/src/test/java/uk/gov/pay/api/resources/GetOnePaymentStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetOnePaymentStrategyTest.java
@@ -40,8 +40,8 @@ public class GetOnePaymentStrategyTest {
     }
 
     @Test
-    public void validateAndExecuteUsesFutureStrategyOnly() {
-        String strategy = "future-behaviour";
+    @Parameters({"", "unknown"})
+    public void validateAndExecuteUsesDefaultStrategy(String strategy) {
         getOnePaymentStrategy = new GetOnePaymentStrategy(strategy, mockAccountId, mockPaymentId, mockGetPaymentService);
         getOnePaymentStrategy.validateAndExecute();
 
@@ -49,8 +49,8 @@ public class GetOnePaymentStrategyTest {
     }
 
     @Test
-    @Parameters({"", "unknown"})
-    public void validateAndExecuteShouldUseConnectorOnlyStrategy(String strategy) {
+    public void validateAndExecuteShouldUseConnectorOnlyStrategy() {
+        String strategy = "connector-only";
         getOnePaymentStrategy = new GetOnePaymentStrategy(strategy, mockAccountId, mockPaymentId, mockGetPaymentService);
 
         getOnePaymentStrategy.validateAndExecute();

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentEventsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentEventsStrategyTest.java
@@ -40,8 +40,8 @@ public class GetPaymentEventsStrategyTest {
     }
 
     @Test
-    public void validateAndExecuteUsesFutureStrategyOnly() {
-        String strategy = "future-behaviour";
+    @Parameters({"", "unknown"})
+    public void validateAndExecuteUsesDefaultStrategy(String strategy) {
         getPaymentEventsStrategy = new GetPaymentEventsStrategy(strategy, mockAccountId, mockPaymentId, getPaymentEventsService);
         getPaymentEventsStrategy.validateAndExecute();
 
@@ -49,8 +49,9 @@ public class GetPaymentEventsStrategyTest {
     }
 
     @Test
-    @Parameters({"", "unknown"})
-    public void validateAndExecuteShouldUseConnectorOnlyStrategy(String strategy) {
+    
+    public void validateAndExecuteShouldUseConnectorOnlyStrategy() {
+        String strategy = "connector-only";
         getPaymentEventsStrategy = new GetPaymentEventsStrategy(strategy, mockAccountId, mockPaymentId, getPaymentEventsService);
 
         getPaymentEventsStrategy.validateAndExecute();

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundStrategyTest.java
@@ -40,8 +40,8 @@ public class GetPaymentRefundStrategyTest {
     }
 
     @Test
-    public void validateAndExecuteUsesFutureStrategyOnly() {
-        String strategy = "future-behaviour";
+    @Parameters({"", "unknown"})
+    public void validateAndExecuteUsesDefaultStrategy(String strategy) {
         getPaymentRefundStrategy = new GetPaymentRefundStrategy(strategy, account, paymentId, refundId, mockGetPaymentRefundService);
         getPaymentRefundStrategy.validateAndExecute();
 
@@ -49,8 +49,8 @@ public class GetPaymentRefundStrategyTest {
     }
 
     @Test
-    @Parameters({"", "unknown"})
-    public void validateAndExecuteShouldUseConnectorOnlyStrategy(String strategy) {
+    public void validateAndExecuteShouldUseConnectorOnlyStrategy() {
+        String strategy = "connector-only";
         getPaymentRefundStrategy = new GetPaymentRefundStrategy(strategy, account, paymentId, refundId, mockGetPaymentRefundService);
 
         getPaymentRefundStrategy.validateAndExecute();

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategyTest.java
@@ -28,7 +28,7 @@ public class GetPaymentRefundsStrategyTest {
     private Account account = new Account("account-id", TokenPaymentType.CARD);
 
     @Test
-    @Parameters({"ledger-only", "future-behaviour"})
+    @Parameters({"ledger-only", "", "unknown"})
     public void validateAndExecuteShouldUseLedgerOnlyForListedStrategies(String strategy) {
         getPaymentRefundsStrategy = new GetPaymentRefundsStrategy(strategy, account, paymentId, mockGetPaymentRefundsService);
         getPaymentRefundsStrategy.validateAndExecute();
@@ -38,8 +38,8 @@ public class GetPaymentRefundsStrategyTest {
     }
 
     @Test
-    @Parameters({"", "unknown"})
-    public void validateAndExecuteShouldUseConnectorOnlyForDefaultOrUnknownStrategy(String strategy) {
+    @Parameters({"connector-only"})
+    public void validateAndExecuteShouldUseConnectorOnlyStrategy(String strategy) {
         getPaymentRefundsStrategy = new GetPaymentRefundsStrategy(strategy, account, paymentId, mockGetPaymentRefundsService);
 
         getPaymentRefundsStrategy.validateAndExecute();


### PR DESCRIPTION
Why?
Apart from removing feature flag, it's important to update the actual strategies
to use future strategy by default now.

These changes introduce "connector-only" strategy and swaps the behaviour between
default and future strategy (default becomes connector only and future becomes default strategy).