### PR TITLE
PP-7104 Log when API keys are used

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-09-11T17:02:50Z",
+  "generated_at": "2020-11-09T17:15:25Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -70,7 +70,7 @@
       {
         "hashed_secret": "a0936a38d2c31ad225d670f529a82319fc5bb915",
         "is_verified": false,
-        "line_number": 58,
+        "line_number": 79,
         "type": "Secret Keyword"
       }
     ],

--- a/src/main/java/uk/gov/pay/api/auth/AccountAuthenticator.java
+++ b/src/main/java/uk/gov/pay/api/auth/AccountAuthenticator.java
@@ -5,7 +5,8 @@ import io.dropwizard.auth.Authenticator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
-import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.api.model.publicauth.AuthResponse;
+import uk.gov.pay.commons.model.ErrorIdentifier;
 
 import javax.inject.Inject;
 import javax.ws.rs.ServiceUnavailableException;
@@ -14,18 +15,18 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Optional;
 
+import static java.lang.String.format;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
-import static uk.gov.pay.api.model.TokenPaymentType.CARD;
-import static uk.gov.pay.api.model.TokenPaymentType.fromString;
+import static net.logstash.logback.argument.StructuredArguments.kv;
 
 public class AccountAuthenticator implements Authenticator<String, Account> {
     private static Logger logger = LoggerFactory.getLogger(AccountAuthenticator.class);
 
     private final Client client;
     private final String publicAuthUrl;
-    
+
     @Inject
     public AccountAuthenticator(Client client, PublicApiConfig configuration) {
         this.client = client;
@@ -41,8 +42,19 @@ public class AccountAuthenticator implements Authenticator<String, Account> {
                 .get();
 
         if (response.getStatus() == OK.getStatusCode()) {
-            return readAccountFromResponse(response);
+            AuthResponse authResponse = response.readEntity(AuthResponse.class);
+            logger.info(format("Successfully authenticated using API key with token_link %s", authResponse.getTokenLink()),
+                    kv("token_link", authResponse.getTokenLink()));
+            return Optional.of(new Account(authResponse.getAccountId(), authResponse.getTokenType()));
         } else if (response.getStatus() == UNAUTHORIZED.getStatusCode()) {
+            JsonNode unauthorisedResponse = response.readEntity(JsonNode.class);
+            ErrorIdentifier errorIdentifier = ErrorIdentifier.valueOf(unauthorisedResponse.get("error_identifier").asText());
+            if (errorIdentifier == ErrorIdentifier.AUTH_TOKEN_REVOKED) {
+                String tokenLink = unauthorisedResponse.get("token_link").asText();
+                logger.warn(format("Attempt to authenticate using revoked API key with token_link %s", tokenLink), kv("token_link", tokenLink));
+            } else {
+                logger.warn("Attempt to authenticate using invalid API with valid checksum");
+            }
             response.close();
             return Optional.empty();
         } else {
@@ -50,14 +62,5 @@ public class AccountAuthenticator implements Authenticator<String, Account> {
             logger.warn("Unexpected status code " + response.getStatus() + " from auth.");
             throw new ServiceUnavailableException();
         }
-    }
-
-    private Optional<Account> readAccountFromResponse(Response response) {
-        JsonNode responseEntity = response.readEntity(JsonNode.class);
-        String accountId = responseEntity.get("account_id").asText();
-        String tokenType = Optional.ofNullable(responseEntity.get("token_type"))
-                .map(JsonNode::asText).orElse(CARD.toString());
-        TokenPaymentType tokenPaymentType = fromString(tokenType);
-        return Optional.of(new Account(accountId, tokenPaymentType));
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/TokenPaymentType.java
+++ b/src/main/java/uk/gov/pay/api/model/TokenPaymentType.java
@@ -10,14 +10,6 @@ public enum TokenPaymentType {
         this.friendlyName = friendlyName;
     }
 
-    public static TokenPaymentType fromString(final String type) {
-        try {
-            return TokenPaymentType.valueOf(type);
-        } catch (Exception e) {
-            return CARD;
-        }
-    }
-
     public String getFriendlyName() {
         return this.friendlyName;
     }

--- a/src/main/java/uk/gov/pay/api/model/publicauth/AuthResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/publicauth/AuthResponse.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.api.model.publicauth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import uk.gov.pay.api.model.TokenPaymentType;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AuthResponse {
+
+    private String accountId;
+    private String tokenLink;
+    private TokenPaymentType tokenType;
+
+    public AuthResponse() {
+    }
+
+    public AuthResponse(String accountId, String tokenLink, TokenPaymentType tokenType) {
+        this.accountId = accountId;
+        this.tokenLink = tokenLink;
+        this.tokenType = tokenType;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public String getTokenLink() {
+        return tokenLink;
+    }
+
+    public TokenPaymentType getTokenType() {
+        return tokenType;
+    }
+}

--- a/src/test/java/uk/gov/pay/api/auth/AccountAuthenticatorTest.java
+++ b/src/test/java/uk/gov/pay/api/auth/AccountAuthenticatorTest.java
@@ -1,11 +1,23 @@
 package uk.gov.pay.api.auth;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.model.publicauth.AuthResponse;
 
 import javax.ws.rs.ServiceUnavailableException;
 import javax.ws.rs.client.Client;
@@ -13,6 +25,7 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -21,29 +34,51 @@ import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.api.model.TokenPaymentType.CARD;
 import static uk.gov.pay.api.model.TokenPaymentType.DIRECT_DEBIT;
+import static uk.gov.pay.commons.model.ErrorIdentifier.AUTH_TOKEN_INVALID;
+import static uk.gov.pay.commons.model.ErrorIdentifier.AUTH_TOKEN_REVOKED;
 
+@ExtendWith(MockitoExtension.class)
 public class AccountAuthenticatorTest {
 
     private AccountAuthenticator accountAuthenticator;
     private ObjectMapper objectMapper = new ObjectMapper();
-    private Response mockResponse;
 
     private final String bearerToken = "aaa";
     private final String accountId = "accountId";
+    
+    @Mock
+    private Client publicAuthMock;
+    
+    @Mock
+    private WebTarget mockTarget;
+    
+    @Mock
+    private Invocation.Builder mockRequest;
+    
+    @Mock 
+    private Response mockResponse;
+    
+    @Mock
+    private PublicApiConfig mockConfiguration;
+
+    @Mock
+    private Appender<ILoggingEvent> mockAppender;
+
+    @Captor
+    ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
     @BeforeEach
     public void setup() {
-        Client publicAuthMock = mock(Client.class);
-        WebTarget mockTarget = mock(WebTarget.class);
-        Invocation.Builder mockRequest = mock(Invocation.Builder.class);
-        mockResponse = mock(Response.class);
-        PublicApiConfig mockConfiguration = mock(PublicApiConfig.class);
+        Logger logger = (Logger) LoggerFactory.getLogger(AccountAuthenticator.class);
+        logger.setLevel(Level.INFO);
+        logger.addAppender(mockAppender);
+        
         when(mockConfiguration.getPublicAuthUrl()).thenReturn("");
         accountAuthenticator = new AccountAuthenticator(publicAuthMock, mockConfiguration);
         when(publicAuthMock.target("")).thenReturn(mockTarget);
@@ -55,37 +90,53 @@ public class AccountAuthenticatorTest {
 
     @Test
     public void shouldReturnValidAccount() {
-        Map<String, String> responseEntity = ImmutableMap.of(
-                "account_id", accountId,
-                "token_type", "DIRECT_DEBIT"
-        );
-        JsonNode response = objectMapper.valueToTree(responseEntity);
+        AuthResponse authResponse = new AuthResponse(accountId, "a-token-link", DIRECT_DEBIT);
         when(mockResponse.getStatus()).thenReturn(OK.getStatusCode());
-        when(mockResponse.readEntity(JsonNode.class)).thenReturn(response);
+        when(mockResponse.readEntity(AuthResponse.class)).thenReturn(authResponse);
         Optional<Account> maybeAccount = accountAuthenticator.authenticate(bearerToken);
         assertThat(maybeAccount.get().getName(), is(accountId));
         assertThat(maybeAccount.get().getAccountId(), is(accountId));
         assertThat(maybeAccount.get().getPaymentType(), is(DIRECT_DEBIT));
+        
+        verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logEvents, hasSize(1));
+        assertThat(logEvents.get(0).getFormattedMessage(), is("Successfully authenticated using API key with token_link a-token-link"));
     }
 
     @Test
-    public void shouldReturnCCAccount_ifTokenTypeIsMissing() {
+    public void shouldNotReturnAccount_ifUnauthorisedDueToTokenRevoked() {
         Map<String, String> responseEntity = ImmutableMap.of(
-                "account_id", accountId
+                "error_identifier", AUTH_TOKEN_REVOKED.toString(),
+                "token_link", "a-token-link"
         );
         JsonNode response = objectMapper.valueToTree(responseEntity);
-        when(mockResponse.getStatus()).thenReturn(OK.getStatusCode());
+        when(mockResponse.getStatus()).thenReturn(UNAUTHORIZED.getStatusCode());
         when(mockResponse.readEntity(JsonNode.class)).thenReturn(response);
         Optional<Account> maybeAccount = accountAuthenticator.authenticate(bearerToken);
-        assertThat(maybeAccount.get().getName(), is(accountId));
-        assertThat(maybeAccount.get().getPaymentType(), is(CARD));
+        assertThat(maybeAccount.isPresent(), is(false));
+
+        verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logEvents, hasSize(1));
+        assertThat(logEvents.get(0).getFormattedMessage(), is("Attempt to authenticate using revoked API key with token_link a-token-link"));
     }
 
     @Test
-    public void shouldNotReturnAccount_ifUnauthorised() {
+    public void shouldNotReturnAccount_ifUnauthorisedDueToInvalidToken() {
+        Map<String, String> responseEntity = ImmutableMap.of(
+                "error_identifier", AUTH_TOKEN_INVALID.toString()
+        );
+        JsonNode response = objectMapper.valueToTree(responseEntity);
         when(mockResponse.getStatus()).thenReturn(UNAUTHORIZED.getStatusCode());
+        when(mockResponse.readEntity(JsonNode.class)).thenReturn(response);
         Optional<Account> maybeAccount = accountAuthenticator.authenticate(bearerToken);
         assertThat(maybeAccount.isPresent(), is(false));
+
+        verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logEvents, hasSize(1));
+        assertThat(logEvents.get(0).getFormattedMessage(), is("Attempt to authenticate using invalid API with valid checksum"));
     }
 
     @Test


### PR DESCRIPTION
Log at INFO level when a valid API key is used. Log the token_link for the API key, which is returned by public auth.

Log at WARN level when an API key with an invalid checksum is used. Log the IP address the request originates from to help us detect brute force attempts.

Log at WARN level when an invalid API key with a valid checksum is used.

Log at WARN level when a revoked API key is used. Log the token_link for the API key, which is returned by public auth.

Remove logic that maps a non-existent/unknown value for `token_type` returned from public auth to TokenPaymentType.CARD. Public auth will always return a `token_type`, and if it doesn't this will result in a `com.fasterxml.jackson.databind.exc.InvalidFormatException` which will be wrapped in a 500 response. This will show up in Sentry so we should be able to catch it if there are any future issues introduced.

Add an integration test to ensure this is the case

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition