### PR TITLE
PP-6077 Modify Pact Tests for creating MOTO Payments

### DIFF
--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -87,6 +87,7 @@ public class CreatePaymentServiceTest {
         assertThat(payment.getCreatedDate(), is("2016-01-01T12:00:00Z"));
         assertThat(payment.getLanguage(), is(SupportedLanguage.ENGLISH));
         assertThat(payment.getDelayedCapture(), is(false));
+        assertThat(payment.getMoto(), is(false));
         assertThat(paymentResponse.getLinks().getSelf(), is(new Link("http://publicapi.test.localhost/v1/payments/ch_ab2341da231434l", "GET")));
         assertThat(paymentResponse.getLinks().getNextUrl(), is(new Link("http://frontend_connector/charge/token_1234567asdf", "GET")));
         PostLink expectedLink = new PostLink("http://frontend_connector/charge/", "POST", "application/x-www-form-urlencoded", Collections.singletonMap("chargeTokenId", "token_1234567asdf"));
@@ -108,6 +109,7 @@ public class CreatePaymentServiceTest {
                 .description("a description")
                 .metadata(new ExternalMetadata(metadata))
                 .delayedCapture(Boolean.TRUE)
+                .moto(Boolean.TRUE)
                 .language(SupportedLanguage.WELSH)
                 .email("joe.bogs@example.org")
                 .cardholderName("J. Bogs")

--- a/src/test/resources/pacts/publicapi-connector-create-payment-with-minimum-fields.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment-with-minimum-fields.json
@@ -7,7 +7,7 @@
   },
   "interactions": [
     {
-      "description": "a create charge request",
+      "description": "a create charge request with minimum fields",
       "providerStates": [
         {
           "name": "a gateway account with external id exists",

--- a/src/test/resources/pacts/publicapi-connector-create-payment-with-minimum-fields.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment-with-minimum-fields.json
@@ -46,6 +46,7 @@
           "created_date": "2016-01-01T12:00:00Z",
           "language": "en",
           "delayed_capture": false,
+          "moto": false,
           "links": [
             {
               "href": "http://connector.service.backend/v1/api/accounts/123456/charges/ch_ab2341da231434l",

--- a/src/test/resources/pacts/publicapi-connector-create-payment.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment.json
@@ -14,6 +14,12 @@
           "params": {
             "gateway_account_id": "123456"
           }
+        },
+        {
+          "name": "a gateway account has moto payments enabled",
+          "params": {
+            "gateway_account_id": "123456"
+          }
         }
       ],
       "request": {

--- a/src/test/resources/pacts/publicapi-connector-create-payment.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment.json
@@ -37,6 +37,7 @@
             }
           },
           "delayed_capture": true,
+          "moto": true,
           "metadata": {
             "ledger_code": 123,
             "fund_code": "ISIN122038",
@@ -64,6 +65,7 @@
           "created_date": "2016-01-01T12:00:00Z",
           "language": "cy",
           "delayed_capture": true,
+          "moto": true,
           "email": "joe.bogs@example.org",
           "card_details": {
             "cardholder_name": "J. Bogs",


### PR DESCRIPTION
Description:
- Set moto to false in publicapi-connector-create-payment-with-minimum-fields
- Set moto to true in publicapi-connector-create-payment as that test includes all optional fields

## How to test

- Run Pact tests locally