### PR TITLE
PP-7154 Add dummy url for dd connector for PaaS

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -24,9 +24,13 @@ applications:
       JPA_LOG_LEVEL: 'INFO'
       JPA_SQL_LOG_LEVEL: 'INFO'
 
+      # We are no deploying DDConnector into PaaS but for now Publicapi
+      # still requires the url. This is a dummy value so that Publicapi will
+      # start. This can be removed as part of removing DD from Publicapi.
+      CONNECTOR_DD_URL: "http://localhost:9999"
+
       # Provided by the app-catalog service 
       CONNECTOR_URL: ""
-      CONNECTOR_DD_URL: ""
       PUBLIC_AUTH_URL: ""
       LEDGER_URL: ""
       PUBLICAPI_BASE: ""

--- a/src/main/resources/env-map.yml
+++ b/src/main/resources/env-map.yml
@@ -1,6 +1,5 @@
 env_vars:
   CONNECTOR_URL:                        '.[][] | select(.name == "app-catalog")              | .credentials.card_connector_url'
-  CONNECTOR_DD_URL:                     '.[][] | select(.name == "app-catalog")              | .credentials.directdebit_connector_url'
   PUBLIC_AUTH_URL:                      '.[][] | select(.name == "app-catalog")              | .credentials.publicauth_api_path_url'
   LEDGER_URL:                           '.[][] | select(.name == "app-catalog")              | .credentials.ledger_url'
   PUBLICAPI_BASE:                       '.[][] | select(.name == "app-catalog")              | .credentials.publicapi_url'


### PR DESCRIPTION
We are no deploying DDConnector into PaaS but for now Publicapi
still requires the url. This is a dummy value so that Publicapi will
start. This can be removed as part of removing DD from Publicapi.

## WHAT YOU DID
We no longer deploy dd connector and do not provide it's url via the app-catalogue. I've tried this by manually pushing to staging and it works.