### PR TITLE
PP-5970 Accept header for search ledger refunds

### DIFF
--- a/src/main/java/uk/gov/pay/api/service/LedgerService.java
+++ b/src/main/java/uk/gov/pay/api/service/LedgerService.java
@@ -102,6 +102,7 @@ public class LedgerService {
         Response response = client
                 .target(ledgerUriGenerator.transactionsURIWithParams(paramsAsMap))
                 .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
                 .get();
 
         if (response.getStatus() == SC_OK) {


### PR DESCRIPTION
## WHAT YOU DID
- Add MediaType `json` to search for refunds from ledger, as ledger now supports both json and csv on same endpoint (https://github.com/alphagov/pay-ledger/pull/470)

