### PR TITLE
PP-7560 Clear MDC at both the beginning and end of a request

### DIFF
--- a/src/main/java/uk/gov/pay/api/filter/ClearMdcValuesFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ClearMdcValuesFilter.java
@@ -22,6 +22,7 @@ public class ClearMdcValuesFilter implements Filter {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        MDC.clear();
         try {
             chain.doFilter(request, response);
         } finally {


### PR DESCRIPTION
We are observing in our logs that sometimes the remote_address from a previous request seems to be logged even though the MDC should have been cleared at the end of that request.

Additionally clear the MDC at the beginning of the request (it should have no values at this point so we shouldn’t lose anything we want) to see if this makes things better.

with @katstevens