### PR TITLE
PP-8695 Remove Jenkins deploy step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,14 +144,6 @@ pipeline {
         }
       }
     }
-     stage('Deploy') {
-       when {
-         branch 'master'
-       }
-       steps {
-         deployEcs("publicapi")
-       }
-     }
      stage('Smoke Tests') {
          when { branch 'master' }
          steps { runSmokeTest('smoke-card') }


### PR DESCRIPTION
CI Jenkins no longer needs to deploy Publicapi.

## WHAT YOU DID
Interestingly publicapi didn't seem to be checking pact compatibility before deployment.