### PR TITLE
[BAU] code clean-up (cont)

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -179,7 +179,7 @@ public class PublicApi extends Application<PublicApiConfig> {
     }
 
     private void initialiseMetrics(PublicApiConfig configuration, Environment environment) {
-        GraphiteSender graphiteUDP = new GraphiteUDP(configuration.getGraphiteHost(), Integer.valueOf(configuration.getGraphitePort()));
+        GraphiteSender graphiteUDP = new GraphiteUDP(configuration.getGraphiteHost(), Integer.parseInt(configuration.getGraphitePort()));
         GraphiteReporter.forRegistry(environment.metrics())
                 .prefixedWith(SERVICE_METRICS_NODE)
                 .build(graphiteUDP)

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapper.java
@@ -39,7 +39,7 @@ public class CreateRefundExceptionMapper implements ExceptionMapper<CreateRefund
         }
 
         if (status == INTERNAL_SERVER_ERROR) {
-            LOGGER.info("Connector invalid response was {}.\n Returning http status {} with error body {} {}", exception.getMessage(), status, paymentError);
+            LOGGER.info("Connector invalid response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, paymentError);
         }
 
         return Response

--- a/src/main/java/uk/gov/pay/api/exception/mapper/GetEventsExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/GetEventsExceptionMapper.java
@@ -30,7 +30,7 @@ public class GetEventsExceptionMapper implements ExceptionMapper<GetEventsExcept
         } else {
             paymentError = aPaymentError(GET_PAYMENT_EVENTS_CONNECTOR_ERROR);
             status = INTERNAL_SERVER_ERROR;
-            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {} {}", exception.getMessage(), status, paymentError);
+            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, paymentError);
         }
 
         return Response

--- a/src/main/java/uk/gov/pay/api/exception/mapper/GetRefundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/GetRefundExceptionMapper.java
@@ -30,7 +30,7 @@ public class GetRefundExceptionMapper implements ExceptionMapper<GetRefundExcept
         } else {
             paymentError = aPaymentError(GET_PAYMENT_REFUND_CONNECTOR_ERROR);
             status = INTERNAL_SERVER_ERROR;
-            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {} {}", exception.getMessage(), status, paymentError);
+            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, paymentError);
         }
 
         return Response

--- a/src/main/java/uk/gov/pay/api/exception/mapper/GetRefundsExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/GetRefundsExceptionMapper.java
@@ -30,7 +30,7 @@ public class GetRefundsExceptionMapper implements ExceptionMapper<GetRefundsExce
         } else {
             paymentError = aPaymentError(GET_PAYMENT_REFUNDS_CONNECTOR_ERROR);
             status = INTERNAL_SERVER_ERROR;
-            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {} {}", exception.getMessage(), status, paymentError);
+            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, paymentError);
         }
 
         return Response

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterKey.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterKey.java
@@ -23,11 +23,11 @@ public class RateLimiterKey {
 
         final String pathType = PathHelper.getPathType(requestContext.getUriInfo().getPath(), method);
         if (!pathType.isBlank()) {
-            builder.append("-" + pathType);
+            builder.append("-").append(pathType);
         }
 
         final String keyType = builder.toString();
-        builder.append("-" + accountId);
+        builder.append("-").append(accountId);
 
         return new RateLimiterKey(builder.toString(), keyType, method);
     }

--- a/src/main/java/uk/gov/pay/api/validation/CardExpiryValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/CardExpiryValidator.java
@@ -6,7 +6,7 @@ import java.util.regex.Pattern;
 
 public class CardExpiryValidator implements ConstraintValidator<ValidCardExpiryDate, String> {
     
-    private Pattern pattern = Pattern.compile("(0[1-9]|1[0-2])\\/\\d{2}");
+    private Pattern pattern = Pattern.compile("(0[1-9]|1[0-2])/\\d{2}");
     
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {

--- a/src/main/java/uk/gov/pay/api/validation/MaxLengthValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/MaxLengthValidator.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.api.validation;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 class MaxLengthValidator {
     static boolean isInvalid(String value, int maxLength) {
-        return !isBlank(value) && value.length() > maxLength;
+        return isNotBlank(value) && value.length() > maxLength;
     }
 }

--- a/src/main/java/uk/gov/pay/api/validation/SearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/SearchValidator.java
@@ -9,13 +9,13 @@ import static org.eclipse.jetty.util.StringUtil.isNotBlank;
 class SearchValidator {
 
     static void validatePageIfNotNull(String pageNumber, List<String> validationErrors) {
-        if (isNotBlank(pageNumber) && (!NumericValidator.isValid(pageNumber) || Integer.valueOf(pageNumber) < 1)) {
+        if (isNotBlank(pageNumber) && (!NumericValidator.isValid(pageNumber) || Integer.parseInt(pageNumber) < 1)) {
             validationErrors.add("page");
         }
     }
 
     static void validateDisplaySizeIfNotNull(String displaySize, List<String> validationErrors) {
-        if (isNotBlank(displaySize) && (!NumericValidator.isValid(displaySize) || Integer.valueOf(displaySize) < 1 || Integer.valueOf(displaySize) > 500)) {
+        if (isNotBlank(displaySize) && (!NumericValidator.isValid(displaySize) || Integer.parseInt(displaySize) < 1 || Integer.parseInt(displaySize) > 500)) {
             validationErrors.add("display_size");
         }
     }

--- a/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
@@ -33,15 +33,12 @@ public class RateLimiterFilterTest {
     public static final String ACCOUNT_ID = "account-id";
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
-    private String authorization = "Bearer whateverAuthorizationToken";
     private RateLimiterFilter rateLimiterFilter;
     private RateLimiter rateLimiter;
     @Mock
     private ContainerRequestContext mockContainerRequestContext;
     @Mock
     private UriInfo uriInfo;
-    @Mock
-    private RateLimiterKey rateLimiterKey;
 
     @Before
     public void setup() {

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiterTest.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class RedisRateLimiterTest {
 
-    private static final String POST = "POST";
     private static final String accountId = "account-id";
     @Rule
     public ExpectedException expectedException = ExpectedException.none();

--- a/src/test/java/uk/gov/pay/api/json/CreateCardPaymentRequestDeserializerTest.java
+++ b/src/test/java/uk/gov/pay/api/json/CreateCardPaymentRequestDeserializerTest.java
@@ -52,7 +52,7 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
                 "}";
 
-        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
+        CreateCardPaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
 
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
@@ -75,7 +75,7 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"language\": \"en\"\n" +
                 "}";
 
-        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
+        CreateCardPaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
 
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
@@ -95,7 +95,7 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"language\": \"cy\"\n" +
                 "}";
 
-        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
+        CreateCardPaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
 
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
@@ -115,7 +115,7 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"delayed_capture\": true\n" +
                 "}";
 
-        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
+        CreateCardPaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
 
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
@@ -135,7 +135,7 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"delayed_capture\": false\n" +
                 "}";
 
-        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
+        CreateCardPaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
 
         assertThat(paymentRequest.getAmount(), is(27432));
         assertThat(paymentRequest.getReference(), is("Some reference"));
@@ -450,7 +450,7 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "\"country\": \"GB\"\n" +
                 "}" + "}" + "}";
 
-        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(payload), ctx);
+        CreateCardPaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(payload), ctx);
         assertThat(paymentRequest.getAmount(), is(1000));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
@@ -485,7 +485,7 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "\"cardholder_name\": \"J Bogs\"\n" +
                 "}" + "}";
 
-        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(payload), ctx);
+        CreateCardPaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(payload), ctx);
         assertThat(paymentRequest.getAmount(), is(1000));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
@@ -515,7 +515,7 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "\"country\": null\n" +
                 "}" + "}" + "}";
 
-        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(payload), ctx);
+        CreateCardPaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(payload), ctx);
         assertThat(paymentRequest.getAmount(), is(1000));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));
@@ -551,7 +551,7 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "\"country\": \"\"\n" +
                 "}" + "}" + "}";
 
-        CreateCardPaymentRequest paymentRequest = (CreateCardPaymentRequest) deserializer.deserialize(jsonFactory.createParser(payload), ctx);
+        CreateCardPaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(payload), ctx);
         assertThat(paymentRequest.getAmount(), is(1000));
         assertThat(paymentRequest.getReference(), is("Some reference"));
         assertThat(paymentRequest.getDescription(), is("Some description"));

--- a/src/test/java/uk/gov/pay/api/json/RequestJsonParserTest.java
+++ b/src/test/java/uk/gov/pay/api/json/RequestJsonParserTest.java
@@ -39,7 +39,7 @@ public class RequestJsonParserTest {
 
         JsonNode jsonNode = objectMapper.readTree(payload);
 
-        CreateCardPaymentRequest createPaymentRequest = (CreateCardPaymentRequest) parsePaymentRequest(jsonNode);
+        CreateCardPaymentRequest createPaymentRequest = parsePaymentRequest(jsonNode);
 
         assertThat(createPaymentRequest, is(notNullValue()));
         assertThat(createPaymentRequest.getAmount(), is(1000));
@@ -62,7 +62,7 @@ public class RequestJsonParserTest {
 
         JsonNode jsonNode = objectMapper.readTree(payload);
 
-        CreateCardPaymentRequest createPaymentRequest = (CreateCardPaymentRequest) parsePaymentRequest(jsonNode);
+        CreateCardPaymentRequest createPaymentRequest = parsePaymentRequest(jsonNode);
 
         assertThat(createPaymentRequest, is(notNullValue()));
         assertThat(createPaymentRequest.getAmount(), is(1000));
@@ -338,7 +338,7 @@ public class RequestJsonParserTest {
 
         JsonNode jsonNode = objectMapper.readTree(payload);
 
-        CreateCardPaymentRequest createPaymentRequest = (CreateCardPaymentRequest) parsePaymentRequest(jsonNode);
+        CreateCardPaymentRequest createPaymentRequest = parsePaymentRequest(jsonNode);
 
         assertThat(createPaymentRequest, is(notNullValue()));
         assertThat(createPaymentRequest.getAmount(), is(1000));
@@ -380,7 +380,7 @@ public class RequestJsonParserTest {
 
         JsonNode jsonNode = objectMapper.readTree(payload);
 
-        CreateCardPaymentRequest createPaymentRequest = (CreateCardPaymentRequest) parsePaymentRequest(jsonNode);
+        CreateCardPaymentRequest createPaymentRequest = parsePaymentRequest(jsonNode);
 
         assertThat(createPaymentRequest, is(notNullValue()));
         assertThat(createPaymentRequest.getAmount(), is(1000));

--- a/src/test/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParamsTest.java
+++ b/src/test/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParamsTest.java
@@ -34,8 +34,8 @@ public class DirectDebitSearchMandatesParamsTest {
         assertThat(paramsAsMap, hasEntry("bank_statement_reference", "a bank statement reference"));
         assertThat(paramsAsMap, hasEntry("display_size", String.valueOf(10)));
         assertThat(paramsAsMap, hasEntry("email", "test@test.test"));
-        assertThat(paramsAsMap, hasEntry("from_date", yesterday.toString()));
-        assertThat(paramsAsMap, hasEntry("to_date", tomorrow.toString()));
+        assertThat(paramsAsMap, hasEntry("from_date", yesterday));
+        assertThat(paramsAsMap, hasEntry("to_date", tomorrow));
         assertThat(paramsAsMap, hasEntry("name", "test"));
         assertThat(paramsAsMap, hasEntry("page", String.valueOf(1)));
         assertThat(paramsAsMap, hasEntry("reference", "a reference"));

--- a/src/test/java/uk/gov/pay/api/service/ConnectorUriGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/api/service/ConnectorUriGeneratorTest.java
@@ -73,13 +73,13 @@ public class ConnectorUriGeneratorTest {
     }
 
     @Test
-    public void buildEventsURIFromBeforeParameter() throws Exception {
+    public void buildEventsURIFromBeforeParameter() {
         String uri = connectorUriGenerator.eventsURI(cardAccount, Optional.of(ZonedDateTime.parse("2018-03-13T10:00:05.000Z")), Optional.empty(), null, null, null, null);
         assertThat(URLDecoder.decode(uri, StandardCharsets.UTF_8), is("https://bla.test/v1/events?to_date=2018-03-13T10:00:05.000Z&page=1&display_size=500"));
     }
 
     @Test
-    public void buildEventsURIFromAfterParameter() throws UnsupportedEncodingException {
+    public void buildEventsURIFromAfterParameter() {
         String uri = connectorUriGenerator.eventsURI(cardAccount, Optional.empty(), Optional.of(ZonedDateTime.parse("2018-03-13T10:00:05.000Z")), null, null, null, null);
         assertThat(URLDecoder.decode(uri, StandardCharsets.UTF_8), is("https://bla.test/v1/events?from_date=2018-03-13T10:00:05.000Z&page=1&display_size=500"));
     }
@@ -91,7 +91,7 @@ public class ConnectorUriGeneratorTest {
     }
 
     @Test
-    public void buildEventsURIFromAllParameters() throws UnsupportedEncodingException {
+    public void buildEventsURIFromAllParameters() {
         String uri = connectorUriGenerator.eventsURI(cardAccount, Optional.of(ZonedDateTime.parse("2018-03-13T10:00:05.000Z")), Optional.of(ZonedDateTime.parse("2018-03-13T10:00:05Z")), 1, 300, "1", "2");
         assertThat(URLDecoder.decode(uri, StandardCharsets.UTF_8), is("https://bla.test/v1/events?to_date=2018-03-13T10:00:05.000Z&from_date=2018-03-13T10:00:05.000Z&mandate_external_id=1&payment_external_id=2&page=1&display_size=300"));
     }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -62,16 +62,6 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
     private static final String CONNECTOR_MOCK_CHARGE_REFUNDS_PATH = CONNECTOR_MOCK_CHARGE_PATH + "/refunds";
     private static final String CONNECTOR_MOCK_SEARCH_REFUNDS_PATH = CONNECTOR_MOCK_ACCOUNTS_PATH + "/refunds";
     private static final String CONNECTOR_MOCK_CHARGE_REFUND_BY_ID_PATH = CONNECTOR_MOCK_CHARGE_REFUNDS_PATH + "/%s";
-    private static final String REFERENCE_KEY = "reference";
-    private static final String EMAIL_KEY = "email";
-    private static final String STATE_KEY = "state";
-    private static final String CARD_BRAND = "master-card";
-    private static final String CARD_BRAND_KEY = "card_brand";
-    private static final String CARDHOLDER_NAME_KEY = "cardholder_name";
-    public static final String FIRST_DIGITS_CARD_NUMBER_KEY = "first_digits_card_number";
-    public static final String LAST_DIGITS_CARD_NUMBER_KEY = "last_digits_card_number";
-    private static final String FROM_DATE_KEY = "from_date";
-    private static final String TO_DATE_KEY = "to_date";
     private static final DateFormat SDF = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
     public ConnectorMockClient(WireMockClassRule connectorMock) {
@@ -309,13 +299,6 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                 .withBody(buildGetRefundResponse(refundId, amount, refundAmountAvailable, status, createdDate)));
     }
 
-    public void respondOk_whenSearchCharges(String accountId, String expectedResponse) {
-        whenSearchCharges(accountId, aResponse()
-                .withStatus(OK_200)
-                .withHeader(CONTENT_TYPE, APPLICATION_JSON)
-                .withBody(expectedResponse));
-    }
-
     public void respondNotFound_whenCreateCharge(String gatewayAccountId) {
         mockCreateCharge(gatewayAccountId, aResponse().withStatus(NOT_FOUND_404));
     }
@@ -384,27 +367,6 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                 .add("_embedded", refundList);
 
         whenGetAllRefunds(gatewayAccountId, chargeId, aResponse()
-                .withStatus(OK_200)
-                .withHeader(CONTENT_TYPE, APPLICATION_JSON)
-                .withBody(jsonStringBuilder.build()));
-    }
-
-    public void respondWithSearchRefunds(String gatewayAccountId, PaymentRefundSearchJsonFixture... refunds) {
-
-        Map<String, Link> links = (ImmutableMap.of("first_page", new Link("http://server:port/first-link?page=1"),
-                "prev_page", new Link("http://server:port/prev-link?page=2"),
-                "self", new Link("http://server:port/self-link?page=3"),
-                "last_page", new Link("http://server:port/last-link?page=5"),
-                "next_page", new Link("http://server:port/next-link?page=4")));
-
-        JsonStringBuilder jsonStringBuilder = new JsonStringBuilder()
-                .add("total", 1)
-                .add("count", 1)
-                .add("page", 1)
-                .add("results", Arrays.asList(refunds))
-                .add("_links", links);
-
-        whenSearchRefunds(gatewayAccountId, aResponse()
                 .withStatus(OK_200)
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON)
                 .withBody(jsonStringBuilder.build()));

--- a/src/test/java/uk/gov/pay/api/utils/mocks/TransactionFromLedgerFixture.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/TransactionFromLedgerFixture.java
@@ -18,7 +18,7 @@ public class TransactionFromLedgerFixture {
     private String transactionId;
     private String returnUrl;
     private String paymentProvider;
-    private List<PaymentConnectorResponseLink> links = new ArrayList<>();
+    private List<PaymentConnectorResponseLink> links;
     private RefundSummary refundSummary;
     private SettlementSummary settlementSummary;
     private CardDetails cardDetails;


### PR DESCRIPTION
Changes:
* remove redundant casting
* remove redundant `toString` call
* remove unnecessary boxing (valueOf -> parseInt)
* remove redundant escape sequence from regexp
* chain append instead of using string concatenation
* remove redundant `throws` clause
* remove redundant logger placeholders
* remove unused [test] methods and variables