### PR TITLE
PP-7896 Remove swagger (v2) annotations from models

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
         <guice.version>5.0.1</guice.version>
         <guava.version>29.0-jre</guava.version>
         <wiremock.version>2.27.2</wiremock.version>
-        <swagger.jersey2.version>1.6.2</swagger.jersey2.version>
         <hamcrest.version>2.2</hamcrest.version>
         <jackson.version>2.12.2</jackson.version>
         <logback.version>1.2.3</logback.version>
@@ -228,19 +227,6 @@
             <scope>test</scope>
         </dependency>
         <!-- swagger -->
-        <!-- the excluded dependencies are already pulled by io.dropwizard:dropwizard-jersey transitively -->
-        <dependency>
-            <groupId>io.swagger</groupId>
-            <artifactId>swagger-jersey2-jaxrs</artifactId>
-            <version>${swagger.jersey2.version}</version>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.glassfish.jersey.containers</groupId>
-                    <artifactId>jersey-container-servlet-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>

--- a/src/main/java/uk/gov/pay/api/model/Address.java
+++ b/src/main/java/uk/gov/pay/api/model/Address.java
@@ -3,8 +3,6 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import javax.validation.constraints.Size;
@@ -14,7 +12,6 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(NON_NULL)
-@ApiModel(value = "Address", description = "A structure representing the billing address of a card")
 @Schema(name = "Address", description = "A structure representing the billing address of a card")
 public class Address {
 
@@ -44,31 +41,26 @@ public class Address {
         this.country = country;
     }
 
-    @ApiModelProperty(example = "address line 1")
     @Schema(example = "address line 1")
     public String getLine1() {
         return line1;
     }
 
-    @ApiModelProperty(example = "address line 2")
     @Schema(example = "address line 2")
     public String getLine2() {
         return line2;
     }
 
-    @ApiModelProperty(example = "AB1 2CD")
     @Schema(example = "AB1 2CD")
     public String getPostcode() {
         return postcode;
     }
 
-    @ApiModelProperty(example = "address city")
     @Schema(example = "address city")
     public String getCity() {
         return city;
     }
 
-    @ApiModelProperty(example = "GB")
     @Schema(example = "GB")
     public String getCountry() {
         return country;

--- a/src/main/java/uk/gov/pay/api/model/CardDetails.java
+++ b/src/main/java/uk/gov/pay/api/model/CardDetails.java
@@ -3,8 +3,6 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Optional;
@@ -13,7 +11,6 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.ALWAYS;
 import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
 @JsonInclude(ALWAYS)
-@ApiModel(value = "CardDetails", description = "A structure representing the payment card")
 @Schema(name = "CardDetails", description = "A structure representing the payment card")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CardDetails {
@@ -55,25 +52,21 @@ public class CardDetails {
         this.cardType = cardType;
     }
 
-    @ApiModelProperty(example = "1234")
     @Schema(example = "1234", accessMode = READ_ONLY)
     public String getLastDigitsCardNumber() {
         return lastDigitsCardNumber;
     }
 
-    @ApiModelProperty(example = "123456")
     @Schema(example = "123456", accessMode = READ_ONLY)
     public String getFirstDigitsCardNumber() {
         return firstDigitsCardNumber;
     }
 
-    @ApiModelProperty(example = "Mr. Card holder")
     @Schema(example = "Mr. Card holder")
     public String getCardHolderName() {
         return cardHolderName;
     }
 
-    @ApiModelProperty(value = "The expiry date of the card in MM/yy format", example = "04/24")
     @Schema(description = "The expiry date of the card in MM/yy format", example = "04/24", accessMode = READ_ONLY)
     public String getExpiryDate() {
         return expiryDate;
@@ -83,13 +76,11 @@ public class CardDetails {
         return Optional.ofNullable(billingAddress);
     }
 
-    @ApiModelProperty(example = "Visa")
     @Schema(example = "Visa", accessMode = READ_ONLY)
     public String getCardBrand() {
         return cardBrand;
     }
 
-    @ApiModelProperty(value = "The card type, `debit` or `credit` or `null` if not able to determine", allowableValues = "debit,credit,null", example = "debit")
     @Schema(description = "The card type, `debit` or `credit` or `null` if not able to determine", allowableValues = {"debit","credit","null"}, example = "debit", accessMode = READ_ONLY)
     public String getCardType() {
         return cardType;

--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.service.payments.commons.api.json.ExternalMetadataSerialiser;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
@@ -18,7 +16,6 @@ import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
 
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
-@ApiModel(value = "CardPayment")
 @Schema(name = "CardPayment")
 public class CardPayment extends Payment {
 
@@ -32,7 +29,6 @@ public class CardPayment extends Payment {
     private final CardDetails cardDetails;
 
     @JsonSerialize(using = ToStringSerializer.class)
-    @ApiModelProperty(name = "language", access = "language")
     private final SupportedLanguage language;
 
     @JsonProperty("delayed_capture")
@@ -54,12 +50,10 @@ public class CardPayment extends Payment {
     private final Long netAmount;
 
     @JsonProperty("provider_id")
-    @ApiModelProperty(example = "reference-from-payment-gateway")
     @Schema(example = "reference-from-payment-gateway", accessMode = READ_ONLY)
     private final String providerId;
 
     @JsonSerialize(using = ExternalMetadataSerialiser.class)
-    @ApiModelProperty(name = "metadata", dataType = "Map[String,String]")
     @Schema(name = "metadata", example = "{\"property1\": \"value1\", \"property2\": \"value2\"}\"")
     private final ExternalMetadata metadata;
 
@@ -105,7 +99,6 @@ public class CardPayment extends Payment {
      *
      * @return
      */
-    @ApiModelProperty(value = "Card Brand", example = "Visa", notes = "Deprecated. Please use card_details.card_brand instead")
     @Schema(description = "Card Brand. Deprecated, please use card_details.card_brand instead", example = "Visa",
             accessMode = READ_ONLY, deprecated = true)
     @JsonProperty("card_brand")
@@ -118,51 +111,42 @@ public class CardPayment extends Payment {
         return metadata;
     }
 
-    @ApiModelProperty(dataType = "uk.gov.pay.api.model.RefundSummary")
     public Optional<RefundSummary> getRefundSummary() {
         return Optional.ofNullable(refundSummary);
     }
 
-    @ApiModelProperty(dataType = "uk.gov.pay.api.model.PaymentSettlementSummary")
     public Optional<PaymentSettlementSummary> getSettlementSummary() {
         return Optional.ofNullable(settlementSummary);
     }
 
-    @ApiModelProperty(dataType = "uk.gov.pay.api.model.CardDetails")
     public Optional<CardDetails> getCardDetails() {
         return Optional.ofNullable(cardDetails);
     }
 
-    @ApiModelProperty(example = "en", allowableValues = "en,cy")
     @Schema(name = "language", example = "en")
     public SupportedLanguage getLanguage() {
         return language;
     }
 
-    @ApiModelProperty(value = "delayed capture flag", example = "false")
     @Schema(description = "delayed capture flag", example = "false", accessMode = READ_ONLY)
     public boolean getDelayedCapture() {
         return delayedCapture;
     }
 
-    @ApiModelProperty(value = "Mail Order / Telephone Order (MOTO) payment flag", example = "false")
     @Schema(description = "Mail Order / Telephone Order (MOTO) payment flag", example = "false")
     public boolean getMoto() { return moto; }
 
-    @ApiModelProperty(example = "250")
     @Schema(example = "250", accessMode = READ_ONLY)
     public Optional<Long> getCorporateCardSurcharge() {
         return Optional.ofNullable(corporateCardSurcharge);
     }
 
-    @ApiModelProperty(example = "5", value = "processing fee taken by the GOV.UK Pay platform, in pence. Only available depending on payment service provider")
     @Schema(example = "5", description = "processing fee taken by the GOV.UK Pay platform, in pence. Only available depending on payment service provider",
             accessMode = READ_ONLY)
     public Optional<Long> getFee() {
         return Optional.ofNullable(fee);
     }
 
-    @ApiModelProperty(example = "1195", value = "amount including all surcharges and less all fees, in pence. Only available depending on payment service provider")
     @Schema(example = "1195", 
             description = "amount including all surcharges and less all fees, in pence. Only available depending on payment service provider",
             accessMode = READ_ONLY)
@@ -170,7 +154,6 @@ public class CardPayment extends Payment {
         return Optional.ofNullable(netAmount);
     }
 
-    @ApiModelProperty(example = "1450")
     @Schema(example = "1450", accessMode = READ_ONLY)
     public Optional<Long> getTotalAmount() {
         return Optional.ofNullable(totalAmount);
@@ -180,19 +163,16 @@ public class CardPayment extends Payment {
         return providerId;
     }
 
-    @ApiModelProperty(example = "http://your.service.domain/your-reference")
     @Schema(example = "http://your.service.domain/your-reference", accessMode = READ_ONLY)
     public Optional<String> getReturnUrl() {
         return Optional.ofNullable(returnUrl);
     }
 
-    @ApiModelProperty(example = "your email")
     @Schema(example = "your email")
     public Optional<String> getEmail() {
         return Optional.ofNullable(email);
     }
 
-    @ApiModelProperty(dataType = "uk.gov.pay.api.model.PaymentState")
     public PaymentState getState() {
         return state;
     }

--- a/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.hibernate.validator.constraints.Length;
 import uk.gov.pay.api.utils.JsonStringBuilder;
@@ -17,7 +15,6 @@ import javax.validation.constraints.Size;
 import java.util.Optional;
 import java.util.StringJoiner;
 
-@ApiModel(description = "The Payment Request Payload")
 @Schema(description = "The Payment Request Payload")
 public class CreateCardPaymentRequest {
 
@@ -80,7 +77,6 @@ public class CreateCardPaymentRequest {
     
     private final Boolean moto;
 
-    @ApiModelProperty(name = "metadata", dataType = "Map[String,String]")
     @Schema(name = "metadata", example = "{\"property1\": \"value1\", \"property2\": \"value2\"}\"")
     private final ExternalMetadata metadata;
     
@@ -103,52 +99,44 @@ public class CreateCardPaymentRequest {
         this.internal = builder.getInternal();
     }
     
-    @ApiModelProperty(value = "amount in pence", required = true, allowableValues = "range[1, 10000000]", example = "12000")
     @Schema(description = "amount in pence", required = true, minimum = "1", maximum = "10000000", example = "12000")
     public int getAmount() {
         return amount;
     }
 
-    @ApiModelProperty(value = "payment reference", required = true, example = "12345")
     @Schema(description = "payment reference", required = true, example = "12345")
     public String getReference() {
         return reference;
     }
 
-    @ApiModelProperty(value = "payment description", required = true, example = "New passport application")
     @Schema(description = "payment description", required = true, example = "New passport application")
     public String getDescription() {
         return description;
     }
 
-    @ApiModelProperty(value = "ISO-639-1 Alpha-2 code of a supported language to use on the payment pages", required = false, example = "en", allowableValues = "en,cy")
     @Schema(description = "ISO-639-1 Alpha-2 code of a supported language to use on the payment pages", example = "en")
     @JsonProperty(LANGUAGE_FIELD_NAME)
     public Optional<SupportedLanguage> getLanguage() {
         return Optional.ofNullable(language);
     }
 
-    @ApiModelProperty(value = "email", required = false, example = "Joe.Bogs@example.org")
     @Schema(name = "email", example = "Joe.Bogs@example.org", description = "email")
     @JsonProperty(EMAIL_FIELD_NAME)
     public Optional<String> getEmail() {
         return Optional.ofNullable(email);
     }
     
-    @ApiModelProperty(value = "service return url", required = true, example = "https://service-name.gov.uk/transactions/12345")
     @Schema(description = "service return url", required = true, example = "https://service-name.gov.uk/transactions/12345")
     public String getReturnUrl() {
         return returnUrl;
     }
 
-    @ApiModelProperty(value = "prefilled_cardholder_details")
     @Schema(description = "prefilled_cardholder_details")
     @JsonProperty(CreateCardPaymentRequest.PREFILLED_CARDHOLDER_DETAILS_FIELD_NAME)
     public Optional<PrefilledCardholderDetails> getPrefilledCardholderDetails() {
         return Optional.ofNullable(prefilledCardholderDetails);
     }
 
-    @ApiModelProperty(value = "delayed capture flag", example = "false")
     @Schema(description = "delayed capture flag", example = "false")
     @JsonProperty(DELAYED_CAPTURE_FIELD_NAME)
     public Optional<Boolean> getDelayedCapture() {
@@ -156,18 +144,12 @@ public class CreateCardPaymentRequest {
     }
 
     @JsonProperty(MOTO_FIELD_NAME)
-    @ApiModelProperty(value = "Mail Order / Telephone Order (MOTO) payment flag", example = "false")
     @Schema(description = "Mail Order / Telephone Order (MOTO) payment flag", example = "false")
     public Optional<Boolean> getMoto() {
         return Optional.ofNullable(moto);
     }
 
     @JsonProperty("metadata")
-    @ApiModelProperty(value = "Additional metadata - up to 10 name/value pairs - on the payment. " +
-            "Each key must be between 1 and 30 characters long. " +
-            "The value, if a string, must be no greater than 50 characters long. " +
-            "Other permissible value types: boolean, number.",
-            dataType = "java.util.Map", example = "{\"ledger_code\":\"123\", \"reconciled\": true}")
     @Schema(description = "Additional metadata - up to 10 name/value pairs - on the payment. " +
             "Each key must be between 1 and 30 characters long. " +
             "The value, if a string, must be no greater than 50 characters long. " +
@@ -178,7 +160,6 @@ public class CreateCardPaymentRequest {
     }
 
     @JsonProperty("internal")
-    @ApiModelProperty(hidden = true)
     @Schema(hidden = true)
     public Optional<Internal> getInternal() {
         return Optional.ofNullable(internal);

--- a/src/main/java/uk/gov/pay/api/model/CreateDirectDebitPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateDirectDebitPaymentRequest.java
@@ -2,8 +2,6 @@ package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.hibernate.validator.constraints.NotBlank;
 
@@ -12,7 +10,6 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
 import java.util.StringJoiner;
 
-@ApiModel(description = "The Direct Debit Payment Request Payload")
 @Schema(description = "The Direct Debit Payment Request Payload")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CreateDirectDebitPaymentRequest {
@@ -46,25 +43,21 @@ public class CreateDirectDebitPaymentRequest {
         //To enable Jackson serialisation we need a default constructor
     }
     
-    @ApiModelProperty(value = "amount in pence", required = true, allowableValues = "range[1, 10000000]", example = "12000")
     @Schema(description = "amount in pence", required = true, example = "12000", minimum = "1", maximum = "10000000")
     public int getAmount() {
         return amount;
     }
 
-    @ApiModelProperty(value = "payment reference", required = true, example = "12345")
     @Schema(description = "payment reference", required = true, example = "12345")
     public String getReference() {
         return reference;
     }
 
-    @ApiModelProperty(value = "payment description", required = true, example = "New passport application")
     @Schema(description = "payment description", required = true, example = "New passport application")
     public String getDescription() {
         return description;
     }
 
-    @ApiModelProperty(value = "ID of the mandates being used to collect the payment", required = false, example = "33890b55-b9ea-4e2f-90fd-77ae0e9009e2")
     @Schema(description = "ID of the mandates being used to collect the payment", required = false, example = "33890b55-b9ea-4e2f-90fd-77ae0e9009e2")
     public String getMandateId() {
         return mandateId;

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRefundRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRefundRequest.java
@@ -1,15 +1,12 @@
 package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Optional;
 
 import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
-@ApiModel(value = "PaymentRefundRequest", description = "The Payment Refund Request Payload")
 @Schema(name = "PaymentRefundRequest", description = "The Payment Refund Request Payload")
 public class CreatePaymentRefundRequest {
 
@@ -32,7 +29,6 @@ public class CreatePaymentRefundRequest {
         this.refundAmountAvailable = refundAmountAvailable;
     }
 
-    @ApiModelProperty(value = "Amount in pence. Can't be more than the available amount for refunds", required = true, allowableValues = "range[1, 10000000]", example = "150000")
     public int getAmount() {
         return amount;
     }
@@ -42,7 +38,6 @@ public class CreatePaymentRefundRequest {
      *
      * @return
      */
-    @ApiModelProperty(value = "Amount in pence. Total amount still available before issuing the refund", required = false, allowableValues = "range[1, 10000000]", example = "200000")
     public Optional<Integer> getRefundAmountAvailable() {
         return Optional.ofNullable(refundAmountAvailable);
     }

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentResult.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentResult.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.PaymentLinks;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
@@ -14,60 +12,48 @@ import static uk.gov.pay.api.model.Payment.LINKS_JSON_ATTRIBUTE;
 /**
  * Defines swagger specs for create payment
  */
-@ApiModel
 public class CreatePaymentResult {
 
     @JsonProperty
-    @ApiModelProperty(name = "amount", value = "The amount in pence.", example = "1200")
     @Schema(name = "amount", description = "The amount in pence.", example = "1200")
     private long amount;
 
     @JsonProperty
-    @ApiModelProperty(dataType = "uk.gov.pay.api.model.PaymentState")
     private PaymentState state;
 
     @JsonProperty
-    @ApiModelProperty(value = "The human-readable description you gave the payment.", example = "New passport application")
     @Schema(description = "The human-readable description you gave the payment.", example = "New passport application")
     private String description;
 
     @JsonProperty
-    @ApiModelProperty(value = "The reference number you associated with this payment.", example = "12345")
     @Schema(description = "The reference number you associated with this payment.", example = "12345")
     private String reference;
 
     @JsonProperty
-    @ApiModelProperty(name = "language", value = "Which language your users will see on the payment pages when they make a payment.", access = "language", example = "en", allowableValues = "en,cy")
     @Schema(name = "language", description = "Which language your users will see on the payment pages when they make a payment.", example = "en")
     private SupportedLanguage language;
 
     @JsonProperty
-    @ApiModelProperty(name = "payment_id", value = "The unique identifier of the payment.", example = "hu20sqlact5260q2nanm0q8u93")
     @Schema(name = "payment_id", description = "The unique identifier of the payment.", example = "hu20sqlact5260q2nanm0q8u93")
     private String paymentId;
 
     @JsonProperty
-    @ApiModelProperty(name = "payment_provider", example = "worldpay")
     @Schema(name = "payment_provider", example = "worldpay")
     private String paymentProvider;
 
     @JsonProperty
-    @ApiModelProperty(name = "return_url", value = "An HTTPS URL on your site that your user will be sent back to once they have completed their payment attempt on GOV.UK Pay.", example = "https://service-name.gov.uk/transactions/12345")
     @Schema(name = "return_url", description = "An HTTPS URL on your site that your user will be sent back to once they have completed their payment attempt on GOV.UK Pay.", example = "https://service-name.gov.uk/transactions/12345")
     private String returnUrl;
 
     @JsonProperty
-    @ApiModelProperty(name = "created_date", value = "The date you created the payment.", example = "2016-01-21T17:15:00Z")
     @Schema(name = "created_date", description = "The date you created the payment.", example = "2016-01-21T17:15:00Z")
     private String createdDate;
 
     @JsonProperty
-    @ApiModelProperty(name = "delayed_capture", access = "delayed_capture", value = "Whether to [delay capturing](https://docs.payments.service.gov.uk/optional_features/delayed_capture/) this payment.", example = "false")
     @Schema(name = "delayed_capture", description = "Whether to [delay capturing](https://docs.payments.service.gov.uk/optional_features/delayed_capture/) this payment.", example = "false", accessMode = READ_ONLY)
     private boolean delayedCapture;
 
     @JsonProperty
-    @ApiModelProperty(value = "Mail Order / Telephone Order (MOTO) payment flag.", example = "false")
     @Schema(description = "Mail Order / Telephone Order (MOTO) payment flag.", example = "false")
     private boolean moto;
 
@@ -78,27 +64,22 @@ public class CreatePaymentResult {
     private PaymentSettlementSummary settlementSummary;
 
     @JsonProperty
-    @ApiModelProperty(name = LINKS_JSON_ATTRIBUTE, value = "API endpoints related to the payment.")
     @Schema(name = LINKS_JSON_ATTRIBUTE, description = "API endpoints related to the payment.")
     private PaymentLinks links;
 
     @JsonProperty
-    @ApiModelProperty(name = "provider_id", value = "The reference number the payment gateway associated with the payment.", example = "null")
     @Schema(name = "provider_id", description = "The reference number the payment gateway associated with the payment.", example = "null")
     private String providerId;
 
     @JsonProperty
-    @ApiModelProperty(name = "metadata", value = "[Custom metadata](https://docs.payments.service.gov.uk/optional_features/custom_metadata/) you added to the payment.", dataType = "Map[String,String]")
     @Schema(name = "metadata", description = "[Custom metadata](https://docs.payments.service.gov.uk/optional_features/custom_metadata/) you added to the payment.")
     private ExternalMetadata metadata;
 
     @JsonProperty
-    @ApiModelProperty(name = "email", value = "The email address of your user.", example = "citizen@example.org")
     @Schema(name = "email", description = "The email address of your user.", example = "citizen@example.org")
     private String email;
 
     @JsonProperty(value = "card_details")
-    @ApiModelProperty(name = "card_details")
     @Schema(name = "card_details")
     private CardDetails cardDetails;
 }

--- a/src/main/java/uk/gov/pay/api/model/Payment.java
+++ b/src/main/java/uk/gov/pay/api/model/Payment.java
@@ -2,17 +2,12 @@ package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.directdebit.mandates.DirectDebitPayment;
 
 import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
-
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
-@ApiModel(value = "Payment", discriminator = "paymentType", subTypes = {
-        CardPayment.class, DirectDebitPayment.class})
 @Schema(name = "Payment", subTypes = {CardPayment.class, DirectDebitPayment.class})
 public abstract class Payment {
     public static final String LINKS_JSON_ATTRIBUTE = "_links";
@@ -49,37 +44,31 @@ public abstract class Payment {
         this.createdDate = createdDate;
     }
 
-    @ApiModelProperty(example = "2016-01-21T17:15:000Z")
     @Schema(example = "2016-01-21T17:15:000Z", accessMode = READ_ONLY)
     public String getCreatedDate() {
         return createdDate;
     }
 
-    @ApiModelProperty(example = "hu20sqlact5260q2nanm0q8u93")
     @Schema(example = "hu20sqlact5260q2nanm0q8u93", accessMode = READ_ONLY)
     public String getPaymentId() {
         return paymentId;
     }
 
-    @ApiModelProperty(example = "1200")
     @Schema(example = "1200")
     public long getAmount() {
         return amount;
     }
 
-    @ApiModelProperty(example = "Your Service Description")
     @Schema(example = "Your Service Description")
     public String getDescription() {
         return description;
     }
 
-    @ApiModelProperty(example = "your-reference")
     @Schema(example = "your-reference")
     public String getReference() {
         return reference;
     }
 
-    @ApiModelProperty(example = "worldpay")
     @Schema(example = "worldpay", accessMode = READ_ONLY)
     public String getPaymentProvider() {
         return paymentProvider;

--- a/src/main/java/uk/gov/pay/api/model/PaymentError.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentError.java
@@ -1,15 +1,12 @@
 package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static com.google.common.collect.ObjectArrays.concat;
 import static java.lang.String.format;
 
-@ApiModel(value = "PaymentError", description = "A Payment Error response")
 @Schema(name = "PaymentError", description = "A Payment Error response")
 @JsonInclude(NON_NULL)
 public class PaymentError {
@@ -108,19 +105,16 @@ public class PaymentError {
         this.description = format(code.getFormat(), concat(fieldName, parameters));
     }
 
-    @ApiModelProperty(example = "amount")
     @Schema(example = "amount")
     public String getField() {
         return field;
     }
 
-    @ApiModelProperty(example = "P0102")
     @Schema(example = "P0102")
     public String getCode() {
         return code.value();
     }
 
-    @ApiModelProperty(example = "Invalid attribute value: amount. Must be less than or equal to 10000000")
     @Schema(example = "Invalid attribute value: amount. Must be less than or equal to 10000000")
     public String getDescription() {
         return description;

--- a/src/main/java/uk/gov/pay/api/model/PaymentEventResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentEventResponse.java
@@ -2,14 +2,11 @@ package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.PaymentEventLink;
 
 import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
-@ApiModel(value="PaymentEvent", description = "A List of Payment Events information")
 @Schema(name = "PaymentEvent", description = "A List of Payment Events information")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PaymentEventResponse {
@@ -40,25 +37,21 @@ public class PaymentEventResponse {
         this.paymentLink = new PaymentEventLink(paymentLink);
     }
 
-    @ApiModelProperty(example = "hu20sqlact5260q2nanm0q8u93")
     @Schema(example = "hu20sqlact5260q2nanm0q8u93", accessMode = READ_ONLY)
     public String getPaymentId() {
         return paymentId;
     }
 
-    @ApiModelProperty(value = "state", dataType = "uk.gov.pay.api.model.PaymentState")
     @Schema(description = "state")
     public PaymentState getState() {
         return state;
     }
 
-    @ApiModelProperty(value = "updated",example = "2017-01-10T16:44:48.646Z")
     @Schema(description = "updated", example = "2017-01-10T16:44:48.646Z", accessMode = READ_ONLY)
     public String getUpdated() {
         return updated;
     }
 
-    @ApiModelProperty(dataType = "uk.gov.pay.api.model.links.PaymentEventLink")
     public PaymentEventLink getPaymentLink() {
         return paymentLink;
     }

--- a/src/main/java/uk/gov/pay/api/model/PaymentEventsResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentEventsResponse.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.PaymentLinksForEvents;
 
@@ -12,7 +10,6 @@ import java.util.stream.Collectors;
 
 import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
-@ApiModel(value="PaymentEvents", description = "A List of Payment Events information")
 @Schema(name = "PaymentEvents", description = "A List of Payment Events information")
 public class PaymentEventsResponse {
     @JsonProperty("payment_id")
@@ -47,7 +44,6 @@ public class PaymentEventsResponse {
         return new PaymentEventsResponse(transactionEvents.getTransactionId(), events, paymentLinksForEvents);
     }
 
-    @ApiModelProperty(example = "hu20sqlact5260q2nanm0q8u93")
     @Schema(example = "hu20sqlact5260q2nanm0q8u93", accessMode = READ_ONLY)
     public String getPaymentId() {
         return paymentId;

--- a/src/main/java/uk/gov/pay/api/model/PaymentSettlementSummary.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentSettlementSummary.java
@@ -3,15 +3,12 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@ApiModel(value="PaymentSettlementSummary", description = "A structure representing information about a settlement")
 @Schema(name = "PaymentSettlementSummary", description = "A structure representing information about a settlement")
 public class PaymentSettlementSummary {
 
@@ -32,20 +29,17 @@ public class PaymentSettlementSummary {
         this.settledDate = settledDate;
     }
 
-    @ApiModelProperty(value = "Date and time capture request has been submitted. May be null if capture request was not immediately acknowledged by payment gateway.", example = "2016-01-21T17:15:000Z")
     @Schema(description = "Date and time capture request has been submitted. May be null if capture request was not immediately acknowledged by payment gateway.",
             example = "2016-01-21T17:15:000Z", accessMode = READ_ONLY)
     public String getCaptureSubmitTime() {
         return captureSubmitTime;
     }
 
-    @ApiModelProperty(value = "Date of the capture event.", example = "2016-01-21")
     @Schema(description = "Date of the capture event.", example = "2016-01-21", accessMode = READ_ONLY)
     public String getCapturedDate() {
         return capturedDate;
     }
 
-    @ApiModelProperty(value = "The date that the transaction was paid into the service's account.", example = "2016-01-21")
     @Schema(description = "The date that the transaction was paid into the service's account.", example = "2016-01-21",
             accessMode = READ_ONLY)
     public String getSettledDate() {

--- a/src/main/java/uk/gov/pay/api/model/PaymentState.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentState.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Objects;
@@ -14,7 +12,6 @@ import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@ApiModel(value = "PaymentState", description = "A structure representing the current state of the payment in its lifecycle.")
 @Schema(name = "PaymentState", description = "A structure representing the current state of the payment in its lifecycle.")
 public class PaymentState {
     @JsonProperty("status")
@@ -53,26 +50,22 @@ public class PaymentState {
         this.code = code;
     }
 
-    @ApiModelProperty(value = "Current progress of the payment in its lifecycle", example = "created")
     @Schema(description = "Current progress of the payment in its lifecycle", example = "created", accessMode = READ_ONLY)
     public String getStatus() {
         return status;
     }
 
-    @ApiModelProperty(value = "Whether the payment has finished")
     @Schema(description = "Whether the payment has finished", accessMode = READ_ONLY)
     public boolean isFinished() {
         return finished;
     }
 
-    @ApiModelProperty(value = "What went wrong with the Payment if it finished with an error - English message", example = "User cancelled the payment")
     @Schema(description = "What went wrong with the Payment if it finished with an error - English message",
             example = "User cancelled the payment", accessMode = READ_ONLY)
     public String getMessage() {
         return message;
     }
 
-    @ApiModelProperty(value = "What went wrong with the Payment if it finished with an error - error code", example = "P010")
     @Schema(description = "What went wrong with the Payment if it finished with an error - error code", example = "P010",
             accessMode = READ_ONLY)
     public String getCode() {

--- a/src/main/java/uk/gov/pay/api/model/PrefilledCardholderDetails.java
+++ b/src/main/java/uk/gov/pay/api/model/PrefilledCardholderDetails.java
@@ -2,7 +2,6 @@ package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import javax.validation.Valid;
@@ -14,12 +13,10 @@ import java.util.Optional;
 public class PrefilledCardholderDetails {
 
     @JsonProperty("cardholder_name")
-    @ApiModelProperty(name = "cardholder_name", value = "prefilled cardholder name", required = false, example = "J. Bogs")
     @Schema(name = "cardholder_name", description = "prefilled cardholder name", example = "J. Bogs")
     @Size(max = 255, message = "Must be less than or equal to {max} characters length")
     private String cardholderName;
 
-    @ApiModelProperty(name = "billing_address", value = "prefilled billing address", required = false)
     @Schema(name = "billing_address", description = "prefilled billing address")
     @JsonProperty("billing_address")
     @Valid

--- a/src/main/java/uk/gov/pay/api/model/RefundError.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundError.java
@@ -1,15 +1,12 @@
 package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static com.google.common.collect.ObjectArrays.concat;
 import static java.lang.String.format;
 
-@ApiModel(value = "RefundError", description = "A Refund Error response")
 @Schema(name = "RefundError", description = "A Refund Error response")
 @JsonInclude(NON_NULL)
 public class RefundError {
@@ -61,19 +58,16 @@ public class RefundError {
         this.description = format(code.getFormat(), concat(fieldName, parameters));
     }
 
-    @ApiModelProperty(example = "amount_submitted")
     @Schema(example = "amount_submitted")
     public String getField() {
         return field;
     }
 
-    @ApiModelProperty(example = "P0102")
     @Schema(example = "P0102")
     public String getCode() {
         return code.value();
     }
 
-    @ApiModelProperty(example = "Invalid attribute value: amountSubmitted. Must be less than or equal to 10000000")
     @Schema(example = "Invalid attribute value: amountSubmitted. Must be less than or equal to 10000000")
     public String getDescription() {
         return description;

--- a/src/main/java/uk/gov/pay/api/model/RefundSettlementSummary.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundSettlementSummary.java
@@ -3,15 +3,12 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@ApiModel(value="RefundSettlementSummary", description = "A structure representing information about a settlement for refunds")
 @Schema(name = "RefundSettlementSummary", description = "A structure representing information about a settlement for refunds")
 public class RefundSettlementSummary {
 
@@ -24,7 +21,6 @@ public class RefundSettlementSummary {
         this.settledDate = settledDate;
     }
 
-    @ApiModelProperty(value = "The date that the transaction was refunded from the service's account.", example = "2016-01-21")
     @Schema(description = "The date that the transaction was refunded from the service's account.", example = "2016-01-21",
             accessMode = READ_ONLY)
     public String getSettledDate() {

--- a/src/main/java/uk/gov/pay/api/model/RefundSummary.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundSummary.java
@@ -2,13 +2,10 @@ package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
-@ApiModel(value = "RefundSummary", description = "A structure representing the refunds availability")
 @Schema(name = "RefundSummary", description = "A structure representing the refunds availability")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RefundSummary {
@@ -29,19 +26,16 @@ public class RefundSummary {
         this.amountSubmitted = amountSubmitted;
     }
 
-    @ApiModelProperty(value = "Availability status of the refund", example = "available")
     @Schema(description = "Availability status of the refund", example = "available")
     public String getStatus() {
         return status;
     }
 
-    @ApiModelProperty(value = "Amount available for refund in pence", example = "100")
     @Schema(description = "Amount available for refund in pence", example = "100", accessMode = READ_ONLY)
     public long getAmountAvailable() {
         return amountAvailable;
     }
 
-    @ApiModelProperty(value = "Amount submitted for refunds on this Payment in pence")
     @Schema(description = "Amount submitted for refunds on this Payment in pence", accessMode = READ_ONLY)
     public long getAmountSubmitted() {
         return amountSubmitted;

--- a/src/main/java/uk/gov/pay/api/model/directdebit/DirectDebitPaymentLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/DirectDebitPaymentLinks.java
@@ -2,8 +2,6 @@ package uk.gov.pay.api.model.directdebit;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.Link;
 
@@ -12,7 +10,6 @@ import java.net.URI;
 import static javax.ws.rs.HttpMethod.GET;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
-@ApiModel(value = "DirectDebitPaymentLinks", description = "links for payment")
 @Schema(name = "DirectDebitPaymentLinks", description = "links for payment")
 public class DirectDebitPaymentLinks {
     
@@ -20,7 +17,6 @@ public class DirectDebitPaymentLinks {
     private Link self;
 
     //Hidden because it is currently unused
-    @ApiModelProperty(hidden = true)
     @Schema(hidden = true)
     @JsonProperty("events")
     private Link events;

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/CreateMandateRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/CreateMandateRequest.java
@@ -3,8 +3,6 @@ package uk.gov.pay.api.model.directdebit.mandates;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.hibernate.validator.constraints.NotBlank;
 import uk.gov.pay.api.validation.ValidReturnUrl;
@@ -14,7 +12,6 @@ import javax.validation.constraints.Size;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@ApiModel(description = "The Payload to create a new Mandate")
 @Schema(description = "The Payload to create a new Mandate")
 public class CreateMandateRequest {
 
@@ -34,19 +31,16 @@ public class CreateMandateRequest {
     @Size(min = 1, max = 255, message = "Must have a size between {min} and {max}")
     private String description;
 
-    @ApiModelProperty(value = "mandate description")
     @Schema(description = "mandate description")
     public String getDescription() {
         return description;
     }
 
-    @ApiModelProperty(value = "mandate return url", required = true, example = "https://service-name.gov.uk/transactions/12345")
     @Schema(description = "mandate return url", required = true, example = "https://service-name.gov.uk/transactions/12345")
     public String getReturnUrl() {
         return returnUrl;
     }
 
-    @ApiModelProperty(value = "mandate reference", example = "test_service_reference")
     @Schema(description = "mandate reference", example = "test_service_reference")
     public String getReference() {
         return reference;

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/DirectDebitPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/DirectDebitPayment.java
@@ -2,7 +2,6 @@ package uk.gov.pay.api.model.directdebit.mandates;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.DirectDebitPaymentState;
 import uk.gov.pay.api.model.Payment;
@@ -18,9 +17,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 import static uk.gov.pay.api.model.directdebit.DirectDebitPaymentLinks.DirectDebitPaymentLinksBuilder.aDirectDebitPaymentLinks;
 import static uk.gov.pay.api.model.directdebit.mandates.DirectDebitPayment.DirectDebitPaymentBuilder.aDirectDebitPayment;
 
-
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
-@ApiModel(value = "DirectDebitPayment")
 @Schema(description = "DirectDebitPayment")
 public class DirectDebitPayment extends Payment {
 

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateError.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateError.java
@@ -1,15 +1,12 @@
 package uk.gov.pay.api.model.directdebit.mandates;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static com.google.common.collect.ObjectArrays.concat;
 import static java.lang.String.format;
 
-@ApiModel(value = "MandateError", description = "A Mandate Error response")
 @Schema(name = "MandateError", description = "A Mandate Error response")
 @JsonInclude(NON_NULL)
 public class MandateError {
@@ -66,19 +63,16 @@ public class MandateError {
         this.description = format(code.getFormat(), concat(fieldName, parameters));
     }
 
-    @ApiModelProperty(example = "return_url")
     @Schema(example = "return_url")
     public String getField() {
         return field;
     }
 
-    @ApiModelProperty(example = "P0102")
     @Schema(example = "P0102")
     public String getCode() {
         return code.value();
     }
 
-    @ApiModelProperty(example = "Invalid attribute value: return_url. Must be a valid url.")
     @Schema(example = "Invalid attribute value: return_url. Must be a valid url.")
     public String getDescription() {
         return description;

--- a/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/directdebit/mandates/MandateResponse.java
@@ -2,7 +2,6 @@ package uk.gov.pay.api.model.directdebit.mandates;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.directdebit.MandateLinks;
 import uk.gov.pay.api.service.PublicApiUriGenerator;
@@ -47,77 +46,65 @@ public class MandateResponse {
         this.payer = mandate.getPayer();
     }
 
-    @ApiModelProperty(value = "payer")
     @Schema(description = "payer")
     @JsonProperty(value = "payer")
     public Payer getPayer() {
         return payer;
     }
 
-    @ApiModelProperty(value = "description")
     @Schema(description = "description", accessMode = READ_ONLY)
     @JsonProperty(value = "description")
     public String getDescription() {
         return description;
     }
 
-    @ApiModelProperty(value = "payment_provider")
     @Schema(description = "payment_provider", accessMode = READ_ONLY)
     @JsonProperty(value = "payment_provider")
     public String getPaymentProvider() {
         return paymentProvider;
     }
     
-    @ApiModelProperty(value = "mandate created date")
     @Schema(description = "mandate created date", accessMode = READ_ONLY)
     @JsonProperty("created_date")
     public String getCreatedDate() {
         return createdDate;
     }
 
-    @ApiModelProperty(value = "mandate id", example = "jhjcvaiqlediuhh23d89hd3")
     @Schema(description = "mandate id", example = "jhjcvaiqlediuhh23d89hd3", accessMode = READ_ONLY)
     @JsonProperty(value = "mandate_id")
     public String getMandateId() {
         return this.mandateId;
     }
 
-    @ApiModelProperty(value = "provider id", example = "jhjcvaiqlediuhh23d89hd3")
     @Schema(description = "provider id", example = "jhjcvaiqlediuhh23d89hd3", accessMode = READ_ONLY)
     @JsonProperty(value = "provider_id")
     public String getProviderId() { return providerId; }
 
-    @ApiModelProperty(value = "service return url", example = "https://service-name.gov.uk/transactions/12345")
     @Schema(description = "service return url", example = "https://service-name.gov.uk/transactions/12345", accessMode = READ_ONLY)
     @JsonProperty("return_url")
     public String getReturnUrl() {
         return returnUrl;
     }
 
-    @ApiModelProperty(value = "mandate state", example = "CREATED")
     @Schema(description = "mandate state")
     @JsonProperty(value = "state")
     public MandateStatus getState() {
         return state;
     }
 
-    @ApiModelProperty(value = "links")
     @Schema(name = "_links", description = "payment, events, self and next links of a Mandate")
     @JsonProperty(value = "_links")
     public MandateLinks getLinks() {
         return links;
     }
 
-    @ApiModelProperty(value = "service reference", example = "jhjcvaiqlediuhh23d89hd3")
     @Schema(description = "service reference", example = "jhjcvaiqlediuhh23d89hd3", accessMode = READ_ONLY)
     @JsonProperty(value = "reference")
     public String getReference() { return reference; }
 
-    @ApiModelProperty(value = "This value comes from GoCardless when a mandate has been created.")
     @Schema(description = "This value comes from GoCardless when a mandate has been created.", accessMode = READ_ONLY)
     @JsonProperty(value = "bank_statement_reference")
     public String getMandateReference() {
         return mandateReference;
     }
-
 }

--- a/src/main/java/uk/gov/pay/api/model/links/Link.java
+++ b/src/main/java/uk/gov/pay/api/model/links/Link.java
@@ -2,8 +2,6 @@ package uk.gov.pay.api.model.links;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Objects;
@@ -11,7 +9,6 @@ import java.util.Objects;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
-@ApiModel(value = "Link", description = "A link related to a payment")
 @Schema(name = "Link", description = "A link related to a payment")
 @JsonInclude(Include.NON_NULL)
 public class Link {
@@ -34,12 +31,10 @@ public class Link {
 
     public Link() {}
 
-    @ApiModelProperty(example = "https://an.example.link/from/payment/platform")
     public String getHref() {
         return href;
     }
 
-    @ApiModelProperty(example = "GET")
     public String getMethod() {
         return method;
     }

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentEventLink.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentEventLink.java
@@ -1,13 +1,10 @@
 package uk.gov.pay.api.model.links;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import static javax.ws.rs.HttpMethod.GET;
 
-@ApiModel(value = "PaymentEventLink", description = "Resource link for a payment of a payment event")
 @Schema(name = "PaymentEventLink", description = "Resource link for a payment of a payment event")
 public class PaymentEventLink {
 
@@ -21,7 +18,6 @@ public class PaymentEventLink {
         this.paymentLink = new Link(href, GET);
     }
 
-    @ApiModelProperty(value = PAYMENT_LINK, dataType = "uk.gov.pay.api.model.links.Link")
     @Schema(name = PAYMENT_LINK)
     public Link getPaymentLink() {
         return paymentLink;

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentLinks.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.api.model.links;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 
@@ -11,7 +9,6 @@ import java.util.List;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 
-@ApiModel(value = "PaymentLinks", description = "links for payment")
 @Schema(name = "PaymentLinks", description = "links for payment")
 public class PaymentLinks {
 
@@ -44,37 +41,30 @@ public class PaymentLinks {
     @JsonProperty(value = CAPTURE)
     private PostLink capture;
 
-    @ApiModelProperty(value = SELF, dataType = "uk.gov.pay.api.model.links.Link")
     public Link getSelf() {
         return self;
     }
 
-    @ApiModelProperty(value = NEXT_URL, dataType = "uk.gov.pay.api.model.links.Link")
     public Link getNextUrl() {
         return nextUrl;
     }
 
-    @ApiModelProperty(value = NEXT_URL_POST, dataType = "uk.gov.pay.api.model.links.PostLink")
     public PostLink getNextUrlPost() {
         return nextUrlPost;
     }
 
-    @ApiModelProperty(value = EVENTS, dataType = "uk.gov.pay.api.model.links.Link")
     public Link getEvents() {
         return events;
     }
 
-    @ApiModelProperty(value = REFUNDS, dataType = "uk.gov.pay.api.model.links.Link")
     public Link getRefunds() {
         return refunds;
     }
 
-    @ApiModelProperty(value = CANCEL, dataType = "uk.gov.pay.api.model.links.PostLink")
     public PostLink getCancel() {
         return cancel;
     }
 
-    @ApiModelProperty(value = CAPTURE, dataType = "uk.gov.pay.api.model.links.PostLink")
     public PostLink getCapture() {
         return capture;
     }

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentLinksForEvents.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentLinksForEvents.java
@@ -1,13 +1,10 @@
 package uk.gov.pay.api.model.links;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import static javax.ws.rs.HttpMethod.GET;
 
-@ApiModel(value = "PaymentLinksForEvents", description = "links for events resource")
 @Schema(name = "PaymentLinksForEvents", description = "links for events resource")
 public class PaymentLinksForEvents {
 
@@ -16,7 +13,6 @@ public class PaymentLinksForEvents {
     @JsonProperty(value = SELF)
     private Link self;
 
-    @ApiModelProperty(value = SELF, dataType = "uk.gov.pay.api.model.links.Link")
     @Schema(description = SELF)
     public Link getSelf() {
         return self;

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentLinksForSearch.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentLinksForSearch.java
@@ -1,14 +1,11 @@
 package uk.gov.pay.api.model.links;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 
-@ApiModel(value = "PaymentLinksForSearch", description = "links for search payment resource")
 @Schema(name = "PaymentLinksForSearch", description = "links for search payment resource")
 public class PaymentLinksForSearch {
 
@@ -33,27 +30,22 @@ public class PaymentLinksForSearch {
     @JsonProperty(value = CAPTURE)
     private PostLink capture;
 
-    @ApiModelProperty(value = SELF, dataType = "uk.gov.pay.api.model.links.Link")
     public Link getSelf() {
         return self;
     }
 
-    @ApiModelProperty(value = CANCEL, dataType = "uk.gov.pay.api.model.links.PostLink")
     public PostLink getCancel() {
         return cancel;
     }
 
-    @ApiModelProperty(value = EVENTS, dataType = "uk.gov.pay.api.model.links.Link")
     public Link getEvents() {
         return events;
     }
 
-    @ApiModelProperty(value = REFUNDS, dataType = "uk.gov.pay.api.model.links.Link")
     public Link getRefunds() {
         return refunds;
     }
 
-    @ApiModelProperty(value = CAPTURE, dataType = "uk.gov.pay.api.model.links.PostLink")
     @Schema(name = CAPTURE, implementation = PostLink.class)
     public Link getCapture() {
         return capture;

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -2,18 +2,16 @@ package uk.gov.pay.api.model.links;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.CardPayment;
 import uk.gov.pay.api.model.Charge;
-import uk.gov.pay.api.model.directdebit.mandates.DirectDebitPayment;
 import uk.gov.pay.api.model.Payment;
 import uk.gov.pay.api.model.PaymentConnectorResponseLink;
+import uk.gov.pay.api.model.PaymentSettlementSummary;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
-import uk.gov.pay.api.model.PaymentSettlementSummary;
 import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.api.model.directdebit.mandates.DirectDebitPayment;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
@@ -22,7 +20,6 @@ import java.util.List;
 
 import static uk.gov.pay.api.model.Payment.LINKS_JSON_ATTRIBUTE;
 
-@ApiModel
 public class PaymentWithAllLinks {
 
     @JsonUnwrapped
@@ -31,12 +28,10 @@ public class PaymentWithAllLinks {
     @JsonProperty(LINKS_JSON_ATTRIBUTE)
     private PaymentLinks links = new PaymentLinks();
 
-    @ApiModelProperty(name = LINKS_JSON_ATTRIBUTE, dataType = "uk.gov.pay.api.model.links.PaymentLinks")
     public PaymentLinks getLinks() {
         return links;
     }
 
-    @ApiModelProperty // don't name this property (so it is generated in docs unwrapped)
     public Payment getPayment() {
         return payment;
     }

--- a/src/main/java/uk/gov/pay/api/model/links/PostLink.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PostLink.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.api.model.links;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Map;
@@ -11,7 +9,6 @@ import java.util.Objects;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
-@ApiModel(value = "PostLink", description = "A POST link related to a payment")
 @Schema(name = "PostLink", description = "A POST link related to a payment")
 @JsonInclude(Include.NON_NULL)
 public class PostLink extends Link {
@@ -29,19 +26,16 @@ public class PostLink extends Link {
         super(href, method);
     }
 
-    @ApiModelProperty(example = "POST")
     @Schema(example = "POST", accessMode = READ_ONLY)
     public String getMethod() {
         return super.getMethod();
     }
 
-    @ApiModelProperty(example = "application/x-www-form-urlencoded")
     @Schema(example = "application/x-www-form-urlencoded")
     public String getType() {
         return type;
     }
 
-    @ApiModelProperty(example = "\"description\":\"This is a value for a parameter called description\"")
     @Schema(example = "{\"description\": \"This is a value for a parameter called description\"}")
     public Map<String, Object> getParams() {
         return params;

--- a/src/main/java/uk/gov/pay/api/model/links/RefundLinksForSearch.java
+++ b/src/main/java/uk/gov/pay/api/model/links/RefundLinksForSearch.java
@@ -1,13 +1,10 @@
 package uk.gov.pay.api.model.links;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import static javax.ws.rs.HttpMethod.GET;
 
-@ApiModel(value = "RefundLinksForSearch", description = "links for search refunds resource")
 @Schema(name = "RefundLinksForSearch", description = "links for search refunds resource")
 public class RefundLinksForSearch {
 
@@ -17,14 +14,12 @@ public class RefundLinksForSearch {
     private Link self;
     private Link payment;
 
-    @ApiModelProperty(value = SELF, dataType = "uk.gov.pay.api.model.links.Link")
     @Schema(description = "self")
     @JsonProperty(value = SELF)
     public Link getSelf() {
         return self;
     }
 
-    @ApiModelProperty(value = PAYMENT, dataType = "uk.gov.pay.api.model.links.Link")
     @Schema(description = "payment")
     @JsonProperty(value = PAYMENT)
     public Link getPayment() {

--- a/src/main/java/uk/gov/pay/api/model/links/SearchNavigationLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/SearchNavigationLinks.java
@@ -1,10 +1,8 @@
 package uk.gov.pay.api.model.links;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@ApiModel(value = "SearchNavigationLinks", description = "Links to navigate through pages")
 @Schema(name = "SearchNavigationLinks", description = "Links to navigate through pages")
 public class SearchNavigationLinks {
 

--- a/src/main/java/uk/gov/pay/api/model/links/directdebit/MandateLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/directdebit/MandateLinks.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.api.model.links.directdebit;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 import uk.gov.pay.api.model.links.Link;
@@ -13,7 +11,6 @@ import java.util.List;
 
 import static javax.ws.rs.HttpMethod.GET;
 
-@ApiModel(value = "MandateLinks", description = "payment, events, self and next links of a Mandate")
 @Schema(name = "MandateLinks", description = "payment, events, self and next links of a Mandate")
 public class MandateLinks {
 
@@ -35,35 +32,29 @@ public class MandateLinks {
     @JsonProperty(PAYMENTS)
     private final Link payments;
     
-    @ApiModelProperty(hidden = true)
     @Schema(hidden = true)
     @JsonProperty(EVENTS)
     private final Link events;
 
-    @ApiModelProperty(value = SELF, dataType = "uk.gov.pay.api.model.links.Link")
     @Schema(name = SELF, description = "A link related to mandate")
     public Link getSelf() {
         return self;
     }
 
-    @ApiModelProperty(value = NEXT_URL, dataType = "uk.gov.pay.api.model.links.Link")
     @Schema(name = NEXT_URL, description = "A link related to mandate")
     public Link getNextUrl() {
         return nextUrl;
     }
 
-    @ApiModelProperty(value = NEXT_URL_POST, dataType = "uk.gov.pay.api.model.links.PostLink")
     public PostLink getNextUrlPost() {
         return nextUrlPost;
     }
 
-    @ApiModelProperty(value = PAYMENTS, dataType = "uk.gov.pay.api.model.links.Link")
     @Schema(name = PAYMENTS, description = "A link related to payments")
     public Link getPayments() {
         return payments;
     }
 
-    @ApiModelProperty(value = EVENTS, dataType = "uk.gov.pay.api.model.links.Link", hidden = true)
     @Schema(hidden = true)
     public Link getEvents() {
         return events;

--- a/src/main/java/uk/gov/pay/api/model/search/card/GetPaymentResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/GetPaymentResult.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.api.model.search.card;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.CardPayment;
 import uk.gov.pay.api.model.PaymentSettlementSummary;
@@ -14,11 +12,9 @@ import uk.gov.service.payments.commons.model.SupportedLanguage;
 /**
  * Defines swagger specs for Get payment
  */
-@ApiModel
 public class GetPaymentResult extends CardPayment {
 
     @JsonProperty(LINKS_JSON_ATTRIBUTE)
-    @ApiModelProperty(name = LINKS_JSON_ATTRIBUTE, dataType = "uk.gov.pay.api.model.links.PaymentLinks")
     private PaymentLinks links;
 
     public GetPaymentResult(String chargeId, long amount, PaymentState state, String returnUrl, String description,

--- a/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.api.model.search.card;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.CardPayment;
@@ -18,7 +16,6 @@ import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 import java.net.URI;
 import java.util.List;
 
-@ApiModel(value = "PaymentDetailForSearch")
 @Schema(name = "PaymentDetailForSearch")
 public class PaymentForSearchResult extends CardPayment {
 
@@ -85,7 +82,6 @@ public class PaymentForSearchResult extends CardPayment {
                 paymentResult.getNetAmount());
     }
 
-    @ApiModelProperty(name = LINKS_JSON_ATTRIBUTE, dataType = "uk.gov.pay.api.model.links.PaymentLinksForSearch")
     public PaymentLinksForSearch getLinks() {
         return links;
     }

--- a/src/main/java/uk/gov/pay/api/model/search/card/PaymentSearchResults.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/PaymentSearchResults.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.api.model.search.card;
 
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.SearchNavigationLinks;
 import uk.gov.pay.api.model.search.SearchPagination;
@@ -12,17 +11,13 @@ import java.util.List;
  */
 public class PaymentSearchResults implements SearchPagination {
 
-    @ApiModelProperty(name = "total", example = "100")
     @Schema(name = "total", example = "100")
     private int total;
-    @ApiModelProperty(name = "count", example = "20")
     @Schema(name = "count", example = "20")
     private int count;
-    @ApiModelProperty(name = "page", example = "1")
     @Schema(name = "page", example = "1")
     private int page;
     private List<PaymentForSearchResult> results;
-    @ApiModelProperty(name = "_links")
     @Schema(name = "_links")
     SearchNavigationLinks links;
 
@@ -42,7 +37,6 @@ public class PaymentSearchResults implements SearchPagination {
         return page;
     }
 
-    @ApiModelProperty(name = "results")
     @Schema(name = "results")
     public List<PaymentForSearchResult> getPayments() {
         return results;

--- a/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
@@ -2,8 +2,6 @@ package uk.gov.pay.api.model.search.card;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.RefundSettlementSummary;
 import uk.gov.pay.api.model.ledger.RefundTransactionFromLedger;
@@ -14,17 +12,14 @@ import java.net.URI;
 import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@ApiModel(value = "RefundDetailForSearch")
 @Schema(name = "RefundDetailForSearch")
 public class RefundForSearchRefundsResult {
 
     @JsonProperty("refund_id")
-    @ApiModelProperty(example = "act4c33g40j3edfmi8jknab84x")
     @Schema(example = "act4c33g40j3edfmi8jknab84x", accessMode = READ_ONLY)
     private String refundId;
 
     @JsonProperty("created_date")
-    @ApiModelProperty(example = "2017-01-10T16:52:07.855Z")
     @Schema(example = "2017-01-10T16:52:07.855Z", accessMode = READ_ONLY)
     private String createdDate;
 
@@ -35,7 +30,6 @@ public class RefundForSearchRefundsResult {
     private RefundLinksForSearch links = new RefundLinksForSearch();
 
     @JsonProperty("status")
-    @ApiModelProperty(example = "success", allowableValues = "submitted,success,error")
     @Schema(example = "success", allowableValues = {"submitted", "success", "error"}, accessMode = READ_ONLY)
     private String status;
 
@@ -71,7 +65,6 @@ public class RefundForSearchRefundsResult {
     }
 
     @JsonProperty("payment_id")
-    @ApiModelProperty(example = "2q1r18djndhsrm3closjqr81fx", hidden = true)
     @Schema(hidden = true)
     public String getChargeId() {
         return chargeId;
@@ -90,19 +83,16 @@ public class RefundForSearchRefundsResult {
     }
 
     @JsonProperty("amount")
-    @ApiModelProperty(example = "120")
     @Schema(example = "120", accessMode = READ_ONLY)
     public Long getAmount() {
         return amount;
     }
 
-    @ApiModelProperty(dataType = "uk.gov.pay.api.model.links.RefundLinksForSearch")
     @JsonProperty("_links")
     public RefundLinksForSearch getLinks() {
         return links;
     }
 
-    @ApiModelProperty(dataType = "uk.gov.pay.api.model.RefundSettlementSummary")
     @JsonProperty("settlement_summary")
     @Schema(accessMode = READ_ONLY)
     public RefundSettlementSummary getSettlementSummary() {

--- a/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchResult.java
@@ -1,30 +1,23 @@
 package uk.gov.pay.api.model.search.card;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.RefundLinksForSearch;
 
 import java.util.List;
 
-@ApiModel
 public class RefundForSearchResult {
 
-    @ApiModelProperty(name = "payment_id", example = "hu20sqlact5260q2nanm0q8u93")
     @Schema(name = "payment_id", example = "hu20sqlact5260q2nanm0q8u93")
     private String paymentId;
-    @ApiModelProperty(name = "_links")
     @Schema(name = "_links")
     private RefundLinksForSearch links;
     @JsonProperty(value = "_embedded")
     @Schema(name = "_embedded")
     private Embedded embedded;
 
-    @ApiModel(value = "EmbeddedRefunds")
     @Schema(name = "EmbeddedRefunds")
     public class Embedded {
-        @ApiModelProperty
         private List<RefundResult> refunds;
 
         public List<RefundResult> getRefunds() {

--- a/src/main/java/uk/gov/pay/api/model/search/card/RefundResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/RefundResult.java
@@ -1,19 +1,14 @@
 package uk.gov.pay.api.model.search.card;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.RefundLinksForSearch;
 
-@ApiModel(value = "Refund")
 @Schema(name = "Refund")
 public class RefundResult {
 
-    @ApiModelProperty
     @JsonUnwrapped
     private RefundForSearchRefundsResult refunds;
-    @ApiModelProperty(name = "_links")
     @Schema(name = "_links")
     private RefundLinksForSearch links;
 

--- a/src/main/java/uk/gov/pay/api/model/search/card/SearchRefundsResults.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/SearchRefundsResults.java
@@ -3,31 +3,23 @@ package uk.gov.pay.api.model.search.card;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.SearchNavigationLinks;
 import uk.gov.pay.api.model.search.SearchPagination;
 
 import java.util.List;
 
-@ApiModel(value = "RefundSearchResults")
 @Schema(name = "RefundSearchResults")
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class SearchRefundsResults implements SearchPagination {
 
-    @ApiModelProperty(name = "total", example = "100")
     @Schema(example = "100")
     private int total;
-    @ApiModelProperty(name = "count", example = "20")
     @Schema(example = "20")
     private int count;
-    @ApiModelProperty(name = "page", example = "1")
     @Schema(example = "1")
     private int page;
-    @ApiModelProperty(name = "results")
     private List<RefundForSearchRefundsResult> results;
-    @ApiModelProperty(name = "_links")
     @JsonProperty("_links")
     private SearchNavigationLinks links;
 

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchMandatesParams.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.api.model.search.directdebit;
 
-import io.swagger.annotations.ApiParam;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.service.payments.commons.validation.ValidDate;
@@ -35,27 +34,23 @@ public class DirectDebitSearchMandatesParams {
     @QueryParam("name")
     private String name;
 
-    @ApiParam(value = "From date of mandates to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z")
     @Parameter(description = "From date of mandates to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z")
     @QueryParam("from_date")
     @ValidDate()
     private String fromDate;
 
     @QueryParam("to_date")
-    @ApiParam(value = "To date of mandates to be searched (this date is exclusive). Example=2015-08-13T12:35:00Z")
     @Parameter(description = "To date of mandates to be searched (this date is exclusive). Example=2015-08-13T12:35:00Z")
     @ValidDate()
     private String toDate;
 
     @QueryParam("page")
-    @ApiParam(value = "Page number requested for the search, should be a positive integer (optional, defaults to 1)")
     @Parameter(description = "Page number requested for the search, should be a positive integer (optional, defaults to 1)", schema = @Schema(minimum = "1"))
     @DefaultValue("1")
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     private int page;
 
     @QueryParam("display_size")
-    @ApiParam(value = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)")
     @Parameter(description = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)",
      schema = @Schema(minimum = "1", maximum = "500"))
     @DefaultValue("500")

--- a/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
+++ b/src/main/java/uk/gov/pay/api/model/search/directdebit/DirectDebitSearchPaymentsParams.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.api.model.search.directdebit;
 
-import io.swagger.annotations.ApiParam;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.service.payments.commons.validation.ValidDate;
@@ -18,45 +17,38 @@ import static uk.gov.pay.api.model.CreateDirectDebitPaymentRequest.REFERENCE_MAX
 public class DirectDebitSearchPaymentsParams {
     
     @QueryParam("reference")
-    @ApiParam(value = "Your payment reference to search")
     @Parameter(description = "Your payment reference to search", schema = @Schema(minLength = 1, maxLength = REFERENCE_MAX_LENGTH))
     @Size(min = 1, max = REFERENCE_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     private String reference;
     
     @QueryParam("state")
-    @ApiParam(value = "State of payments to be searched. Example=success")
     @Parameter(description = "State of payments to be searched. Example=success")
     @Pattern(regexp = "created|pending|success|failed|cancelled|paidout|indemnityclaim|error",
             message = "Must be one of created, pending, success, failed, cancelled, paidout, indemnityclaim or error")
     private String state;
     
     @QueryParam("mandate_id")
-    @ApiParam(value = "The GOV.UK Pay identifier for the mandate")
     @Parameter(description = "The GOV.UK Pay identifier for the mandate", schema = @Schema(minLength = 1, maxLength = MANDATE_ID_MAX_LENGTH))
     @Size(min = 1, max = MANDATE_ID_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     private String mandateId;
     
     @QueryParam("from_date")
-    @ApiParam(value = "From date of Direct Debit payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z")
     @Parameter(description = "From date of Direct Debit payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z")
     @ValidDate
     private String fromDate;
     
     @QueryParam("to_date")
-    @ApiParam(value = "To date of Direct Debit payments to be searched (this date is exclusive). Example=2015-08-13T12:35:00Z")
     @Parameter(description = "To date of Direct Debit payments to be searched (this date is exclusive). Example=2015-08-13T12:35:00Z")
     @ValidDate
     private String toDate;
     
     @QueryParam("page")
-    @ApiParam(value = "Page number requested for the search, should be a positive integer (optional, defaults to 1)")
     @Parameter(description = "Page number requested for the search, should be a positive integer (optional, defaults to 1)",
             schema = @Schema(minimum = "1"))
     @Min(value = 1, message = "Must be greater than or equal to {value}")
     private Integer page;
     
     @QueryParam("display_size")
-    @ApiParam(value = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)")
     @Parameter(description = "Number of results to be shown per page, should be a positive integer (optional, defaults to 500, max 500)",
             schema = @Schema(minimum = "1", maximum = "500"))
     @Min(value = 1, message = "Must be greater than or equal to {value}")

--- a/src/main/java/uk/gov/pay/api/resources/DirectDebitEventsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/DirectDebitEventsResource.java
@@ -4,7 +4,6 @@ import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.auth.Auth;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.links.directdebit.DirectDebitEventsResponse;
-import uk.gov.pay.api.resources.error.ApiErrorResponse;
 import uk.gov.pay.api.service.ConnectorUriGenerator;
 import uk.gov.pay.api.service.DirectDebitEventService;
 import uk.gov.pay.api.validation.DirectDebitEventSearchValidator;
@@ -16,7 +15,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import java.time.ZonedDateTime;
-import java.util.List;
 import java.util.Optional;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;

--- a/src/main/java/uk/gov/pay/api/resources/error/ApiErrorResponse.java
+++ b/src/main/java/uk/gov/pay/api/resources/error/ApiErrorResponse.java
@@ -1,14 +1,11 @@
 package uk.gov.pay.api.resources.error;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static java.lang.String.format;
 
-@ApiModel(value = "ErrorResponse", description = "An error response")
 @Schema(name = "ErrorResponse", description = "An error response")
 @JsonInclude(NON_NULL)
 public class ApiErrorResponse {
@@ -46,13 +43,11 @@ public class ApiErrorResponse {
         this.description = format(code.getFormat(), parameters);
     }
 
-    @ApiModelProperty(example = "P0900")
     @Schema(example = "P0900")
     public String getCode() {
         return code.value();
     }
 
-    @ApiModelProperty(example = "Too many requests")
     @Schema(example = "Too many requests")
     public String getDescription() {
         return description;


### PR DESCRIPTION
## WHAT YOU DID
- Remove swagger annotations from models
- Removed `swagger-jersey2-jaxrs` library as it is no longer needed
