### PR TITLE
PP-7589 Handle connector error for telephone payments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <jackson.version>2.12.0</jackson.version>
         <logback.version>1.2.3</logback.version>
         <docker-client.version>8.16.0</docker-client.version>
-        <pay-java-commons.version>1.0.20210104125628</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20210107154625</pay-java-commons.version>
         <junit5.version>5.7.0</junit5.version>
         <pact.version>3.6.15</pact.version>
         <swagger.lib.version>2.1.6</swagger.lib.version>

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -18,6 +18,7 @@ import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_MANDATE_ID_I
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_MANDATE_STATE_INVALID;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_MOTO_NOT_ENABLED;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_VALIDATION_ERROR;
+import static uk.gov.pay.api.model.PaymentError.Code.RESOURCE_ACCESS_FORBIDDEN;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 
 public class CreateChargeExceptionMapper implements ExceptionMapper<CreateChargeException> {
@@ -51,6 +52,10 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
                 case MANDATE_STATE_INVALID:
                     statusCode = HttpStatus.CONFLICT_409;
                     paymentError = aPaymentError(CREATE_PAYMENT_MANDATE_STATE_INVALID);
+                    break;
+                case TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED:
+                    statusCode = HttpStatus.FORBIDDEN_403;
+                    paymentError = aPaymentError(RESOURCE_ACCESS_FORBIDDEN);
                     break;
                 default:
                     paymentError = aPaymentError(CREATE_PAYMENT_CONNECTOR_ERROR);

--- a/src/main/java/uk/gov/pay/api/model/PaymentError.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentError.java
@@ -65,7 +65,8 @@ public class PaymentError {
         GET_PAYMENT_REFUNDS_CONNECTOR_ERROR("P0898", "Downstream system error"),
 
         TOO_MANY_REQUESTS_ERROR("P0900", "Too many requests"),
-        REQUEST_DENIED_ERROR("P0920", "Request blocked by security rules. Please consult API documentation for more information.");
+        REQUEST_DENIED_ERROR("P0920", "Request blocked by security rules. Please consult API documentation for more information."),
+        RESOURCE_ACCESS_FORBIDDEN("P0930", "Access to this resource is not enabled for this account. Please contact support.");
 
         private String value;
         private String format;

--- a/src/test/java/uk/gov/pay/api/it/telephone/CreateTelephonePaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/telephone/CreateTelephonePaymentIT.java
@@ -146,4 +146,15 @@ public class CreateTelephonePaymentIT extends TelephonePaymentResourceITBase {
                 .body("state.status", is("success"))
                 .body("state.finished", is(true));
     }
+
+    @Test
+    public void telephonePaymentNotificationsNotEnabledForAccount_shouldRespondWith403() {
+        connectorMockClient.respondTelephoneNotificationsNotEnabled(GATEWAY_ACCOUNT_ID);
+
+        postPaymentResponse(toJson(requestBody))
+                .statusCode(403)
+                .contentType(JSON)
+                .body("code", is("P0930"))
+                .body("description", is("Access to this resource is not enabled for this account. Please contact support."));
+    }
 }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -40,6 +40,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.jetty.http.HttpStatus.ACCEPTED_202;
 import static org.eclipse.jetty.http.HttpStatus.BAD_REQUEST_400;
 import static org.eclipse.jetty.http.HttpStatus.CREATED_201;
+import static org.eclipse.jetty.http.HttpStatus.FORBIDDEN_403;
 import static org.eclipse.jetty.http.HttpStatus.INTERNAL_SERVER_ERROR_500;
 import static org.eclipse.jetty.http.HttpStatus.NOT_FOUND_404;
 import static org.eclipse.jetty.http.HttpStatus.NO_CONTENT_204;
@@ -53,6 +54,7 @@ import static uk.gov.pay.commons.model.ErrorIdentifier.GENERIC;
 import static uk.gov.pay.commons.model.ErrorIdentifier.MOTO_NOT_ALLOWED;
 import static uk.gov.pay.commons.model.ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH;
 import static uk.gov.pay.commons.model.ErrorIdentifier.REFUND_NOT_AVAILABLE;
+import static uk.gov.pay.commons.model.ErrorIdentifier.TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED;
 import static uk.gov.pay.commons.model.ErrorIdentifier.ZERO_AMOUNT_NOT_ALLOWED;
 
 public class ConnectorMockClient extends BaseConnectorMockClient {
@@ -316,6 +318,10 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
 
     public void respondMotoPaymentNotAllowed(String gatewayAccountId) {
         mockCreateCharge(gatewayAccountId, withStatusAndErrorMessage(UNPROCESSABLE_ENTITY_422, "anything", MOTO_NOT_ALLOWED));
+    }
+
+    public void respondTelephoneNotificationsNotEnabled(String gatewayAccountId) {
+        mockCreateTelephoneCharge(gatewayAccountId, withStatusAndErrorMessage(FORBIDDEN_403, "anything", TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED));
     }
 
     public void respondWithChargeFound(String chargeTokenId, String gatewayAccountId, ChargeResponseFromConnector chargeResponseFromConnector) {


### PR DESCRIPTION
Handle connector error when telephone payment notifications are not enabled for the account by responding with a 403 forbidden and a new P error code P0930.