### PR TITLE
PP-9495 Accept description and user_identifier when creating agreements

### DIFF
--- a/src/main/java/uk/gov/pay/api/agreement/model/CreateAgreementRequest.java
+++ b/src/main/java/uk/gov/pay/api/agreement/model/CreateAgreementRequest.java
@@ -12,12 +12,22 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CreateAgreementRequest {
     
-    public static final int REFERENCE_MIN_LENGTH = 1;
-    public static final int REFERENCE_MAX_LENGTH = 255;
+    public static final String USER_IDENTIFIER_FIELD = "user_identifier";
+
+    public static final int MIN_LENGTH = 1;
+    public static final int MAX_LENGTH = 255;
 
     @JsonProperty("reference")
-    @Size(min= REFERENCE_MIN_LENGTH, max = REFERENCE_MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
+    @Size(min= MIN_LENGTH, max = MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
     private String reference;
+
+    @JsonProperty("description")
+    @Size(min= MIN_LENGTH, max = MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
+    private String description;
+
+    @JsonProperty(USER_IDENTIFIER_FIELD)
+    @Size(min= MIN_LENGTH, max = MAX_LENGTH, message = "Must be less than or equal to {max} characters length")
+    private String userIdentifier;
 
     public CreateAgreementRequest() {
         // for Jackson
@@ -25,16 +35,31 @@ public class CreateAgreementRequest {
     
     public CreateAgreementRequest(CreateAgreementRequestBuilder builder) {
         this.reference = builder.getReference();
+        this.description = builder.getDescription();
+        this.userIdentifier = builder.getUserIdentifier();
     }
 
     public String getReference() {
         return reference;
     }
 
+    public String getDescription() {
+        return description;
+    }
+
+    public String getUserIdentifier() {
+        return userIdentifier;
+    }
+
     public String toConnectorPayload() {
-        return new JsonStringBuilder()
+        var stringBuilder = new JsonStringBuilder()
                 .add("reference", this.getReference())
-                .build();
+                .add("description", this.getDescription());
+
+        if (this.getUserIdentifier() != null) {
+            stringBuilder.add("user_identifier", this.getUserIdentifier());
+        }
+        return stringBuilder.build();
     }
 
     @Override
@@ -42,11 +67,11 @@ public class CreateAgreementRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         CreateAgreementRequest that = (CreateAgreementRequest) o;
-        return Objects.equals(reference, that.reference);
+        return Objects.equals(reference, that.reference) && Objects.equals(description, that.description) && Objects.equals(userIdentifier, that.userIdentifier);
     }
     
     @Override
     public int hashCode() {
-        return Objects.hash(reference);
+        return Objects.hash(reference, description, userIdentifier);
     }
 }

--- a/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
+++ b/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
+import static uk.gov.pay.api.agreement.model.CreateAgreementRequest.USER_IDENTIFIER_FIELD;
 import static uk.gov.pay.api.model.CreateCardPaymentRequest.AMOUNT_FIELD_NAME;
 import static uk.gov.pay.api.model.CreateCardPaymentRequest.DELAYED_CAPTURE_FIELD_NAME;
 import static uk.gov.pay.api.model.CreateCardPaymentRequest.DESCRIPTION_FIELD_NAME;
@@ -117,7 +118,15 @@ class RequestJsonParser {
 
     static CreateAgreementRequest parseAgreementRequest(JsonNode agreementRequest) {
         var builder = CreateAgreementRequestBuilder.builder()
-                .reference(validateAndGetReference(agreementRequest));
+                .reference(validateAndGetReference(agreementRequest))
+                .description(validateAndGetDescription(agreementRequest));
+
+        if (agreementRequest.has(USER_IDENTIFIER_FIELD)) {
+            String userIdentifier = validateSkipNullValueAndGetString(agreementRequest.get(USER_IDENTIFIER_FIELD),
+                    aPaymentError(USER_IDENTIFIER_FIELD, CREATE_PAYMENT_VALIDATION_ERROR, "Field must be a string"));
+            builder.userIdentifier(userIdentifier);
+        }
+
         return builder.build();
     }
 

--- a/src/main/java/uk/gov/pay/api/model/CreateAgreementRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateAgreementRequestBuilder.java
@@ -4,6 +4,8 @@ import uk.gov.pay.api.agreement.model.CreateAgreementRequest;
 
 public class CreateAgreementRequestBuilder {
     private String reference;
+    private String description;
+    private String userIdentifier;
     public static CreateAgreementRequestBuilder builder() {
         return new CreateAgreementRequestBuilder();
     }
@@ -17,7 +19,25 @@ public class CreateAgreementRequestBuilder {
         return this;
     }
 
+    public CreateAgreementRequestBuilder description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public CreateAgreementRequestBuilder userIdentifier(String userIdentifier) {
+        this.userIdentifier = userIdentifier;
+        return this;
+    }
+
     public String getReference() {
         return reference;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getUserIdentifier() {
+        return userIdentifier;
     }
 }

--- a/src/test/java/uk/gov/pay/api/json/CreateAgreementRequestDeserializerTest.java
+++ b/src/test/java/uk/gov/pay/api/json/CreateAgreementRequestDeserializerTest.java
@@ -30,8 +30,8 @@ public class CreateAgreementRequestDeserializerTest {
     }
 
     @Test
-    public void deserialize_shouldDeserializeACreateAgreementRequestWithReferenceSuccessfully() throws Exception {
-        String validJson = "{\"reference\": \"Some reference\"}";
+    public void deserialize_shouldDeserializeACreateAgreementRequestWithPayloadSuccessfully() throws Exception {
+        String validJson = "{\"reference\": \"Some reference\", \"description\": \"A valid description\", \"user_identifier\": \"a-valid-user-identifier\"}";
         CreateAgreementRequest agreementRequest = deserializer.deserialize(jsonFactory.createParser(validJson), ctx);
         assertThat(agreementRequest.getReference(), is("Some reference"));
     }
@@ -66,6 +66,14 @@ public class CreateAgreementRequestDeserializerTest {
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
         assertThat(badRequestException, aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: reference"));
+    }
+
+    @Test
+    public void deserialize_shouldThrowBadRequestException_whenDescriptionIsMissing() {
+        String invalidJson = "{\"reference\": \"Some reference\"}";
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> deserializer.deserialize(jsonFactory.createParser(invalidJson), ctx));
+        assertThat(badRequestException, aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: description"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/service/CreateAgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreateAgreementServiceTest.java
@@ -30,6 +30,7 @@ import static uk.gov.pay.api.utils.mocks.CreateAgreementRequestParams.CreateAgre
 @ExtendWith(MockitoExtension.class)
 class CreateAgreementServiceTest {
     private static final String REFERENCE_ID = "test";
+    private static final String DESCRIPTION = "a valid description";
     private static final String AGREEMENT_ID = "12345678901234567890123456";
     private static final String AGREEMENTS_CONNECTOR_URI = "/v1/api/accounts/GATEWAY_ACCOUNT_ID/agreements";
     private AgreementService service;

--- a/src/test/java/uk/gov/pay/api/utils/mocks/CreateAgreementRequestParams.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/CreateAgreementRequestParams.java
@@ -5,17 +5,31 @@ import java.util.Objects;
 
 public class CreateAgreementRequestParams {
     private final String reference;
+    private final String description;
+    private final String userIdentifier;
 
     private CreateAgreementRequestParams(CreateAgreementRequestParamsBuilder builder) {
         this.reference = builder.reference;
+        this.description = builder.description;
+        this.userIdentifier = builder.userIdentifier;
     }
 
     public String getReference() {
         return reference;
     }
 
+    public String getDescription() {
+        return description;
+    }
+
+    public String getUserIdentifier() {
+        return userIdentifier;
+    }
+
     public static final class CreateAgreementRequestParamsBuilder {
         private String reference;
+        private String description;
+        private String userIdentifier;
 
         private CreateAgreementRequestParamsBuilder() {
         }
@@ -26,6 +40,16 @@ public class CreateAgreementRequestParams {
 
         public CreateAgreementRequestParamsBuilder withReference(String reference) {
             this.reference = reference;
+            return this;
+        }
+
+        public CreateAgreementRequestParamsBuilder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public CreateAgreementRequestParamsBuilder withUserIdentifier(String userIdentifier) {
+            this.userIdentifier = userIdentifier;
             return this;
         }
 


### PR DESCRIPTION
Accept and validation `description` and `user_identifier` fields on the
create agreement endpoint.

`description` is required and will throw an appropriate error if
missing.

`user_identifier` is optional but must be a string if set.

Note this does not extend the expected agreement repsonse from Connector
as Ledger will be used to serve agreements and this should be removed in
the next change.