### PR TITLE
PP-6708 Use Junit5 ParamaterisedTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <version>${junit5.version}</version>

--- a/src/test/java/uk/gov/pay/api/app/config/StringToListConverterTest.java
+++ b/src/test/java/uk/gov/pay/api/app/config/StringToListConverterTest.java
@@ -1,10 +1,8 @@
 package uk.gov.pay.api.app.config;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collections;
 import java.util.List;
@@ -12,23 +10,22 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@RunWith(JUnitParamsRunner.class)
 public class StringToListConverterTest {
 
     private StringToListConverter converter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         converter = new StringToListConverter();
     }
 
-    @Test
-    @Parameters
+    @ParameterizedTest
+    @MethodSource("parametersForConvertsStringInputToListOfStrings")
     public void convertsStringInputToListOfStrings(String input, List<String> expectedOutput) {
         assertThat(converter.convert(input), is(expectedOutput));
     }
 
-    public Object[] parametersForConvertsStringInputToListOfStrings() {
+    static Object[] parametersForConvertsStringInputToListOfStrings() {
         return new Object[]{
                 new Object[]{null, Collections.emptyList()},
                 new Object[]{"", Collections.emptyList()},

--- a/src/test/java/uk/gov/pay/api/filter/RateLimiterKeyTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/RateLimiterKeyTest.java
@@ -1,46 +1,47 @@
 package uk.gov.pay.api.filter;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.UriInfo;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.when;
 
-@RunWith(JUnitParamsRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RateLimiterKeyTest {
 
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule();
-    
     @Mock
     private ContainerRequestContext containerRequestContext;
-    
+
     @Mock
     private UriInfo uriInfo;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         when(containerRequestContext.getUriInfo()).thenReturn(uriInfo);
     }
-    
-    @Test
-    @Parameters({
-            "/v1/payments,POST,POST-create_payment,POST-create_payment-account_id",
-            "/v1/payments/paymentId/capture,POST,POST-capture_payment,POST-capture_payment-account_id",
-            "/v1/payments/paymentId/cancel,POST,POST,POST-account_id",
-            "/v1/payments,GET,GET,GET-account_id"
-    })
+
+    static Stream<Arguments> rateLimitParams() {
+        return Stream.of(
+                arguments("/v1/payments", "POST", "POST-create_payment", "POST-create_payment-account_id"),
+                arguments("/v1/payments/paymentId/capture", "POST", "POST-capture_payment", "POST-capture_payment-account_id"),
+                arguments("/v1/payments/paymentId/cancel", "POST", "POST", "POST-account_id"),
+                arguments("/v1/payments", "GET", "GET", "GET-account_id")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("rateLimitParams")
     public void returnsRateLimiterKey(String path, String method, String expectedKeyType, String expectedKey) {
         when(uriInfo.getPath()).thenReturn(path);
         when(containerRequestContext.getMethod()).thenReturn(method);

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimitManagerTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimitManagerTest.java
@@ -1,13 +1,10 @@
 package uk.gov.pay.api.filter.ratelimit;
 
-import junitparams.JUnitParamsRunner;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.api.app.config.RateLimiterConfig;
 import uk.gov.pay.api.filter.RateLimiterKey;
 
@@ -17,18 +14,15 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
-@RunWith(JUnitParamsRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RateLimitManagerTest {
 
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule();
-    
     @Mock
     private RateLimiterConfig rateLimiterConfig;
 
     private RateLimitManager rateLimitManager;
     
-    @Before
+    @BeforeEach
     public void setUp() {
         when(rateLimiterConfig.getElevatedAccounts()).thenReturn(List.of("1"));
     }

--- a/src/test/java/uk/gov/pay/api/json/CreateCardPaymentRequestDeserializerTest.java
+++ b/src/test/java/uk/gov/pay/api/json/CreateCardPaymentRequestDeserializerTest.java
@@ -3,17 +3,13 @@ package uk.gov.pay.api.json;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import junitparams.converters.Nullable;
 import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 import uk.gov.pay.api.exception.BadRequestException;
 import uk.gov.pay.api.model.Address;
 import uk.gov.pay.api.model.CreateCardPaymentRequest;
@@ -30,11 +26,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.pay.api.matcher.BadRequestExceptionMatcher.aBadRequestExceptionWithError;
 import static uk.gov.pay.commons.model.Source.CARD_PAYMENT_LINK;
 
-@RunWith(JUnitParamsRunner.class)
 public class CreateCardPaymentRequestDeserializerTest {
-
-    @Rule
-    public MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
     private DeserializationContext ctx;
@@ -42,7 +34,7 @@ public class CreateCardPaymentRequestDeserializerTest {
     private JsonFactory jsonFactory = new JsonFactory(new ObjectMapper());
     private CreateCardPaymentRequestDeserializer deserializer;
 
-    @Before
+    @BeforeEach
     public void setup() {
         deserializer = new CreateCardPaymentRequestDeserializer();
     }
@@ -149,8 +141,8 @@ public class CreateCardPaymentRequestDeserializerTest {
         assertThat(paymentRequest.getDelayedCapture(), is(Optional.of(Boolean.FALSE)));
     }
 
-    @Parameters({"true", "false"})
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = {"true", "false"})
     public void deserialize_shouldDeserializeARequestWithMotoFieldSuccessfully(String value) throws Exception {
         // language=JSON
         String validJson = "{\n" +
@@ -491,8 +483,8 @@ public class CreateCardPaymentRequestDeserializerTest {
                 "Invalid attribute value: delayed_capture. Must be true or false"));
     }
 
-    @Test
-    @Parameters({"null", "\"true\"", "0"})
+    @ParameterizedTest
+    @ValueSource(strings = {"null", "\"true\"", "0"})
     public void deserialize_shouldThrowValidationException_whenMotoIsNotABoolean(@Nullable String value) throws Exception {
         // language=JSON
         String json = "{\n" +

--- a/src/test/java/uk/gov/pay/api/resources/GetOnePaymentStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetOnePaymentStrategyTest.java
@@ -1,13 +1,11 @@
 package uk.gov.pay.api.resources;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.service.GetPaymentService;
@@ -15,11 +13,8 @@ import uk.gov.pay.api.service.GetPaymentService;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-@RunWith(JUnitParamsRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class GetOnePaymentStrategyTest {
-
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule();
 
     @Mock
     private GetPaymentService mockGetPaymentService;
@@ -39,8 +34,8 @@ public class GetOnePaymentStrategyTest {
         verify(mockGetPaymentService, never()).getPayment(mockAccountId, mockPaymentId);
     }
 
-    @Test
-    @Parameters({"", "unknown"})
+    @ParameterizedTest
+    @ValueSource(strings = {"", "unknown"})
     public void validateAndExecuteUsesDefaultStrategy(String strategy) {
         getOnePaymentStrategy = new GetOnePaymentStrategy(strategy, mockAccountId, mockPaymentId, mockGetPaymentService);
         getOnePaymentStrategy.validateAndExecute();

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentEventsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentEventsStrategyTest.java
@@ -1,13 +1,11 @@
 package uk.gov.pay.api.resources;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.service.GetPaymentEventsService;
@@ -15,11 +13,8 @@ import uk.gov.pay.api.service.GetPaymentEventsService;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-@RunWith(JUnitParamsRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class GetPaymentEventsStrategyTest {
-
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule();
 
     @Mock
     private GetPaymentEventsService getPaymentEventsService;
@@ -39,8 +34,8 @@ public class GetPaymentEventsStrategyTest {
         verify(getPaymentEventsService, never()).getPaymentEvents(mockAccountId, mockPaymentId);
     }
 
-    @Test
-    @Parameters({"", "unknown"})
+    @ParameterizedTest
+    @ValueSource(strings = {"", "unknown"})
     public void validateAndExecuteUsesDefaultStrategy(String strategy) {
         getPaymentEventsStrategy = new GetPaymentEventsStrategy(strategy, mockAccountId, mockPaymentId, getPaymentEventsService);
         getPaymentEventsStrategy.validateAndExecute();
@@ -49,7 +44,6 @@ public class GetPaymentEventsStrategyTest {
     }
 
     @Test
-    
     public void validateAndExecuteShouldUseConnectorOnlyStrategy() {
         String strategy = "connector-only";
         getPaymentEventsStrategy = new GetPaymentEventsStrategy(strategy, mockAccountId, mockPaymentId, getPaymentEventsService);

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundStrategyTest.java
@@ -1,12 +1,10 @@
 package uk.gov.pay.api.resources;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.service.GetPaymentRefundService;
@@ -15,11 +13,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-@RunWith(JUnitParamsRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class GetPaymentRefundStrategyTest {
-
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule();
 
     private GetPaymentRefundService mockGetPaymentRefundService = mock(GetPaymentRefundService.class);
     private GetPaymentRefundStrategy getPaymentRefundStrategy;
@@ -39,8 +34,8 @@ public class GetPaymentRefundStrategyTest {
         verify(mockGetPaymentRefundService, never()).getPaymentRefund(account, paymentId, refundId);
     }
 
-    @Test
-    @Parameters({"", "unknown"})
+    @ParameterizedTest
+    @ValueSource(strings = {"", "unknown"})
     public void validateAndExecuteUsesDefaultStrategy(String strategy) {
         getPaymentRefundStrategy = new GetPaymentRefundStrategy(strategy, account, paymentId, refundId, mockGetPaymentRefundService);
         getPaymentRefundStrategy.validateAndExecute();

--- a/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategyTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategyTest.java
@@ -1,12 +1,10 @@
 package uk.gov.pay.api.resources;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.service.GetPaymentRefundsService;
@@ -15,11 +13,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-@RunWith(JUnitParamsRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class GetPaymentRefundsStrategyTest {
-
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule();
 
     private GetPaymentRefundsService mockGetPaymentRefundsService = mock(GetPaymentRefundsService.class);
     private GetPaymentRefundsStrategy getPaymentRefundsStrategy;
@@ -27,8 +22,8 @@ public class GetPaymentRefundsStrategyTest {
     private String paymentId = "payment-id";
     private Account account = new Account("account-id", TokenPaymentType.CARD);
 
-    @Test
-    @Parameters({"ledger-only", "", "unknown"})
+    @ParameterizedTest
+    @ValueSource(strings = {"ledger-only", "", "unknown"})
     public void validateAndExecuteShouldUseLedgerOnlyForListedStrategies(String strategy) {
         getPaymentRefundsStrategy = new GetPaymentRefundsStrategy(strategy, account, paymentId, mockGetPaymentRefundsService);
         getPaymentRefundsStrategy.validateAndExecute();

--- a/src/test/java/uk/gov/pay/api/utils/PathHelperTest.java
+++ b/src/test/java/uk/gov/pay/api/utils/PathHelperTest.java
@@ -1,26 +1,31 @@
 package uk.gov.pay.api.utils;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-@RunWith(JUnitParamsRunner.class)
 public class PathHelperTest {
 
-    @Test
-    @Parameters({
-            "/v1/payments,POST,create_payment",
-            "/v1/payments/,POST,create_payment",
-            "/v1/payments/paymentId/capture,POST,capture_payment",
-            "/v1/payments/paymentId/capture/,POST,capture_payment",
-            "/v1/payments/paymentId/cancel,POST,",
-            "/v1/payments,GET,"
-    })
+    @ParameterizedTest
+    @MethodSource("rateLimitParams")
     public void returnsPathType(String path, String method, String pathType) {
         assertThat(PathHelper.getPathType(path, method), is(pathType));
+    }
+
+    static Stream<Arguments> rateLimitParams() {
+        return Stream.of(
+                arguments("/v1/payments", "POST", "create_payment"),
+                arguments("/v1/payments/", "POST", "create_payment"),
+                arguments("/v1/payments/paymentId/capture", "POST", "capture_payment"),
+                arguments("/v1/payments/paymentId/capture/", "POST", "capture_payment"),
+                arguments("/v1/payments/paymentId/cancel", "POST", ""),
+                arguments("/v1/payments", "GET", "")
+        );
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Uses Junit5 `junit-jupiter-params` library for parameterised unit tests as `JUnitParams` library does support Junit5.
- Although this feature is experimental it is more likely to be become stable. see https://github.com/junit-team/junit5/issues/1093#issuecomment-503590220

