### PR TITLE
BAU Pull redis docker image prior to CI build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,7 @@ pipeline {
                   string(credentialsId: 'pact_broker_username', variable: 'PACT_BROKER_USERNAME'),
                   string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
           ) {
+              sh 'docker pull redis:latest'
               sh 'mvn -version'
               sh "mvn clean verify pact:publish -DPACT_BROKER_URL=https://pact-broker-test.cloudapps.digital -DPACT_CONSUMER_VERSION=${commit}" +
                       " -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${branchName}"
@@ -67,6 +68,7 @@ pipeline {
                   string(credentialsId: 'pact_broker_username', variable: 'PACT_BROKER_USERNAME'),
                   string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
           ) {
+              sh 'docker pull redis:latest'
               sh 'mvn -version'
               sh "mvn clean verify pact:publish -DPACT_BROKER_URL=https://pact-broker-test.cloudapps.digital -DPACT_CONSUMER_VERSION=${commit}" +
                       " -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${branchName}"


### PR DESCRIPTION
The docker registry v1 API, which is used by the spotify docker-client
maven plugin that we use has been switched off.
https://www.docker.com/blog/registry-v1-api-deprecation/

We need to use the v2 API, which test containers use.

In the meantime, pull the docker image prior to running tests on CI so
the build will pass