### PR TITLE
PP-7242 Use regex from CardExpiryDate to validate card expiry dates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <jackson.version>2.11.2</jackson.version>
         <logback.version>1.2.3</logback.version>
         <docker-client.version>8.16.0</docker-client.version>
-        <pay-java-commons.version>1.0.20200925142115</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20201001124822</pay-java-commons.version>
         <junit5.version>5.7.0</junit5.version>
         <pact.version>3.6.15</pact.version>
         <swagger.lib.version>2.1.4</swagger.lib.version>

--- a/src/main/java/uk/gov/pay/api/validation/CardExpiryValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/CardExpiryValidator.java
@@ -1,20 +1,15 @@
 package uk.gov.pay.api.validation;
 
+import uk.gov.pay.commons.model.CardExpiryDate;
+
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
-import java.util.regex.Pattern;
 
 public class CardExpiryValidator implements ConstraintValidator<ValidCardExpiryDate, String> {
-    
-    private Pattern pattern = Pattern.compile("(0[1-9]|1[0-2])/\\d{2}");
-    
+
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
-        
-        if (value == null) {
-            return true;
-        }
-        
-        return pattern.matcher(value).matches();
+        return value == null || CardExpiryDate.CARD_EXPIRY_DATE_PATTERN.matcher(value).matches();
     }
+
 }


### PR DESCRIPTION
Replace the current regex for validating card expiry dates with the one from `CardExpiryDate` from Pay Java commons.

The two regexes are not identical. The old one is:

```
(0[1-9]|1[0-2])/\d{2}
```

… while the new one is:

```
(0[1-9]|1[0-2])/([0-9]{2})
```

However, these are equivalent.

Both regexes are identical up to and including the slash. After this, the new regex has parentheses (used for a capturing group) but these don’t actually make any difference to what’s matched.

In Java, the character class `\d` matches only the digits in the range 0 to 9 inclusive, so `\d{2}` and `[0-9]{2}` are equivalent (this is not the case in all languages!).