### PR TITLE
PP-7429 Do not log empty token_link

### DIFF
--- a/src/main/java/uk/gov/pay/api/filter/LoggingMDCRequestFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/LoggingMDCRequestFilter.java
@@ -26,7 +26,7 @@ public class LoggingMDCRequestFilter implements ContainerRequestFilter {
     public void filter(ContainerRequestContext requestContext) {
         Optional<Account> mayBeAccount = getAccount(requestContext);
         MDC.put(GATEWAY_ACCOUNT_ID, mayBeAccount.map(Account::getName).orElse(EMPTY));
-        MDC.put("token_link", mayBeAccount.map(Account::getTokenLink).orElse(EMPTY));
+        mayBeAccount.ifPresent(account -> MDC.put("token_link", account.getTokenLink()));
 
         String clientAddress = getClientAddress(requestContext);
         MDC.put(REMOTE_ADDRESS, clientAddress);


### PR DESCRIPTION
## WHAT YOU DID
- Adds token_link to MDC only when it is available. Adding empty token_link is causing the field to be logged multiple times (empty value and token identifier) when API token is authenticated
