### PR TITLE
PP-6763 - Remove direct debit smoke test from public auth Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,10 +160,6 @@ pipeline {
            when { branch 'master' }
            steps { runSmokeTest('smoke-card') }
          }
-         stage('Direct Debit Smoke Test') {
-           when { branch 'master' }
-           steps { runSmokeTest("smoke-directdebit") }
-         }
        }
      }
      stage('Pact Tag') {


### PR DESCRIPTION
Description:
- Before we can turn off the direct debit smoke test we need to ensure that no pipeline calls it. This ensures that the publicapi Jenkins pipeline doesn't call the direct debit smoke Jenkins function.
