### PR TITLE
PP-8210 - Pact test for gateway account credentials in created

### DIFF
--- a/src/test/resources/pacts/publicapi-connector-create-payment-with-credentials-in-created-not-allowed.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment-with-credentials-in-created-not-allowed.json
@@ -1,0 +1,48 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "a create charge request with gateway account credentials in CREATED state is not allowed",
+      "providerStates": [
+        {
+          "name": "a Worldpay gateway account with id 444 with gateway account credentials with id 555 and valid credentials",
+          "params": {
+            "gateway_account_id": "444"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/v1/api/accounts/444/charges",
+        "body": {
+          "amount": 100,
+          "reference": "a reference",
+          "description": "a description",
+          "return_url": "https://somewhere.gov.uk/rainbow/1"
+        }
+      },
+      "response": {
+        "status": 400,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "error_identifier": "ACCOUNT_NOT_LINKED_WITH_PSP"
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
Description:
- I re-used the state as I only needed a gateway_account_credential in a CREATED state
- Checks if Connector returns 400 when the gateway_account_credential is in a CREATED state