### PR TITLE
PP-8696: Remove unneeded stages from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,19 +144,6 @@ pipeline {
         }
       }
     }
-     stage('Smoke Tests') {
-         when { branch 'master' }
-         steps { runSmokeTest('smoke-card') }
-     }
-     stage('Pact Tag') {
-       when {
-         branch 'master'
-       }
-       steps {
-         echo 'Tagging consumer pact with "test"'
-         tagPact("publicapi", gitCommit(), "test")
-       }
-     }
      stage('Complete') {
        failFast true
        parallel {
@@ -166,14 +153,6 @@ pipeline {
            }
            steps {
              tagDeployment("publicapi")
-           }
-         }
-         stage('Trigger Deploy Notification') {
-           when {
-             branch 'master'
-           }
-           steps {
-             triggerGraphiteDeployEvent("publicapi")
            }
          }
        }


### PR DESCRIPTION
Given Jenkins doesn't do deployment anymore, these stages aren't needed.