### PR TITLE
PP-8550 Rate limit requests for low traffic accounts

### DIFF
--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimitManager.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RateLimitManager.java
@@ -6,7 +6,7 @@ import uk.gov.pay.api.filter.RateLimiterKey;
 import javax.ws.rs.HttpMethod;
 
 public class RateLimitManager {
-   
+
     private RateLimiterConfig configuration;
 
     public RateLimitManager(RateLimiterConfig config) {
@@ -14,18 +14,33 @@ public class RateLimitManager {
     }
 
     public int getAllowedNumberOfRequests(RateLimiterKey rateLimiterKey, String account) {
-        if(configuration.getElevatedAccounts().contains(account)) {
-            if(HttpMethod.POST.equals(rateLimiterKey.getMethod())) {
+        if (configuration.getElevatedAccounts().contains(account)) {
+            if (HttpMethod.POST.equals(rateLimiterKey.getMethod())) {
                 return configuration.getNoOfPostReqForElevatedAccounts();
             }
 
             return configuration.getNoOfReqForElevatedAccounts();
         }
 
-        if(HttpMethod.POST.equals(rateLimiterKey.getMethod())) {
+        if (configuration.getLowTrafficAccounts().contains(account)) {
+            if (HttpMethod.POST.equals(rateLimiterKey.getMethod())) {
+                return configuration.getNoOfPostReqForLowTrafficAccounts();
+            }
+            return configuration.getNoOfReqForLowTrafficAccounts();
+        }
+
+        if (HttpMethod.POST.equals(rateLimiterKey.getMethod())) {
             return configuration.getNoOfReqForPost();
         }
-        
+
         return configuration.getNoOfReq();
+    }
+
+    public int getRateLimitInterval(String account) {
+        if (configuration.getLowTrafficAccounts().contains(account)) {
+            return configuration.getIntervalInMillisForLowTrafficAccounts();
+        }
+
+        return configuration.getPerMillis();
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Rate limits requests for low traffic accounts as per the configuration (RATE_LIMITER_LOW_TRAFFIC_ACCOUNTS and related env variables).
	- Number of post requests are defaulted to 1 request per minute and per bucket (capture, create and the rest)
	- Number of get requests allowed will be the same as the rate limit for standard accounts (4500 requests per minute which is equivalent to 75 req per second) but rate limit interval is per minute.
