### PR TITLE
PP-6670 add settlement summary to refunds

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/RefundResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundResponse.java
@@ -26,6 +26,8 @@ public class RefundResponse {
     private RefundLinksForSearch links;
     @Schema(example = "success", allowableValues = {"submitted", "success", "error"}, accessMode = READ_ONLY)
     private String status;
+    @Schema(hidden = true)
+    private SettlementSummary settlementSummary;
 
     private RefundResponse(RefundFromConnector refund, URI selfLink, URI paymentLink) {
         this.refundId = refund.getRefundId();
@@ -33,6 +35,7 @@ public class RefundResponse {
         this.status = refund.getStatus();
         this.createdDate = refund.getCreatedDate();
         this.links = new RefundLinksForSearch();
+        this.settlementSummary = new SettlementSummary();
 
         links.addSelf(selfLink.toString());
         links.addPayment(paymentLink.toString());
@@ -43,6 +46,7 @@ public class RefundResponse {
         this.amount = refund.getAmount();
         this.status = refund.getState().getStatus();
         this.createdDate = refund.getCreatedDate();
+        this.settlementSummary = refund.getSettlementSummary();
         this.links = new RefundLinksForSearch();
 
         links.addSelf(selfLink.toString());
@@ -106,5 +110,9 @@ public class RefundResponse {
 
     public RefundLinksForSearch getLinks() {
         return links;
+    }
+
+    public SettlementSummary getSettlementSummary() {
+        return settlementSummary;
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/ledger/RefundTransactionFromLedger.java
+++ b/src/main/java/uk/gov/pay/api/model/ledger/RefundTransactionFromLedger.java
@@ -3,6 +3,7 @@ package uk.gov.pay.api.model.ledger;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import uk.gov.pay.api.model.SettlementSummary;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -16,6 +17,7 @@ public class RefundTransactionFromLedger {
     String transactionId;
     String parentTransactionId;
     TransactionState state;
+    SettlementSummary settlementSummary;
 
     public Long getAmount() {
         return amount;
@@ -47,5 +49,9 @@ public class RefundTransactionFromLedger {
 
     public TransactionState getState() {
         return state;
+    }
+
+    public SettlementSummary getSettlementSummary() {
+        return settlementSummary;
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import uk.gov.pay.api.model.SettlementSummary;
 import uk.gov.pay.api.model.ledger.RefundTransactionFromLedger;
 import uk.gov.pay.api.model.links.RefundLinksForSearch;
 
@@ -37,11 +38,15 @@ public class RefundForSearchRefundsResult {
     @ApiModelProperty(example = "success", allowableValues = "submitted,success,error")
     @Schema(example = "success", allowableValues = {"submitted", "success", "error"}, accessMode = READ_ONLY)
     private String status;
+    
+    private SettlementSummary settlementSummary;
 
     public RefundForSearchRefundsResult() {
     }
 
-    public RefundForSearchRefundsResult(String refundId, String createdDate, String status, String chargeId, Long amount, URI paymentURI, URI refundsURI) {
+    public RefundForSearchRefundsResult(String refundId, String createdDate, String status,
+                                        String chargeId, Long amount, URI paymentURI, URI refundsURI,
+                                        SettlementSummary settlementSummary) {
         this.refundId = refundId;
         this.createdDate = createdDate;
         this.status = status;
@@ -49,6 +54,7 @@ public class RefundForSearchRefundsResult {
         this.amount = amount;
         this.links.addSelf(refundsURI.toString());
         this.links.addPayment(paymentURI.toString());
+        this.settlementSummary = settlementSummary;
     }
 
     public String getRefundId() {
@@ -95,6 +101,13 @@ public class RefundForSearchRefundsResult {
         return links;
     }
 
+    @ApiModelProperty(hidden = true, dataType = "uk.gov.pay.api.model.SettlementSummary")
+    @JsonProperty("settlement_summary")
+    @Schema(hidden = true)
+    public SettlementSummary getSettlementSummary() {
+        return settlementSummary;
+    }
+
     public static RefundForSearchRefundsResult valueOf(RefundTransactionFromLedger refundResult, URI paymentURI, URI refundsURI) {
         return new RefundForSearchRefundsResult(
                 refundResult.getTransactionId(),
@@ -103,7 +116,8 @@ public class RefundForSearchRefundsResult {
                 refundResult.getParentTransactionId(),
                 refundResult.getAmount(),
                 paymentURI,
-                refundsURI);
+                refundsURI,
+                refundResult.getSettlementSummary());
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/api/utils/mocks/RefundTransactionFromLedgerFixture.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/RefundTransactionFromLedgerFixture.java
@@ -2,6 +2,7 @@ package uk.gov.pay.api.utils.mocks;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import uk.gov.pay.api.model.SettlementSummary;
 import uk.gov.pay.api.model.ledger.TransactionState;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
@@ -11,6 +12,7 @@ public class RefundTransactionFromLedgerFixture {
     private final String createdDate;
     private final String transactionId;
     private final String parentTransactionId;
+    private final SettlementSummary settlementSummary;
 
     public RefundTransactionFromLedgerFixture(RefundTransactionFromLedgerBuilder builder) {
         this.amount = builder.amount;
@@ -18,6 +20,7 @@ public class RefundTransactionFromLedgerFixture {
         this.createdDate = builder.createdDate;
         this.transactionId = builder.transactionId;
         this.parentTransactionId = builder.parentTransactionId;
+        this.settlementSummary = builder.settlementSummary;
     }
 
     public Long getAmount() {
@@ -40,12 +43,17 @@ public class RefundTransactionFromLedgerFixture {
         return parentTransactionId;
     }
 
+    public SettlementSummary getSettlementSummary() {
+        return settlementSummary;
+    }
+
     public static final class RefundTransactionFromLedgerBuilder {
         private Long amount;
         private TransactionState state;
         private String createdDate;
         private String transactionId;
         private String parentTransactionId;
+        private SettlementSummary settlementSummary = new SettlementSummary();
 
         private RefundTransactionFromLedgerBuilder() {
         }
@@ -81,6 +89,11 @@ public class RefundTransactionFromLedgerFixture {
 
         public RefundTransactionFromLedgerFixture build() {
             return new RefundTransactionFromLedgerFixture(this);
+        }
+
+        public RefundTransactionFromLedgerBuilder withSettlementSummary(String settledDate) {
+            this.settlementSummary = new SettlementSummary(null, null, settledDate);
+            return this;
         }
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- add settlement_summary to refund responses
- settlement_summary is the same as payments' one but will never have capture details. refunds from connector are always an empty object {}
- add/extend tests

