### PR TITLE
PP-8466 - Send expire call with increment

### DIFF
--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
@@ -55,11 +55,7 @@ public class RedisRateLimiter {
     synchronized private Long updateAllowance(String key, int rateLimitInterval) {
         String derivedKey = getKeyForWindow(key, rateLimitInterval);
         Long count = redisClientManager.getRedisConnection().sync().incr(derivedKey);
-
-        if (count == 1) {
-            redisClientManager.getRedisConnection().sync().expire(derivedKey, rateLimitInterval / 1000);
-        }
-
+        redisClientManager.getRedisConnection().sync().expire(derivedKey, rateLimitInterval / 1000);
         return count;
     }
 


### PR DESCRIPTION
Description:
- Currently we only send the EXPIRE call when derived key has been created and we now want to send EXPIRE call every time we increment
- The reason for making a change was that in the case that the Redis connection is lost an EXPIRE call may never be sent which has led to an incident where
every minute for a particular second the client is rate-limited
- The options discussed were (1) Send EXPIRE calls when we do an increment, (2) Make the keys unique and (3) Set the NX flag on EXPIRE
- Option (3) is unworkable as AWS Elasticache doesn't support Redis 7.0 currently
- Option (2) is tricky due to finding a granular enough unique identifier to avoid the problem above
- So Option (1) was decided but without the MULTI clause as our library doesn't support it in a thread-safe manner
- Testing: Quite difficult to get the derivedKey directly so an argument matcher was introduced. If the expire call isn't made then there is a Mockito unnecessary
 stubbing exception