### PR TITLE
PP-9142 Accept authorisation_mode and return in responses.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ target
 bin
 
 .DS_Store
+dependency-reduced-pom.xml

--- a/openapi/publicapi_spec.json
+++ b/openapi/publicapi_spec.json
@@ -892,9 +892,9 @@
           },
           "card_type" : {
             "type" : "string",
-            "description" : "The card type, `credit` or `null` if not able to determine",
-            "enum" : [ "credit", "null" ],
-            "example" : "credit",
+            "description" : "The card type, `debit` or `credit` or `null` if not able to determine",
+            "enum" : [ "debit", "credit", "null" ],
+            "example" : "debit",
             "readOnly" : true
           },
           "cardholder_name" : {
@@ -1115,6 +1115,11 @@
             "format" : "int64",
             "example" : 1200
           },
+          "authorisation_mode" : {
+            "type" : "string",
+            "description" : "How the payment will be authorised. Payments created in `web` mode require the paying user to visit the `next_url` to complete the payment.",
+            "enum" : [ "web", "moto_api", "external" ]
+          },
           "authorisation_summary" : {
             "$ref" : "#/components/schemas/AuthorisationSummary"
           },
@@ -1247,6 +1252,11 @@
             "type" : "integer",
             "format" : "int64",
             "example" : 1200
+          },
+          "authorisation_mode" : {
+            "type" : "string",
+            "description" : "How the payment will be authorised. Payments created in `web` mode require the paying user to visit the `next_url` to complete the payment.",
+            "enum" : [ "web", "moto_api", "external" ]
           },
           "authorisation_summary" : {
             "$ref" : "#/components/schemas/AuthorisationSummary"

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <jackson.version>2.13.2</jackson.version>
         <logback.version>1.2.11</logback.version>
         <docker-client.version>8.16.0</docker-client.version>
-        <pay-java-commons.version>1.0.20220411103640</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20220414105607</pay-java-commons.version>
         <junit5.version>5.8.2</junit5.version>
         <pact.version>3.6.15</pact.version>
         <swagger.lib.version>2.2.0</swagger.lib.version>

--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.service.payments.commons.api.json.ExternalMetadataSerialiser;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
@@ -72,12 +73,16 @@ public class CardPayment extends Payment {
     
     @JsonProperty("agreement_id")
     private String agreementId;
+    
+    @JsonProperty("authorisation_mode")
+    private AuthorisationMode authorisationMode;
 
     public CardPayment(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                        String reference, String email, String paymentProvider, String createdDate,
                        RefundSummary refundSummary, PaymentSettlementSummary settlementSummary, CardDetails cardDetails,
                        SupportedLanguage language, boolean delayedCapture, boolean moto, Long corporateCardSurcharge, Long totalAmount,
-                       String providerId, ExternalMetadata metadata, Long fee, Long netAmount, AuthorisationSummary authorisationSummary, String agreementId) {
+                       String providerId, ExternalMetadata metadata, Long fee, Long netAmount, AuthorisationSummary authorisationSummary, String agreementId,
+                       AuthorisationMode authorisationMode) {
         super(chargeId, amount, description, reference, paymentProvider, createdDate);
         this.state = state;
         this.refundSummary = refundSummary;
@@ -97,6 +102,7 @@ public class CardPayment extends Payment {
         this.returnUrl = returnUrl;
         this.authorisationSummary = authorisationSummary;
         this.agreementId = agreementId;
+        this.authorisationMode = authorisationMode;
     }
 
     /**
@@ -188,8 +194,14 @@ public class CardPayment extends Payment {
         return authorisationSummary;
     }
     
+    @Schema(hidden = true)
     public String getAgreementId() {
         return agreementId;
+    }
+
+    @Schema(description = "How the payment will be authorised. Payments created in `web` mode require the paying user to visit the `next_url` to complete the payment.")
+    public AuthorisationMode getAuthorisationMode() {
+        return authorisationMode;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/api/model/Charge.java
+++ b/src/main/java/uk/gov/pay/api/model/Charge.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.model;
 
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
@@ -55,6 +56,8 @@ public class Charge {
     private ExternalMetadata metadata;
 
     private AuthorisationSummary authorisationSummary;
+    
+    private AuthorisationMode authorisationMode;
 
     public Charge(String chargeId, Long amount, PaymentState state, String returnUrl, String description,
                   String reference, String email, String paymentProvider, String createdDate,
@@ -62,7 +65,7 @@ public class Charge {
                   PaymentSettlementSummary settlementSummary, CardDetails cardDetails,
                   List<PaymentConnectorResponseLink> links, Long corporateCardSurcharge, Long totalAmount,
                   String gatewayTransactionId, ExternalMetadata metadata, Long fee, Long netAmount,
-                  AuthorisationSummary authorisationSummary, String agreementId) {
+                  AuthorisationSummary authorisationSummary, String agreementId, AuthorisationMode authorisationMode) {
         this.chargeId = chargeId;
         this.amount = amount;
         this.state = state;
@@ -87,6 +90,7 @@ public class Charge {
         this.netAmount = netAmount;
         this.authorisationSummary = authorisationSummary;
         this.agreementId = agreementId;
+        this.authorisationMode = authorisationMode;
     }
 
     public static Charge from(ChargeFromResponse chargeFromResponse) {
@@ -114,7 +118,8 @@ public class Charge {
                 chargeFromResponse.getFee(),
                 chargeFromResponse.getNetAmount(),
                 chargeFromResponse.getAuthorisationSummary(),
-                chargeFromResponse.getAgreementId()
+                chargeFromResponse.getAgreementId(),
+                chargeFromResponse.getAuthorisationMode()
         );
     }
 
@@ -143,7 +148,8 @@ public class Charge {
                 transactionResponse.getFee(),
                 transactionResponse.getNetAmount(),
                 transactionResponse.getAuthorisationSummary(),
-                null);
+                null,
+                transactionResponse.getAuthorisationMode());
     }
 
     public Optional<ExternalMetadata> getMetadata() {
@@ -244,5 +250,9 @@ public class Charge {
 
     public String getAgreementId() {
         return agreementId;
+    }
+
+    public AuthorisationMode getAuthorisationMode() {
+        return authorisationMode;
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/ChargeFromResponse.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.api.model.telephone.PaymentOutcome;
 import uk.gov.pay.api.utils.CustomSupportedLanguageDeserializer;
 import uk.gov.service.payments.commons.api.json.ExternalMetadataDeserialiser;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
@@ -83,6 +84,8 @@ public class ChargeFromResponse {
     private ExternalMetadata metadata;
 
     private AuthorisationSummary authorisationSummary;
+    
+    private AuthorisationMode authorisationMode;
 
     public Optional<ExternalMetadata> getMetadata() {
         return Optional.ofNullable(metadata);
@@ -214,4 +217,8 @@ public class ChargeFromResponse {
     public AuthorisationSummary getAuthorisationSummary() {
         return authorisationSummary;
     };
+
+    public AuthorisationMode getAuthorisationMode() {
+        return authorisationMode;
+    }
 }

--- a/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import org.hibernate.validator.constraints.Length;
 import uk.gov.pay.api.utils.JsonStringBuilder;
 import uk.gov.pay.api.validation.ValidReturnUrl;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
@@ -44,6 +45,7 @@ public class CreateCardPaymentRequest {
     public static final String SOURCE_FIELD_NAME = "source";
     public static final String METADATA = "metadata";
     public static final String INTERNAL = "internal";
+    public static final String AUTHORISATION_MODE = "authorisation_mode";
     private static final String PREFILLED_CARDHOLDER_DETAILS = "prefilled_cardholder_details";
     private static final String BILLING_ADDRESS = "billing_address";
     
@@ -89,6 +91,8 @@ public class CreateCardPaymentRequest {
 
     @Valid
     private final PrefilledCardholderDetails prefilledCardholderDetails;
+
+    private final AuthorisationMode authorisationMode;
     
     public CreateCardPaymentRequest(CreateCardPaymentRequestBuilder builder) {
         this.amount = builder.getAmount();
@@ -103,6 +107,7 @@ public class CreateCardPaymentRequest {
         this.prefilledCardholderDetails = builder.getPrefilledCardholderDetails();
         this.internal = builder.getInternal();
         this.setUpAgreement = builder.getSetUpAgreement();
+        this.authorisationMode = builder.getAuthorisationMode();
     }
     
     @Schema(description = "amount in pence", required = true, minimum = "1", maximum = "10000000", example = "12000")
@@ -177,6 +182,12 @@ public class CreateCardPaymentRequest {
         return setUpAgreement;
     }
 
+    @JsonProperty("authorisation_mode")
+    @Schema(hidden = true)
+    public Optional<AuthorisationMode> getAuthorisationMode() {
+        return Optional.ofNullable(authorisationMode);
+    }
+
     public String toConnectorPayload() {
         JsonStringBuilder request = new JsonStringBuilder()
                 .add("amount", this.getAmount())
@@ -189,6 +200,7 @@ public class CreateCardPaymentRequest {
         getMetadata().ifPresent(metadata -> request.add("metadata", metadata.getMetadata()));
         getEmail().ifPresent(email -> request.add("email", email));
         getInternal().flatMap(Internal::getSource).ifPresent(source -> request.add("source", source));
+        getAuthorisationMode().ifPresent((authorisationMode -> request.add("authorisation_mode", authorisationMode.getName())));
         
         getPrefilledCardholderDetails().ifPresent(prefilledDetails -> {
             prefilledDetails.getCardholderName().ifPresent(name -> request.addToMap(PREFILLED_CARDHOLDER_DETAILS, "cardholder_name", name));

--- a/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequestBuilder.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.model;
 
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.Source;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
@@ -24,6 +25,7 @@ public class CreateCardPaymentRequestBuilder {
     private Source source;
     private Internal internal;
     private String setUpAgreement;
+    private AuthorisationMode authorisationMode;
 
     public static CreateCardPaymentRequestBuilder builder() {
         return new CreateCardPaymentRequestBuilder();
@@ -110,6 +112,11 @@ public class CreateCardPaymentRequestBuilder {
 
     public CreateCardPaymentRequestBuilder source(Source source) {
         this.source = source;
+        return this;
+    }
+    
+    public CreateCardPaymentRequestBuilder authorisationMode(AuthorisationMode authorisationMode) {
+        this.authorisationMode = authorisationMode;
         return this;
     }
 
@@ -199,6 +206,11 @@ public class CreateCardPaymentRequestBuilder {
 
     public void setUpAgreement(String setUpAgreement) {
         this.setUpAgreement = setUpAgreement;
+    
+    }
+
+    public AuthorisationMode getAuthorisationMode() {
+        return authorisationMode;
     }
 
     public String getSetUpAgreement() {

--- a/src/main/java/uk/gov/pay/api/model/Payment.java
+++ b/src/main/java/uk/gov/pay/api/model/Payment.java
@@ -72,4 +72,6 @@ public abstract class Payment {
     public String getPaymentProvider() {
         return paymentProvider;
     }
+    
+    
 }

--- a/src/main/java/uk/gov/pay/api/model/TransactionResponse.java
+++ b/src/main/java/uk/gov/pay/api/model/TransactionResponse.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import uk.gov.pay.api.utils.CustomSupportedLanguageDeserializer;
 import uk.gov.service.payments.commons.api.json.ExternalMetadataDeserialiser;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
@@ -79,6 +80,9 @@ public class TransactionResponse {
 
     @JsonProperty("authorisation_summary")
     private AuthorisationSummary authorisationSummary;
+    
+    @JsonProperty("authorisation_mode")
+    private AuthorisationMode authorisationMode;
 
     public Optional<ExternalMetadata> getMetadata() {
         return Optional.ofNullable(metadata);
@@ -181,5 +185,9 @@ public class TransactionResponse {
 
     public AuthorisationSummary getAuthorisationSummary() {
         return authorisationSummary;
+    }
+
+    public AuthorisationMode getAuthorisationMode() {
+        return authorisationMode;
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -11,6 +11,7 @@ import uk.gov.pay.api.model.Payment;
 import uk.gov.pay.api.model.PaymentSettlementSummary;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
@@ -38,10 +39,10 @@ public class PaymentWithAllLinks {
                                boolean delayedCapture, boolean moto, RefundSummary refundSummary, PaymentSettlementSummary settlementSummary, CardDetails cardDetails,
                                List<PaymentConnectorResponseLink> paymentConnectorResponseLinks, URI selfLink, URI paymentEventsUri, URI paymentCancelUri,
                                URI paymentRefundsUri, URI paymentCaptureUri, Long corporateCardSurcharge, Long totalAmount, String providerId, ExternalMetadata metadata,
-                               Long fee, Long netAmount, AuthorisationSummary authorisationSummary, String agreementId) {
+                               Long fee, Long netAmount, AuthorisationSummary authorisationSummary, String agreementId, AuthorisationMode authorisationMode) {
         this.payment = new CardPayment(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate,
                 refundSummary, settlementSummary, cardDetails, language, delayedCapture, moto, corporateCardSurcharge, totalAmount,
-                providerId, metadata, fee, netAmount, authorisationSummary, agreementId);
+                providerId, metadata, fee, netAmount, authorisationSummary, agreementId, authorisationMode);
         this.links.addSelf(selfLink.toString());
         this.links.addKnownLinksValueOf(paymentConnectorResponseLinks);
         this.links.addEvents(paymentEventsUri.toString());
@@ -91,7 +92,8 @@ public class PaymentWithAllLinks {
                 paymentConnector.getFee(),
                 paymentConnector.getNetAmount(),
                 paymentConnector.getAuthorisationSummary(),
-                paymentConnector.getAgreementId());
+                paymentConnector.getAgreementId(),
+                paymentConnector.getAuthorisationMode());
     }
 
     public static PaymentWithAllLinks getPaymentWithLinks(

--- a/src/main/java/uk/gov/pay/api/model/search/card/GetPaymentResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/GetPaymentResult.java
@@ -8,6 +8,7 @@ import uk.gov.pay.api.model.PaymentSettlementSummary;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.model.links.PaymentLinks;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 /**
@@ -22,9 +23,10 @@ public class GetPaymentResult extends CardPayment {
                             String reference, String email, String paymentProvider, String createdDate,
                             RefundSummary refundSummary, PaymentSettlementSummary settlementSummary, CardDetails cardDetails,
                             SupportedLanguage language, boolean delayedCapture, boolean moto, Long corporateCardSurcharge,
-                            Long totalAmount, String providerId, Long fee, Long netAmount, AuthorisationSummary authorisationSummary) {
+                            Long totalAmount, String providerId, Long fee, Long netAmount, AuthorisationSummary authorisationSummary,
+                            AuthorisationMode authorisationMode) {
         super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate,
                 refundSummary, settlementSummary, cardDetails, language, delayedCapture, moto, corporateCardSurcharge,
-                totalAmount, providerId, null, fee, netAmount, authorisationSummary, null);
+                totalAmount, providerId, null, fee, netAmount, authorisationSummary, null, authorisationMode);
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
@@ -11,6 +11,7 @@ import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.model.TransactionResponse;
 import uk.gov.pay.api.model.links.PaymentLinksForSearch;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
@@ -28,11 +29,11 @@ public class PaymentForSearchResult extends CardPayment {
                                   boolean delayedCapture, boolean moto, RefundSummary refundSummary, PaymentSettlementSummary settlementSummary, CardDetails cardDetails,
                                   List<PaymentConnectorResponseLink> links, URI selfLink, URI paymentEventsLink, URI paymentCancelLink, URI paymentRefundsLink, URI paymentCaptureUri,
                                   Long corporateCardSurcharge, Long totalAmount, String providerId, ExternalMetadata externalMetadata,
-                                  Long fee, Long netAmount, AuthorisationSummary authorisationSummary) {
+                                  Long fee, Long netAmount, AuthorisationSummary authorisationSummary, AuthorisationMode authorisationMode) {
         
         super(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider,
                 createdDate, refundSummary, settlementSummary, cardDetails, language, delayedCapture, moto, corporateCardSurcharge, totalAmount, providerId, externalMetadata,
-                fee, netAmount, authorisationSummary, null);
+                fee, netAmount, authorisationSummary, null, authorisationMode);
         this.links.addSelf(selfLink.toString());
         this.links.addEvents(paymentEventsLink.toString());
         this.links.addRefunds(paymentRefundsLink.toString());
@@ -81,7 +82,8 @@ public class PaymentForSearchResult extends CardPayment {
                 paymentResult.getMetadata().orElse(null),
                 paymentResult.getFee(),
                 paymentResult.getNetAmount(),
-                paymentResult.getAuthorisationSummary());
+                paymentResult.getAuthorisationSummary(),
+                paymentResult.getAuthorisationMode());
     }
 
     public PaymentLinksForSearch getLinks() {

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchIT.java
@@ -162,6 +162,7 @@ public class PaymentResourceSearchIT extends PaymentResourceITestBase {
                 .body("results[0].card_details.card_brand", is(CARD_DETAILS.getCardBrand()))
                 .body("results[0].card_details", hasKey("card_type"))
                 .body("results[0].metadata", is(nullValue()))
+                .body("results[0].authorisation_mode", is("web"))
                 .extract().asString();
 
         JsonAssert.with(responseBody)

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentResultBuilder.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.api.it.fixtures;
 
 import uk.gov.pay.api.model.PaymentSettlementSummary;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.validation.DateTimeUtils;
 
@@ -141,6 +142,7 @@ public abstract class PaymentResultBuilder {
         public Map<String, ?> metadata;
         public AuthorisationSummary authorisation_summary;
         public String agreement_id;
+        public String authorisation_mode;
     }
 
     protected static class TestPaymentState {
@@ -197,6 +199,7 @@ public abstract class PaymentResultBuilder {
     protected String gatewayTransactionId;
     protected Map<String, Object> metadata;
     protected AuthorisationSummary authorisationSummary;
+    protected AuthorisationMode authorisationMode = AuthorisationMode.WEB;
 
     public abstract String build();
     
@@ -241,6 +244,7 @@ public abstract class PaymentResultBuilder {
         payment.links = links ;
         payment.metadata = metadata;
         payment.authorisation_summary = authorisationSummary;
+        payment.authorisation_mode = authorisationMode.getName();
 
         return payment;
     }

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import uk.gov.pay.api.model.PaymentSettlementSummary;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 
 import java.util.List;
 import java.util.Map;
@@ -100,6 +101,11 @@ public class PaymentSearchResultBuilder extends PaymentResultBuilder {
 
     public PaymentSearchResultBuilder withAuthorisationSummary(uk.gov.pay.api.model.AuthorisationSummary authorisationSummary) {
         this.authorisationSummary = authorisationSummary == null ? null : new AuthorisationSummary(authorisationSummary.getThreeDSecure());
+        return this;
+    }
+    
+    public PaymentSearchResultBuilder withAuthorisationMode(AuthorisationMode authorisationMode) {
+        this.authorisationMode = authorisationMode;
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSingleResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSingleResultBuilder.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.gson.Gson;
 import uk.gov.pay.api.model.PaymentSettlementSummary;
 import uk.gov.pay.api.model.PaymentState;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.util.List;
@@ -128,11 +129,6 @@ public class PaymentSingleResultBuilder extends PaymentResultBuilder {
         return this;
     }
 
-    public String build() {
-        TestPayment result = getPayment();
-        return new Gson().toJson(result, new TypeReference<TestPayment>() {}.getType()); 
-    }
-
     public PaymentSingleResultBuilder withMetadata(Map<String, Object> metadata) {
         this.metadata = metadata;
         return this;
@@ -141,5 +137,15 @@ public class PaymentSingleResultBuilder extends PaymentResultBuilder {
     public PaymentSingleResultBuilder withAuthorisationSummary(uk.gov.pay.api.model.AuthorisationSummary authorisationSummary) {
         this.authorisationSummary = authorisationSummary == null ? null : new AuthorisationSummary(authorisationSummary.getThreeDSecure());
         return this;
+    }
+    
+    public PaymentSingleResultBuilder withAuthorisationMode(AuthorisationMode authorisationMode) {
+        this.authorisationMode = authorisationMode;
+        return this;
+    } 
+
+    public String build() {
+        TestPayment result = getPayment();
+        return new Gson().toJson(result, new TypeReference<TestPayment>() {}.getType());
     }
 }

--- a/src/test/java/uk/gov/pay/api/it/ledger/TransactionsResourceIT.java
+++ b/src/test/java/uk/gov/pay/api/it/ledger/TransactionsResourceIT.java
@@ -132,6 +132,7 @@ public class TransactionsResourceIT {
                 .body("results[0].authorisation_summary", is(notNullValue()))
                 .body("results[0].authorisation_summary.three_d_secure", is(notNullValue()))
                 .body("results[0].authorisation_summary.three_d_secure.required", is(true))
+                .body("results[0].authorisation_mode", is("web"))
                 .body("_links.self.href", is(expectedChargesLocationFor("?reference=reference&display_size=500&page=1")))
                 .body("_links.first_page.href", is(expectedChargesLocationFor("?reference=reference&display_size=500&page=1")))
                 .body("_links.last_page.href", is(expectedChargesLocationFor("?reference=reference&display_size=500&page=1")));

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -23,6 +23,7 @@ import uk.gov.pay.api.service.GetPaymentEventsService;
 import uk.gov.pay.api.service.GetPaymentService;
 import uk.gov.pay.api.service.PaymentSearchService;
 import uk.gov.pay.api.service.PublicApiUriGenerator;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import javax.ws.rs.core.Response;
@@ -121,6 +122,8 @@ public class PaymentsResourceCreatePaymentTest {
                 null,
                 null,
                 null,
-                null, null);
+                null,
+                null,
+                AuthorisationMode.WEB);
     }
 }

--- a/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServiceTest.java
@@ -163,7 +163,8 @@ public class CardPaymentSearchServiceTest {
                 .assertThat("results[0].state", hasKey("finished"))
                 .assertThat("results[0]", hasKey("authorisation_summary"))
                 .assertThat("results[0].authorisation_summary", hasKey("three_d_secure"))
-                .assertThat("results[0].authorisation_summary.three_d_secure.required", is(true));
+                .assertThat("results[0].authorisation_summary.three_d_secure.required", is(true))
+                .assertThat("results[0].authorisation_mode", is("web"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -20,6 +20,7 @@ import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.links.Link;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 import uk.gov.pay.api.model.links.PostLink;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
@@ -149,6 +150,26 @@ public class CreatePaymentServiceTest {
         assertThat(billingAddress.getCity(), is("address city"));
         assertThat(billingAddress.getPostcode(), is("AB1 CD2"));
         assertThat(billingAddress.getCountry(), is("GB"));
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector-create-payment-with-authorisation-mode-moto-api"})
+    public void testCreatePaymentWithAuthorisationModeMotoApi() {
+        Account account = new Account("123456", TokenPaymentType.CARD, "a-token-link");
+        var requestPayload = CreateCardPaymentRequestBuilder.builder()
+                .amount(100)
+                .returnUrl("https://somewhere.gov.uk/rainbow/1")
+                .reference("a reference")
+                .description("a description")
+                .authorisationMode(AuthorisationMode.MOTO_API)
+                .build();
+
+        PaymentWithAllLinks paymentResponse = createPaymentService.create(account, requestPayload);
+        CardPayment payment = (CardPayment) paymentResponse.getPayment();
+
+        assertThat(payment.getPaymentId(), is("ch_ab2341da231434l"));
+        assertThat(payment.getAuthorisationMode(), is(AuthorisationMode.MOTO_API));
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/api/service/GetPaymentServiceLedgerTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentServiceLedgerTest.java
@@ -19,6 +19,7 @@ import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 import uk.gov.pay.api.utils.mocks.ConnectorMockClient;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
@@ -114,6 +115,7 @@ public class GetPaymentServiceLedgerTest {
         assertThat(payment.getDelayedCapture(), is(true));
         assertThat(payment.getCorporateCardSurcharge(), is(Optional.empty()));
         assertThat(payment.getTotalAmount(), is(Optional.empty()));
+        assertThat(payment.getAuthorisationMode(), is(AuthorisationMode.WEB));
         assertThat(paymentResponse.getLinks().getSelf().getHref(), containsString("v1/payments/" + CHARGE_ID_NON_EXISTENT_IN_CONNECTOR));
         assertThat(paymentResponse.getLinks().getSelf().getMethod(), is("GET"));
         assertThat(paymentResponse.getLinks().getRefunds().getHref(), containsString("v1/payments/" + CHARGE_ID_NON_EXISTENT_IN_CONNECTOR + "/refunds"));

--- a/src/test/java/uk/gov/pay/api/service/GetPaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 import uk.gov.pay.api.model.links.PostLink;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
@@ -82,6 +83,7 @@ public class GetPaymentServiceTest {
         assertThat(payment.getDelayedCapture(), is(true));
         assertThat(payment.getCorporateCardSurcharge(), is(Optional.empty()));
         assertThat(payment.getTotalAmount(), is(Optional.empty()));
+        assertThat(payment.getAuthorisationMode(), is(AuthorisationMode.WEB));
         assertThat(paymentResponse.getLinks().getSelf().getHref(), containsString("v1/payments/" + CHARGE_ID));
         assertThat(paymentResponse.getLinks().getSelf().getMethod(), is("GET"));
         assertThat(paymentResponse.getLinks().getRefunds().getHref(), containsString("v1/payments/" + CHARGE_ID + "/refunds"));

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ChargeResponseFromConnector.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ChargeResponseFromConnector.java
@@ -6,6 +6,7 @@ import uk.gov.pay.api.model.PaymentSettlementSummary;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.model.telephone.PaymentOutcome;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.util.ArrayList;
@@ -31,6 +32,7 @@ public class ChargeResponseFromConnector {
     private final Long netAmount;
     private final AuthorisationSummary authorisationSummary;
     private String agreementId;
+    private AuthorisationMode authorisationMode;
 
     public Long getAmount() {
         return amount;
@@ -148,6 +150,14 @@ public class ChargeResponseFromConnector {
         return authorisationSummary;
     }
 
+    public String getAgreementId() {
+        return this.agreementId;
+    }
+    
+    public AuthorisationMode getAuthorisationMode() {
+        return authorisationMode;
+    }
+
     private ChargeResponseFromConnector(ChargeResponseFromConnectorBuilder builder) {
         this.amount = builder.amount;
         this.chargeId = builder.chargeId;
@@ -179,6 +189,7 @@ public class ChargeResponseFromConnector {
         this.netAmount = builder.netAmount;
         this.authorisationSummary = builder.authorisationSummary;
         this.agreementId = builder.agreementId;
+        this.authorisationMode = builder.authorisationMode;
     }
 
     public static final class ChargeResponseFromConnectorBuilder {
@@ -198,6 +209,8 @@ public class ChargeResponseFromConnector {
         private Long netAmount = null;
         private AuthorisationSummary authorisationSummary = null;
         private String agreementId;
+        private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
+        
         private ChargeResponseFromConnectorBuilder() {
         }
 
@@ -229,7 +242,8 @@ public class ChargeResponseFromConnector {
                     .withNetAmount(responseFromConnector.getNetAmount())
                     .withFee(responseFromConnector.getFee())
                     .withAuthorisationSummary(responseFromConnector.getAuthorisationSummary())
-                    .withAgreementId(responseFromConnector.getAgreementId());
+                    .withAgreementId(responseFromConnector.getAgreementId())
+                    .withAuthorisationMode(responseFromConnector.getAuthorisationMode());
         }
 
         public ChargeResponseFromConnectorBuilder withAmount(long amount) {
@@ -391,9 +405,11 @@ public class ChargeResponseFromConnector {
             this.agreementId = agreementId;
             return this;
         }
+        
+        public ChargeResponseFromConnectorBuilder withAuthorisationMode(AuthorisationMode authorisationMode) {
+            this.authorisationMode = authorisationMode;
+            return this;
+        }
     }
-
-    public String getAgreementId() {
-        return this.agreementId;
-    }
+    
 }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -88,7 +88,8 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                 .withMoto(responseFromConnector.isMoto())
                 .withAgreementId(responseFromConnector.getAgreementId())
                 .withLinks(responseFromConnector.getLinks())
-                .withSettlementSummary(responseFromConnector.getSettlementSummary());
+                .withSettlementSummary(responseFromConnector.getSettlementSummary())
+                .withAuthorisationMode(responseFromConnector.getAuthorisationMode());
         
         ofNullable(responseFromConnector.getCardDetails()).ifPresent(resultBuilder::withCardDetails);
         ofNullable(responseFromConnector.getRefundSummary()).ifPresent(resultBuilder::withRefundSummary);

--- a/src/test/java/uk/gov/pay/api/utils/mocks/CreateChargeRequestParams.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/CreateChargeRequestParams.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.utils.mocks;
 
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.Source;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
@@ -24,6 +25,7 @@ public class CreateChargeRequestParams {
     private final SupportedLanguage language;
     private final Source source;
     private final String setUpAgreement;
+    private final AuthorisationMode authorisationMode;
 
     private CreateChargeRequestParams(CreateChargeRequestParamsBuilder builder) {
         this.amount = builder.amount;
@@ -42,6 +44,7 @@ public class CreateChargeRequestParams {
         this.language = builder.language;
         this.source = builder.source;
         this.setUpAgreement = builder.setUpAgreement;
+        this.authorisationMode = builder.authorisationMode;
     }
 
     public int getAmount() {
@@ -108,6 +111,10 @@ public class CreateChargeRequestParams {
         return setUpAgreement;
     }
 
+    public AuthorisationMode getAuthorisationMode() {
+        return authorisationMode;
+    }
+
     public static final class CreateChargeRequestParamsBuilder {
         private Integer amount;
         private String returnUrl;
@@ -125,6 +132,7 @@ public class CreateChargeRequestParams {
         private SupportedLanguage language;
         private Source source;
         public String setUpAgreement;
+        public AuthorisationMode authorisationMode;
 
         private CreateChargeRequestParamsBuilder() {
         }
@@ -215,6 +223,11 @@ public class CreateChargeRequestParams {
 
         public CreateChargeRequestParamsBuilder withSetUpAgreement(String setUpAgreement) {
             this.setUpAgreement = setUpAgreement;
+            return this;
+        }
+        
+        public CreateChargeRequestParamsBuilder withAuthorisationMode(AuthorisationMode authorisationMode) {
+            this.authorisationMode = authorisationMode;
             return this;
         }
     }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/TransactionFromLedgerFixture.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/TransactionFromLedgerFixture.java
@@ -8,6 +8,7 @@ import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 import uk.gov.pay.api.model.PaymentSettlementSummary;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.util.ArrayList;
@@ -39,6 +40,7 @@ public class TransactionFromLedgerFixture {
     private String gatewayTransactionId;
     private Map<String, Object> metadata;
     private AuthorisationSummary authorisationSummary;
+    private AuthorisationMode authorisationMode;
 
     public String getReturnUrl() {
         return returnUrl;
@@ -116,6 +118,10 @@ public class TransactionFromLedgerFixture {
         return authorisationSummary;
     }
 
+    public AuthorisationMode getAuthorisationMode() {
+        return authorisationMode;
+    }
+
     public TransactionFromLedgerFixture(TransactionFromLedgerBuilder builder) {
         this.amount = builder.amount;
         this.state = builder.state;
@@ -140,6 +146,7 @@ public class TransactionFromLedgerFixture {
         this.gatewayTransactionId = builder.gatewayTransactionId;
         this.metadata = builder.metadata;
         this.authorisationSummary = builder.authorisationSummary;
+        this.authorisationMode = builder.authorisationMode;
     }
 
     public Long getAmount() {
@@ -183,6 +190,7 @@ public class TransactionFromLedgerFixture {
         private String gatewayTransactionId;
         private Map<String, Object> metadata;
         private AuthorisationSummary authorisationSummary;
+        private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
 
         private TransactionFromLedgerBuilder() {
         }
@@ -303,6 +311,11 @@ public class TransactionFromLedgerFixture {
 
         public TransactionFromLedgerBuilder withAuthorisationSummary(AuthorisationSummary authorisationSummary) {
             this.authorisationSummary = authorisationSummary;
+            return this;
+        }
+        
+        public TransactionFromLedgerBuilder withAuthorisationMode(AuthorisationMode authorisationMode) {
+            this.authorisationMode = authorisationMode;
             return this;
         }
 

--- a/src/test/resources/pacts/publicapi-connector-create-payment-with-authorisation-mode-moto-api.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment-with-authorisation-mode-moto-api.json
@@ -1,0 +1,103 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "a create charge request with authorisation_mode of moto_api",
+      "providerStates": [
+        {
+          "name": "a gateway account with external id exists",
+          "params": {
+            "gateway_account_id": "123456"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/v1/api/accounts/123456/charges",
+        "body": {
+          "amount": 100,
+          "reference": "a reference",
+          "description": "a description",
+          "return_url": "https://somewhere.gov.uk/rainbow/1",
+          "authorisation_mode": "moto_api"
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/json",
+          "Location": "/v1/api/accounts/123456/charges/ch_ab2341da231434l"
+        },
+        "body": {
+          "charge_id": "ch_ab2341da231434l",
+          "amount": 100,
+          "reference": "a reference",
+          "description": "a description",
+          "state": {
+            "status": "created",
+            "finished": false
+          },
+          "payment_provider": "Sandbox",
+          "created_date": "2016-01-01T12:00:00Z",
+          "language": "en",
+          "delayed_capture": false,
+          "moto": false,
+          "authorisation_mode": "moto_api"
+        },
+        "matchingRules": {
+          "header": {
+            "Location": {
+              "matchers": [
+                {
+                  "regex": "https*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/[a-z0-9]*"
+                }
+              ]
+            }
+          },
+          "body": {
+            "$.charge_id": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.amount": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.reference": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.email": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.description": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.state.status": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.return_url": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.payment_provider": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.created_date": {
+              "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}

--- a/src/test/resources/pacts/publicapi-connector-get-created-payment.json
+++ b/src/test/resources/pacts/publicapi-connector-get-created-payment.json
@@ -76,7 +76,8 @@
             "captured_date": null
           },
           "delayed_capture": true,
-          "moto": false
+          "moto": false,
+          "authorisation_mode": "web"
         },
         "matchingRules": {
           "body": {
@@ -132,6 +133,9 @@
               "matchers": [{"match": "type"}]
             },
             "$.payment_provider": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.authorisation_mode": {
               "matchers": [{"match": "type"}]
             }
           }

--- a/src/test/resources/pacts/publicapi-ledger-get-payment-with-delayed-capture-true.json
+++ b/src/test/resources/pacts/publicapi-ledger-get-payment-with-delayed-capture-true.json
@@ -54,7 +54,8 @@
             "capture_submit_time": null,
             "captured_date": null
           },
-          "delayed_capture": true
+          "delayed_capture": true,
+          "authorisation_mode": "web"
         },
         "matchingRules": {
           "body": {
@@ -69,6 +70,9 @@
             },
             "$.created_date": {
               "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
+            },
+            "$.authorisation_mode": {
+              "matchers": [{"match": "type"}]
             }
           }
         }

--- a/src/test/resources/pacts/publicapi-ledger-search-payments.json
+++ b/src/test/resources/pacts/publicapi-ledger-search-payments.json
@@ -73,7 +73,8 @@
                   "required": true,
                   "version": "2.1.0"
                 }
-              }
+              },
+              "authorisation_mode": "web"
             }
           ],
           "_links": {
@@ -178,6 +179,13 @@
               "matchers": [
                 {
                   "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+                }
+              ]
+            },
+            "$.results[*].authorisation_mode": {
+              "matchers": [
+                {
+                  "match": "type"
                 }
               ]
             }


### PR DESCRIPTION
Accept a new authorisation_mode property when creating a new payment.
Validate that this is a valid AuthorisationMode, and is one of the
allowed values - "web" or "moto_api". Ensure payments cannot be created
with `authorisation_mode` of "external", as this should only be set
internally for payments created using the telephone payment notification
API.

Return the `authorisation_mode` from connector/ledger in get and search
responses.

In the swagger file, hide the property on the create payment request as
we do not want people creating payments with this property set yet.
However, document the property on the payment response objects, as we
will start returning it immediately with a value of "web" for existing
payments.