### PR TITLE
PP-9390 map connector responses with authorisation mode `moto_api`

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -15,6 +15,7 @@ import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static uk.gov.pay.api.model.RequestError.Code.ACCOUNT_NOT_LINKED_WITH_PSP;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_ACCOUNT_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_AGREEMENT_ID_ERROR;
+import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_AUTHORISATION_API_NOT_ENABLED;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_CONNECTOR_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_MOTO_NOT_ENABLED;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_VALIDATION_ERROR;
@@ -57,6 +58,10 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
                 case ACCOUNT_NOT_LINKED_WITH_PSP:
                     statusCode = HttpStatus.FORBIDDEN_403;
                     requestError = aRequestError(ACCOUNT_NOT_LINKED_WITH_PSP);
+                    break;
+                case AUTHORISATION_API_NOT_ALLOWED:
+                    statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
+                    requestError = aRequestError(CREATE_PAYMENT_AUTHORISATION_API_NOT_ENABLED);
                     break;
                 default:
                     requestError = aRequestError(CREATE_PAYMENT_CONNECTOR_ERROR);

--- a/src/main/java/uk/gov/pay/api/model/RequestError.java
+++ b/src/main/java/uk/gov/pay/api/model/RequestError.java
@@ -22,6 +22,7 @@ public class RequestError {
         CREATE_AGREEMENT_PARSING_ERROR("P0197", "Unable to parse JSON"),
         CREATE_PAYMENT_MOTO_NOT_ENABLED("P0196", "MOTO payments are not enabled for this account. Please contact support if you would like to process MOTO payments"),
         
+        CREATE_PAYMENT_AUTHORISATION_API_NOT_ENABLED("P0195","Using authorisation_mode of moto_api is not allowed for this account"),
         CREATE_PAYMENT_MISSING_FIELD_ERROR("P0101", "Missing mandatory attribute: %s"),
         CREATE_PAYMENT_VALIDATION_ERROR("P0102", "Invalid attribute value: %s. %s"),
 

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentLinks.java
@@ -12,33 +12,37 @@ import static javax.ws.rs.HttpMethod.POST;
 @Schema(name = "PaymentLinks", description = "links for payment")
 public class PaymentLinks {
 
-    private static final String SELF = "self";
-    private static final String NEXT_URL = "next_url";
-    private static final String NEXT_URL_POST = "next_url_post";
-    private static final String EVENTS = "events";
-    private static final String CANCEL = "cancel";
-    private static final String REFUNDS = "refunds";
-    private static final String CAPTURE = "capture";
+    private static final String SELF_FIELD = "self";
+    private static final String NEXT_URL_FIELD = "next_url";
+    private static final String NEXT_URL_POST_FIELD = "next_url_post";
+    private static final String AUTH_URL_POST_FIELD = "auth_url_post";
+    private static final String EVENTS_FIELD = "events";
+    private static final String CANCEL_FIELD = "cancel";
+    private static final String REFUNDS_FIELD = "refunds";
+    private static final String CAPTURE_FIELD = "capture";
 
-    @JsonProperty(value = SELF)
+    @JsonProperty(value = SELF_FIELD)
     private Link self;
 
-    @JsonProperty(NEXT_URL)
+    @JsonProperty(NEXT_URL_FIELD)
     private Link nextUrl;
 
-    @JsonProperty(NEXT_URL_POST)
+    @JsonProperty(NEXT_URL_POST_FIELD)
     private PostLink nextUrlPost;
+    
+    @JsonProperty(AUTH_URL_POST_FIELD)
+    private PostLink authUrlPost;
 
-    @JsonProperty(value = EVENTS)
+    @JsonProperty(value = EVENTS_FIELD)
     private Link events;
 
-    @JsonProperty(value = REFUNDS)
+    @JsonProperty(value = REFUNDS_FIELD)
     private Link refunds;
 
-    @JsonProperty(value = CANCEL)
+    @JsonProperty(value = CANCEL_FIELD)
     private PostLink cancel;
     
-    @JsonProperty(value = CAPTURE)
+    @JsonProperty(value = CAPTURE_FIELD)
     private PostLink capture;
 
     public Link getSelf() {
@@ -51,6 +55,10 @@ public class PaymentLinks {
 
     public PostLink getNextUrlPost() {
         return nextUrlPost;
+    }
+    
+    public PostLink getAuthUrlPost() {
+        return authUrlPost;
     }
 
     public Link getEvents() {
@@ -72,6 +80,7 @@ public class PaymentLinks {
     public void addKnownLinksValueOf(List<PaymentConnectorResponseLink> chargeLinks) {
         addNextUrlIfPresent(chargeLinks);
         addNextUrlPostIfPresent(chargeLinks);
+        addAuthUrlPostIfPresent(chargeLinks);
         addCaptureUrlIfPresent(chargeLinks);
     }
 
@@ -94,24 +103,31 @@ public class PaymentLinks {
     public void addCapture(String href) {
         this.capture = new PostLink(href, POST);
     }
+    
+    private void addAuthUrlPostIfPresent(List<PaymentConnectorResponseLink> chargeLinks) {
+        chargeLinks.stream()
+                .filter(links -> AUTH_URL_POST_FIELD.equals(links.getRel()))
+                .findFirst()
+                .ifPresent(links -> this.authUrlPost = new PostLink(links.getHref(), links.getMethod(), links.getType(), links.getParams()));
+    }
 
     private void addNextUrlPostIfPresent(List<PaymentConnectorResponseLink> chargeLinks) {
         chargeLinks.stream()
-                .filter(chargeLink -> NEXT_URL_POST.equals(chargeLink.getRel()))
+                .filter(chargeLink -> NEXT_URL_POST_FIELD.equals(chargeLink.getRel()))
                 .findFirst()
                 .ifPresent(chargeLink -> this.nextUrlPost = new PostLink(chargeLink.getHref(), chargeLink.getMethod(), chargeLink.getType(), chargeLink.getParams()));
     }
 
     private void addNextUrlIfPresent(List<PaymentConnectorResponseLink> chargeLinks) {
         chargeLinks.stream()
-                .filter(chargeLink -> NEXT_URL.equals(chargeLink.getRel()))
+                .filter(chargeLink -> NEXT_URL_FIELD.equals(chargeLink.getRel()))
                 .findFirst()
                 .ifPresent(chargeLink -> this.nextUrl = new Link(chargeLink.getHref(), chargeLink.getMethod()));
     }
 
     private void addCaptureUrlIfPresent(List<PaymentConnectorResponseLink> chargeLinks) {
         chargeLinks.stream()
-                .filter(chargeLink -> CAPTURE.equals(chargeLink.getRel()))
+                .filter(chargeLink -> CAPTURE_FIELD.equals(chargeLink.getRel()))
                 .findFirst()
                 .ifPresent(chargeLink -> this.capture = new PostLink(chargeLink.getHref(), chargeLink.getMethod()));
     }

--- a/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
+++ b/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
@@ -29,7 +29,8 @@ public class CreateChargeExceptionMapperTest {
     @CsvSource({
             "TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED, RESOURCE_ACCESS_FORBIDDEN, 403",
             "ACCOUNT_NOT_LINKED_WITH_PSP, ACCOUNT_NOT_LINKED_WITH_PSP, 403",
-            "MOTO_NOT_ALLOWED, CREATE_PAYMENT_MOTO_NOT_ENABLED, 422"
+            "MOTO_NOT_ALLOWED, CREATE_PAYMENT_MOTO_NOT_ENABLED, 422",
+            "AUTHORISATION_API_NOT_ALLOWED, CREATE_PAYMENT_AUTHORISATION_API_NOT_ENABLED, 422"
     })
     public void testExceptionMapping(String errorIdentifier, String requestError, int expectedStatusCode) {
         when(mockResponse.readEntity(ConnectorErrorResponse.class))

--- a/src/test/java/uk/gov/pay/api/it/GetPaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/GetPaymentIT.java
@@ -187,12 +187,12 @@ public class GetPaymentIT extends PaymentResourceITestBase {
     public void getPaymentWithAuthorisationModeMotoApiThroughConnector_ReturnsPayment() {
         connectorMockClient.respondWithChargeFound(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, getConnectorCharge()
                 .withAuthorisationMode(AuthorisationMode.MOTO_API)
-                .build());
+                .build(), true);
 
         ValidatableResponse response = getPaymentResponse(CHARGE_ID);
 
         assertCommonPaymentFields(response);
-        assertConnectorOnlyPaymentFields(response);
+        assertConnectorOnlyMotoApiPaymentFields(response);
         response.body("authorisation_mode", is("moto_api"));
     }
 
@@ -260,6 +260,14 @@ public class GetPaymentIT extends PaymentResourceITestBase {
                 .body("_links.next_url_post.method", is("POST"))
                 .body("_links.next_url_post.type", is("application/x-www-form-urlencoded"))
                 .body("_links.next_url_post.params.chargeTokenId", is(CHARGE_TOKEN_ID));
+    }
+
+    private void assertConnectorOnlyMotoApiPaymentFields(ValidatableResponse paymentResponse) {
+        paymentResponse
+                .body("_links.auth_url_post.href", is("/v1/api/charges/authorise"))
+                .body("_links.auth_url_post.method", is("POST"))
+                .body("_links.auth_url_post.type", is("application/json"))
+                .body("_links.auth_url_post.params.one_time_token", is(CHARGE_TOKEN_ID));
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/api/service/GetPaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentServiceTest.java
@@ -136,4 +136,27 @@ public class GetPaymentServiceTest {
         assertThat(paymentResponse.getLinks().getNextUrl(), is(nullValue()));
         assertThat(paymentResponse.getLinks().getNextUrlPost(), is(nullValue()));
     }
+
+    @Test
+    @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector-get-motoapi-created-payment"})
+    public void testGetMotoApiPayment() {
+        Account account = new Account(ACCOUNT_ID, TokenPaymentType.CARD, "a-token-link");
+
+        PaymentWithAllLinks paymentResponse = getPaymentService.getPayment(account, CHARGE_ID);
+        CardPayment payment = (CardPayment) paymentResponse.getPayment();
+
+        assertThat(payment.getAmount(), is(100L));
+        assertThat(payment.getState(), is(new PaymentState("created", false)));
+        assertThat(payment.getDescription(), is("a description"));
+        assertThat(payment.getReference(), is("a reference"));
+        assertThat(payment.getPaymentId(), is(CHARGE_ID));
+        assertThat(payment.getMoto(), is (true));
+        assertThat(payment.getAuthorisationMode(), is(AuthorisationMode.MOTO_API));
+        assertThat(paymentResponse.getLinks().getSelf().getHref(), containsString("v1/payments/" + CHARGE_ID));
+        assertThat(paymentResponse.getLinks().getSelf().getMethod(), is("GET"));
+        assertThat(paymentResponse.getLinks().getRefunds().getHref(), containsString("v1/payments/" + CHARGE_ID + "/refunds"));
+        assertThat(paymentResponse.getLinks().getRefunds().getMethod(), is("GET"));
+        assertThat(paymentResponse.getLinks().getAuthUrlPost(), is(new PostLink("https://connector/v1/api/charges/authorise", "POST", "application/json", Collections.singletonMap("one_time_token", "token_1234567asdf"))));
+    }
 }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
@@ -26,7 +26,7 @@ public abstract class BaseConnectorMockClient {
     static String CONNECTOR_MOCK_TELEPHONE_CHARGES_PATH = CONNECTOR_MOCK_ACCOUNTS_PATH + "/telephone-charges";
     static String CONNECTOR_MOCK_CHARGE_PATH = CONNECTOR_MOCK_CHARGES_PATH + "/%s";
     static String CONNECTOR_MOCK_AGREEMENT_PATH = CONNECTOR_MOCK_ACCOUNTS_PATH + "/agreements";
-   
+    static String CONNECTOR_MOCK_AUTHORISATION_PATH = "/v1/api/charges/authorise";
 
     WireMockClassRule wireMockClassRule;
     Gson gson = new Gson();
@@ -55,7 +55,7 @@ public abstract class BaseConnectorMockClient {
     String chargeLocation(String accountId, String chargeId) {
         return format(CONNECTOR_MOCK_CHARGE_PATH, accountId, chargeId);
     }
-
+    
     abstract String nextUrlPost();
 
     String nextUrl(String tokenId) {

--- a/src/test/resources/pacts/publicapi-connector-create-payment-with-authorisation-mode-moto-api-not-allowed.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment-with-authorisation-mode-moto-api-not-allowed.json
@@ -1,0 +1,49 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "a create charge request when gateway account has moto_api auth mode disabled",
+      "providerStates": [
+        {
+          "name": "a gateway account with MOTO enabled and an external id 667 exists in the database",
+          "params": {
+            "gateway_account_id": "667"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/v1/api/accounts/667/charges",
+        "body": {
+          "amount": 100,
+          "reference": "a reference",
+          "description": "a description",
+          "return_url": "https://somewhere.gov.uk/rainbow/1",
+          "authorisation_mode": "moto_api"
+        }
+      },
+      "response": {
+        "status": 422,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "error_identifier": "AUTHORISATION_API_NOT_ALLOWED"
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}

--- a/src/test/resources/pacts/publicapi-connector-get-motoapi-created-payment.json
+++ b/src/test/resources/pacts/publicapi-connector-get-motoapi-created-payment.json
@@ -7,37 +7,24 @@
   },
   "interactions": [
     {
-      "description": "a create charge request with authorisation_mode of moto_api",
+      "description": "get a charge request for a moto_api created payment",
       "providerStates": [
         {
-          "name": "a gateway account with external id exists",
+          "name": "a charge with authorisation mode moto_api exists",
           "params": {
-            "gateway_account_id": "123456"
-          }
-        },
-        {
-          "name": "a gateway account has authorisation_api enabled",
-          "params": {
-            "gateway_account_id": "123456"
+            "gateway_account_id": "123456",
+            "charge_id": "ch_123abc456def"
           }
         }
       ],
       "request": {
-        "method": "POST",
-        "path": "/v1/api/accounts/123456/charges",
-        "body": {
-          "amount": 100,
-          "reference": "a reference",
-          "description": "a description",
-          "return_url": "https://somewhere.gov.uk/rainbow/1",
-          "authorisation_mode": "moto_api"
-        }
+        "method": "GET",
+        "path": "/v1/api/accounts/123456/charges/ch_123abc456def"
       },
       "response": {
-        "status": 201,
+        "status": 200,
         "headers": {
-          "Content-Type": "application/json",
-          "Location": "/v1/api/accounts/123456/charges/ch_123abc456def"
+          "Content-Type": "application/json"
         },
         "body": {
           "charge_id": "ch_123abc456def",
@@ -76,15 +63,6 @@
           ]
         },
         "matchingRules": {
-          "header": {
-            "Location": {
-              "matchers": [
-                {
-                  "regex": "https*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/[a-z0-9]*"
-                }
-              ]
-            }
-          },
           "body": {
             "$.charge_id": {
               "matchers": [{"match": "type"}]


### PR DESCRIPTION
## WHAT YOU DID
- Updated the PaymentLinks model to handle `auth_url_post` links when using the `moto_api` authorisation mode.
- Updated CreateChargeExceptionMapper to handle new error state when gateway acounts do not have `moto_api` enabled.
- Added new error identifier for bad authorisation permissions
- Added new Pact tests between PublicAPI and Connector to model scenarios involving charge creation and retrieval using the `moto_api` authorisation mode.
