### PR TITLE
PP-8844 - Add connect and socket timeout values for Redis

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -134,7 +134,7 @@
         "filename": "src/test/resources/config/empty-elevated-accounts-test-config.yaml",
         "hashed_secret": "3d4478f77d368235803ceb52bbd45b7240e6af62",
         "is_verified": false,
-        "line_number": 50
+        "line_number": 51
       }
     ],
     "src/test/resources/config/test-config.yaml": [
@@ -143,7 +143,7 @@
         "filename": "src/test/resources/config/test-config.yaml",
         "hashed_secret": "3d4478f77d368235803ceb52bbd45b7240e6af62",
         "is_verified": false,
-        "line_number": 52
+        "line_number": 53
       }
     ],
     "src/test/resources/pacts/publicapi-connector-get-payment-refund.json": [
@@ -156,5 +156,5 @@
       }
     ]
   },
-  "generated_at": "2021-10-18T16:01:00Z"
+  "generated_at": "2021-11-24T12:04:57Z"
 }

--- a/src/main/java/uk/gov/pay/api/app/config/RedisConfiguration.java
+++ b/src/main/java/uk/gov/pay/api/app/config/RedisConfiguration.java
@@ -20,14 +20,22 @@ public class RedisConfiguration {
     private boolean ssl;
     
     @Valid
-    @JsonProperty("timeout")
-    private Duration timeout;
+    @JsonProperty("commandTimeout")
+    private Duration commandTimeout;
+
+    @Valid
+    @JsonProperty("connectTimeout")
+    private Duration connectTimeout;
 
     public String getUrl() {
         return format("%s://%s", ssl ? "rediss" : "redis", endpoint);
     }
 
-    public Long getTimeout() {
-        return timeout.toMilliseconds();
+    public Long getCommandTimeout() {
+        return commandTimeout.toMilliseconds();
+    }
+
+    public Long getConnectTimeout() {
+        return connectTimeout.toMilliseconds();
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -56,7 +56,8 @@ rateLimiter:  # rate = noOfReq per perMillis
 redis:
   endpoint: ${REDIS_URL:-localhost:6379}
   ssl: false
-  timeout: 2s
+  commandTimeout: ${REDIS_COMMAND_TIMEOUT:-250ms}
+  connectTimeout: ${REDIS_CONNECT_TIMEOUT:-500ms}
 
 allowHttpForReturnUrl: ${ALLOW_HTTP_FOR_RETURN_URL:-false}
 

--- a/src/test/resources/config/empty-elevated-accounts-test-config.yaml
+++ b/src/test/resources/config/empty-elevated-accounts-test-config.yaml
@@ -43,7 +43,8 @@ rateLimiter:
 redis:
   endpoint: localhost:6379
   ssl: false
-  timeout: 100ms
+  commandTimeout: 250ms
+  connectTimeout: 500ms
 
 allowHttpForReturnUrl: false
 

--- a/src/test/resources/config/empty-low-traffic-accounts-test-config.yaml
+++ b/src/test/resources/config/empty-low-traffic-accounts-test-config.yaml
@@ -43,7 +43,8 @@ rateLimiter:
 redis:
   endpoint: localhost:6379
   ssl: false
-  timeout: 100ms
+  commandTimeout: 250ms
+  connectTimeout: 500ms
 
 allowHttpForReturnUrl: false
 

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -45,7 +45,8 @@ rateLimiter:
 redis:
   endpoint: localhost:6379
   ssl: false
-  timeout: 100ms
+  commandTimeout: 250ms
+  connectTimeout: 500ms
 
 allowHttpForReturnUrl: false
 


### PR DESCRIPTION
Description:
- Added support to specify a socket timeout. Command timeout is when a TCP connection is established to Redis and we are waiting for Redis to process the command. Socket timeout is when a TCP connection isn't established and we are waiting for Redis to respond.

### Local testing of REDIS_COMMAND_TIMEOUT:
- To test that the environment variables do what they are defined I set `REDIS_COMMAND_TIMEOUT=20s` and `REDIS_CONNECT_TIMEOUT=20s`.
- I spun up our local environment and pointed publicapi to a local Redis docker container
- I ran:
```
seq 1 5000 | xargs -I {} -P 500 curl -s -o /dev/null -w "{} = connect %{time_connect} total %{time_total} status_code %{http_code}\n" -H "Authorization: Bearer <api token from above>" http://localhost:9100/v1/payments/<payment id from above>
```
-  which began making requests to publicapi then shortly thereafter I ran `docker stop redis` and a snippet of the results which represents the time when I stopped Redis as follows

```
886 = connect 0.001698 total 4.855643 status_code 200
628 = connect 0.001720 total 7.636339 status_code 200
821 = connect 0.001672 total 5.765302 status_code 200
866 = connect 0.001776 total 5.466552 status_code 200
655 = connect 0.001868 total 7.435139 status_code 200
845 = connect 0.002619 total 5.619233 status_code 200
881 = connect 0.002206 total 4.964343 status_code 200
270 = connect 0.157226 total 15.441112 status_code 200
649 = connect 0.002295 total 7.780905 status_code 200
860 = connect 0.001904 total 20.987590 status_code 429
710 = connect 0.001610 total 22.252105 status_code 429
695 = connect 0.001740 total 22.322062 status_code 429
694 = connect 0.002098 total 22.355100 status_code 429
670 = connect 0.001682 total 22.562804 status_code 429
766 = connect 0.001785 total 21.648938 status_code 429
815 = connect 0.001795 total 21.341459 status_code 429
878 = connect 0.001947 total 20.856304 status_code 429
686 = connect 0.002436 total 22.582132 status_code 200
674 = connect 0.001597 total 22.647884 status_code 200
705 = connect 0.001663 total 22.434690 status_code 200

```
- The change to 20 indicating when I stopped Redis

### Local testing of REDIS_CONNECT_TIMEOUT:
- To test that the environment variables do what they are defined I set `REDIS_COMMAND_TIMEOUT=20s` and `REDIS_CONNECT_TIMEOUT=20s`.
- I spun up our local environment and to simulate connection timeout I ran:

```
docker run --rm -it --network files_default --cap-add=NET_ADMIN --name redis ubuntu  bash
root@d106be36598c:/#apt-get -qq update
root@d106be36598c:/#apt-get install -y iptables
root@d106be36598c:/#iptables -A INPUT -m state --state NEW -j DROP
```
- These then dropped the packets sent from publicapi
- Then I ran the following script:
```#!/bin/bash

OUTPUT_FILE="$1"
if [ -z "$OUTPUT_FILE" ]; then
  echo "Usage: $0 output_file_name"
fi

if [ -s "$OUTPUT_FILE" ]; then
  echo "Deleting existing file: ${OUTPUT_FILE}"
  rm "$OUTPUT_FILE"
fi

API_KEY=<api-key>
PAYMENT_ID=<payment-id>
TMP_RESULTS_FILE="<directory>/results$(date '+%s')"
TOTAL_REQUEST=50
CONCURRENT_REQUESTS=50

function runGetTests {
  seq 1 "$TOTAL_REQUEST" | xargs -I {} -P "$CONCURRENT_REQUESTS" \
    curl -s -o /dev/null \
    -w "%{time_connect} %{time_total} %{http_code}\n" \
    -H "Authorization: Bearer ${API_KEY}" \
    "http://localhost:9100/v1/payments/${PAYMENT_ID}" \
    | tee -a "$TMP_RESULTS_FILE"

  gawk -v concurrent_requests="$CONCURRENT_REQUESTS" '\
    {connect[NR] = $1; total[NR] = $2} \
    END{asort(connect); asort(total); \
    print "Total requests: " NR; \
    print "Concurrent requests: " concurrent_requests ; \
    print "p50 connect: " connect[int(NR*0.5)]; \
    print "p90 connect: " connect[int(NR*0.9)]; \
    print "p50 total: " total[int(NR*0.5)]; \
    print "p90 total: " total[int(NR*0.9)] \
  }' "$TMP_RESULTS_FILE" | tee -a "$OUTPUT_FILE"
}

runGetTests

printf "\n\n\nFinal results:\n\n"
cat "$OUTPUT_FILE"
```

- Which gave the following:
```Final results:

Total requests: 50
Concurrent requests: 50
p50 connect: 0.001711
p90 connect: 0.003762
p50 total: 20.281547
p90 total: 20.362726
```

- Where the total indicate the connect timeout

### Performance testing:
- Testing was done in the performance environment for command timeout with the connect timeout set to `500ms`.
- For a command timeout of 750ms corresponding to Build 31 (started at 03:37:38) no switchover to local rate limiter was present in the logs
- For a command timeout of 250ms corresponding to Build 32 (started at 04:05:31) no switchover to local rate limiter was present in the logs
- For a command timeout of 100ms corresponding to Build 33 (started at 04:40:38) no switchover to local rate limiter was present in the logs
- For a command timeout of 1ms corresponding to Build 35 (started at 05:15:44) a switchover to local rate limiter was present in the logs (i.e. `"Exception occurred checking rate limits using RedisRateLimiter, falling back to LocalRateLimiter"| spath environment | search environment="test-perf-1"` during Monday 29th November 2021)

### Conclusion:
- REDIS_COMMAND_TIMEOUT=250ms and REDIS_CONNECT_TIMEOUT=500ms
- Testing in the performance environment indicated that switching to local rate limiter fell at 1ms <= t < 100ms so 250ms for a command timeout seemed a suitable value
- Since Redis going offline is a rare occasion as discussed 500ms was a reasonable delay.