### PR TITLE
PP-6077: Create moto payment when not enabled

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -16,6 +16,7 @@ import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_ACCOUNT_ERRO
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_CONNECTOR_ERROR;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_MANDATE_ID_INVALID;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_MANDATE_STATE_INVALID;
+import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_MOTO_NOT_ENABLED;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_VALIDATION_ERROR;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 
@@ -42,6 +43,10 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
                     statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
                     paymentError = aPaymentError("amount", CREATE_PAYMENT_VALIDATION_ERROR,
                             "Must be greater than or equal to 1");
+                    break;
+                case MOTO_NOT_ALLOWED:
+                    statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
+                    paymentError = aPaymentError(CREATE_PAYMENT_MOTO_NOT_ENABLED);
                     break;
                 case MANDATE_STATE_INVALID:
                     statusCode = HttpStatus.CONFLICT_409;

--- a/src/main/java/uk/gov/pay/api/model/PaymentError.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentError.java
@@ -19,6 +19,8 @@ public class PaymentError {
         CREATE_PAYMENT_ACCOUNT_ERROR("P0199", "There is an error with this account. Please contact support"),
         CREATE_PAYMENT_CONNECTOR_ERROR("P0198", "Downstream system error"),
         CREATE_PAYMENT_PARSING_ERROR("P0197", "Unable to parse JSON"),
+        CREATE_PAYMENT_MOTO_NOT_ENABLED("P0196", "MOTO payments are not enabled for this account. Please contact support if you would like to process MOTO payments"),
+        
         CREATE_PAYMENT_MISSING_FIELD_ERROR("P0101", "Missing mandatory attribute: %s"),
         CREATE_PAYMENT_VALIDATION_ERROR("P0102", "Invalid attribute value: %s. %s"),
 

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
@@ -454,6 +454,29 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
     }
 
     @Test
+    public void createPayment_responseWith422_whenMototNotAllowed() {
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+
+        connectorMockClient.respondMotoPaymentNotAllowed(GATEWAY_ACCOUNT_ID);
+
+        String createMotoPaymentPayload = paymentPayload(aCreateChargeRequestParams()
+                .withAmount(AMOUNT)
+                .withDescription(DESCRIPTION)
+                .withReference(REFERENCE)
+                .withReturnUrl(RETURN_URL)
+                .withMoto(true)
+                .build());
+        
+        postPaymentResponse(createMotoPaymentPayload)
+                .statusCode(422)
+                .contentType(JSON)
+                .body("code", is("P0196"))
+                .body("description", is("MOTO payments are not enabled for this account. Please contact support if you would like to process MOTO payments"));
+
+        connectorMockClient.verifyCreateChargeConnectorRequest(GATEWAY_ACCOUNT_ID, createMotoPaymentPayload);
+    }
+    
+    @Test
     public void createPayment_responseWith422_whenZeroAmountNotAllowed() {
         publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 

--- a/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
@@ -113,6 +113,7 @@ public abstract class BaseConnectorMockClient {
     }
 
     public void verifyCreateChargeConnectorRequest(String gatewayAccountId, String payload) {
+        wireMockClassRule.getAllServeEvents();
         wireMockClassRule.verify(1,
                 postRequestedFor(urlEqualTo(format(CONNECTOR_MOCK_CHARGES_PATH, gatewayAccountId)))
                         .withRequestBody(equalToJson(payload, true, true)));

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -50,6 +50,7 @@ import static uk.gov.pay.api.it.GetPaymentIT.AWAITING_CAPTURE_REQUEST;
 import static uk.gov.pay.api.it.fixtures.PaymentSingleResultBuilder.aSuccessfulSinglePayment;
 import static uk.gov.pay.api.utils.mocks.ChargeResponseFromConnector.ChargeResponseFromConnectorBuilder.aCreateOrGetChargeResponseFromConnector;
 import static uk.gov.pay.commons.model.ErrorIdentifier.GENERIC;
+import static uk.gov.pay.commons.model.ErrorIdentifier.MOTO_NOT_ALLOWED;
 import static uk.gov.pay.commons.model.ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH;
 import static uk.gov.pay.commons.model.ErrorIdentifier.REFUND_NOT_AVAILABLE;
 import static uk.gov.pay.commons.model.ErrorIdentifier.ZERO_AMOUNT_NOT_ALLOWED;
@@ -311,6 +312,10 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
 
     public void respondZeroAmountNotAllowed(String gatewayAccountId) {
         mockCreateCharge(gatewayAccountId, withStatusAndErrorMessage(UNPROCESSABLE_ENTITY_422, "anything", ZERO_AMOUNT_NOT_ALLOWED));
+    }
+
+    public void respondMotoPaymentNotAllowed(String gatewayAccountId) {
+        mockCreateCharge(gatewayAccountId, withStatusAndErrorMessage(UNPROCESSABLE_ENTITY_422, "anything", MOTO_NOT_ALLOWED));
     }
 
     public void respondWithChargeFound(String chargeTokenId, String gatewayAccountId, ChargeResponseFromConnector chargeResponseFromConnector) {

--- a/src/test/java/uk/gov/pay/api/utils/mocks/CreateChargeRequestParams.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/CreateChargeRequestParams.java
@@ -150,11 +150,6 @@ public class CreateChargeRequestParams {
             this.metadata = metadata;
             return this;
         }
-
-        public CreateChargeRequestParamsBuilder withMoto(Boolean moto) {
-            this.moto = moto;
-            return this;
-        }
         
         public CreateChargeRequestParamsBuilder withEmail(String email) {
             this.email = email;
@@ -203,6 +198,11 @@ public class CreateChargeRequestParams {
 
         public CreateChargeRequestParamsBuilder withSource(Source source) {
             this.source = source;
+            return this;
+        }
+
+        public CreateChargeRequestParamsBuilder withMoto(boolean moto) {
+            this.moto = moto;
             return this;
         }
     }


### PR DESCRIPTION
Assign error code for moto payment not enabled

If someone tries to send a MOTO payment but their account has not had MOTO
payments enabled, then they will get an error message.

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition