### PR TITLE
PP-6077 - Modify Pact for get payment moto field

### DIFF
--- a/src/test/java/uk/gov/pay/api/service/GetPaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentServiceTest.java
@@ -99,6 +99,7 @@ public class GetPaymentServiceTest {
         assertThat(payment.getReturnUrl().get(), is("https://somewhere.gov.uk/rainbow/1"));
         assertThat(payment.getPaymentProvider(), is("sandbox"));
         assertThat(payment.getCreatedDate(), is("2018-09-07T13:12:02.121Z"));
+        assertThat(payment.getMoto(), is (false));
         assertThat(payment.getDelayedCapture(), is(true));
         assertThat(payment.getCorporateCardSurcharge(), is(Optional.empty()));
         assertThat(payment.getTotalAmount(), is(Optional.empty()));

--- a/src/test/resources/pacts/publicapi-connector-get-payment-with-awaiting-capture-request-state.json
+++ b/src/test/resources/pacts/publicapi-connector-get-payment-with-awaiting-capture-request-state.json
@@ -66,7 +66,8 @@
             "capture_submit_time": null,
             "captured_date": null
           },
-          "delayed_capture": true
+          "delayed_capture": true,
+          "moto": false
         },
         "matchingRules": {
           "body": {

--- a/src/test/resources/pacts/publicapi-connector-get-payment-with-corporate-surcharge.json
+++ b/src/test/resources/pacts/publicapi-connector-get-payment-with-corporate-surcharge.json
@@ -63,7 +63,8 @@
             "capture_submit_time": null,
             "captured_date": null
           },
-          "delayed_capture": false
+          "delayed_capture": false,
+          "moto": false
         },
         "matchingRules": {
           "body": {

--- a/src/test/resources/pacts/publicapi-connector-get-payment-with-delayed-capture-true.json
+++ b/src/test/resources/pacts/publicapi-connector-get-payment-with-delayed-capture-true.json
@@ -75,7 +75,8 @@
             "capture_submit_time": null,
             "captured_date": null
           },
-          "delayed_capture": true
+          "delayed_capture": true,
+          "moto": false
         },
         "matchingRules": {
           "body": {

--- a/src/test/resources/pacts/publicapi-connector-get-payment-with-fee-and-net-amount.json
+++ b/src/test/resources/pacts/publicapi-connector-get-payment-with-fee-and-net-amount.json
@@ -63,7 +63,8 @@
             "capture_submit_time": null,
             "captured_date": null
           },
-          "delayed_capture": false
+          "delayed_capture": false,
+          "moto": false
         },
         "matchingRules": {
           "body": {

--- a/src/test/resources/pacts/publicapi-connector-get-payment-with-gateway-transaction-id.json
+++ b/src/test/resources/pacts/publicapi-connector-get-payment-with-gateway-transaction-id.json
@@ -63,7 +63,8 @@
             "capture_submit_time": null,
             "captured_date": null
           },
-          "delayed_capture": false
+          "delayed_capture": false,
+          "moto": false
         },
         "matchingRules": {
           "body": {

--- a/src/test/resources/pacts/publicapi-connector-get-payment-with-metadata.json
+++ b/src/test/resources/pacts/publicapi-connector-get-payment-with-metadata.json
@@ -66,7 +66,8 @@
             "capture_submit_time": null,
             "captured_date": null
           },
-          "delayed_capture": false
+          "delayed_capture": false,
+          "moto": false
         },
         "matchingRules": {
           "body": {


### PR DESCRIPTION
Description:
- Adds moto field to get payment pact tests. No real need to add a get payment with moto as a previous pact test checks whether a moto payment can be created