### PR TITLE
PP-8263 Update the `pre-commit` and `detect-secrets` setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/Yelp/detect-secrets
+  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
+  hooks:
+    - id: detect-secrets
+      args: ['--baseline', '.secrets.baseline']
+      exclude: package.lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,19 +1,15 @@
 {
-  "exclude": {
-    "files": null,
-    "lines": null
-  },
-  "generated_at": "2020-11-09T17:15:25Z",
+  "version": "1.1.0",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -22,8 +18,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "IbmCloudIamDetector"
@@ -35,8 +31,8 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
@@ -57,67 +53,108 @@
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
   "results": {
+    ".pre-commit-config.yaml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
     "dev.yml": [
       {
+        "type": "Secret Keyword",
+        "filename": "dev.yml",
         "hashed_secret": "1af17e73721dbe0c40011b82ed4bb1a7dbe3ce29",
         "is_verified": false,
-        "line_number": 7,
-        "type": "Secret Keyword"
+        "line_number": 7
       }
     ],
     "src/test/java/uk/gov/pay/api/filter/AuthorizationValidationFilterTest.java": [
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/api/filter/AuthorizationValidationFilterTest.java",
+        "hashed_secret": "70abceeb20d82fc2d55e8934d1ad05ad17609752",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/api/filter/AuthorizationValidationFilterTest.java",
         "hashed_secret": "a0936a38d2c31ad225d670f529a82319fc5bb915",
         "is_verified": false,
-        "line_number": 79,
-        "type": "Secret Keyword"
-      }
-    ],
-    "src/test/java/uk/gov/pay/api/validation/PaymentSearchValidatorTest.java": [
-      {
-        "hashed_secret": "d4445ee4de67d11803d35527d7ee8aa2af71ebd8",
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Hex High Entropy String"
+        "line_number": 79
       }
     ],
     "src/test/resources/config/empty-elevated-accounts-test-config.yaml": [
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/config/empty-elevated-accounts-test-config.yaml",
         "hashed_secret": "3d4478f77d368235803ceb52bbd45b7240e6af62",
         "is_verified": false,
-        "line_number": 47,
-        "type": "Secret Keyword"
+        "line_number": 47
       }
     ],
     "src/test/resources/config/test-config.yaml": [
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/config/test-config.yaml",
         "hashed_secret": "3d4478f77d368235803ceb52bbd45b7240e6af62",
         "is_verified": false,
-        "line_number": 49,
-        "type": "Secret Keyword"
+        "line_number": 49
       }
     ],
     "src/test/resources/pacts/publicapi-connector-get-payment-refund.json": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/pacts/publicapi-connector-get-payment-refund.json",
         "hashed_secret": "4c39a6a28507c3d7ea6de26da0bd1d27cff4a4af",
         "is_verified": false,
-        "line_number": 25,
-        "type": "Base64 High Entropy String"
-      }
-    ],
-    "src/test/resources/pacts/publicapi-direct-debit-connector-collect-payment.json": [
-      {
-        "hashed_secret": "f92a698c421a80441450d9b38d331391f6221ec5",
-        "is_verified": false,
-        "line_number": 24,
-        "type": "Base64 High Entropy String"
+        "line_number": 25
       }
     ]
   },
-  "version": "0.13.1",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "generated_at": "2021-08-12T14:36:32Z"
 }


### PR DESCRIPTION
## What you did
- Add a local `.pre-commit.yaml`
  - This will run `detect-secrets` when you try to commit a file.
- Update the existing `.secrets.baseline` file
  - To ignore the SHA specified in the `.pre-commit.yaml`

## How to test

- Maake sure the `.pre-commit.yaml` has been added.
- Make sure the `.secrets.baseline` has been updated.
  - This file is automatically updated by using `detect-secrets`.