### PR TITLE
PP-8095 Make security.txt require cache revalidation every request

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/SecuritytxtResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SecuritytxtResource.java
@@ -2,8 +2,10 @@ package uk.gov.pay.api.resources;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.core.Response;
 import java.net.URI;
+import java.util.Date;
 
 @Path("/")
 public class SecuritytxtResource {
@@ -24,7 +26,7 @@ public class SecuritytxtResource {
     }
 
     private static Response redirectToCabinetOfficeSecuritytxt() {
-        return Response.temporaryRedirect(CABINET_OFFICE_SECURITY_TXT).build();
+        return Response.temporaryRedirect(CABINET_OFFICE_SECURITY_TXT).cacheControl(CacheControl.valueOf("no-cache")).expires(new Date()).build();
     }
 
 }


### PR DESCRIPTION
Send a `Cache-Control: no-cache` header and an `Expires` header with the current time when redirecting from `/.well-known/security.txt` and `/security.txt`.

Without these headers, clients will use heuristics to decide how long to cache the response for, which could be a problem if we want to update our `security.txt`.