### PR TITLE
PP-8210 - Return 403 when PSP not linked with gateway account

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <jackson.version>2.12.4</jackson.version>
         <logback.version>1.2.3</logback.version>
         <docker-client.version>8.16.0</docker-client.version>
-        <pay-java-commons.version>1.0.20210705090548</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20210712145710</pay-java-commons.version>
         <junit5.version>5.7.2</junit5.version>
         <pact.version>3.6.15</pact.version>
         <swagger.lib.version>2.1.10</swagger.lib.version>

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -12,6 +12,7 @@ import javax.ws.rs.ext.ExceptionMapper;
 
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static uk.gov.pay.api.model.PaymentError.Code.ACCOUNT_NOT_LINKED_WITH_PSP;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_ACCOUNT_ERROR;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_CONNECTOR_ERROR;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_MANDATE_ID_INVALID;
@@ -56,6 +57,10 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
                 case TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED:
                     statusCode = HttpStatus.FORBIDDEN_403;
                     paymentError = aPaymentError(RESOURCE_ACCESS_FORBIDDEN);
+                    break;
+                case ACCOUNT_NOT_LINKED_WITH_PSP:
+                    statusCode = HttpStatus.FORBIDDEN_403;
+                    paymentError = aPaymentError(ACCOUNT_NOT_LINKED_WITH_PSP);
                     break;
                 default:
                     paymentError = aPaymentError(CREATE_PAYMENT_CONNECTOR_ERROR);

--- a/src/main/java/uk/gov/pay/api/model/PaymentError.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentError.java
@@ -63,7 +63,8 @@ public class PaymentError {
 
         TOO_MANY_REQUESTS_ERROR("P0900", "Too many requests"),
         REQUEST_DENIED_ERROR("P0920", "Request blocked by security rules. Please consult API documentation for more information."),
-        RESOURCE_ACCESS_FORBIDDEN("P0930", "Access to this resource is not enabled for this account. Please contact support.");
+        RESOURCE_ACCESS_FORBIDDEN("P0930", "Access to this resource is not enabled for this account. Please contact support."),
+        ACCOUNT_NOT_LINKED_WITH_PSP("P0940", "Account is not fully configured. Please refer to documentation to setup your account or contact support.");
 
         private String value;
         private String format;

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
@@ -499,6 +499,19 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
     }
 
     @Test
+    public void createPayment_Returns403_WhenGatewayAccountCredentialsNotFullyConfigured() {
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+        connectorMockClient.respondGatewayAccountCredentialNotConfigured(GATEWAY_ACCOUNT_ID);
+        postPaymentResponse(SUCCESS_PAYLOAD)
+                .statusCode(403)
+                .contentType(JSON)
+                .body("code", is("P0940"))
+                .body("description", is("Account is not fully configured. Please refer to documentation to setup your account or contact support."));
+
+        connectorMockClient.verifyCreateChargeConnectorRequest(GATEWAY_ACCOUNT_ID, SUCCESS_PAYLOAD);
+    }
+
+    @Test
     public void createPayment_Returns_WhenPublicAuthInaccessible() {
         publicAuthMockClient.respondWithError();
         postPaymentResponse(SUCCESS_PAYLOAD).statusCode(503);

--- a/src/test/java/uk/gov/pay/api/model/PaymentErrorTest.java
+++ b/src/test/java/uk/gov/pay/api/model/PaymentErrorTest.java
@@ -8,8 +8,7 @@ import static org.hamcrest.core.Is.is;
 public class PaymentErrorTest {
 
     @Test
-    public void shouldGetExpectedValuesWhenToStringIsCalled() {
-
+    void shouldGetExpectedValuesWhenToStringIsCalled() {
         PaymentError paymentError = PaymentError.aPaymentError(PaymentError.Code.CREATE_PAYMENT_ACCOUNT_ERROR);
         assertThat(paymentError.toString(), is("PaymentError{field=null, code=P0199, name=CREATE_PAYMENT_ACCOUNT_ERROR, description='There is an error with this account. Please contact support'}"));
     }

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -7,28 +7,24 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.Address;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.CreateCardPaymentRequestBuilder;
+import uk.gov.pay.api.model.PaymentSettlementSummary;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
-import uk.gov.pay.api.model.PaymentSettlementSummary;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 import uk.gov.pay.api.service.CancelPaymentService;
 import uk.gov.pay.api.service.CapturePaymentService;
-import uk.gov.pay.api.service.ConnectorUriGenerator;
 import uk.gov.pay.api.service.CreatePaymentService;
-import uk.gov.pay.api.service.GetDirectDebitPaymentService;
 import uk.gov.pay.api.service.GetPaymentEventsService;
 import uk.gov.pay.api.service.GetPaymentService;
 import uk.gov.pay.api.service.PaymentSearchService;
 import uk.gov.pay.api.service.PublicApiUriGenerator;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
-import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.Collections;
@@ -46,9 +42,6 @@ public class PaymentsResourceCreatePaymentTest {
     private PaymentsResource paymentsResource;
 
     @Mock
-    private Client client;
-
-    @Mock
     private CreatePaymentService createPaymentService;
 
     @Mock
@@ -56,9 +49,6 @@ public class PaymentsResourceCreatePaymentTest {
 
     @Mock
     private PublicApiUriGenerator publicApiUriGenerator;
-
-    @Mock
-    private ConnectorUriGenerator connectorUriGenerator;
 
     @Mock
     private GetPaymentService getPaymentService;
@@ -72,23 +62,17 @@ public class PaymentsResourceCreatePaymentTest {
     @Mock
     private GetPaymentEventsService getPaymentEventsService;
 
-    @Mock
-    private PublicApiConfig configuration;
-
-    @Mock
-    private GetDirectDebitPaymentService getDirectDebitPaymentService;
-
-    private final String paymentUri = "https://my.link/v1/payments/abc123";
+    private final String PAYMENT_URI = "https://my.link/v1/payments/abc123";
 
     @BeforeEach
     public void setup() {
-        when(publicApiUriGenerator.getPaymentURI(anyString())).thenReturn(URI.create(paymentUri));
+        when(publicApiUriGenerator.getPaymentURI(anyString())).thenReturn(URI.create(PAYMENT_URI));
     }
 
     @Test
-    public void createNewPayment_withCardPayment_invokesCreatePaymentService() {
-        final Account account = new Account("foo", TokenPaymentType.CARD, "a-token-link");
-        final var createPaymentRequest = CreateCardPaymentRequestBuilder.builder()
+    void createNewPayment_withCardPayment_invokesCreatePaymentService() {
+        Account account = new Account("foo", TokenPaymentType.CARD, "a-token-link");
+        var createPaymentRequest = CreateCardPaymentRequestBuilder.builder()
                 .amount(100)
                 .returnUrl("https://somewhere.test")
                 .reference("my_ref")
@@ -99,10 +83,10 @@ public class PaymentsResourceCreatePaymentTest {
 
         when(createPaymentService.create(account, createPaymentRequest)).thenReturn(injectedResponse);
 
-        final Response newPayment = paymentsResource.createNewPayment(account, createPaymentRequest);
+        Response newPayment = paymentsResource.createNewPayment(account, createPaymentRequest);
 
         assertThat(newPayment.getStatus(), is(201));
-        assertThat(newPayment.getLocation(), is(URI.create(paymentUri)));
+        assertThat(newPayment.getLocation(), is(URI.create(PAYMENT_URI)));
         assertThat(newPayment.getEntity(), sameInstance(injectedResponse));
     }
 
@@ -126,11 +110,11 @@ public class PaymentsResourceCreatePaymentTest {
                 new PaymentSettlementSummary(),
                 new CardDetails("9876", "482393", "Anne Onymous", "12/20", cardholderAddress, "visa", null),
                 Collections.emptyList(),
-                URI.create(paymentUri),
-                URI.create(paymentUri + "/events"),
-                URI.create(paymentUri + "/cancel"),
-                URI.create(paymentUri + "/refunds"),
-                URI.create(paymentUri + "/capture"),
+                URI.create(PAYMENT_URI),
+                URI.create(PAYMENT_URI + "/events"),
+                URI.create(PAYMENT_URI + "/cancel"),
+                URI.create(PAYMENT_URI + "/refunds"),
+                URI.create(PAYMENT_URI + "/capture"),
                 null,
                 null,
                 "providerId",

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -50,6 +50,7 @@ import static org.eclipse.jetty.http.HttpStatus.UNPROCESSABLE_ENTITY_422;
 import static uk.gov.pay.api.it.GetPaymentIT.AWAITING_CAPTURE_REQUEST;
 import static uk.gov.pay.api.it.fixtures.PaymentSingleResultBuilder.aSuccessfulSinglePayment;
 import static uk.gov.pay.api.utils.mocks.ChargeResponseFromConnector.ChargeResponseFromConnectorBuilder.aCreateOrGetChargeResponseFromConnector;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.ACCOUNT_NOT_LINKED_WITH_PSP;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.GENERIC;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.MOTO_NOT_ALLOWED;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH;
@@ -322,6 +323,10 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
 
     public void respondTelephoneNotificationsNotEnabled(String gatewayAccountId) {
         mockCreateTelephoneCharge(gatewayAccountId, withStatusAndErrorMessage(FORBIDDEN_403, "anything", TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED));
+    }
+
+    public void respondGatewayAccountCredentialNotConfigured(String gatewayAccountId) {
+        mockCreateCharge(gatewayAccountId, withStatusAndErrorMessage(BAD_REQUEST_400, "Payment provider details are not configured on this account", ACCOUNT_NOT_LINKED_WITH_PSP));
     }
 
     public void respondWithChargeFound(String chargeTokenId, String gatewayAccountId, ChargeResponseFromConnector chargeResponseFromConnector) {


### PR DESCRIPTION
Description:
- Return 403 and error code of P0940 with the description message when we receive 400 from Connector with the error identifier as 'ACCOUNT_NOT_LINKED_WITH_PSP' and the message as 'Payment provider details are not configured on this account'
- Removed 'public' from PaymentErrorTest as methods don't need to be in JUnit 5
- Removed unused emocks in PaymentsResourceCreatePaymentTest