### PR TITLE
BAU remove time unit from redis metrics

### DIFF
--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
@@ -59,8 +59,8 @@ public class RedisRateLimiter {
 
     private Long updateAllowance(String key, int rateLimitInterval) throws Exception {
         String derivedKey = getKeyForWindow(key, rateLimitInterval);
-        Long count = time("redis.incr_nanoseconds", () -> redisClientManager.getRedisConnection().sync().incr(derivedKey));
-        time("redis.expire_nanoseconds", () -> redisClientManager.getRedisConnection().sync().expire(derivedKey, rateLimitInterval / 1000));
+        Long count = time("redis.incr", () -> redisClientManager.getRedisConnection().sync().incr(derivedKey));
+        time("redis.expire", () -> redisClientManager.getRedisConnection().sync().expire(derivedKey, rateLimitInterval / 1000));
         return count;
     }
 


### PR DESCRIPTION
Although dropwizard metrics says that timers measure time durations in
nanoseconds, the actual metric value emitted to graphite is determined by the
configuration of the `GraphiteReporter`. Ours is configured in the
[`initialiseMetrics`][1] method.

The setting which controls how time intervals/durations are emitted can be
controlled by the [`convertDurationsTo`][2] method of the builder. Since
we don't specify that when we set this up, it falls back to the default, which
[appears to be Milliseconds][3].

Since the time unit is not controlled at the point that the metric is emitted,
it's better not to specify it in the name of the metric, as it risks causing
confusion at best. All time metrics will use the same unit controlled by the
configuration of the GraphiteReporter.

Therefore, remove the `_nanoseconds` suffix from these metrics.

[1]: https://github.com/alphagov/pay-publicapi/blob/master/src/main/java/uk/gov/pay/api/app/PublicApi.java#L169
[2]: https://github.com/dropwizard/metrics/blob/release/4.2.x/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java#L157
[3]: https://github.com/dropwizard/metrics/blob/release/4.2.x/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java#L83

# How to review

View a [simple dashboard of these metrics](https://www.hostedgraphite.com/07ab03f8/grafana/d/4LTibYh7k/redis-operation-times?orgId=2&from=now-7d&to=now). P99 values hover around 30/40, I can't believe these are measured in nanoseconds.. redis isn't that fast!

As far as I'm aware there are no risky side effects of this change. I don't think we have any alerts set up for these metrics. 