### PR TITLE
PP-7589 Use pact state for telephone notifications

### DIFF
--- a/src/test/resources/pacts/publicapi-connector-create-telephone-payment-notification.json
+++ b/src/test/resources/pacts/publicapi-connector-create-telephone-payment-notification.json
@@ -14,6 +14,12 @@
           "params": {
             "gateway_account_id": "123456"
           }
+        },
+        {
+          "name": "a gateway account has telephone payment notifications enabled",
+          "params": {
+            "gateway_account_id": "123456"
+          }
         }
       ],
       "request": {


### PR DESCRIPTION
We will start checking that this flag is enabled for the account in connector, adding this pact state will mean pact tests will pass when the change in connector to do this is made.