### PR TITLE
PP-7229 Remove unused jackson-datatype-joda dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,11 +284,6 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-joda</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-base</artifactId>
             <version>${jackson.version}</version>


### PR DESCRIPTION
Remove `jackson-datatype-joda` dependency from the POM because it’s not used.