### PR TITLE
PP-7896 Update deprecated class 

### DIFF
--- a/src/main/java/uk/gov/pay/api/ledger/model/TransactionSearchResults.java
+++ b/src/main/java/uk/gov/pay/api/ledger/model/TransactionSearchResults.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.api.ledger.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.api.model.links.SearchNavigationLinks;
 import uk.gov.pay.api.model.search.SearchPagination;
@@ -9,7 +9,7 @@ import uk.gov.pay.api.model.search.card.PaymentForSearchResult;
 
 import java.util.List;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TransactionSearchResults implements SearchPagination {
 
     private int total;

--- a/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
@@ -3,7 +3,7 @@ package uk.gov.pay.api.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.api.model.telephone.PaymentOutcome;
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ChargeFromResponse {
     
     private String chargeId;

--- a/src/main/java/uk/gov/pay/api/model/RefundResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundResponse.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.ledger.RefundTransactionFromLedger;
@@ -12,7 +12,7 @@ import java.net.URI;
 
 import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Schema(name = "Refund")
 public class RefundResponse {
 

--- a/src/main/java/uk/gov/pay/api/model/TransactionEvents.java
+++ b/src/main/java/uk/gov/pay/api/model/TransactionEvents.java
@@ -1,13 +1,13 @@
 package uk.gov.pay.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TransactionEvents {
 
     private String transactionId;

--- a/src/main/java/uk/gov/pay/api/model/ledger/RefundTransactionFromLedger.java
+++ b/src/main/java/uk/gov/pay/api/model/ledger/RefundTransactionFromLedger.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.api.model.ledger;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.api.model.RefundSettlementSummary;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RefundTransactionFromLedger {
 

--- a/src/main/java/uk/gov/pay/api/model/ledger/RefundsFromLedger.java
+++ b/src/main/java/uk/gov/pay/api/model/ledger/RefundsFromLedger.java
@@ -1,12 +1,12 @@
 package uk.gov.pay.api.model.ledger;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import java.util.List;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RefundsFromLedger {
 

--- a/src/main/java/uk/gov/pay/api/model/ledger/TransactionState.java
+++ b/src/main/java/uk/gov/pay/api/model/ledger/TransactionState.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.api.model.ledger;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TransactionState {
 

--- a/src/main/java/uk/gov/pay/api/model/publicauth/AuthResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/publicauth/AuthResponse.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.api.model.publicauth;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.api.model.TokenPaymentType;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AuthResponse {
 

--- a/src/main/java/uk/gov/pay/api/model/search/card/SearchRefundsResults.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/SearchRefundsResults.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.api.model.search.card;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.SearchNavigationLinks;
@@ -10,7 +10,7 @@ import uk.gov.pay.api.model.search.SearchPagination;
 import java.util.List;
 
 @Schema(name = "RefundSearchResults")
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SearchRefundsResults implements SearchPagination {
 
     @Schema(example = "100")

--- a/src/main/java/uk/gov/pay/api/model/telephone/CreateTelephonePaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/telephone/CreateTelephonePaymentRequest.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.api.model.telephone;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.api.utils.JsonStringBuilder;
 import uk.gov.pay.api.validation.ValidCardExpiryDate;
@@ -17,7 +17,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.Optional;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CreateTelephonePaymentRequest {
 
     public static final int REFERENCE_MAX_LENGTH = 255;

--- a/src/main/java/uk/gov/pay/api/model/telephone/Supplemental.java
+++ b/src/main/java/uk/gov/pay/api/model/telephone/Supplemental.java
@@ -2,12 +2,12 @@ package uk.gov.pay.api.model.telephone;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import java.util.Optional;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Supplemental {
     
     @JsonProperty("error_code")

--- a/src/main/java/uk/gov/pay/api/model/telephone/TelephonePaymentResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/telephone/TelephonePaymentResponse.java
@@ -2,14 +2,14 @@ package uk.gov.pay.api.model.telephone;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.api.model.ChargeFromResponse;
 import uk.gov.pay.api.model.PaymentState;
 
 import java.util.Optional;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TelephonePaymentResponse {
     
     private Long amount;

--- a/src/main/java/uk/gov/pay/api/resources/MandatesResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/MandatesResource.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
@@ -66,15 +67,15 @@ public class MandatesResource {
                     "The Authorisation token needs to be specified in the 'Authorization' header " +
                     "as 'Authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+                    @ApiResponse(responseCode = "200", description = "OK",
                             content = @Content(schema = @Schema(implementation = MandateResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                    @ApiResponse(responseCode = "401",
                             description = "Credentials are required to access this resource"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
+                    @ApiResponse(responseCode = "404", description = "Not found",
                             content = @Content(schema = @Schema(implementation = MandateError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = "Too many requests",
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = "Downstream system error",
                             content = @Content(schema = @Schema(implementation = MandateError.class)))
             }
     )
@@ -97,18 +98,18 @@ public class MandatesResource {
                     "The Authorisation token needs to be specified in the 'Authorization' header " +
                     "as 'Authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+                    @ApiResponse(responseCode = "200", description = "OK",
                             content = @Content(schema = @Schema(implementation = SearchMandateResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                    @ApiResponse(responseCode = "401",
                             description = "Credentials are required to access this resource"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
+                    @ApiResponse(responseCode = "404", description = "Not found",
                             content = @Content(schema = @Schema(implementation = MandateError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422", 
+                    @ApiResponse(responseCode = "422", 
                             description = "Invalid parameters: from_date, to_date, state, page, display_size. See Public API documentation for the correct data formats",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = "Too many requests",
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = "Downstream system error",
                             content = @Content(schema = @Schema(implementation = MandateError.class)))
             }
     )
@@ -133,15 +134,15 @@ public class MandatesResource {
                     "The Authorisation token needs to be specified in the 'Authorization' header " +
                     "as 'Authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Created",
+                    @ApiResponse(responseCode = "201", description = "Created",
                             content = @Content(schema = @Schema(implementation = MandateResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Bad request",
+                    @ApiResponse(responseCode = "400", description = "Bad request",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                    @ApiResponse(responseCode = "401",
                             description = "Credentials are required to access this resource"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = "Too many requests",
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = "Downstream system error",
                             content = @Content(schema = @Schema(implementation = PaymentError.class)))
             }
     )

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
@@ -84,14 +85,14 @@ public class PaymentRefundsResource {
             description = "Return refunds for a payment. " +
                     "The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+                    @ApiResponse(responseCode = "200", description = "OK",
                             content = @Content(schema = @Schema(implementation = RefundForSearchResult.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Credentials are required to access this resource"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
+                    @ApiResponse(responseCode = "401", description = "Credentials are required to access this resource"),
+                    @ApiResponse(responseCode = "404", description = "Not found",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = "Too many requests",
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = "Downstream system error",
                             content = @Content(schema = @Schema(implementation = PaymentError.class)))
             }
     )
@@ -118,14 +119,14 @@ public class PaymentRefundsResource {
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+                    @ApiResponse(responseCode = "200", description = "OK",
                             content = @Content(schema = @Schema(implementation = RefundResult.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Credentials are required to access this resource"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
+                    @ApiResponse(responseCode = "401", description = "Credentials are required to access this resource"),
+                    @ApiResponse(responseCode = "404", description = "Not found",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = "Too many requests",
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = "Downstream system error",
                             content = @Content(schema = @Schema(implementation = PaymentError.class)))
             }
     )
@@ -156,16 +157,16 @@ public class PaymentRefundsResource {
             description = "Return issued refund information. " +
                     "The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "successful operation",
+                    @ApiResponse(responseCode = "200", description = "successful operation",
                             content = @Content(schema = @Schema(implementation = RefundResult.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "202", description = "ACCEPTED"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Credentials are required to access this resource"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
+                    @ApiResponse(responseCode = "202", description = "ACCEPTED"),
+                    @ApiResponse(responseCode = "401", description = "Credentials are required to access this resource"),
+                    @ApiResponse(responseCode = "404", description = "Not found",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "412", description = "Refund amount available mismatch"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "412", description = "Refund amount available mismatch"),
+                    @ApiResponse(responseCode = "429", description = "Too many requests",
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = "Downstream system error",
                             content = @Content(schema = @Schema(implementation = PaymentError.class)))
             }
     )

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.http.HttpStatus;
@@ -90,15 +91,15 @@ public class PaymentsResource {
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+                    @ApiResponse(responseCode = "200", description = "OK",
                             content = @Content(schema = @Schema(implementation = GetPaymentResult.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                    @ApiResponse(responseCode = "401",
                             description = "Credentials are required to access this resource"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
+                    @ApiResponse(responseCode = "404", description = "Not found",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = "Too many requests",
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = "Downstream system error",
                             content = @Content(schema = @Schema(implementation = PaymentError.class)))
             }
     )
@@ -128,15 +129,15 @@ public class PaymentsResource {
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+                    @ApiResponse(responseCode = "200", description = "OK",
                             content = @Content(schema = @Schema(implementation = PaymentEventsResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                    @ApiResponse(responseCode = "401",
                             description = "Credentials are required to access this resource"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
+                    @ApiResponse(responseCode = "404", description = "Not found",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = "Too many requests",
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = "Downstream system error",
                             content = @Content(schema = @Schema(implementation = PaymentError.class)))
             }
     )
@@ -167,16 +168,16 @@ public class PaymentsResource {
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+                    @ApiResponse(responseCode = "200", description = "OK",
                             content = @Content(schema = @Schema(implementation = PaymentSearchResults.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                    @ApiResponse(responseCode = "401",
                             description = "Credentials are required to access this resource"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422",
+                    @ApiResponse(responseCode = "422",
                             description = "Invalid parameters: from_date, to_date, status, display_size. See Public API documentation for the correct data formats",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = "Too many requests",
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = "Downstream system error",
                             content = @Content(schema = @Schema(implementation = PaymentError.class)))
             }
     )
@@ -252,18 +253,18 @@ public class PaymentsResource {
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Created",
+                    @ApiResponse(responseCode = "201", description = "Created",
                             content = @Content(schema = @Schema(implementation = CreatePaymentResult.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Bad request",
+                    @ApiResponse(responseCode = "400", description = "Bad request",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                    @ApiResponse(responseCode = "401",
                             description = "Credentials are required to access this resource"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422",
+                    @ApiResponse(responseCode = "422",
                             description = "Invalid attribute value: description. Must be less than or equal to 255 characters length",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = "Too many requests",
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = "Downstream system error",
                             content = @Content(schema = @Schema(implementation = PaymentError.class)))
             }
     )
@@ -295,18 +296,18 @@ public class PaymentsResource {
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be cancelled if it's in " +
                     "a state that isn't finished.",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "No Content"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Cancellation of payment failed",
+                    @ApiResponse(responseCode = "204", description = "No Content"),
+                    @ApiResponse(responseCode = "400", description = "Cancellation of payment failed",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                    @ApiResponse(responseCode = "401",
                             description = "Credentials are required to access this resource"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
+                    @ApiResponse(responseCode = "404", description = "Not found",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Conflict",
+                    @ApiResponse(responseCode = "409", description = "Conflict",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = "Too many requests",
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = "Downstream system error",
                             content = @Content(schema = @Schema(implementation = PaymentError.class)))
             }
     )
@@ -332,18 +333,18 @@ public class PaymentsResource {
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'. A payment can only be captured if it's in " +
                     "'submitted' state",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "No Content"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Capture of payment failed",
+                    @ApiResponse(responseCode = "204", description = "No Content"),
+                    @ApiResponse(responseCode = "400", description = "Capture of payment failed",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                    @ApiResponse(responseCode = "401",
                             description = "Credentials are required to access this resource"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
+                    @ApiResponse(responseCode = "404", description = "Not found",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Conflict",
+                    @ApiResponse(responseCode = "409", description = "Conflict",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = "Too many requests",
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = "Downstream system error",
                             content = @Content(schema = @Schema(implementation = PaymentError.class)))
             }
     )

--- a/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchRefundsResource.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
@@ -52,11 +53,11 @@ public class SearchRefundsResource {
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SearchRefundsResults.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Credentials are required to access this resource"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422", description = "Invalid parameters. See Public API documentation for the correct data formats",
+                    @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SearchRefundsResults.class))),
+                    @ApiResponse(responseCode = "401", description = "Credentials are required to access this resource"),
+                    @ApiResponse(responseCode = "422", description = "Invalid parameters. See Public API documentation for the correct data formats",
                             content = @Content(schema = @Schema(implementation = RefundError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = "Downstream system error",
                             content = @Content(schema = @Schema(implementation = RefundError.class))),
             }
     )

--- a/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/directdebit/DirectDebitPaymentsResource.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
@@ -71,18 +72,18 @@ public class DirectDebitPaymentsResource {
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Created",
+                    @ApiResponse(responseCode = "201", description = "Created",
                             content = @Content(schema = @Schema(implementation = DirectDebitPayment.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Bad request",
+                    @ApiResponse(responseCode = "400", description = "Bad request",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", 
+                    @ApiResponse(responseCode = "401", 
                             description = "Credentials are required to access this resource"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422", 
+                    @ApiResponse(responseCode = "422", 
                             description = "Invalid parameters: amount, reference, description, mandate id. See Public API documentation for the correct data formats",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = "Too many requests",
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = "Downstream system error",
                             content = @Content(schema = @Schema(implementation = PaymentError.class)))
             }
     )
@@ -105,16 +106,16 @@ public class DirectDebitPaymentsResource {
                     "The Authorisation token needs to be specified in the 'Authorization' header " +
                     "as 'Authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+                    @ApiResponse(responseCode = "200", description = "OK",
                             content = @Content(schema = @Schema(implementation = DirectDebitSearchResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                    @ApiResponse(responseCode = "401",
                             description = "Credentials are required to access this resource"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "422",
+                    @ApiResponse(responseCode = "422",
                             description = "Invalid parameter. See Public API documentation for the correct data formats",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = "Too many requests",
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = "Downstream system error",
                             content = @Content(schema = @Schema(implementation = PaymentError.class)))
             }
     )
@@ -139,15 +140,15 @@ public class DirectDebitPaymentsResource {
                     "The Authorisation token needs to be specified in the 'Authorization' header " +
                     "as 'Authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK",
+                    @ApiResponse(responseCode = "200", description = "OK",
                             content = @Content(schema = @Schema(implementation = DirectDebitPayment.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401",
+                    @ApiResponse(responseCode = "401",
                             description = "Credentials are required to access this resource"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Not found",
+                    @ApiResponse(responseCode = "404", description = "Not found",
                             content = @Content(schema = @Schema(implementation = PaymentError.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = "Too many requests",
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = "Downstream system error",
                             content = @Content(schema = @Schema(implementation = PaymentError.class)))
             }
     )

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentRefundSearchJsonFixture.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentRefundSearchJsonFixture.java
@@ -3,7 +3,7 @@ package uk.gov.pay.api.it.fixtures;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.api.model.links.Link;
 
@@ -13,7 +13,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(NON_NULL)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PaymentRefundSearchJsonFixture {
 
     @JsonProperty(value = "amount_submitted")

--- a/src/test/java/uk/gov/pay/api/utils/mocks/RefundTransactionFromLedgerFixture.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/RefundTransactionFromLedgerFixture.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.api.utils.mocks;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.api.model.RefundSettlementSummary;
 import uk.gov.pay.api.model.ledger.TransactionState;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RefundTransactionFromLedgerFixture {
     private final Long amount;
     private final TransactionState state;

--- a/src/test/java/uk/gov/pay/api/utils/mocks/TransactionEventFixture.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/TransactionEventFixture.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.api.utils.mocks;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.api.model.PaymentState;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TransactionEventFixture {
     private PaymentState state;
     private String timestamp;

--- a/src/test/java/uk/gov/pay/api/utils/mocks/TransactionFromLedgerFixture.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/TransactionFromLedgerFixture.java
@@ -1,19 +1,19 @@
 package uk.gov.pay.api.utils.mocks;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.PaymentConnectorResponseLink;
+import uk.gov.pay.api.model.PaymentSettlementSummary;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
-import uk.gov.pay.api.model.PaymentSettlementSummary;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TransactionFromLedgerFixture {
     private String transactionId;
     private String returnUrl;


### PR DESCRIPTION
## WHAT YOU DID
- Update deprecated `PropertyNamingStrategy` class to `PropertyNamingStrategies`
- Remove fully qualified annotation `@io.swagger.v3.oas.annotations.responses.ApiResponse` as we no longer have swagger v2 annotations