### PR TITLE
PP-6127: Add missing hmac secret mapping to env-map.yml

### DIFF
--- a/src/main/resources/env-map.yml
+++ b/src/main/resources/env-map.yml
@@ -4,6 +4,7 @@ env_vars:
   PUBLIC_AUTH_URL: '.[][] | select(.name == "app-catalog")                               | .credentials.publicauth_api_path_url'
   LEDGER_URL: '.[][] | select(.name == "app-catalog")                                    | .credentials.ledger_url'
   PUBLICAPI_BASE: '.[][] | select(.name == "app-catalog")                                | .credentials.publicapi_url'
+  TOKEN_API_HMAC_SECRET: '.[][] | select(.name == "publicapi-secret-service")            | .credentials.token_api_hmac_secret'
   SENTRY_DSN: '.[][] | select(.name == "publicapi-secret-service")                       | .credentials.sentry_dsn'
   RATE_LIMITER_VALUE: '.[][] | select(.name == "publicapi-secret-service")               | .credentials.rate_limiter_value'
   RATE_LIMITER_VALUE_POST: '.[][] | select(.name == "publicapi-secret-service")          | .credentials.rate_limiter_value_post'


### PR DESCRIPTION
## WHAT YOU DID
Add missing hmac secret mapping to env-map.yml. This change ensures the secret is mapped to an environment variable from the user-provided "secret" CF service.