### PR TITLE
PP-6010 Add pact test for search Refunds for page not found

### DIFF
--- a/src/test/resources/pacts/publicapi-ledger-search-refunds-page-not-found.json
+++ b/src/test/resources/pacts/publicapi-ledger-search-refunds-page-not-found.json
@@ -1,0 +1,49 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "ledger"
+  },
+  "interactions": [
+    {
+      "description": "Search refunds with a page number that does not exist",
+      "providerStates": [
+        {
+          "name": "refund transactions exists for a gateway account",
+          "params": {
+            "gateway_account_id": "888"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/transaction",
+        "query": {
+          "account_id": [
+            "888"
+          ],
+          "status_version": ["1"],
+          "transaction_type": ["REFUND"],
+          "page": [
+            "999"
+          ],
+          "display_size": [
+            "500"
+          ]
+        }
+      },
+      "response": {
+        "status": 404
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
Add a pact test to verify that calling ledger to search for refunds with a page number that doesn't exist returns a 404 response.