### PR TITLE
PP-7104 Fix logging when API key fails checksum

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <jackson.version>2.11.3</jackson.version>
         <logback.version>1.2.3</logback.version>
         <docker-client.version>8.16.0</docker-client.version>
-        <pay-java-commons.version>1.0.20201103173727</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20201110163111</pay-java-commons.version>
         <junit5.version>5.7.0</junit5.version>
         <pact.version>3.6.15</pact.version>
         <swagger.lib.version>2.1.5</swagger.lib.version>

--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -110,10 +110,10 @@ public class PublicApi extends Application<PublicApiConfig> {
         environment.servlets().addFilter("ClearMdcValuesFilter", injector.getInstance(ClearMdcValuesFilter.class))
                 .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
 
-        environment.servlets().addFilter("AuthorizationValidationFilter", injector.getInstance(AuthorizationValidationFilter.class))
-                .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
-
         environment.servlets().addFilter("LoggingFilter", injector.getInstance(LoggingFilter.class))
+                .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
+        
+        environment.servlets().addFilter("AuthorizationValidationFilter", injector.getInstance(AuthorizationValidationFilter.class))
                 .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
 
         /*


### PR DESCRIPTION
Move the initialisation of filters for the application so that the request id is added to the MDC for logging before the AuthorizationValidationFilter runs.

Fix logging the "remote_address" for the line logged when the API key fails checksum validation so that it logs the client address obtained from the "X-Forwarded-For" header, which is added by the proxies the request passes through.