### PR TITLE
BAU: code clean up

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapper.java
@@ -1,7 +1,5 @@
 package uk.gov.pay.api.exception.mapper;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.exception.CreateMandateException;
@@ -9,9 +7,11 @@ import uk.gov.pay.api.model.directdebit.mandates.MandateError;
 import uk.gov.pay.api.model.directdebit.mandates.MandateError.Code;
 import uk.gov.pay.commons.model.ErrorIdentifier;
 
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
-import static uk.gov.pay.api.model.directdebit.mandates.MandateError.aMandateError;
 
 public class CreateAgreementExceptionMapper implements ExceptionMapper<CreateMandateException> {
 

--- a/src/main/java/uk/gov/pay/api/exception/mapper/GetAgreementExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/GetAgreementExceptionMapper.java
@@ -11,7 +11,6 @@ import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static uk.gov.pay.api.model.directdebit.mandates.MandateError.Code.GET_MANDATE_CONNECTOR_ERROR;
 import static uk.gov.pay.api.model.directdebit.mandates.MandateError.Code.GET_MANDATE_NOT_FOUND_ERROR;
-import static uk.gov.pay.api.model.directdebit.mandates.MandateError.aMandateError;
 
 public class GetAgreementExceptionMapper implements ExceptionMapper<GetMandateException> {
 

--- a/src/main/java/uk/gov/pay/api/filter/AuthorizationValidationFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/AuthorizationValidationFilter.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.api.filter;
 
 import com.google.common.io.BaseEncoding;
+import org.apache.commons.codec.digest.HmacAlgorithms;
 import org.apache.commons.codec.digest.HmacUtils;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 
@@ -68,7 +69,7 @@ public class AuthorizationValidationFilter implements Filter {
     private boolean tokenMatchesHmac(String token, String currentHmac) {
         final String hmacCalculatedFromToken = BaseEncoding.base32Hex()
                 .lowerCase().omitPadding()
-                .encode(HmacUtils.hmacSha1(apiKeyHmacSecret, token));
+                .encode(new HmacUtils(HmacAlgorithms.HMAC_SHA_1, apiKeyHmacSecret).hmac(token));
         return hmacCalculatedFromToken.equals(currentHmac);
     }
 }

--- a/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
+++ b/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
@@ -227,8 +227,7 @@ class RequestJsonParser {
     }
 
     private static String validateSkipNullValueAndGetString(JsonNode jsonNode, PaymentError validationError) {
-        String value = validateSkipNullAndGetValue(jsonNode, validationError, JsonNode::isTextual, JsonNode::asText);
-        return value;
+        return validateSkipNullAndGetValue(jsonNode, validationError, JsonNode::isTextual, JsonNode::asText);
     }
     
     private static <T> T validateSkipNullAndGetValue(JsonNode jsonNode,

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateConnectorResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateConnectorResponse.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -7,7 +7,6 @@ import io.swagger.annotations.ApiModelProperty;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.CardPayment;
 import uk.gov.pay.api.model.Charge;
-import uk.gov.pay.api.model.ChargeFromResponse;
 import uk.gov.pay.api.model.directdebit.mandates.DirectDebitPayment;
 import uk.gov.pay.api.model.Payment;
 import uk.gov.pay.api.model.PaymentConnectorResponseLink;
@@ -130,12 +129,10 @@ public class PaymentWithAllLinks {
             URI paymentCancelUri,
             URI paymentRefundsUri,
             URI paymentsCaptureUri) {
-        switch (paymentType) {
-            case DIRECT_DEBIT:
-                return PaymentWithAllLinks.valueOf(paymentConnector, selfLink);
-            default:
-                return PaymentWithAllLinks.valueOf(paymentConnector, selfLink, paymentEventsUri, paymentCancelUri, paymentRefundsUri, paymentsCaptureUri);
+        if (paymentType == TokenPaymentType.DIRECT_DEBIT) {
+            return PaymentWithAllLinks.valueOf(paymentConnector, selfLink);
         }
+        return PaymentWithAllLinks.valueOf(paymentConnector, selfLink, paymentEventsUri, paymentCancelUri, paymentRefundsUri, paymentsCaptureUri);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/api/model/links/directdebit/MandateLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/directdebit/MandateLinks.java
@@ -123,8 +123,7 @@ public class MandateLinks {
         }
 
         public MandateLinks build() {
-            MandateLinks mandateLinks = new MandateLinks(self, nextUrl, nextUrlPost, payments, events);
-            return mandateLinks;
+            return new MandateLinks(self, nextUrl, nextUrlPost, payments, events);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/search/card/PaymentSearchResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/PaymentSearchResponse.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.api.model.search.card;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import uk.gov.pay.api.model.ChargeFromResponse;
 import uk.gov.pay.api.model.links.SearchNavigationLinks;
 import uk.gov.pay.api.model.search.SearchPagination;
 

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
@@ -63,7 +63,7 @@ public class DirectDebitSearchMandatesParams {
     @Max(value = 500, message = "Must be less than or equal to {value}")
     private int displaySize;
 
-    public DirectDebitSearchMandatesParams() { };
+    public DirectDebitSearchMandatesParams() { }
 
     private DirectDebitSearchMandatesParams(DirectDebitSearchMandatesParamsBuilder builder) {
         this.reference = builder.reference;
@@ -123,8 +123,8 @@ public class DirectDebitSearchMandatesParams {
                 params.put("bank_statement_reference", bankStatementReference));
         this.getEmail().ifPresent(email -> params.put("email", email));
         this.getName().ifPresent(name -> params.put("name", name));
-        this.getFromDate().ifPresent(fromDate -> params.put("from_date", String.valueOf(fromDate)));
-        this.getToDate().ifPresent(toDate -> params.put("to_date", String.valueOf(toDate)));
+        this.getFromDate().ifPresent(fromDate -> params.put("from_date", fromDate));
+        this.getToDate().ifPresent(toDate -> params.put("to_date", toDate));
         this.getReference().ifPresent(reference -> params.put("reference", reference));
         this.getState().ifPresent(state -> params.put("state", state));
 

--- a/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
@@ -25,7 +25,6 @@ import uk.gov.pay.api.service.SearchRefundsService;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;

--- a/src/main/java/uk/gov/pay/api/resources/telephone/TelephonePaymentNotificationResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/telephone/TelephonePaymentNotificationResource.java
@@ -3,7 +3,6 @@ package uk.gov.pay.api.resources.telephone;
 import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.auth.Auth;
 import io.swagger.annotations.Api;
-import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.auth.Account;

--- a/src/main/java/uk/gov/pay/api/service/MandatesService.java
+++ b/src/main/java/uk/gov/pay/api/service/MandatesService.java
@@ -3,7 +3,6 @@ package uk.gov.pay.api.service;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CreateMandateException;
 import uk.gov.pay.api.exception.GetMandateException;
@@ -11,7 +10,6 @@ import uk.gov.pay.api.model.directdebit.mandates.CreateMandateRequest;
 import uk.gov.pay.api.model.directdebit.mandates.MandateConnectorRequest;
 import uk.gov.pay.api.model.directdebit.mandates.MandateConnectorResponse;
 import uk.gov.pay.api.model.directdebit.mandates.MandateResponse;
-import uk.gov.pay.api.model.links.directdebit.MandateLinks;
 import uk.gov.pay.api.service.directdebit.DirectDebitConnectorUriGenerator;
 
 import javax.inject.Inject;
@@ -19,8 +17,6 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import static uk.gov.pay.api.model.links.directdebit.MandateLinks.MandateLinksBuilder.aMandateLinks;
 
 public class MandatesService {
 

--- a/src/main/java/uk/gov/pay/api/service/PublicApiUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/PublicApiUriGenerator.java
@@ -7,7 +7,6 @@ import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
 
 import static java.lang.String.format;
 

--- a/src/main/java/uk/gov/pay/api/validation/DirectDebitEventSearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/DirectDebitEventSearchValidator.java
@@ -34,18 +34,18 @@ public class DirectDebitEventSearchValidator {
     }
 
     private static void validateBeforeDate(String toDate, List<String> validationErrors) {
-        if (!validateDate(toDate)) {
+        if (isDateInvalid(toDate)) {
             validationErrors.add("from_date");
         }
     }
 
     private static void validateAfterDate(String fromDate, List<String> validationErrors) {
-        if (!validateDate(fromDate)) {
+        if (isDateInvalid(fromDate)) {
             validationErrors.add("to_date");
         }
     }
 
-    private static boolean validateDate(String value) {
-        return DateValidator.isValid(value);
+    private static boolean isDateInvalid(String value) {
+        return !DateValidator.isValid(value);
     }
 }

--- a/src/main/java/uk/gov/pay/api/validation/MaxLengthValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/MaxLengthValidator.java
@@ -3,7 +3,7 @@ package uk.gov.pay.api.validation;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 class MaxLengthValidator {
-    static boolean isValid(String value, int maxLength) {
-        return isBlank(value) || value.length() <= maxLength;
+    static boolean isInvalid(String value, int maxLength) {
+        return !isBlank(value) && value.length() > maxLength;
     }
 }

--- a/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/PaymentSearchValidator.java
@@ -18,7 +18,7 @@ import static uk.gov.pay.api.model.CreateDirectDebitPaymentRequest.MANDATE_ID_MA
 import static uk.gov.pay.api.model.PaymentError.Code.SEARCH_PAYMENTS_VALIDATION_ERROR;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
-import static uk.gov.pay.api.validation.MaxLengthValidator.isValid;
+import static uk.gov.pay.api.validation.MaxLengthValidator.isInvalid;
 import static uk.gov.pay.api.validation.SearchValidator.validateDisplaySizeIfNotNull;
 import static uk.gov.pay.api.validation.SearchValidator.validateFromDate;
 import static uk.gov.pay.api.validation.SearchValidator.validatePageIfNotNull;
@@ -77,7 +77,7 @@ public class PaymentSearchValidator {
     }
 
     private static void validateMandateId(String mandate_id, List<String> validationErrors) {
-        if (!isValid(mandate_id, MANDATE_ID_MAX_LENGTH)) {
+        if (isInvalid(mandate_id, MANDATE_ID_MAX_LENGTH)) {
             validationErrors.add("mandate_id");
         }
     }
@@ -95,19 +95,19 @@ public class PaymentSearchValidator {
     }
 
     private static void validateReference(String reference, List<String> validationErrors) {
-        if (!isValid(reference, REFERENCE_MAX_LENGTH)) {
+        if (isInvalid(reference, REFERENCE_MAX_LENGTH)) {
             validationErrors.add("reference");
         }
     }
 
     private static void validateEmail(String email, List<String> validationErrors) {
-        if (!isValid(email, EMAIL_MAX_LENGTH)) {
+        if (isInvalid(email, EMAIL_MAX_LENGTH)) {
             validationErrors.add("email");
         }
     }
 
     private static void validateCardBrand(String cardBrand, List<String> validationErrors) {
-        if (!isValid(cardBrand, 20)) {
+        if (isInvalid(cardBrand, 20)) {
             validationErrors.add("card_brand");
         }
     }

--- a/src/test/java/uk/gov/pay/api/filter/AuthorizationValidationFilterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/AuthorizationValidationFilterTest.java
@@ -13,7 +13,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.api.utils.ApiKeyGenerator.apiKeyValueOf;
 
@@ -62,7 +62,7 @@ public class AuthorizationValidationFilterTest {
 
         authorizationValidationFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
-        verifyZeroInteractions(mockFilterChain);
+        verifyNoInteractions(mockFilterChain);
         verify(mockResponse).sendError(401, "Unauthorized");
     }
 
@@ -73,7 +73,7 @@ public class AuthorizationValidationFilterTest {
 
         authorizationValidationFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
-        verifyZeroInteractions(mockFilterChain);
+        verifyNoInteractions(mockFilterChain);
         verify(mockResponse).sendError(401, "Unauthorized");
     }
 
@@ -87,7 +87,7 @@ public class AuthorizationValidationFilterTest {
 
         authorizationValidationFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
-        verifyZeroInteractions(mockFilterChain);
+        verifyNoInteractions(mockFilterChain);
         verify(mockResponse).sendError(401, "Unauthorized");
     }
 
@@ -101,7 +101,7 @@ public class AuthorizationValidationFilterTest {
 
         authorizationValidationFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
-        verifyZeroInteractions(mockFilterChain);
+        verifyNoInteractions(mockFilterChain);
         verify(mockResponse).sendError(401, "Unauthorized");
     }
 }

--- a/src/test/java/uk/gov/pay/api/filter/RestClientLoggingFilterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/RestClientLoggingFilterTest.java
@@ -107,7 +107,7 @@ public class RestClientLoggingFilterTest {
         String endLogMessage = loggingEvents.get(1).getFormattedMessage();
         assertThat(endLogMessage, containsString(format("[%s] - %s to %s ended - total time ", requestId, requestMethod, requestUrl)));
         String[] timeTaken = StringUtils.substringsBetween(endLogMessage, "total time ", "ms");
-        assertTrue(NumberUtils.isNumber(timeTaken[0]));
+        assertTrue(NumberUtils.isCreatable(timeTaken[0]));
 
     }
 }

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimiterTest.java
@@ -10,7 +10,6 @@ import uk.gov.pay.api.filter.RateLimiterKey;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RateLimiterTest {

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceCaptureIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceCaptureIT.java
@@ -2,7 +2,6 @@ package uk.gov.pay.api.it;
 
 import com.jayway.jsonassert.JsonAssert;
 import io.restassured.response.ValidatableResponse;
-import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.api.utils.PublicAuthMockClient;
 import uk.gov.pay.api.utils.mocks.ConnectorMockClient;

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterIT.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterIT.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hamcrest.core.IsIterableContaining.hasItem;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.api.it.fixtures.PaginatedTransactionSearchResultFixture.aPaginatedTransactionSearchResult;
 import static uk.gov.pay.api.it.fixtures.PaymentSearchResultBuilder.aSuccessfulSearchPayment;

--- a/src/test/java/uk/gov/pay/api/it/rule/RedisContainer.java
+++ b/src/test/java/uk/gov/pay/api/it/rule/RedisContainer.java
@@ -6,7 +6,6 @@ import com.spotify.docker.client.LogStream;
 import com.spotify.docker.client.exceptions.DockerException;
 import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.ContainerInfo;
-import com.spotify.docker.client.messages.ExecCreation;
 import com.spotify.docker.client.messages.HostConfig;
 import com.spotify.docker.client.messages.LogConfig;
 import com.spotify.docker.client.messages.PortBinding;
@@ -15,7 +14,6 @@ import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 

--- a/src/test/java/uk/gov/pay/api/it/telephone/TelephonePaymentResourceITBase.java
+++ b/src/test/java/uk/gov/pay/api/it/telephone/TelephonePaymentResourceITBase.java
@@ -12,11 +12,8 @@ import org.junit.Rule;
 import uk.gov.pay.api.app.PublicApi;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.it.rule.RedisDockerRule;
-import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.telephone.CreateTelephonePaymentRequest;
 import uk.gov.pay.api.utils.ApiKeyGenerator;
-import uk.gov.pay.api.utils.PublicAuthMockClient;
-import uk.gov.pay.api.utils.mocks.ConnectorDDMockClient;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -26,8 +23,6 @@ import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
-import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
-import static uk.gov.pay.api.utils.Urls.paymentLocationFor;
 import static uk.gov.pay.commons.testing.port.PortFactory.findFreePort;
 
 public abstract class TelephonePaymentResourceITBase {

--- a/src/test/java/uk/gov/pay/api/it/telephone/pact/CreateTelephonePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/it/telephone/pact/CreateTelephonePaymentServiceTest.java
@@ -11,36 +11,21 @@ import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
-import uk.gov.pay.api.exception.CreateChargeException;
-import uk.gov.pay.api.model.Address;
-import uk.gov.pay.api.model.CardPayment;
 import uk.gov.pay.api.model.ChargeFromResponse;
-import uk.gov.pay.api.model.CreateCardPaymentRequestBuilder;
-import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.TokenPaymentType;
-import uk.gov.pay.api.model.links.Link;
-import uk.gov.pay.api.model.links.PaymentWithAllLinks;
-import uk.gov.pay.api.model.links.PostLink;
 import uk.gov.pay.api.model.telephone.CreateTelephonePaymentRequest;
 import uk.gov.pay.api.model.telephone.PaymentOutcome;
 import uk.gov.pay.api.model.telephone.Supplemental;
 import uk.gov.pay.api.service.ConnectorUriGenerator;
 import uk.gov.pay.api.service.telephone.CreateTelephonePaymentService;
-import uk.gov.pay.commons.model.ErrorIdentifier;
-import uk.gov.pay.commons.model.SupportedLanguage;
-import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.pay.commons.testing.pact.consumers.Pacts;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentResourceSearchValidationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentResourceSearchValidationIT.java
@@ -11,6 +11,7 @@ import uk.gov.pay.api.it.PaymentResourceITestBase;
 import uk.gov.pay.api.utils.PublicAuthMockClient;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
@@ -192,7 +193,7 @@ public class PaymentResourceSearchValidationIT extends PaymentResourceITestBase 
                 .contentType(JSON).extract()
                 .body().asInputStream();
 
-        String json = IOUtils.toString(body, "UTF-8");
+        String json = IOUtils.toString(body, StandardCharsets.UTF_8);
 
         JsonAssert.with(json)
                 .assertThat("$.*", hasSize(2))
@@ -213,7 +214,7 @@ public class PaymentResourceSearchValidationIT extends PaymentResourceITestBase 
                 .contentType(JSON).extract()
                 .body().asInputStream();
 
-        String json = IOUtils.toString(body, "UTF-8");
+        String json = IOUtils.toString(body, StandardCharsets.UTF_8);
 
         JsonAssert.with(json)
                 .assertThat("$.*", hasSize(2))

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceLanguageValidationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceLanguageValidationIT.java
@@ -9,7 +9,6 @@ import uk.gov.pay.api.it.PaymentResourceITestBase;
 import uk.gov.pay.api.utils.PublicAuthMockClient;
 import uk.gov.pay.api.utils.mocks.ConnectorMockClient;
 
-import java.io.IOException;
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
@@ -89,7 +88,7 @@ public class PaymentsResourceLanguageValidationIT extends PaymentResourceITestBa
     }
 
     @Test
-    public void createPayment_responseWith400_whenLanguageIsNull() throws IOException {
+    public void createPayment_responseWith400_whenLanguageIsNull() {
         // language=JSON
         String payload = "{\n" +
                 "  \"amount\": 9900,\n" +
@@ -109,7 +108,7 @@ public class PaymentsResourceLanguageValidationIT extends PaymentResourceITestBa
     }
 
     @Test
-    public void createPayment_responseWith400_whenLanguageHasNotAValidJsonValue() throws IOException {
+    public void createPayment_responseWith400_whenLanguageHasNotAValidJsonValue() {
         String payload = "{" +
                 "  \"amount\" : 9900," +
                 "  \"reference\" : \"Some reference\"," +
@@ -127,7 +126,7 @@ public class PaymentsResourceLanguageValidationIT extends PaymentResourceITestBa
     }
 
     @Test
-    public void createPayment_responseWith400_whenLanguageFieldIsNotExpectedJsonField() throws IOException {
+    public void createPayment_responseWith400_whenLanguageFieldIsNotExpectedJsonField() {
         // language=JSON
         String payload = "{\n" +
                 "  \"amount\": 9900,\n" +

--- a/src/test/java/uk/gov/pay/api/json/CreateCardPaymentRequestDeserializerTest.java
+++ b/src/test/java/uk/gov/pay/api/json/CreateCardPaymentRequestDeserializerTest.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.pay.api.matcher.BadRequestExceptionMatcher.aBadRequestExceptionWithError;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -612,6 +612,6 @@ public class CreateCardPaymentRequestDeserializerTest {
 
     @After
     public void tearDown() {
-        verifyZeroInteractions(ctx);
+        verifyNoInteractions(ctx);
     }
 }

--- a/src/test/java/uk/gov/pay/api/json/CreatePaymentRefundRequestDeserializerTest.java
+++ b/src/test/java/uk/gov/pay/api/json/CreatePaymentRefundRequestDeserializerTest.java
@@ -17,7 +17,7 @@ import uk.gov.pay.api.validation.PaymentRefundRequestValidator;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.pay.api.matcher.BadRequestExceptionMatcher.aBadRequestExceptionWithError;
 import static uk.gov.pay.api.matcher.PaymentValidationExceptionMatcher.aValidationExceptionContaining;
 
@@ -123,6 +123,6 @@ public class CreatePaymentRefundRequestDeserializerTest {
 
     @After
     public void tearDown() {
-        verifyZeroInteractions(ctx);
+        verifyNoInteractions(ctx);
     }
 }

--- a/src/test/java/uk/gov/pay/api/service/ConnectorUriGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/api/service/ConnectorUriGeneratorTest.java
@@ -10,6 +10,7 @@ import uk.gov.pay.api.auth.Account;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
@@ -74,13 +75,13 @@ public class ConnectorUriGeneratorTest {
     @Test
     public void buildEventsURIFromBeforeParameter() throws Exception {
         String uri = connectorUriGenerator.eventsURI(cardAccount, Optional.of(ZonedDateTime.parse("2018-03-13T10:00:05.000Z")), Optional.empty(), null, null, null, null);
-        assertThat(URLDecoder.decode(uri, "UTF-8"), is("https://bla.test/v1/events?to_date=2018-03-13T10:00:05.000Z&page=1&display_size=500"));
+        assertThat(URLDecoder.decode(uri, StandardCharsets.UTF_8), is("https://bla.test/v1/events?to_date=2018-03-13T10:00:05.000Z&page=1&display_size=500"));
     }
 
     @Test
     public void buildEventsURIFromAfterParameter() throws UnsupportedEncodingException {
         String uri = connectorUriGenerator.eventsURI(cardAccount, Optional.empty(), Optional.of(ZonedDateTime.parse("2018-03-13T10:00:05.000Z")), null, null, null, null);
-        assertThat(URLDecoder.decode(uri, "UTF-8"), is("https://bla.test/v1/events?from_date=2018-03-13T10:00:05.000Z&page=1&display_size=500"));
+        assertThat(URLDecoder.decode(uri, StandardCharsets.UTF_8), is("https://bla.test/v1/events?from_date=2018-03-13T10:00:05.000Z&page=1&display_size=500"));
     }
 
     @Test
@@ -92,6 +93,6 @@ public class ConnectorUriGeneratorTest {
     @Test
     public void buildEventsURIFromAllParameters() throws UnsupportedEncodingException {
         String uri = connectorUriGenerator.eventsURI(cardAccount, Optional.of(ZonedDateTime.parse("2018-03-13T10:00:05.000Z")), Optional.of(ZonedDateTime.parse("2018-03-13T10:00:05Z")), 1, 300, "1", "2");
-        assertThat(URLDecoder.decode(uri, "UTF-8"), is("https://bla.test/v1/events?to_date=2018-03-13T10:00:05.000Z&from_date=2018-03-13T10:00:05.000Z&mandate_external_id=1&payment_external_id=2&page=1&display_size=300"));
+        assertThat(URLDecoder.decode(uri, StandardCharsets.UTF_8), is("https://bla.test/v1/events?to_date=2018-03-13T10:00:05.000Z&from_date=2018-03-13T10:00:05.000Z&mandate_external_id=1&payment_external_id=2&page=1&display_size=300"));
     }
 }

--- a/src/test/java/uk/gov/pay/api/utils/ApiKeyGenerator.java
+++ b/src/test/java/uk/gov/pay/api/utils/ApiKeyGenerator.java
@@ -1,12 +1,13 @@
 package uk.gov.pay.api.utils;
 
 import com.google.common.io.BaseEncoding;
+import org.apache.commons.codec.digest.HmacAlgorithms;
 import org.apache.commons.codec.digest.HmacUtils;
 
 public class ApiKeyGenerator {
 
     public static String apiKeyValueOf(String token, String secret) {
-        byte[] hmacBytes = HmacUtils.hmacSha1(secret, token);
+        byte[] hmacBytes = new HmacUtils(HmacAlgorithms.HMAC_SHA_1, secret).hmac(token);
         String encodedHmac = BaseEncoding.base32Hex().lowerCase().omitPadding().encode(hmacBytes);
         return token + encodedHmac;
     }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -337,25 +337,21 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
         String chargeId = chargeResponseFromConnector.getChargeId();
 
         var responseFromConnector = aCreateOrGetChargeResponseFromConnector(chargeResponseFromConnector)
-                .withLink(validGetLink(chargeLocation(gatewayAccountId, chargeId), "self"));
+                .withLink(validGetLink(chargeLocation(gatewayAccountId, chargeId), "self"))
+                .withLink(validGetLink(chargeLocation(gatewayAccountId, chargeId) + "/refunds", "refunds"));
 
         if (AWAITING_CAPTURE_REQUEST == chargeResponseFromConnector.getState()) {
-
-            responseFromConnector.withLink(validGetLink(chargeLocation(gatewayAccountId, chargeId) + "/refunds", "refunds"))
+            responseFromConnector
                     .withLink(validPostLink(chargeLocation(gatewayAccountId, chargeId) + "/capture", "capture", "application/x-www-form-urlencoded", new HashMap<>()))
                     .build();
-
-            chargeResponseBody = buildChargeResponse(responseFromConnector.build());
-
         } else {
-
-            responseFromConnector.withLink(validGetLink(chargeLocation(gatewayAccountId, chargeId) + "/refunds", "refunds"))
+            responseFromConnector
                     .withLink(validGetLink(nextUrl(chargeId), "next_url"))
                     .withLink(validPostLink(nextUrlPost(), "next_url_post", "application/x-www-form-urlencoded", getChargeIdTokenMap(chargeTokenId)))
                     .build();
-
-            chargeResponseBody = buildChargeResponse(responseFromConnector.build());
         }
+
+        chargeResponseBody = buildChargeResponse(responseFromConnector.build());
         whenGetCharge(gatewayAccountId, chargeId, aResponse()
                 .withStatus(OK_200)
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON)

--- a/src/test/java/uk/gov/pay/api/utils/mocks/CreateChargeRequestParams.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/CreateChargeRequestParams.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.api.utils.mocks;
 
-import uk.gov.pay.api.utils.JsonStringBuilder;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.util.List;

--- a/src/test/java/uk/gov/pay/api/utils/mocks/DDConnectorResponseToGetMandateParams.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/DDConnectorResponseToGetMandateParams.java
@@ -2,7 +2,6 @@ package uk.gov.pay.api.utils.mocks;
 
 import uk.gov.pay.api.model.directdebit.mandates.MandateState;
 import uk.gov.pay.api.model.directdebit.mandates.Payer;
-import uk.gov.pay.api.utils.ChargeEventBuilder;
 
 public class DDConnectorResponseToGetMandateParams {
 

--- a/src/test/java/uk/gov/pay/api/validation/PaymentOutcomeValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/PaymentOutcomeValidatorTest.java
@@ -140,7 +140,7 @@ public class PaymentOutcomeValidatorTest {
 
         CreateTelephonePaymentRequest telephonePaymentRequest = builder
                 .withPaymentOutcome(null)
-                .build();;
+                .build();
 
         Set<ConstraintViolation<CreateTelephonePaymentRequest>> constraintViolations = validator.validate(telephonePaymentRequest);
 

--- a/src/test/resources/pacts/publicapi-connector-create-payment-with-zero-amount-not-allowed.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment-with-zero-amount-not-allowed.json
@@ -29,7 +29,7 @@
       "response": {
         "status": 422,
         "headers": {
-          "Content-Type": "application/json",
+          "Content-Type": "application/json"
         },
         "body": {
           "error_identifier": "ZERO_AMOUNT_NOT_ALLOWED"


### PR DESCRIPTION
Changes:
* replace deprecated methods
* use Charset constant (instead of string)
* extract common parts from if in ConnectorMockClient
* replace switch with if (too few branches) - PaymentWithAllLinks
* invert boolean method - the usages are always in negated context
* remove redundant 'throws' clause
* remove unnecessary import(s)
* inline variables