### PR TITLE
PP-6146: Remove manifest vars configured by terraform

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -43,9 +43,7 @@ applications:
       SENTRY_DSN: ""
 
       AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
-      REDIS_URL: ((redis_url))
+      REDIS_URL: ""
 
       RUN_APP: 'true'
       RUN_MIGRATION: ((run_migration))
-    routes:
-      - route: ((publicapi_route))


### PR DESCRIPTION
## WHAT YOU DID
Removes manifest vars which are defined in PaaS using terraform and don't need to be interpolated into the manifest.yml file by Concourse.

Redis will be added as a bound service in a later story.