### PR TITLE
PP-6708 Remove deprecated ExpectedException rule

### DIFF
--- a/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/RateLimiterFilterTest.java
@@ -1,11 +1,9 @@
 package uk.gov.pay.api.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.api.auth.Account;
@@ -32,8 +30,6 @@ import static org.mockito.Mockito.when;
 public class RateLimiterFilterTest {
 
     public static final String ACCOUNT_ID = "account-id";
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
     private RateLimiterFilter rateLimiterFilter;
     private RateLimiter rateLimiter;
     @Mock

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/LocalRateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/LocalRateLimiterTest.java
@@ -6,11 +6,9 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
-import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -40,8 +38,6 @@ public class LocalRateLimiterTest {
 
     private static final String POST = "POST";
     private static final String accountId = "account-id";
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
     LocalRateLimiter localRateLimiter;
 
     @Captor

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiterTest.java
@@ -5,11 +5,9 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
-import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -33,8 +31,6 @@ import static org.mockito.Mockito.when;
 public class RedisRateLimiterTest {
 
     private static final String accountId = "account-id";
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
     @Mock
     private RateLimitManager rateLimitManager;
     @Mock
@@ -99,6 +95,5 @@ public class RedisRateLimiterTest {
             assertEquals("RedisRateLimiter - Rate limit exceeded for account [account-id] and method [POST] - count: 3, rate allowed: 2",
                     loggingEvents.get(0).getFormattedMessage());
         });
-
     }
 }

--- a/src/test/java/uk/gov/pay/api/json/CreateCardPaymentRequestDeserializerTest.java
+++ b/src/test/java/uk/gov/pay/api/json/CreateCardPaymentRequestDeserializerTest.java
@@ -10,7 +10,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
@@ -26,6 +25,7 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.pay.api.matcher.BadRequestExceptionMatcher.aBadRequestExceptionWithError;
 import static uk.gov.pay.commons.model.Source.CARD_PAYMENT_LINK;
@@ -35,9 +35,6 @@ public class CreateCardPaymentRequestDeserializerTest {
 
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
-    
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Mock
     private DeserializationContext ctx;
@@ -182,10 +179,10 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"return_url\" : \"https://somewhere.gov.uk/rainbow/1\"" +
                 "}";
 
-        expectedException.expect(BadRequestException.class);
-        expectedException.expect(aBadRequestExceptionWithError("P0197", "Unable to parse JSON"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(invalidJson), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(invalidJson), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0197", "Unable to parse JSON"));
     }
 
     @Test
@@ -197,9 +194,10 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: amount"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: amount"));
     }
 
     @Test
@@ -212,9 +210,10 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: amount"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: amount"));
     }
 
     @Test
@@ -227,9 +226,11 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: amount. Must be a valid numeric format"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0102",
+                "Invalid attribute value: amount. Must be a valid numeric format"));
     }
 
     @Test
@@ -242,9 +243,11 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"return_url\": 1\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: return_url. Must be a valid URL format"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0102",
+                "Invalid attribute value: return_url. Must be a valid URL format"));
     }
 
     @Test
@@ -256,9 +259,11 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"description\": \"Some description\"\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: return_url"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0101",
+                "Missing mandatory attribute: return_url"));
     }
 
     @Test
@@ -271,9 +276,11 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"return_url\": null\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: return_url"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0101",
+                "Missing mandatory attribute: return_url"));
     }
 
     @Test
@@ -285,9 +292,11 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: reference"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0101",
+                "Missing mandatory attribute: reference"));
     }
 
     @Test
@@ -300,9 +309,11 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: reference"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0101",
+                "Missing mandatory attribute: reference"));
     }
 
     @Test
@@ -315,9 +326,11 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: reference. Must be a valid string format"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0102",
+                "Invalid attribute value: reference. Must be a valid string format"));
     }
 
     @Test
@@ -329,9 +342,11 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: description"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0101",
+                "Missing mandatory attribute: description"));
     }
 
     @Test
@@ -344,9 +359,11 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: description"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0101",
+                "Missing mandatory attribute: description"));
     }
 
     @Test
@@ -359,9 +376,11 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"return_url\": \"https://somewhere.gov.uk/rainbow/1\"\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: description. Must be a valid string format"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0102",
+                "Invalid attribute value: description. Must be a valid string format"));
     }
 
     @Test
@@ -375,9 +394,11 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"language\": 1234\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: language. Must be \"en\" or \"cy\""));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0102",
+                "Invalid attribute value: language. Must be \"en\" or \"cy\""));
     }
 
     @Test
@@ -391,9 +412,11 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"language\": null\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: language. Must be \"en\" or \"cy\""));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0102",
+                "Invalid attribute value: language. Must be \"en\" or \"cy\""));
     }
 
     @Test
@@ -407,9 +430,11 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"language\": \"\"\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: language. Must be \"en\" or \"cy\""));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0102",
+                "Invalid attribute value: language. Must be \"en\" or \"cy\""));
     }
 
     @Test
@@ -423,9 +448,11 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"delayed_capture\": \"true\"\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: delayed_capture. Must be true or false"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0102",
+                "Invalid attribute value: delayed_capture. Must be true or false"));
     }
 
     @Test
@@ -439,9 +466,11 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"delayed_capture\": null\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: delayed_capture. Must be true or false"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0102",
+                "Invalid attribute value: delayed_capture. Must be true or false"));
     }
 
     @Test
@@ -455,9 +484,11 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"delayed_capture\": 0\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: delayed_capture. Must be true or false"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0102",
+                "Invalid attribute value: delayed_capture. Must be true or false"));
     }
 
     @Test
@@ -472,11 +503,13 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "  \"moto\": " + value + "\n" +
                 "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: moto. Must be true or false"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0102",
+                "Invalid attribute value: moto. Must be true or false"));
     }
-    
+
     @Test
     public void shouldDeserializeARequestWithPrefilledCardholderDetailsSuccessfully() throws Exception {
         // language=JSON
@@ -634,9 +667,11 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "\"country\": null\n" +
                 "}" + "}" + "}";
 
-        expectedException.expect(aBadRequestExceptionWithError("P0102", "Invalid attribute value: line1. Field must be a string"));
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
 
-        deserializer.deserialize(jsonFactory.createParser(json), ctx);
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0102",
+                "Invalid attribute value: line1. Field must be a string"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/service/SearchRefundsServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/SearchRefundsServiceTest.java
@@ -1,11 +1,9 @@
 package uk.gov.pay.api.service;
 
 import au.com.dius.pact.consumer.PactVerification;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -28,14 +26,13 @@ import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.api.matcher.RefundValidationExceptionMatcher.aValidationExceptionContaining;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SearchRefundsServiceTest {
 
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
     @Rule
     public PactProviderRule connectorRule = new PactProviderRule("connector", this);
     @Rule
@@ -66,12 +63,13 @@ public class SearchRefundsServiceTest {
         String invalid = "invalid_param";
         RefundsParams params = new RefundsParams(null, null, invalid, invalid);
 
-        expectedException.expect(RefundsValidationException.class);
-        expectedException.expect(aValidationExceptionContaining(
+        RefundsValidationException refundsValidationException = assertThrows(RefundsValidationException.class,
+                () -> searchRefundsService.searchLedgerRefunds(account, params));
+
+        assertThat(refundsValidationException, aValidationExceptionContaining(
                 "P1101",
                 format("Invalid parameters: %s. See Public API documentation for the correct data formats",
                         "page, display_size")));
-        searchRefundsService.searchLedgerRefunds(account, params);
     }
 
     @Test
@@ -141,9 +139,10 @@ public class SearchRefundsServiceTest {
         Account account = new Account(ACCOUNT_ID, TokenPaymentType.CARD);
         RefundsParams params = new RefundsParams(null, null, "999", "500");
 
-        expectedException.expect(SearchRefundsException.class);
-        expectedException.expect(hasProperty("errorStatus", Matchers.is(404)));
-        searchRefundsService.searchLedgerRefunds(account, params);
+        SearchRefundsException searchRefundsException = assertThrows(SearchRefundsException.class,
+                () -> searchRefundsService.searchLedgerRefunds(account, params));
+
+        assertThat(searchRefundsException, hasProperty("errorStatus", is(404)));
     }
 
     @Test
@@ -152,11 +151,12 @@ public class SearchRefundsServiceTest {
         String invalid = "invalid_param";
         RefundsParams params = new RefundsParams(null, null, invalid, invalid);
 
-        expectedException.expect(RefundsValidationException.class);
-        expectedException.expect(aValidationExceptionContaining(
+        RefundsValidationException refundsValidationException = assertThrows(RefundsValidationException.class,
+                () -> searchRefundsService.searchLedgerRefunds(account, params));
+
+        assertThat(refundsValidationException, aValidationExceptionContaining(
                 "P1101",
                 format("Invalid parameters: %s. See Public API documentation for the correct data formats",
                         "page, display_size")));
-        searchRefundsService.searchLedgerRefunds(account, params);
     }
 }

--- a/src/test/java/uk/gov/pay/api/validation/RefundSearchValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/RefundSearchValidatorTest.java
@@ -1,15 +1,14 @@
 package uk.gov.pay.api.validation;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import uk.gov.pay.api.exception.RefundsValidationException;
 import uk.gov.pay.api.service.RefundsParams;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static uk.gov.pay.api.matcher.RefundValidationExceptionMatcher.aValidationExceptionContaining;
 
 public class RefundSearchValidatorTest {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void validateSearchParameters_shouldSuccessValidation() {
@@ -24,50 +23,62 @@ public class RefundSearchValidatorTest {
 
     @Test
     public void validateSearchParameters_shouldGiveAValidationError_ForNonValidFromDate() {
-        expectedException.expect(aValidationExceptionContaining(
-                "P1101",
+        RefundsValidationException validationException = assertThrows(RefundsValidationException.class,
+                () -> RefundSearchValidator.validateSearchParameters(
+                        new RefundsParams("nope", "2016-01-25T13:23:55Z", "1", "1")));
+
+        assertThat(validationException, aValidationExceptionContaining("P1101",
                 "Invalid parameters: from_date. See Public API documentation for the correct data formats"));
-        RefundSearchValidator.validateSearchParameters(new RefundsParams("nope", "2016-01-25T13:23:55Z", "1", "1"));
     }
 
     @Test
     public void validateSearchParameters_shouldGiveAValidationError_ForNonValidToDate() {
-        expectedException.expect(aValidationExceptionContaining(
-                "P1101",
+        RefundsValidationException validationException = assertThrows(RefundsValidationException.class,
+                () -> RefundSearchValidator.validateSearchParameters(
+                        new RefundsParams("2016-01-25T13:23:55Z", "nope", "1", "1")));
+
+        assertThat(validationException, aValidationExceptionContaining("P1101",
                 "Invalid parameters: to_date. See Public API documentation for the correct data formats"));
-        RefundSearchValidator.validateSearchParameters(new RefundsParams("2016-01-25T13:23:55Z",  "nope", "1", "1"));
     }
-    
+
     @Test
     public void validateSearchParameters_shouldGiveAValidationError_ForNonNumericPageAndSize() {
         String NON_NUMERIC_STRING = "non-numeric-string";
-        expectedException.expect(aValidationExceptionContaining(
-                "P1101",
+        RefundsValidationException validationException = assertThrows(RefundsValidationException.class,
+                () -> RefundSearchValidator.validateSearchParameters(new RefundsParams("2016-01-25T13:23:55Z",
+                        "2016-01-25T13:23:55Z", NON_NUMERIC_STRING, NON_NUMERIC_STRING)));
+
+        assertThat(validationException, aValidationExceptionContaining("P1101",
                 "Invalid parameters: page, display_size. See Public API documentation for the correct data formats"));
-        RefundSearchValidator.validateSearchParameters(new RefundsParams("2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", NON_NUMERIC_STRING, NON_NUMERIC_STRING));
     }
 
     @Test
     public void validateParams_shouldGiveAnErrorValidation_forZeroPageDisplay() {
-        expectedException.expect(aValidationExceptionContaining(
-                "P1101",
+        RefundsValidationException validationException = assertThrows(RefundsValidationException.class,
+                () -> RefundSearchValidator.validateSearchParameters(
+                        new RefundsParams("2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "0", "0")));
+
+        assertThat(validationException, aValidationExceptionContaining("P1101",
                 "Invalid parameters: page, display_size. See Public API documentation for the correct data formats"));
-        RefundSearchValidator.validateSearchParameters(new RefundsParams("2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "0", "0"));
     }
 
     @Test
     public void validateParams_shouldGiveAnErrorValidation_forMaxedOutValuesPageDisplaySize() {
-        expectedException.expect(aValidationExceptionContaining(
-                "P1101",
+        RefundsValidationException validationException = assertThrows(RefundsValidationException.class,
+                () -> RefundSearchValidator.validateSearchParameters(new RefundsParams("2016-01-25T13:23:55Z",
+                        "2016-01-25T13:23:55Z", String.valueOf(Integer.MAX_VALUE + 1), String.valueOf(Integer.MAX_VALUE + 1))));
+
+        assertThat(validationException, aValidationExceptionContaining("P1101",
                 "Invalid parameters: page, display_size. See Public API documentation for the correct data formats"));
-        RefundSearchValidator.validateSearchParameters(new RefundsParams("2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", String.valueOf(Integer.MAX_VALUE+1), String.valueOf(Integer.MAX_VALUE+1)));
     }
 
     @Test
     public void validateParams_shouldGiveAnErrorValidation_forTooLargePageDisplay() {
-        expectedException.expect(aValidationExceptionContaining(
-                "P1101",
+        RefundsValidationException validationException = assertThrows(RefundsValidationException.class,
+                () -> RefundSearchValidator.validateSearchParameters(
+                        new RefundsParams("2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "0", "501")));
+
+        assertThat(validationException, aValidationExceptionContaining("P1101",
                 "Invalid parameters: page, display_size. See Public API documentation for the correct data formats"));
-        RefundSearchValidator.validateSearchParameters(new RefundsParams("2016-01-25T13:23:55Z", "2016-01-25T13:23:55Z", "0", "501"));
     }
 }


### PR DESCRIPTION
## WHAT YOU DID

Part of upgrading to Junit5
- Removes deprecated ExpectedException rule and replaces with `assertThrows`
