### PR TITLE
PP-9093 Remove explicit dependency on log4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,18 +130,7 @@
             <artifactId>dropwizard-sentry</artifactId>
             <version>2.0.28-8</version>
         </dependency>
-        <!-- We do not use log4j-core or log4j-api but some dependencies do
-             and versions before 2.15.0 are vulnerable to CVE-2021-44228 -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.17.1</version>
-        </dependency>
+
         <!-- testing -->
         <dependency>
             <groupId>uk.gov.service.payments</groupId>


### PR DESCRIPTION
We don't bring in log4j transitively so can safely remove the explicit
dependency.