### PR TITLE
PP-7208 add json ignore unknown properties

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/CardDetails.java
+++ b/src/main/java/uk/gov/pay/api/model/CardDetails.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
@@ -14,6 +15,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 @JsonInclude(ALWAYS)
 @ApiModel(value = "CardDetails", description = "A structure representing the payment card")
 @Schema(name = "CardDetails", description = "A structure representing the payment card")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CardDetails {
 
     @JsonProperty("last_digits_card_number")

--- a/src/main/java/uk/gov/pay/api/model/search/card/PaymentSearchResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/PaymentSearchResponse.java
@@ -1,11 +1,13 @@
 package uk.gov.pay.api.model.search.card;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.pay.api.model.links.SearchNavigationLinks;
 import uk.gov.pay.api.model.search.SearchPagination;
 
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PaymentSearchResponse<T> implements SearchPagination {
 
     @JsonProperty("total")


### PR DESCRIPTION
## WHAT YOU DID
- Adding this property to relevant classes ensures that no breakage or downtime when introducing new fields to payload on other backend systems.
