### PR TITLE
PP-9234: Remove end to end tests from jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,22 +114,6 @@ pipeline {
             }
         }
     }
-    stage('Tests') {
-      failFast true
-      stages {
-        stage('End-to-End Tests') {
-            when {
-                anyOf {
-                  branch 'master'
-                  environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
-                }
-            }
-            steps {
-                runAppE2E("publicapi", "${env.E2E_TESTS}")
-            }
-        }
-      }
-    }
     stage('Docker Tag') {
       steps {
         script {


### PR DESCRIPTION
## WHAT YOU DID
Remove E2E tests on jenkins. Requires https://github.com/alphagov/pay-ci/pull/639 to be merged first

## How to test

Check the only change is removing Jenkins e2e test step

## Code review checklist

### Logging

N/A

### Documentation

N/A

