### PR TITLE
PP-6001 Upgrade dropwizard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>1.3.17</dropwizard.version>
+        <dropwizard.version>2.0.0</dropwizard.version>
         <guice.version>4.2.2</guice.version>
         <guava.version>28.2-jre</guava.version>
         <wiremock.version>2.25.1</wiremock.version>
@@ -17,7 +17,7 @@
         <jackson.version>2.10.2</jackson.version>
         <logback.version>1.2.3</logback.version>
         <docker-client.version>8.16.0</docker-client.version>
-        <pay-java-commons.version>1.0.20191224120315</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20200107160358</pay-java-commons.version>
         <pact.version>3.6.14</pact.version>
         <swagger.lib.version>2.1.1</swagger.lib.version>
         <PACT_BROKER_URL/>
@@ -26,6 +26,12 @@
         <PACT_CONSUMER_VERSION/>
         <PACT_CONSUMER_TAG/>
     </properties>
+
+    <parent>
+        <groupId>io.dropwizard</groupId>
+        <artifactId>dropwizard-dependencies</artifactId>
+        <version>2.0.0</version>
+    </parent>
 
     <repositories>
         <repository>
@@ -128,7 +134,7 @@
         <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>dropwizard-sentry</artifactId>
-            <version>1.3.9-2</version>
+            <version>2.0.0-4</version>
         </dependency>
         <!-- testing -->
         <dependency>

--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -56,6 +56,7 @@ import uk.gov.pay.api.resources.SearchRefundsResource;
 import uk.gov.pay.api.resources.directdebit.DirectDebitPaymentsResource;
 import uk.gov.pay.api.resources.telephone.TelephonePaymentNotificationResource;
 import uk.gov.pay.api.validation.InjectingValidationFeature;
+import uk.gov.pay.api.validation.ReturnUrlValidator;
 import uk.gov.pay.logging.GovUkPayDropwizardRequestJsonLogLayoutFactory;
 import uk.gov.pay.logging.LoggingFilter;
 import uk.gov.pay.logging.LogstashConsoleAppenderFactory;
@@ -108,6 +109,7 @@ public class PublicApi extends Application<PublicApiConfig> {
         environment.jersey().register(injector.getInstance(TransactionsResource.class));
         environment.jersey().register(injector.getInstance(TelephonePaymentNotificationResource.class));
         environment.jersey().register(new InjectingValidationFeature(injector));
+        environment.jersey().register(injector.getInstance(ReturnUrlValidator.class));
 
         environment.jersey().register(injector.getInstance(RateLimiterFilter.class));
         environment.jersey().register(injector.getInstance(LoggingMDCRequestFilter.class));

--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
@@ -2,7 +2,7 @@ package uk.gov.pay.api.app.config;
 
 import com.bendb.dropwizard.redis.JedisFactory;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.cache.CacheBuilderSpec;
+import com.github.benmanes.caffeine.cache.CaffeineSpec;
 import io.dropwizard.Configuration;
 
 import javax.validation.Valid;
@@ -36,7 +36,7 @@ public class PublicApiConfig extends Configuration {
     private String apiKeyHmacSecret;
 
     @NotNull
-    private CacheBuilderSpec authenticationCachePolicy;
+    private CaffeineSpec authenticationCachePolicy;
 
     @Valid
     @NotNull
@@ -96,7 +96,7 @@ public class PublicApiConfig extends Configuration {
         return rateLimiterConfig;
     }
 
-    public CacheBuilderSpec getAuthenticationCachePolicy() {
+    public CaffeineSpec getAuthenticationCachePolicy() {
         return authenticationCachePolicy;
     }
 

--- a/src/main/java/uk/gov/pay/api/validation/CardFirstSixDigitsValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/CardFirstSixDigitsValidator.java
@@ -4,7 +4,7 @@ import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import java.util.regex.Pattern;
 
-public class CardFirstSixDigitsValidator implements ConstraintValidator<ValidCardExpiryDate, String> {
+public class CardFirstSixDigitsValidator implements ConstraintValidator<ValidCardFirstSixDigits, String> {
 
     private Pattern pattern = Pattern.compile("\\d{6}");
 

--- a/src/main/java/uk/gov/pay/api/validation/CardLastFourDigitsValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/CardLastFourDigitsValidator.java
@@ -4,7 +4,7 @@ import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import java.util.regex.Pattern;
 
-public class CardLastFourDigitsValidator implements ConstraintValidator<ValidCardExpiryDate, String> {
+public class CardLastFourDigitsValidator implements ConstraintValidator<ValidCardLastFourDigits, String> {
 
     private Pattern pattern = Pattern.compile("\\d{4}");
 

--- a/src/main/java/uk/gov/pay/api/validation/CardTypeValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/CardTypeValidator.java
@@ -4,9 +4,9 @@ import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import java.util.HashSet;
 
-public class CardTypeValidator implements ConstraintValidator<ValidCardExpiryDate, String> {
+public class CardTypeValidator implements ConstraintValidator<ValidCardType, String> {
     
-    private final static HashSet<String> CARD_TYPES = new HashSet<>();
+    private static final HashSet<String> CARD_TYPES = new HashSet<>();
     
     static {
         CARD_TYPES.add("master-card");


### PR DESCRIPTION
## WHAT 
- Upgrades dropwizard to v2.0.0
- Added `dropwizard-dependencies` as parent as v2.0.0 upgrade doesn't specify transitive dependency versions anymore https://www.dropwizard.io/en/release-2.0.x/manual/upgrade-notes/upgrade-notes-2_0_x.html

  We can also include BOM for transitive dependency versions but versions can't be overridden and we may end up with multiple revisions of same library. For example, `jackson-version` current used is `2.10.2` but dropwizard uses `2.10.1`

- Upgraded dropwizard-sentry library to latest version as container might fail to start with error `java.lang.NoSuchMethodError: 'com.google.common.collect.ImmutableList org.dhatim.dropwizard.sentry.logging.SentryAppenderFactory.getFilterFactories()

- Upgraded pay-java-commons library which is on dropwizard v2.0.0 and defines required library `org.glassfish.jersey.bundles.repackaged`

- Register `ReturnUrlValidator` instance (created by Guice) explicitly as Jersey is not able to create an instance of ReturnUrlValidator and throws following RuntimeException

> "org.glassfish.hk2.api.MultiException: A MultiException has 1 exceptions.  They are:\n1. org.glassfish.hk2.api.UnsatisfiedDependencyException: There was no object available for injection at SystemInjecteeImpl(requiredType=URLValidator,parent=ReturnUrlValidator,qualifiers={},position=0,optional=false,self=false,unqualified=null,807417419)\n\n\tat org.jvnet.hk2.internal.ThreeThirtyResolver.resolve(ThreeThirtyResolver.java:51)\n\tat 

- Few fixes for new version and validators annotation class
