### PR TITLE
PP-8095 Add security.txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,6 @@ For more detailed information you can use our [OpenAPI specifiation](https://git
 
 [MIT License](LICENSE)
 
-## Responsible Disclosure
+## Vulnerability Disclosure
 
-GOV.UK Pay aims to stay secure for everyone. If you are a security researcher and have discovered a security vulnerability in this code, we appreciate your help in disclosing it to us in a responsible manner. We will give appropriate credit to those reporting confirmed issues. Please e-mail gds-team-pay-security@digital.cabinet-office.gov.uk with details of any issue you find, we aim to reply quickly.
+GOV.UK Pay aims to stay secure for everyone. If you are a security researcher and have discovered a security vulnerability in this code, we appreciate your help in disclosing it to us in a responsible manner. Please refer to our [vulnerability disclosure policy](https://www.gov.uk/help/report-vulnerability) and our [security.txt](https://vdp.cabinetoffice.gov.uk/.well-known/security.txt) file for details.

--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -52,6 +52,7 @@ import uk.gov.pay.api.resources.PaymentRefundsResource;
 import uk.gov.pay.api.resources.PaymentsResource;
 import uk.gov.pay.api.resources.RequestDeniedResource;
 import uk.gov.pay.api.resources.SearchRefundsResource;
+import uk.gov.pay.api.resources.SecuritytxtResource;
 import uk.gov.pay.api.resources.directdebit.DirectDebitPaymentsResource;
 import uk.gov.pay.api.resources.telephone.TelephonePaymentNotificationResource;
 import uk.gov.pay.api.validation.InjectingValidationFeature;
@@ -103,6 +104,7 @@ public class PublicApi extends Application<PublicApiConfig> {
         environment.jersey().register(injector.getInstance(TelephonePaymentNotificationResource.class));
         environment.jersey().register(new InjectingValidationFeature(injector));
         environment.jersey().register(injector.getInstance(ReturnUrlValidator.class));
+        environment.jersey().register(injector.getInstance(SecuritytxtResource.class));
 
         environment.jersey().register(injector.getInstance(RateLimiterFilter.class));
         environment.jersey().register(injector.getInstance(LoggingMDCRequestFilter.class));

--- a/src/main/java/uk/gov/pay/api/resources/SecuritytxtResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SecuritytxtResource.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.api.resources;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+
+@Path("/")
+public class SecuritytxtResource {
+
+    // https://gds-way.cloudapps.digital/standards/vulnerability-disclosure.html
+    private static final URI CABINET_OFFICE_SECURITY_TXT = URI.create("https://vdp.cabinetoffice.gov.uk/.well-known/security.txt");
+
+    @GET
+    @Path("/.well-known/security.txt")
+    public Response redirectFromWellKnownSecuritytxt() {
+        return redirectToCabinetOfficeSecuritytxt();
+    }
+
+    @GET
+    @Path("/security.txt")
+    public Response redirectFromSecuritytxt() {
+        return redirectToCabinetOfficeSecuritytxt();
+    }
+
+    private static Response redirectToCabinetOfficeSecuritytxt() {
+        return Response.temporaryRedirect(CABINET_OFFICE_SECURITY_TXT).build();
+    }
+
+}


### PR DESCRIPTION
Make `/.well-known/security.txt` and `/security.txt` redirect to https://vdp.cabinetoffice.gov.uk/.well-known/security.txt.

Update `README.md` to reference the Cabinet Office CDIO Cyber Security vulnerability disclosure policy and security.txt file rather than the GOV.UK Pay security vulnerability email address.