### PR TITLE
PP-8844 - Remove synchronization for Redis calls

### DIFF
--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
@@ -28,7 +28,7 @@ public class RedisRateLimiter {
     /**
      * @throws RateLimitException
      */
-    synchronized void checkRateOf(String accountId, RateLimiterKey key)
+    void checkRateOf(String accountId, RateLimiterKey key)
             throws RedisException, RateLimitException {
 
         Long count;
@@ -52,7 +52,7 @@ public class RedisRateLimiter {
         }
     }
 
-    synchronized private Long updateAllowance(String key, int rateLimitInterval) {
+    private Long updateAllowance(String key, int rateLimitInterval) {
         String derivedKey = getKeyForWindow(key, rateLimitInterval);
         Long count = redisClientManager.getRedisConnection().sync().incr(derivedKey);
         redisClientManager.getRedisConnection().sync().expire(derivedKey, rateLimitInterval / 1000);


### PR DESCRIPTION
Description:
- As described in the kick off the lettuce library used to talk to Redis already has multithreading support so no concurrency issues will arise
- We are removing the synchronization keyword to prevent publicapi processing requests one at a time in the event the Redis cluster goes offline