### PR TITLE
PP-6010 Add Pact test for searching ledger with a non existent page no

### DIFF
--- a/src/test/resources/pacts/publicapi-ledger-search-payments-page-not-found.json
+++ b/src/test/resources/pacts/publicapi-ledger-search-payments-page-not-found.json
@@ -1,0 +1,57 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "ledger"
+  },
+  "interactions": [
+    {
+      "description": "Search payments with a page number that does not exist",
+      "providerStates": [
+        {
+          "name": "a transaction with created state exist",
+          "params": {
+            "transaction_external_id": "charge97837509646393e3C",
+            "gateway_account_id": "123456"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/transaction",
+        "query": {
+          "account_id": [
+            "123456"
+          ],
+          "status_version": [
+            "1"
+          ],
+          "transaction_type": [
+            "PAYMENT"
+          ],
+          "exact_reference_match": [
+            "true"
+          ],
+          "page": [
+            "999"
+          ],
+          "display_size": [
+            "500"
+          ]
+        }
+      },
+      "response": {
+        "status": 404
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
Add a pact test to verify that ledger returns a 404 when a search request is made with a page number that does not exist.

This will allow us to remove an end-to-end test checking this as we already have an integration test to verify that we handle a 404 response from ledger correctly.