### PR TITLE
PP-6019 Source field for create payment endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
@@ -42,7 +42,9 @@ public class CreateCardPaymentRequest {
     public static final String PREFILLED_ADDRESS_POSTCODE_FIELD_NAME = "postcode";
     public static final String PREFILLED_ADDRESS_COUNTRY_FIELD_NAME = "country";
     public static final String DELAYED_CAPTURE_FIELD_NAME = "delayed_capture";
+    public static final String SOURCE_FIELD_NAME = "source";
     public static final String METADATA = "metadata";
+    public static final String INTERNAL = "internal";
     private static final String PREFILLED_CARDHOLDER_DETAILS = "prefilled_cardholder_details";
     private static final String BILLING_ADDRESS = "billing_address";
 
@@ -79,6 +81,8 @@ public class CreateCardPaymentRequest {
     @Schema(name = "metadata", example = "{\"property1\": \"value1\", \"property2\": \"value2\"}\"")
     private final ExternalMetadata metadata;
 
+    private final Internal internal;
+
     @Valid
     private final PrefilledCardholderDetails prefilledCardholderDetails;
     
@@ -92,6 +96,7 @@ public class CreateCardPaymentRequest {
         this.delayedCapture = builder.getDelayedCapture();
         this.metadata = builder.getMetadata();
         this.prefilledCardholderDetails = builder.getPrefilledCardholderDetails();
+        this.internal = builder.getInternal();
     }
 
     @ApiModelProperty(value = "amount in pence", required = true, allowableValues = "range[1, 10000000]", example = "12000")
@@ -161,6 +166,13 @@ public class CreateCardPaymentRequest {
         return Optional.ofNullable(metadata);
     }
 
+    @JsonProperty("internal")
+    @ApiModelProperty(hidden = true)
+    @Schema(hidden = true)
+    public Optional<Internal> getInternal() {
+        return Optional.ofNullable(internal);
+    }
+
     public String toConnectorPayload() {
         JsonStringBuilder request = new JsonStringBuilder()
                 .add("amount", this.getAmount())
@@ -171,6 +183,7 @@ public class CreateCardPaymentRequest {
         getDelayedCapture().ifPresent(delayedCapture -> request.add("delayed_capture", delayedCapture));
         getMetadata().ifPresent(metadata -> request.add("metadata", metadata.getMetadata()));
         getEmail().ifPresent(email -> request.add("email", email));
+        getInternal().flatMap(Internal::getSource).ifPresent(source -> request.add("source", source));
         
         getPrefilledCardholderDetails().ifPresent(prefilledDetails -> {
             prefilledDetails.getCardholderName().ifPresent(name -> request.addToMap(PREFILLED_CARDHOLDER_DETAILS, "cardholder_name", name));
@@ -196,6 +209,7 @@ public class CreateCardPaymentRequest {
         joiner.add("amount: ").add(String.valueOf(getAmount()));
         joiner.add("reference: ").add(getReference());
         joiner.add("return_url: ").add(returnUrl);
+        getInternal().flatMap(Internal::getSource).ifPresent(source -> joiner.add("source: ").add(source.toString()));
         getLanguage().ifPresent(value -> joiner.add("language: ").add(value.toString()));
         getDelayedCapture().ifPresent(value -> joiner.add("delayed_capture: ").add(value.toString()));
         getMetadata().ifPresent(value -> joiner.add("metadata: ").add(value.toString()));

--- a/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequestBuilder.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.model;
 
+import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 
@@ -20,13 +21,15 @@ public class CreateCardPaymentRequestBuilder {
     private String postcode;
     private String country;
     private PrefilledCardholderDetails prefilledCardholderDetails;
-
-    public CreateCardPaymentRequest build() {
-        return new CreateCardPaymentRequest(this);
-    }
+    private Source source;
+    private Internal internal;
 
     public static CreateCardPaymentRequestBuilder builder() {
         return new CreateCardPaymentRequestBuilder();
+    }
+
+    public CreateCardPaymentRequest build() {
+        return new CreateCardPaymentRequest(this);
     }
 
     public CreateCardPaymentRequestBuilder amount(int amount) {
@@ -104,6 +107,11 @@ public class CreateCardPaymentRequestBuilder {
         return this;
     }
 
+    public CreateCardPaymentRequestBuilder source(Source source) {
+        this.source = source;
+        return this;
+    }
+
     public PrefilledCardholderDetails getPrefilledCardholderDetails() {
         if (cardholderName != null) {
             this.prefilledCardholderDetails = new PrefilledCardholderDetails();
@@ -177,5 +185,14 @@ public class CreateCardPaymentRequestBuilder {
 
     public String getCountry() {
         return country;
+    }
+
+    public Internal getInternal() {
+        if (source != null) {
+            this.internal = new Internal();
+            this.internal.setSource(source);
+        }
+
+        return internal;
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/Internal.java
+++ b/src/main/java/uk/gov/pay/api/model/Internal.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.api.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.commons.model.Source;
+
+import java.util.Optional;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Internal {
+
+    @JsonProperty("source")
+    private Source source;
+
+    public Optional<Source> getSource() {
+        return Optional.ofNullable(source);
+    }
+
+    public void setSource(Source source) {
+        this.source = source;
+    }
+}

--- a/src/test/java/uk/gov/pay/api/json/CreateCardPaymentRequestDeserializerTest.java
+++ b/src/test/java/uk/gov/pay/api/json/CreateCardPaymentRequestDeserializerTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.pay.api.matcher.BadRequestExceptionMatcher.aBadRequestExceptionWithError;
+import static uk.gov.pay.commons.model.Source.CARD_PAYMENT_LINK;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CreateCardPaymentRequestDeserializerTest {
@@ -609,6 +610,21 @@ public class CreateCardPaymentRequestDeserializerTest {
         assertThat(true, is(true));
     }
 
+    @Test
+    public void shouldDeserializeARequestAndSetSourceCorrectly() throws Exception {
+        // language=JSON
+        String payload = "{\n" +
+                "  \"amount\": 1000,\n" +
+                "  \"reference\": \"Some reference\",\n" +
+                "  \"description\": \"Some description\",\n" +
+                "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\",\n" +
+                "\"internal\": {\n" +
+                "\"source\": \"CARD_PAYMENT_LINK\"\n" +
+                "}" + "}";
+
+        CreateCardPaymentRequest paymentRequest = deserializer.deserialize(jsonFactory.createParser(payload), ctx);
+        assertThat(paymentRequest.getInternal().get().getSource().get(), is(CARD_PAYMENT_LINK));
+    }
 
     @After
     public void tearDown() {

--- a/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
@@ -17,6 +17,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static java.lang.String.format;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
+import static uk.gov.pay.commons.model.Source.CARD_API;
 
 public abstract class BaseConnectorMockClient {
 
@@ -24,7 +25,7 @@ public abstract class BaseConnectorMockClient {
     static String CONNECTOR_MOCK_CHARGES_PATH = CONNECTOR_MOCK_ACCOUNTS_PATH + "/charges";
     static String CONNECTOR_MOCK_TELEPHONE_CHARGES_PATH = CONNECTOR_MOCK_ACCOUNTS_PATH + "/telephone-charges";
     static String CONNECTOR_MOCK_CHARGE_PATH = CONNECTOR_MOCK_CHARGES_PATH + "/%s";
-    
+
     WireMockClassRule wireMockClassRule;
     Gson gson = new Gson();
     ObjectMapper objectMapper = new ObjectMapper();
@@ -63,7 +64,7 @@ public abstract class BaseConnectorMockClient {
         wireMockClassRule.stubFor(get(urlPathEqualTo(format(CONNECTOR_MOCK_CHARGE_PATH, gatewayAccountId, chargeId)))
                 .willReturn(response));
     }
-    
+
     String createChargePayload(CreateChargeRequestParams params) {
         JsonStringBuilder payload = new JsonStringBuilder()
                 .add("amount", params.getAmount())
@@ -73,7 +74,7 @@ public abstract class BaseConnectorMockClient {
 
         if (!params.getMetadata().isEmpty())
             payload.add("metadata", params.getMetadata());
-        
+
         if (params.getEmail() != null) {
             payload.add("email", params.getEmail());
         }
@@ -81,7 +82,7 @@ public abstract class BaseConnectorMockClient {
         if (params.getCardholderName().isPresent()) {
             payload.addToNestedMap("cardholder_name", params.getCardholderName().get(), "prefilled_cardholder_details");
         }
-        
+
         if (params.getAddressLine1().isPresent()) {
             payload.addToNestedMap("line1", params.getAddressLine1().get(), "prefilled_cardholder_details", "billing_address");
         }
@@ -101,6 +102,8 @@ public abstract class BaseConnectorMockClient {
         if (params.getAddressCountry().isPresent()) {
             payload.addToNestedMap("country", params.getAddressCountry().get(), "prefilled_cardholder_details", "billing_address");
         }
+
+        payload.add("source", params.getSource().orElse(CARD_API));
 
         return payload.build();
     }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/CreateChargeRequestParams.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/CreateChargeRequestParams.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.utils.mocks;
 
+import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.commons.model.SupportedLanguage;
 
 import java.util.List;
@@ -20,6 +21,7 @@ public class CreateChargeRequestParams {
     private final String addressCity;
     private final String addressCountry;
     private final SupportedLanguage language;
+    private final Source source;
 
     private CreateChargeRequestParams(CreateChargeRequestParamsBuilder builder) {
         this.amount = builder.amount;
@@ -35,6 +37,7 @@ public class CreateChargeRequestParams {
         this.addressCity = builder.addressCity;
         this.addressCountry = builder.addressCountry;
         this.language = builder.language;
+        this.source = builder.source;
     }
 
     public int getAmount() {
@@ -89,6 +92,10 @@ public class CreateChargeRequestParams {
         return language;
     }
 
+    public Optional<Source> getSource() {
+        return Optional.ofNullable(source);
+    }
+
     public static final class CreateChargeRequestParamsBuilder {
         private Integer amount;
         private String returnUrl;
@@ -103,6 +110,7 @@ public class CreateChargeRequestParams {
         private String addressCity;
         private String addressCountry;
         private SupportedLanguage language;
+        private Source source;
 
         private CreateChargeRequestParamsBuilder() {
         }
@@ -178,6 +186,11 @@ public class CreateChargeRequestParams {
 
         public CreateChargeRequestParamsBuilder withLanguage(SupportedLanguage language) {
             this.language = language;
+            return this;
+        }
+
+        public CreateChargeRequestParamsBuilder withSource(Source source) {
+            this.source = source;
             return this;
         }
     }


### PR DESCRIPTION
## WHAT YOU DID

- Allowed new JSON object `internal` with field source on `create` payment payload
- Validation for source field
- Updated relevant tests
