### PR TITLE
PP-7589 Refactor TelephonePaymentNotificationResource

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/telephone/TelephonePaymentNotificationResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/telephone/TelephonePaymentNotificationResource.java
@@ -3,6 +3,7 @@ package uk.gov.pay.api.resources.telephone;
 import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.auth.Auth;
 import io.swagger.annotations.Api;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.auth.Account;
@@ -40,12 +41,11 @@ public class TelephonePaymentNotificationResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     public Response newPayment(@Auth Account account, @Valid CreateTelephonePaymentRequest createTelephonePaymentRequest) {
+        Pair<TelephonePaymentResponse, Integer> responseAndStatusCode = createTelephonePaymentService.create(account, createTelephonePaymentRequest);
+        var response = responseAndStatusCode.getLeft();
+        var statusCode = responseAndStatusCode.getRight();
 
-        Response connectorResponse = createTelephonePaymentService.getConnectorResponse(account, createTelephonePaymentRequest);
-        TelephonePaymentResponse telephonePaymentResponse = createTelephonePaymentService
-                .create(connectorResponse);
-
-        return Response.status(connectorResponse.getStatus()).entity(telephonePaymentResponse).build();
+        return Response.status(statusCode).entity(response).build();
     }
 }
 

--- a/src/main/java/uk/gov/pay/api/service/telephone/CreateTelephonePaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/telephone/CreateTelephonePaymentService.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.api.service.telephone;
 
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.HttpStatus;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CreateChargeException;
@@ -28,19 +29,16 @@ public class CreateTelephonePaymentService {
         this.connectorUriGenerator = connectorUriGenerator;
     }
     
-    public Response getConnectorResponse(Account account, CreateTelephonePaymentRequest createTelephonePaymentRequest) {
+    public Pair<TelephonePaymentResponse, Integer> create(Account account, CreateTelephonePaymentRequest createTelephonePaymentRequest) {
         Response connectorResponse = createTelephoneCharge(account, createTelephonePaymentRequest);
 
         if (!createdSuccessfully(connectorResponse)) {
             throw new CreateChargeException(connectorResponse);
         }
-        return connectorResponse;
-    }
-    
-    public TelephonePaymentResponse create(Response connectorResponse) {
 
         ChargeFromResponse chargeFromResponse = connectorResponse.readEntity(ChargeFromResponse.class);
-        return TelephonePaymentResponse.from(chargeFromResponse);
+        TelephonePaymentResponse telephonePaymentResponse = TelephonePaymentResponse.from(chargeFromResponse);
+        return Pair.of(telephonePaymentResponse, connectorResponse.getStatus());
     }
 
     private boolean createdSuccessfully(Response connectorResponse) {


### PR DESCRIPTION
I found the names of methods and interaction with the service slightly confusing. The reason it's like this is because public api will respond with a 200 or 201 depending on the status code from connector.

Refactored so that the service is responsible for constructing the public api response from the connector response, and returns a Pair of the response and the status code to reply with.