### PR TITLE
PP-7067 Increase maximum metadata value length from 50 to 100

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,123 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-09-11T17:02:50Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "dev.yml": [
+      {
+        "hashed_secret": "1af17e73721dbe0c40011b82ed4bb1a7dbe3ce29",
+        "is_verified": false,
+        "line_number": 7,
+        "type": "Secret Keyword"
+      }
+    ],
+    "src/test/java/uk/gov/pay/api/filter/AuthorizationValidationFilterTest.java": [
+      {
+        "hashed_secret": "a0936a38d2c31ad225d670f529a82319fc5bb915",
+        "is_verified": false,
+        "line_number": 58,
+        "type": "Secret Keyword"
+      }
+    ],
+    "src/test/java/uk/gov/pay/api/validation/PaymentSearchValidatorTest.java": [
+      {
+        "hashed_secret": "d4445ee4de67d11803d35527d7ee8aa2af71ebd8",
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "src/test/resources/config/empty-elevated-accounts-test-config.yaml": [
+      {
+        "hashed_secret": "3d4478f77d368235803ceb52bbd45b7240e6af62",
+        "is_verified": false,
+        "line_number": 47,
+        "type": "Secret Keyword"
+      }
+    ],
+    "src/test/resources/config/test-config.yaml": [
+      {
+        "hashed_secret": "3d4478f77d368235803ceb52bbd45b7240e6af62",
+        "is_verified": false,
+        "line_number": 49,
+        "type": "Secret Keyword"
+      }
+    ],
+    "src/test/resources/pacts/publicapi-connector-get-payment-refund.json": [
+      {
+        "hashed_secret": "4c39a6a28507c3d7ea6de26da0bd1d27cff4a4af",
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Base64 High Entropy String"
+      }
+    ],
+    "src/test/resources/pacts/publicapi-direct-debit-connector-collect-payment.json": [
+      {
+        "hashed_secret": "f92a698c421a80441450d9b38d331391f6221ec5",
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Base64 High Entropy String"
+      }
+    ]
+  },
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <jackson.version>2.11.2</jackson.version>
         <logback.version>1.2.3</logback.version>
         <docker-client.version>8.16.0</docker-client.version>
-        <pay-java-commons.version>1.0.20200827095058</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20200911141024</pay-java-commons.version>
         <junit5.version>5.6.2</junit5.version>
         <pact.version>3.6.15</pact.version>
         <swagger.lib.version>2.1.4</swagger.lib.version>


### PR DESCRIPTION
Upgrade Pay Java commons dependency to 1.0.20200911141024, which includes changes to increase the maximum payment metadata value length from 50 characters to 100 characters.

Connector already supports this longer length.

Update `PaymentResourceMetadataValidationFailuresIT` to rely on constants in `ExternalMetadata` rather than repeating limits for the maximum metadata value length etc.