### PR TITLE
PP-6763 - Remove direct debit smoke and end test from publicapi Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
 
   parameters {
     booleanParam(defaultValue: false, description: '', name: 'runEndToEndTestsOnPR')
-    string(defaultValue: 'card,directdebit,products,zap', description: 'The tests to run', name: 'E2E_TESTS')
+    string(defaultValue: 'card,products,zap', description: 'The tests to run', name: 'E2E_TESTS')
   }
 
   options {
@@ -159,10 +159,6 @@ pipeline {
          stage('Card Smoke Test') {
            when { branch 'master' }
            steps { runSmokeTest('smoke-card') }
-         }
-         stage('Direct Debit Smoke Test') {
-           when { branch 'master' }
-           steps { runSmokeTest("smoke-directdebit") }
          }
        }
      }


### PR DESCRIPTION
Description:
- Before we can turn off the direct debit smoke test we need to ensure that no pipeline calls it. This ensures that the publicapi Jenkins pipeline doesn't call the direct debit smoke Jenkins function.
- This also ensures that the direct debit portion of the end to end test suit won't be run