### PR TITLE
PP-8945 Allow connector pact tests to pass

### DIFF
--- a/src/test/java/uk/gov/pay/api/service/GetPaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentServiceTest.java
@@ -62,7 +62,7 @@ public class GetPaymentServiceTest {
     
     @Test
     @PactVerification({"connector"})
-    @Pacts(pacts = {"publicapi-connector-get-payment-with-delayed-capture-true"})
+    @Pacts(pacts = {"publicapi-connector-get-created-payment"})
     public void testGetPayment() {
         Account account = new Account(ACCOUNT_ID, TokenPaymentType.CARD, "a-token-link");
 
@@ -99,8 +99,8 @@ public class GetPaymentServiceTest {
     
     @Test
     @PactVerification({"connector"})
-    @Pacts(pacts = {"publicapi-connector-get-payment"})
-    public void testGetPaymentWithCharge() {
+    @Pacts(pacts = {"publicapi-connector-get-capturable-payment"})
+    public void testGetCapturablePaymentWithMetadataAndCorporateSurcharge() {
         Account account = new Account(ACCOUNT_ID, TokenPaymentType.CARD, "a-token-link");
         PaymentWithAllLinks paymentResponse = getPaymentService.getPayment(account, CHARGE_ID);
         
@@ -109,8 +109,6 @@ public class GetPaymentServiceTest {
         assertThat(payment.getProviderId(), is("gateway-tx-123456"));
         assertThat(payment.getCorporateCardSurcharge().get(), is(250L));
         assertThat(payment.getTotalAmount().get(), is(350L));
-        assertThat(payment.getFee().get(), is(5L));
-        assertThat(payment.getNetAmount().get(), is(345L));
         assertThat(paymentResponse.getLinks().getCapture().getHref(),
                 containsString("v1/payments/" + CHARGE_ID + "/capture"));
         assertThat(paymentResponse.getLinks().getCapture().getMethod(), is("POST"));
@@ -119,5 +117,21 @@ public class GetPaymentServiceTest {
         assertThat(paymentResponse.getLinks().getNextUrl(), is(nullValue()));
         assertThat(paymentResponse.getLinks().getNextUrlPost(), is(nullValue()));
         assertThat(payment.getAuthorisationSummary().getThreeDSecure().isRequired(), is(true));
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector-get-payment-with-fee-and-net-amount"})
+    public void testGetPaymentWithFeeAndNetAmount() {
+        Account account = new Account(ACCOUNT_ID, TokenPaymentType.CARD, "a-token-link");
+        PaymentWithAllLinks paymentResponse = getPaymentService.getPayment(account, CHARGE_ID);
+
+        CardPayment payment = (CardPayment) paymentResponse.getPayment();
+
+        assertThat(payment.getProviderId(), is("gateway-tx-123456"));
+        assertThat(payment.getFee().get(), is(5L));
+        assertThat(payment.getNetAmount().get(), is(345L));
+        assertThat(paymentResponse.getLinks().getNextUrl(), is(nullValue()));
+        assertThat(paymentResponse.getLinks().getNextUrlPost(), is(nullValue()));
     }
 }

--- a/src/test/resources/pacts/publicapi-connector-get-capturable-payment.json
+++ b/src/test/resources/pacts/publicapi-connector-get-capturable-payment.json
@@ -7,7 +7,7 @@
   },
   "interactions": [
     {
-      "description": "get charge",
+      "description": "get a delayed capture charge with metadata that is in a capturable status",
       "providerStates": [
         {
           "name": "a charge exists",
@@ -35,8 +35,6 @@
             "some_key": "key"
           },
           "amount": 100,
-          "fee": 5,
-          "net_amount": 345,
           "state": {
             "finished": false,
             "status": "capturable"

--- a/src/test/resources/pacts/publicapi-connector-get-created-payment.json
+++ b/src/test/resources/pacts/publicapi-connector-get-created-payment.json
@@ -7,7 +7,7 @@
   },
   "interactions": [
     {
-      "description": "get a charge request with delayed capture true",
+      "description": "get a charge request for a created payment",
       "providerStates": [
         {
           "name": "a charge with delayed capture true exists",
@@ -124,6 +124,15 @@
             },
             "$.created_date": {
               "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
+            },
+            "$.delayed_capture": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.moto": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.payment_provider": {
+              "matchers": [{"match": "type"}]
             }
           }
         }

--- a/src/test/resources/pacts/publicapi-connector-get-payment-with-fee-and-net-amount.json
+++ b/src/test/resources/pacts/publicapi-connector-get-payment-with-fee-and-net-amount.json
@@ -1,0 +1,130 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "get charge which has a fee and a net amount",
+      "providerStates": [
+        {
+          "name": "a charge with fee and net_amount exists",
+          "params": {
+            "gateway_account_id": "123456",
+            "charge_id": "ch_123abc456def"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/api/accounts/123456/charges/ch_123abc456def"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "amount": 100,
+          "fee": 5,
+          "net_amount": 345,
+          "state": {
+            "finished": true,
+            "status": "success"
+          },
+          "description": "Test description",
+          "reference": "aReference",
+          "language": "en",
+          "links": [
+            {
+              "rel": "self",
+              "method": "GET",
+              "href": "https://connector/v1/api/accounts/123456/charges/ch_123abc456def"
+            },
+            {
+              "rel": "refunds",
+              "method": "GET",
+              "href": "https://connector/v1/api/accounts/123456/charges/ch_123abc456def/refunds"
+            }
+          ],
+          "charge_id": "ch_123abc456def",
+          "gateway_transaction_id": "gateway-tx-123456",
+          "return_url": "https://somewhere.gov.uk/rainbow/1",
+          "payment_provider": "sandbox",
+          "created_date": "2018-10-16T10:46:02.121Z",
+          "refund_summary": {
+            "status": "available",
+            "user_external_id": null,
+            "amount_available": 350,
+            "amount_submitted": 0
+          },
+          "settlement_summary": {
+            "capture_submit_time": null,
+            "captured_date": null
+          },
+          "delayed_capture": false,
+          "moto": false
+        },
+        "matchingRules": {
+          "body": {
+            "$.reference": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.description": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.links[0].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/ch_123abc456def"
+                }
+              ]
+            },
+            "$.links[1].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/ch_123abc456def\/refunds"
+                }
+              ]
+            },
+            "$.links[2].href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/ch_123abc456def\/capture"
+                }
+              ]
+            },
+            "$.return_url": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.created_date": {
+              "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
+            },
+            "$.refund_summary.amount_available": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.gateway_transaction_id": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.fee": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.net_amount": {
+              "matchers": [{"match": "type"}]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
The pact for getting a charge from connector simulates a scenario
where the payment is in "AWAITING CAPTURE REQUEST" status so that it
can check that a link to capture the payment exists.

It also checks for a fee and net amount, but we would not expect a
fee or net amount to exist on a charge in this state. As a result,
connector is returning a negative `net_amount` as we would expect for
failed payments which have a fee, whereas the pact test is expecting a
positive `net_amount` which will only be returned if the charge is in
a `CAPTURED` status.

Remove the check for `fee` and `net_amount` fields on this pact. Rename
the pact to indicate that it is for a charge in the capturable state.

Add a separate pact test that uses a connector state that has a captured
payment with fees to check the `fee` and `net_amount` fields.

Rename the pact for `with-delayed-capture-true` to
`publicapi-connector-get-created-charge` as the most important part of
this pact is it checks the next_url and next_url_post links are
returned. A separate pact test to just check the delayed capture field
is not required, as pacts shouldn't really test the exact values
returned, just the shape of the request.