### PR TITLE
PP-6085: Map fully qualified url to PUBLIC_AUTH_URL env var

### DIFF
--- a/src/main/resources/env-map.yml
+++ b/src/main/resources/env-map.yml
@@ -1,7 +1,7 @@
 env_vars:
   CONNECTOR_URL: '."user-provided"[0].credentials.card_connector_url'
   CONNECTOR_DD_URL: '."user-provided"[0].credentials.directdebit_connector_url'
-  PUBLIC_AUTH_URL: '."user-provided"[0].credentials.publicauth_url'
+  PUBLIC_AUTH_URL: '."user-provided"[0].credentials.publicauth_api_path_url'
   LEDGER_URL: '."user-provided"[0].credentials.ledger_url'
   PUBLIC_API_BASE: '."user-provided"[0].credentials.publicapi_url'
 


### PR DESCRIPTION
## WHAT YOU DID
Publicapi relies on a fully qualified url/route to be specified in the PUBLIC_AUTH_URL env var, instead of just the hostname. This route has been added to the app-catalog user-provided service (see alphagov/pay-omnibus#85). This PR maps the new url to the public auth url env var.

## How to test
The app-catalog service has been updated. After rebuilding and restaging publicapi it should pick up the new environment variable.