### PR TITLE
PP-9331: modify payments endpoint to support setting up payment instruments

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CancelChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CancelChargeExceptionMapper.java
@@ -8,8 +8,14 @@ import uk.gov.pay.api.model.PaymentError;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
-import static javax.ws.rs.core.Response.Status.*;
-import static uk.gov.pay.api.model.PaymentError.Code.*;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static uk.gov.pay.api.model.PaymentError.Code.CANCEL_PAYMENT_NOT_FOUND_ERROR;
+import static uk.gov.pay.api.model.PaymentError.Code.CANCEL_PAYMENT_CONNECTOR_BAD_REQUEST_ERROR;
+import static uk.gov.pay.api.model.PaymentError.Code.CANCEL_PAYMENT_CONNECTOR_CONFLICT_ERROR;
+import static uk.gov.pay.api.model.PaymentError.Code.CANCEL_PAYMENT_CONNECTOR_ERROR;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 
 public class CancelChargeExceptionMapper implements ExceptionMapper<CancelChargeException> {

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -10,13 +10,14 @@ import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_AGREEMENT_ID_ERROR;
 import static uk.gov.pay.api.model.PaymentError.Code.ACCOUNT_NOT_LINKED_WITH_PSP;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_ACCOUNT_ERROR;
-import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_CONNECTOR_ERROR;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_MOTO_NOT_ENABLED;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_VALIDATION_ERROR;
+import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_CONNECTOR_ERROR;
 import static uk.gov.pay.api.model.PaymentError.Code.RESOURCE_ACCESS_FORBIDDEN;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 
@@ -31,7 +32,12 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
         int statusCode = HttpStatus.INTERNAL_SERVER_ERROR_500;
 
         if (exception.getErrorStatus() == NOT_FOUND.getStatusCode()) {
-            paymentError = aPaymentError(CREATE_PAYMENT_ACCOUNT_ERROR);
+            if (exception.getErrorIdentifier() == ErrorIdentifier.AGREEMENT_NOT_FOUND) {
+                statusCode = HttpStatus.BAD_REQUEST_400;
+                paymentError = aPaymentError("set_up_agreement", CREATE_PAYMENT_AGREEMENT_ID_ERROR);
+            } else {
+                paymentError = aPaymentError(CREATE_PAYMENT_ACCOUNT_ERROR);
+            }
         } else {
             ErrorIdentifier errorIdentifier = exception.getErrorIdentifier();
             switch (errorIdentifier) {

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapper.java
@@ -9,8 +9,14 @@ import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
-import static javax.ws.rs.core.Response.Status.*;
-import static uk.gov.pay.api.model.PaymentError.Code.*;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
+import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_REFUND_AMOUNT_AVAILABLE_MISMATCH;
+import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_REFUND_CONNECTOR_ERROR;
+import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_REFUND_NOT_AVAILABLE;
+import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_REFUND_NOT_FOUND_ERROR;
 import static uk.gov.pay.api.model.PaymentError.aPaymentError;
 
 public class CreateRefundExceptionMapper implements ExceptionMapper<CreateRefundException> {

--- a/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
+++ b/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
@@ -44,6 +44,7 @@ import static uk.gov.pay.api.model.CreateCardPaymentRequest.PREFILLED_CARDHOLDER
 import static uk.gov.pay.api.model.CreateCardPaymentRequest.PREFILLED_CARDHOLDER_NAME_FIELD_NAME;
 import static uk.gov.pay.api.model.CreateCardPaymentRequest.REFERENCE_FIELD_NAME;
 import static uk.gov.pay.api.model.CreateCardPaymentRequest.RETURN_URL_FIELD_NAME;
+import static uk.gov.pay.api.model.CreateCardPaymentRequest.SET_UP_AGREEMENT_FIELD_NAME;
 import static uk.gov.pay.api.model.CreateCardPaymentRequest.SOURCE_FIELD_NAME;
 import static uk.gov.pay.api.model.CreatePaymentRefundRequest.REFUND_AMOUNT_AVAILABLE;
 import static uk.gov.pay.api.model.PaymentError.Code.CREATE_PAYMENT_MISSING_FIELD_ERROR;
@@ -79,7 +80,11 @@ class RequestJsonParser {
         if(paymentRequest.has(MOTO_FIELD_NAME)) {
             builder.moto(validateAndGetMoto(paymentRequest));
         }
-        
+
+        if(paymentRequest.has(SET_UP_AGREEMENT_FIELD_NAME)) {
+            builder.setUpAgreement(validateAndGetSetUpAgreement(paymentRequest));
+        }
+
         if (paymentRequest.has(LANGUAGE_FIELD_NAME)) {
             builder.language(validateAndGetLanguage(paymentRequest));
         }
@@ -162,6 +167,10 @@ class RequestJsonParser {
                 aPaymentError(MOTO_FIELD_NAME, CREATE_PAYMENT_VALIDATION_ERROR, "Must be true or false"),
                 JsonNode::isBoolean,
                 JsonNode::booleanValue);
+    }
+
+    private static String validateAndGetSetUpAgreement(JsonNode paymentRequest) {
+        return paymentRequest.get(SET_UP_AGREEMENT_FIELD_NAME).textValue();
     }
 
     private static Integer validateAndGetAmount(JsonNode paymentRequest, Code validationError, Code missingError) {

--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -13,7 +13,6 @@ import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 import java.util.Optional;
 
 import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
-import static uk.gov.pay.api.model.TokenPaymentType.CARD;
 
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 @Schema(name = "CardPayment")
@@ -70,13 +69,15 @@ public class CardPayment extends Payment {
 
     @JsonProperty("authorisation_summary")
     private AuthorisationSummary authorisationSummary;
-
+    
+    @JsonProperty("agreement_id")
+    private String agreementId;
 
     public CardPayment(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                        String reference, String email, String paymentProvider, String createdDate,
                        RefundSummary refundSummary, PaymentSettlementSummary settlementSummary, CardDetails cardDetails,
                        SupportedLanguage language, boolean delayedCapture, boolean moto, Long corporateCardSurcharge, Long totalAmount,
-                       String providerId, ExternalMetadata metadata, Long fee, Long netAmount, AuthorisationSummary authorisationSummary) {
+                       String providerId, ExternalMetadata metadata, Long fee, Long netAmount, AuthorisationSummary authorisationSummary, String agreementId) {
         super(chargeId, amount, description, reference, paymentProvider, createdDate);
         this.state = state;
         this.refundSummary = refundSummary;
@@ -84,7 +85,7 @@ public class CardPayment extends Payment {
         this.cardDetails = cardDetails;
         this.providerId = providerId;
         this.metadata = metadata;
-        this.paymentType = CARD.getFriendlyName();
+        this.paymentType = TokenPaymentType.CARD.getFriendlyName();
         this.language = language;
         this.delayedCapture = delayedCapture;
         this.moto = moto;
@@ -95,6 +96,7 @@ public class CardPayment extends Payment {
         this.email = email;
         this.returnUrl = returnUrl;
         this.authorisationSummary = authorisationSummary;
+        this.agreementId = agreementId;
     }
 
     /**
@@ -185,6 +187,10 @@ public class CardPayment extends Payment {
     public AuthorisationSummary getAuthorisationSummary() {
         return authorisationSummary;
     }
+    
+    public String getAgreementId() {
+        return agreementId;
+    }
 
     @Override
     public String toString() {
@@ -205,6 +211,7 @@ public class CardPayment extends Payment {
                 ", delayedCapture=" + delayedCapture +
                 ", moto=" + moto +
                 ", createdDate='" + createdDate + '\'' +
+                ", agreementId='" + agreementId + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/Charge.java
+++ b/src/main/java/uk/gov/pay/api/model/Charge.java
@@ -38,6 +38,8 @@ public class Charge {
     
     private boolean moto;
 
+    private String agreementId;
+
     private Long corporateCardSurcharge;
 
     private Long totalAmount;
@@ -60,7 +62,7 @@ public class Charge {
                   PaymentSettlementSummary settlementSummary, CardDetails cardDetails,
                   List<PaymentConnectorResponseLink> links, Long corporateCardSurcharge, Long totalAmount,
                   String gatewayTransactionId, ExternalMetadata metadata, Long fee, Long netAmount,
-                  AuthorisationSummary authorisationSummary) {
+                  AuthorisationSummary authorisationSummary, String agreementId) {
         this.chargeId = chargeId;
         this.amount = amount;
         this.state = state;
@@ -84,6 +86,7 @@ public class Charge {
         this.fee = fee;
         this.netAmount = netAmount;
         this.authorisationSummary = authorisationSummary;
+        this.agreementId = agreementId;
     }
 
     public static Charge from(ChargeFromResponse chargeFromResponse) {
@@ -110,7 +113,8 @@ public class Charge {
                 chargeFromResponse.getMetadata().orElse(null),
                 chargeFromResponse.getFee(),
                 chargeFromResponse.getNetAmount(),
-                chargeFromResponse.getAuthorisationSummary()
+                chargeFromResponse.getAuthorisationSummary(),
+                chargeFromResponse.getAgreementId()
         );
     }
 
@@ -138,8 +142,8 @@ public class Charge {
                 transactionResponse.getMetadata().orElse(null),
                 transactionResponse.getFee(),
                 transactionResponse.getNetAmount(),
-                transactionResponse.getAuthorisationSummary()
-        );
+                transactionResponse.getAuthorisationSummary(),
+                null);
     }
 
     public Optional<ExternalMetadata> getMetadata() {
@@ -236,5 +240,9 @@ public class Charge {
 
     public AuthorisationSummary getAuthorisationSummary() {
         return authorisationSummary;
+    }
+
+    public String getAgreementId() {
+        return agreementId;
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
@@ -47,6 +47,9 @@ public class ChargeFromResponse {
     
     private String telephoneNumber;
 
+    @JsonProperty("agreement_id")
+    private String agreementId;
+
     @JsonDeserialize(using = CustomSupportedLanguageDeserializer.class)
     private SupportedLanguage language;
     
@@ -127,6 +130,10 @@ public class ChargeFromResponse {
 
     public boolean isMoto() {
         return moto;
+    }
+
+    public String getAgreementId() {
+        return agreementId;
     }
 
     public Long getCorporateCardSurcharge() {

--- a/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
@@ -40,6 +40,7 @@ public class CreateCardPaymentRequest {
     public static final String PREFILLED_ADDRESS_COUNTRY_FIELD_NAME = "country";
     public static final String DELAYED_CAPTURE_FIELD_NAME = "delayed_capture";
     public static final String MOTO_FIELD_NAME = "moto";
+    public static final String SET_UP_AGREEMENT_FIELD_NAME = "set_up_agreement";
     public static final String SOURCE_FIELD_NAME = "source";
     public static final String METADATA = "metadata";
     public static final String INTERNAL = "internal";
@@ -81,6 +82,10 @@ public class CreateCardPaymentRequest {
     private final ExternalMetadata metadata;
     
     private final Internal internal;
+    
+    @JsonProperty("set_up_agreement")
+    @Size(min=26, max=26, message = "Field [set_up_agreement] length must be 26")
+    private String setUpAgreement;
 
     @Valid
     private final PrefilledCardholderDetails prefilledCardholderDetails;
@@ -97,6 +102,7 @@ public class CreateCardPaymentRequest {
         this.metadata = builder.getMetadata();
         this.prefilledCardholderDetails = builder.getPrefilledCardholderDetails();
         this.internal = builder.getInternal();
+        this.setUpAgreement = builder.getSetUpAgreement();
     }
     
     @Schema(description = "amount in pence", required = true, minimum = "1", maximum = "10000000", example = "12000")
@@ -165,6 +171,12 @@ public class CreateCardPaymentRequest {
         return Optional.ofNullable(internal);
     }
 
+    @JsonProperty("set_up_agreement")
+    @Schema(description = "agreement ID", required = false, example = "abcefghjklmnopqr1234567890", hidden = true)
+    public String getSetUpAgreement() {
+        return setUpAgreement;
+    }
+
     public String toConnectorPayload() {
         JsonStringBuilder request = new JsonStringBuilder()
                 .add("amount", this.getAmount())
@@ -189,6 +201,11 @@ public class CreateCardPaymentRequest {
             });
         });
         
+        if (this.getSetUpAgreement() != null) {
+            request.add("agreement_id", this.getSetUpAgreement())
+                    .add("save_payment_instrument_to_agreement", true);
+        }
+
         return request.build();
     }
 
@@ -208,6 +225,11 @@ public class CreateCardPaymentRequest {
         getDelayedCapture().ifPresent(value -> joiner.add("delayed_capture: " + value));
         getMoto().ifPresent(value -> joiner.add("moto: " + value));
         getMetadata().ifPresent(value -> joiner.add("metadata: " + value));
+        
+        if (this.getSetUpAgreement() != null) {
+            joiner.add("set_up_agreement: " + this.getSetUpAgreement());
+        }
+        
         return joiner.toString();
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequestBuilder.java
@@ -23,6 +23,7 @@ public class CreateCardPaymentRequestBuilder {
     private PrefilledCardholderDetails prefilledCardholderDetails;
     private Source source;
     private Internal internal;
+    private String setUpAgreement;
 
     public static CreateCardPaymentRequestBuilder builder() {
         return new CreateCardPaymentRequestBuilder();
@@ -194,5 +195,13 @@ public class CreateCardPaymentRequestBuilder {
         }
 
         return internal;
+    }
+
+    public void setUpAgreement(String setUpAgreement) {
+        this.setUpAgreement = setUpAgreement;
+    }
+
+    public String getSetUpAgreement() {
+        return setUpAgreement;
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/PaymentError.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentError.java
@@ -13,6 +13,8 @@ public class PaymentError {
 
     public enum Code {
 
+        CREATE_PAYMENT_AGREEMENT_ID_ERROR("P0103", "Invalid attribute value: set_up_agreement. Agreement ID does not exist"),
+
         CREATE_PAYMENT_ACCOUNT_ERROR("P0199", "There is an error with this account. Please contact support"),
         CREATE_PAYMENT_CONNECTOR_ERROR("P0198", "Downstream system error"),
         CREATE_AGREEMENT_CONNECTOR_ERROR("P0198", "Downstream system error"),

--- a/src/main/java/uk/gov/pay/api/model/RefundResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/RefundResponse.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
-import uk.gov.pay.api.model.ledger.RefundTransactionFromLedger;
 import uk.gov.pay.api.model.links.RefundLinksForSearch;
+import uk.gov.pay.api.model.ledger.RefundTransactionFromLedger;
 
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -2,12 +2,12 @@ package uk.gov.pay.api.model.links;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 import uk.gov.pay.api.model.AuthorisationSummary;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.CardPayment;
 import uk.gov.pay.api.model.Charge;
 import uk.gov.pay.api.model.Payment;
-import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 import uk.gov.pay.api.model.PaymentSettlementSummary;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
@@ -17,14 +17,12 @@ import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 import java.net.URI;
 import java.util.List;
 
-import static uk.gov.pay.api.model.Payment.LINKS_JSON_ATTRIBUTE;
-
 public class PaymentWithAllLinks {
 
     @JsonUnwrapped
     private Payment payment;
 
-    @JsonProperty(LINKS_JSON_ATTRIBUTE)
+    @JsonProperty(Payment.LINKS_JSON_ATTRIBUTE)
     private PaymentLinks links = new PaymentLinks();
 
     public PaymentLinks getLinks() {
@@ -40,10 +38,10 @@ public class PaymentWithAllLinks {
                                boolean delayedCapture, boolean moto, RefundSummary refundSummary, PaymentSettlementSummary settlementSummary, CardDetails cardDetails,
                                List<PaymentConnectorResponseLink> paymentConnectorResponseLinks, URI selfLink, URI paymentEventsUri, URI paymentCancelUri,
                                URI paymentRefundsUri, URI paymentCaptureUri, Long corporateCardSurcharge, Long totalAmount, String providerId, ExternalMetadata metadata,
-                               Long fee, Long netAmount, AuthorisationSummary authorisationSummary) {
+                               Long fee, Long netAmount, AuthorisationSummary authorisationSummary, String agreementId) {
         this.payment = new CardPayment(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate,
                 refundSummary, settlementSummary, cardDetails, language, delayedCapture, moto, corporateCardSurcharge, totalAmount,
-                providerId, metadata, fee, netAmount, authorisationSummary);
+                providerId, metadata, fee, netAmount, authorisationSummary, agreementId);
         this.links.addSelf(selfLink.toString());
         this.links.addKnownLinksValueOf(paymentConnectorResponseLinks);
         this.links.addEvents(paymentEventsUri.toString());
@@ -92,7 +90,8 @@ public class PaymentWithAllLinks {
                 paymentConnector.getMetadata().orElse(null),
                 paymentConnector.getFee(),
                 paymentConnector.getNetAmount(),
-                paymentConnector.getAuthorisationSummary());
+                paymentConnector.getAuthorisationSummary(),
+                paymentConnector.getAgreementId());
     }
 
     public static PaymentWithAllLinks getPaymentWithLinks(

--- a/src/main/java/uk/gov/pay/api/model/search/card/GetPaymentResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/GetPaymentResult.java
@@ -25,6 +25,6 @@ public class GetPaymentResult extends CardPayment {
                             Long totalAmount, String providerId, Long fee, Long netAmount, AuthorisationSummary authorisationSummary) {
         super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate,
                 refundSummary, settlementSummary, cardDetails, language, delayedCapture, moto, corporateCardSurcharge,
-                totalAmount, providerId, null, fee, netAmount, authorisationSummary);
+                totalAmount, providerId, null, fee, netAmount, authorisationSummary, null);
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
@@ -2,10 +2,10 @@ package uk.gov.pay.api.model.search.card;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 import uk.gov.pay.api.model.AuthorisationSummary;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.CardPayment;
-import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 import uk.gov.pay.api.model.PaymentSettlementSummary;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
@@ -32,7 +32,7 @@ public class PaymentForSearchResult extends CardPayment {
         
         super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider,
                 createdDate, refundSummary, settlementSummary, cardDetails, language, delayedCapture, moto, corporateCardSurcharge, totalAmount, providerId, externalMetadata,
-                fee, netAmount, authorisationSummary);
+                fee, netAmount, authorisationSummary, null);
         this.links.addSelf(selfLink.toString());
         this.links.addEvents(paymentEventsLink.toString());
         this.links.addRefunds(paymentRefundsLink.toString());

--- a/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
@@ -35,8 +35,9 @@ public class CreatePaymentService {
         if (!createdSuccessfully(connectorResponse)) {
             throw new CreateChargeException(connectorResponse);
         }
-
+        
         ChargeFromResponse chargeFromResponse = connectorResponse.readEntity(ChargeFromResponse.class);
+        
         return buildResponseModel(Charge.from(chargeFromResponse));
     }
 

--- a/src/test/java/uk/gov/pay/api/auth/AccountAuthenticatorTest.java
+++ b/src/test/java/uk/gov/pay/api/auth/AccountAuthenticatorTest.java
@@ -17,7 +17,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
-import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.publicauth.AuthResponse;
 
 import javax.ws.rs.ServiceUnavailableException;

--- a/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
+++ b/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
@@ -29,7 +29,7 @@ public class CreateChargeExceptionMapperTest {
     @CsvSource({
             "TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED, RESOURCE_ACCESS_FORBIDDEN, 403",
             "ACCOUNT_NOT_LINKED_WITH_PSP, ACCOUNT_NOT_LINKED_WITH_PSP, 403",
-            "MOTO_NOT_ALLOWED, CREATE_PAYMENT_MOTO_NOT_ENABLED, 422",
+            "MOTO_NOT_ALLOWED, CREATE_PAYMENT_MOTO_NOT_ENABLED, 422"
     })
     public void testExceptionMapping(String errorIdentifier, String paymentError, int expectedStatusCode) {
         when(mockResponse.readEntity(ConnectorErrorResponse.class))

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentResultBuilder.java
@@ -140,6 +140,7 @@ public abstract class PaymentResultBuilder {
         public List<Map<?,?>> links;
         public Map<String, ?> metadata;
         public AuthorisationSummary authorisation_summary;
+        public String agreement_id;
     }
 
     protected static class TestPaymentState {
@@ -176,6 +177,7 @@ public abstract class PaymentResultBuilder {
     protected String language = SupportedLanguage.ENGLISH.toString();
     protected Boolean delayedCapture;
     protected boolean moto;
+    protected String agreementId;
     protected TestPaymentState state;
     protected String fromDate = null;
     protected String toDate = null;
@@ -225,6 +227,7 @@ public abstract class PaymentResultBuilder {
         payment.language = SupportedLanguage.ENGLISH.toString();
         payment.delayed_capture = delayedCapture == null ? false : delayedCapture;
         payment.moto = moto;
+        payment.agreement_id = agreementId;
         payment.card_details.card_brand = cardDetails == null ? DEFAULT_CARD_BRAND_LABEL : cardDetails.card_brand;
         payment.card_details = cardDetails == null ? new CardDetails() : cardDetails;
         payment.refund_summary = refundSummary == null ? 

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSingleResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSingleResultBuilder.java
@@ -46,6 +46,11 @@ public class PaymentSingleResultBuilder extends PaymentResultBuilder {
         return this;
     }
 
+    public PaymentSingleResultBuilder withAgreementId(String agreementId) {
+        this.agreementId = agreementId;
+        return this;
+    }
+
     public PaymentSingleResultBuilder withCorporateCardSurcharge(Long surcharge) {
         this.corporateCardSurcharge = surcharge;
         return this;

--- a/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentWithHttpReturnUrlIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentWithHttpReturnUrlIT.java
@@ -21,7 +21,6 @@ import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static java.lang.String.format;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
 import static uk.gov.pay.api.utils.mocks.CreateChargeRequestParams.CreateChargeRequestParamsBuilder.aCreateChargeRequestParams;

--- a/src/test/java/uk/gov/pay/api/model/PaymentErrorTest.java
+++ b/src/test/java/uk/gov/pay/api/model/PaymentErrorTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.api.model;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.pay.api.model.PaymentError;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -12,4 +13,11 @@ public class PaymentErrorTest {
         PaymentError paymentError = PaymentError.aPaymentError(PaymentError.Code.CREATE_PAYMENT_ACCOUNT_ERROR);
         assertThat(paymentError.toString(), is("PaymentError{field=null, code=P0199, name=CREATE_PAYMENT_ACCOUNT_ERROR, description='There is an error with this account. Please contact support'}"));
     }
+
+    @Test
+    void shouldGetExpectedValuesForAgreementNotFoundError() {
+        PaymentError paymentError = PaymentError.aPaymentError("set_up_agreement", PaymentError.Code.CREATE_PAYMENT_AGREEMENT_ID_ERROR);
+        assertThat(paymentError.toString(), is("PaymentError{field=set_up_agreement, code=P0103, name=CREATE_PAYMENT_AGREEMENT_ID_ERROR, description='Invalid attribute value: set_up_agreement. Agreement ID does not exist'}"));
+    }
+
 }

--- a/src/test/java/uk/gov/pay/api/model/RefundErrorTest.java
+++ b/src/test/java/uk/gov/pay/api/model/RefundErrorTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.api.model;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.pay.api.model.RefundError;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -121,6 +121,6 @@ public class PaymentsResourceCreatePaymentTest {
                 null,
                 null,
                 null,
-                null);
+                null, null);
     }
 }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
@@ -104,6 +104,11 @@ public abstract class BaseConnectorMockClient {
         if (params.getAddressCountry().isPresent()) {
             payload.addToNestedMap("country", params.getAddressCountry().get(), "prefilled_cardholder_details", "billing_address");
         }
+        
+        if (params.getSetUpAgreement() != null) {
+            payload.add("agreement_id", params.getSetUpAgreement());
+            payload.add("save_payment_instrument_to_agreement", true);
+        }
 
         payload.add("source", params.getSource().orElse(CARD_API));
 

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ChargeResponseFromConnector.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ChargeResponseFromConnector.java
@@ -30,6 +30,7 @@ public class ChargeResponseFromConnector {
     private final Long fee;
     private final Long netAmount;
     private final AuthorisationSummary authorisationSummary;
+    private String agreementId;
 
     public Long getAmount() {
         return amount;
@@ -177,6 +178,7 @@ public class ChargeResponseFromConnector {
         this.fee = builder.fee;
         this.netAmount = builder.netAmount;
         this.authorisationSummary = builder.authorisationSummary;
+        this.agreementId = builder.agreementId;
     }
 
     public static final class ChargeResponseFromConnectorBuilder {
@@ -195,7 +197,7 @@ public class ChargeResponseFromConnector {
         private Long fee = null;
         private Long netAmount = null;
         private AuthorisationSummary authorisationSummary = null;
-
+        private String agreementId;
         private ChargeResponseFromConnectorBuilder() {
         }
 
@@ -226,7 +228,8 @@ public class ChargeResponseFromConnector {
                     .withMetadata(responseFromConnector.metadata.orElse(null))
                     .withNetAmount(responseFromConnector.getNetAmount())
                     .withFee(responseFromConnector.getFee())
-                    .withAuthorisationSummary(responseFromConnector.getAuthorisationSummary());
+                    .withAuthorisationSummary(responseFromConnector.getAuthorisationSummary())
+                    .withAgreementId(responseFromConnector.getAgreementId());
         }
 
         public ChargeResponseFromConnectorBuilder withAmount(long amount) {
@@ -383,5 +386,14 @@ public class ChargeResponseFromConnector {
             this.authorisationSummary = authorisationSummary;
             return this;
         }
+
+        public ChargeResponseFromConnectorBuilder withAgreementId(String agreementId) {
+            this.agreementId = agreementId;
+            return this;
+        }
+    }
+
+    public String getAgreementId() {
+        return this.agreementId;
     }
 }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -53,6 +53,7 @@ import static uk.gov.pay.api.utils.mocks.AgreementResponseFromConnector.Agreemen
 import static uk.gov.pay.api.utils.mocks.ChargeResponseFromConnector.ChargeResponseFromConnectorBuilder.aCreateOrGetChargeResponseFromConnector;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.ACCOUNT_NOT_LINKED_WITH_PSP;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.GENERIC;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.AGREEMENT_NOT_FOUND;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.MOTO_NOT_ALLOWED;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.REFUND_NOT_AVAILABLE;
@@ -85,6 +86,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                 .withPaymentProvider(responseFromConnector.getPaymentProvider())
                 .withDelayedCapture(responseFromConnector.isDelayedCapture())
                 .withMoto(responseFromConnector.isMoto())
+                .withAgreementId(responseFromConnector.getAgreementId())
                 .withLinks(responseFromConnector.getLinks())
                 .withSettlementSummary(responseFromConnector.getSettlementSummary());
         
@@ -262,6 +264,10 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                 .withLink(validGetLink(nextUrl("chargeTokenId"), "next_url"))
                 .withLink(validPostLink(nextUrlPost(), "next_url_post", "application/x-www-form-urlencoded", getChargeIdTokenMap("chargeTokenId")));
 
+        if (requestParams.getSetUpAgreement() != null) {
+            responseFromConnector.withAgreementId(requestParams.getSetUpAgreement());
+        }
+
         if (!requestParams.getMetadata().isEmpty())
             responseFromConnector.withMetadata(requestParams.getMetadata());
 
@@ -335,6 +341,10 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
 
     public void respondBadRequest_whenCreateAgreement(String gatewayAccountId, String errorMsg) {
         mockCreateAgreement(gatewayAccountId, withStatusAndErrorMessage(INTERNAL_SERVER_ERROR_500, errorMsg, GENERIC));
+    }
+
+    public void respondBadRequest_whenCreateChargeWithAgreementNotFound(String gatewayAccountId, String agreementId, String errorMsg) {
+        mockCreateCharge(gatewayAccountId, withStatusAndErrorMessage(NOT_FOUND_404, format(errorMsg, agreementId), AGREEMENT_NOT_FOUND));
     }
 
     public void respondPreconditionFailed_whenCreateRefund(String gatewayAccountId, String errorMsg, String chargeId) {

--- a/src/test/java/uk/gov/pay/api/utils/mocks/CreateChargeRequestParams.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/CreateChargeRequestParams.java
@@ -23,6 +23,7 @@ public class CreateChargeRequestParams {
     private final String addressCountry;
     private final SupportedLanguage language;
     private final Source source;
+    private final String setUpAgreement;
 
     private CreateChargeRequestParams(CreateChargeRequestParamsBuilder builder) {
         this.amount = builder.amount;
@@ -40,6 +41,7 @@ public class CreateChargeRequestParams {
         this.addressCountry = builder.addressCountry;
         this.language = builder.language;
         this.source = builder.source;
+        this.setUpAgreement = builder.setUpAgreement;
     }
 
     public int getAmount() {
@@ -102,6 +104,10 @@ public class CreateChargeRequestParams {
         return Optional.ofNullable(source);
     }
 
+    public String getSetUpAgreement() {
+        return setUpAgreement;
+    }
+
     public static final class CreateChargeRequestParamsBuilder {
         private Integer amount;
         private String returnUrl;
@@ -118,6 +124,7 @@ public class CreateChargeRequestParams {
         private String addressCountry;
         private SupportedLanguage language;
         private Source source;
+        public String setUpAgreement;
 
         private CreateChargeRequestParamsBuilder() {
         }
@@ -203,6 +210,11 @@ public class CreateChargeRequestParams {
 
         public CreateChargeRequestParamsBuilder withMoto(boolean moto) {
             this.moto = moto;
+            return this;
+        }
+
+        public CreateChargeRequestParamsBuilder withSetUpAgreement(String setUpAgreement) {
+            this.setUpAgreement = setUpAgreement;
             return this;
         }
     }


### PR DESCRIPTION
- Added setup_agreement field to the Resources payload
- if setup_agreement, then forward agreement_id and save_paymentInstrument_to_agreement to Connector and PublicAI
- if setup_agreement, then forward agreement_id and save_paymentInstrument_to_agreement to Connector and Ledger
- added exception management and test cases