### PR TITLE
PP-7526 Do not rate limit calls to healthcheck

### DIFF
--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
@@ -62,6 +62,10 @@ public class RateLimiterFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
+        if ("healthcheck".equals(requestContext.getUriInfo().getPath())) {
+            return;
+        }
+
         String accountId = getAccountId(requestContext);
         RateLimiterKey key = RateLimiterKey.from(requestContext, accountId);
         try {


### PR DESCRIPTION
Do not rate limit calls to the healthcheck endpoint. This is used by the
loadbalancer to test if an instance is healthy and a 429 response is considered
unhealthy. This could lead to the loadbalancer incorrectly setting the instance
as unhealthy.

## WHAT YOU DID
Although we're not sure whether it caused or contributed to an incident where the Publicapi Loadbalancer began returning 503 responses it isn't ideal that we are rate limiting its requests to the `/healthcheck` endpoint.