### PR TITLE
PP-6010 Add search refunds page not found integration test

### DIFF
--- a/src/test/java/uk/gov/pay/api/it/SearchRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/api/it/SearchRefundsResourceIT.java
@@ -81,6 +81,17 @@ public class SearchRefundsResourceIT extends PaymentResourceITestBase {
                 .body("_links.last_page.href", is("http://publicapi.url/v1/refunds?page=5"));
     }
 
+    @Test
+    public void searchRefunds_errorIfLedgerRespondsWith404() {
+        ledgerMockClient.respondWithSearchRefundsNotFound();
+        
+        getRefundsSearchResponse()
+                .statusCode(404)
+                .contentType(JSON)
+                .body("code", is ("P1100"))
+                .body("description", is("Page not found"));
+    }
+
     private ValidatableResponse getRefundsSearchResponse() {
         return given().port(app.getLocalPort())
                 .header(AUTHORIZATION, "Bearer " + PaymentResourceITestBase.API_KEY)

--- a/src/test/java/uk/gov/pay/api/utils/mocks/LedgerMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/LedgerMockClient.java
@@ -100,6 +100,13 @@ public class LedgerMockClient {
                         .withBody(jsonStringBuilder.build())));
     }
 
+    public void respondWithSearchRefundsNotFound() {
+        ledgerMock.stubFor(get(urlPathEqualTo("/v1/transaction"))
+                .willReturn(aResponse()
+                        .withStatus(NOT_FOUND_404)
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)));
+    }
+
     public void respondWithTransaction(String transactionId, TransactionFromLedgerFixture transaction) {
         try {
             var body = mapper.writeValueAsString(transaction);


### PR DESCRIPTION
Add an integration test to check we return the correct response when ledger returns a 404 when searching refunds, which indicates that the requested page was not found.