### PR TITLE
PP-6029 Add java buildpack manifest

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,12 @@
+memory: 500M
+db_password: mysecretpassword
+db_user: products
+db_name: products
+db_ssl_option: ssl=none
+disk_quota: 500M
+disable_internal_https: 'true'
+run_migration: 'true'
+aws_access_key: x
+aws_secret_key: x
+token_api_hmac_secret: something
+

--- a/dev.yml
+++ b/dev.yml
@@ -1,12 +1,17 @@
 memory: 500M
-db_password: mysecretpassword
-db_user: products
-db_name: products
-db_ssl_option: ssl=none
 disk_quota: 500M
 disable_internal_https: 'true'
 run_migration: 'true'
 aws_access_key: x
 aws_secret_key: x
 token_api_hmac_secret: something
+rate_limiter_value: 200
+rate_limiter_value_post: 100
+rate_limiter_reqs_node: 200
+rate_limiter_req_node_post: 100
+rate_limiter_elevated_value_get: 100
+rate_limiter_elevated_value_post: 200
+rate_limiter_elevated_accounts: 31
+redis_url: none
+
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,45 @@
+---
+applications:
+  - name: publicapi
+    buildpacks:
+      - java_buildpack
+    path: target/pay-publicapi-0.1-SNAPSHOT-allinone.jar
+    health-check-type: http
+    health-check-http-endpoint: '/healthcheck'
+    health-check-invocation-timeout: 5
+    memory: ((memory))
+    disk_quota: ((disk_quota))
+    env:
+      ADMIN_PORT: '9101'
+      DISABLE_INTERNAL_HTTPS: ((disable_internal_https))
+      ENVIRONMENT: ((space))
+      JAVA_OPTS: -Xms512m -Xmx1G
+      JBP_CONFIG_JAVA_MAIN: '{ arguments: "server /home/vcap/app/config/config.yaml" }'
+      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ } }'
+      JPA_LOG_LEVEL: 'INFO'
+      JPA_SQL_LOG_LEVEL: 'INFO'
+
+      CONNECTOR_URL: ((connector_url))
+      CONNECTOR_DD_URL: ((connector_dd_url))
+      PUBLIC_AUTH_URL: ((public_auth_url))
+      LEDGER_URL: ((ledger_url))
+      PUBLIC_API_BASE: ((publicapi_route))
+
+      TOKEN_API_HMAC_SECRET: ((token_api_hmac_secret))
+
+      # Provide via publicapi-db service
+      DB_HOST: postgres-((space)).apps.internal
+      DB_NAME: ((db_name))
+      DB_PASSWORD: ((db_password))
+      DB_USER: ((db_user))
+      DB_SSL_OPTION: ((db_ssl_option))
+
+      AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
+
+      # Provide via Sentry service
+      SENTRY_DSN: noop://localhost
+
+      RUN_APP: 'true'
+      RUN_MIGRATION: ((run_migration))
+    routes:
+      - route: ((publicapi_route))

--- a/manifest.yml
+++ b/manifest.yml
@@ -27,14 +27,16 @@ applications:
 
       TOKEN_API_HMAC_SECRET: ((token_api_hmac_secret))
 
-      # Provide via publicapi-db service
-      DB_HOST: postgres-((space)).apps.internal
-      DB_NAME: ((db_name))
-      DB_PASSWORD: ((db_password))
-      DB_USER: ((db_user))
-      DB_SSL_OPTION: ((db_ssl_option))
-
       AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
+
+      RATE_LIMITER_VALUE: ((rate_limiter_value))
+      RATE_LIMITER_VALUE_POST: ((rate_limiter_value_post))
+      REDIS_URL: ((redis_url))
+      RATE_LIMITER_REQS_NODE: ((rate_limiter_reqs_node))
+      RATE_LIMITER_REQS_NODE_POST: ((rate_limiter_req_node_post))
+      RATE_LIMITER_ELEVATED_ACCOUNTS: ((rate_limiter_elevated_accounts))
+      RATE_LIMITER_ELEVATED_VALUE_GET: ((rate_limiter_elevated_value_get))
+      RATE_LIMITER_ELEVATED_VALUE_POST: ((rate_limiter_elevated_value_post))
 
       # Provide via Sentry service
       SENTRY_DSN: noop://localhost


### PR DESCRIPTION
Adds a java buildpack manifest and dev.yml with common development
environment variables. To deploy into a PaaS space log into the space
and run the following from this project's root:

```
cf push --vars-file dev.yml \
  --var space=<space> \
  --var connector_dd_url=directdebit-connector-<space>.apps.internal  \
  --var connector_url=card-connector-<space>.apps.interal \
  --var ledger_url=ledger-<space>.apps.internal \
  --var public_auth_url=pay-publicauth-<space>.london.cloudapps.digital \
  --var publicapi_route=pay-publicapi-<space>.london.cloudapps.digital
```

**How to test**
Push to your dev space. If its the first time you may need to delete the existing docker image based app with `cf delete publicapi` and then recreate the postgres network policy with
`cf add-network-policy publicapi --destination-app postgres --protocol tcp --port 5432` once the new buildpack based version of publicapi exists (likely it'll fail to start first time because it won't be able to connect to postgres).