### PR TITLE
PP-9390 Use publicapi authorisation endpoint for auth_url_post links

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/links/PaymentLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentLinks.java
@@ -3,7 +3,9 @@ package uk.gov.pay.api.model.links;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.PaymentConnectorResponseLink;
+import uk.gov.pay.api.service.PublicApiUriGenerator;
 
+import java.net.URI;
 import java.util.List;
 
 import static javax.ws.rs.HttpMethod.GET;
@@ -11,7 +13,7 @@ import static javax.ws.rs.HttpMethod.POST;
 
 @Schema(name = "PaymentLinks", description = "links for payment")
 public class PaymentLinks {
-
+    
     private static final String SELF_FIELD = "self";
     private static final String NEXT_URL_FIELD = "next_url";
     private static final String NEXT_URL_POST_FIELD = "next_url_post";
@@ -77,10 +79,10 @@ public class PaymentLinks {
         return capture;
     }
 
-    public void addKnownLinksValueOf(List<PaymentConnectorResponseLink> chargeLinks) {
+    public void addKnownLinksValueOf(List<PaymentConnectorResponseLink> chargeLinks, URI paymentAuthorisationUri) {
         addNextUrlIfPresent(chargeLinks);
         addNextUrlPostIfPresent(chargeLinks);
-        addAuthUrlPostIfPresent(chargeLinks);
+        addAuthUrlPostIfPresent(chargeLinks, paymentAuthorisationUri);
         addCaptureUrlIfPresent(chargeLinks);
     }
 
@@ -104,11 +106,11 @@ public class PaymentLinks {
         this.capture = new PostLink(href, POST);
     }
     
-    private void addAuthUrlPostIfPresent(List<PaymentConnectorResponseLink> chargeLinks) {
+    private void addAuthUrlPostIfPresent(List<PaymentConnectorResponseLink> chargeLinks, URI paymentAuthorisationUri) {
         chargeLinks.stream()
                 .filter(links -> AUTH_URL_POST_FIELD.equals(links.getRel()))
                 .findFirst()
-                .ifPresent(links -> this.authUrlPost = new PostLink(links.getHref(), links.getMethod(), links.getType(), links.getParams()));
+                .ifPresent(links -> this.authUrlPost = new PostLink(paymentAuthorisationUri.toString(), links.getMethod(), links.getType(), links.getParams()));
     }
 
     private void addNextUrlPostIfPresent(List<PaymentConnectorResponseLink> chargeLinks) {

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -38,13 +38,13 @@ public class PaymentWithAllLinks {
                                String reference, String email, String paymentProvider, String createdDate, SupportedLanguage language,
                                boolean delayedCapture, boolean moto, RefundSummary refundSummary, PaymentSettlementSummary settlementSummary, CardDetails cardDetails,
                                List<PaymentConnectorResponseLink> paymentConnectorResponseLinks, URI selfLink, URI paymentEventsUri, URI paymentCancelUri,
-                               URI paymentRefundsUri, URI paymentCaptureUri, Long corporateCardSurcharge, Long totalAmount, String providerId, ExternalMetadata metadata,
+                               URI paymentRefundsUri, URI paymentCaptureUri, URI paymentAuthorisationUri,  Long corporateCardSurcharge, Long totalAmount, String providerId, ExternalMetadata metadata,
                                Long fee, Long netAmount, AuthorisationSummary authorisationSummary, String agreementId, AuthorisationMode authorisationMode) {
         this.payment = new CardPayment(chargeId, amount, state, returnUrl, description, reference, email, paymentProvider, createdDate,
                 refundSummary, settlementSummary, cardDetails, language, delayedCapture, moto, corporateCardSurcharge, totalAmount,
                 providerId, metadata, fee, netAmount, authorisationSummary, agreementId, authorisationMode);
         this.links.addSelf(selfLink.toString());
-        this.links.addKnownLinksValueOf(paymentConnectorResponseLinks);
+        this.links.addKnownLinksValueOf(paymentConnectorResponseLinks, paymentAuthorisationUri);
         this.links.addEvents(paymentEventsUri.toString());
         this.links.addRefunds(paymentRefundsUri.toString());
 
@@ -62,7 +62,8 @@ public class PaymentWithAllLinks {
                                               URI paymentEventsUri,
                                               URI paymentCancelUri,
                                               URI paymentRefundsUri,
-                                              URI paymentsCaptureUri) {
+                                              URI paymentsCaptureUri,
+                                              URI paymentAuthorisationUri) {
         return new PaymentWithAllLinks(
                 paymentConnector.getChargeId(),
                 paymentConnector.getAmount(),
@@ -85,6 +86,7 @@ public class PaymentWithAllLinks {
                 paymentCancelUri,
                 paymentRefundsUri,
                 paymentsCaptureUri,
+                paymentAuthorisationUri,
                 paymentConnector.getCorporateCardSurcharge(),
                 paymentConnector.getTotalAmount(),
                 paymentConnector.getGatewayTransactionId(),
@@ -102,9 +104,10 @@ public class PaymentWithAllLinks {
             URI paymentEventsUri,
             URI paymentCancelUri,
             URI paymentRefundsUri,
-            URI paymentsCaptureUri) {
+            URI paymentsCaptureUri,
+            URI paymentAuthorisationUri) {
         
-        return PaymentWithAllLinks.valueOf(paymentConnector, selfLink, paymentEventsUri, paymentCancelUri, paymentRefundsUri, paymentsCaptureUri);
+        return PaymentWithAllLinks.valueOf(paymentConnector, selfLink, paymentEventsUri, paymentCancelUri, paymentRefundsUri, paymentsCaptureUri, paymentAuthorisationUri);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
@@ -48,7 +48,8 @@ public class CreatePaymentService {
                 publicApiUriGenerator.getPaymentEventsURI(chargeFromResponse.getChargeId()),
                 publicApiUriGenerator.getPaymentCancelURI(chargeFromResponse.getChargeId()),
                 publicApiUriGenerator.getPaymentRefundsURI(chargeFromResponse.getChargeId()),
-                publicApiUriGenerator.getPaymentCaptureURI(chargeFromResponse.getChargeId()));
+                publicApiUriGenerator.getPaymentCaptureURI(chargeFromResponse.getChargeId()),
+                publicApiUriGenerator.getPaymentAuthorisationURI());
     }
 
     private boolean createdSuccessfully(Response connectorResponse) {

--- a/src/main/java/uk/gov/pay/api/service/GetPaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/GetPaymentService.java
@@ -51,6 +51,7 @@ public class GetPaymentService {
                 publicApiUriGenerator.getPaymentEventsURI(chargeFromResponse.getChargeId()),
                 publicApiUriGenerator.getPaymentCancelURI(chargeFromResponse.getChargeId()),
                 publicApiUriGenerator.getPaymentRefundsURI(chargeFromResponse.getChargeId()),
-                publicApiUriGenerator.getPaymentCaptureURI(chargeFromResponse.getChargeId()));
+                publicApiUriGenerator.getPaymentCaptureURI(chargeFromResponse.getChargeId()),
+                publicApiUriGenerator.getPaymentAuthorisationURI());
     }
 }

--- a/src/main/java/uk/gov/pay/api/service/PublicApiUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/PublicApiUriGenerator.java
@@ -51,6 +51,12 @@ public class PublicApiUriGenerator {
                 .path("/v1/payments/{paymentId}/capture")
                 .build(chargeId);
     }
+    
+    public URI getPaymentAuthorisationURI(){
+        return UriBuilder.fromUri(baseUrl)
+                .path("/v1/auth")
+                .build();
+    }
 
     public String convertHostToPublicAPI(String link) {
         URI originalUri = UriBuilder.fromUri(link).build();

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
@@ -503,7 +503,7 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
                 .body("authorisation_mode", is(AuthorisationMode.MOTO_API.getName()))
                 .body("_links.auth_url_post.type", is("application/json"))
                 .body("_links.auth_url_post.method", is("POST"))
-                .body("_links.auth_url_post.href", is("/v1/api/charges/authorise"))
+                .body("_links.auth_url_post.href", is("http://publicapi.url/v1/auth"))
                 .body("_links.auth_url_post.params.one_time_token", is(CHARGE_TOKEN_ID));
                 
         connectorMockClient.verifyCreateChargeConnectorRequest(GATEWAY_ACCOUNT_ID, params);

--- a/src/test/java/uk/gov/pay/api/it/GetPaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/GetPaymentIT.java
@@ -264,7 +264,7 @@ public class GetPaymentIT extends PaymentResourceITestBase {
 
     private void assertConnectorOnlyMotoApiPaymentFields(ValidatableResponse paymentResponse) {
         paymentResponse
-                .body("_links.auth_url_post.href", is("/v1/api/charges/authorise"))
+                .body("_links.auth_url_post.href", is("http://publicapi.url/v1/auth"))
                 .body("_links.auth_url_post.method", is("POST"))
                 .body("_links.auth_url_post.type", is("application/json"))
                 .body("_links.auth_url_post.params.one_time_token", is(CHARGE_TOKEN_ID));

--- a/src/test/java/uk/gov/pay/api/model/PaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/model/PaymentTest.java
@@ -23,6 +23,7 @@ public class PaymentTest {
         URI cancelUri = URI.create("http://self.link.com/cancel");
         URI refundsUri = URI.create("http://self.link.com/cancel");
         URI captureUri = URI.create("self.link.com/capture");
+        URI authUri = URI.create("self.link.com/auth");
 
         // language=JSON
         ChargeFromResponse paymentFromConnector = objectMapper.readValue("{\n" +
@@ -48,7 +49,7 @@ public class PaymentTest {
                 "}", ChargeFromResponse.class);
 
         PaymentWithAllLinks payment = PaymentWithAllLinks.valueOf(Charge.from(paymentFromConnector), selfUri, eventsUri,
-                cancelUri, refundsUri, captureUri);
+                cancelUri, refundsUri, captureUri, authUri);
 
         assertThat(payment.toString(), not(containsString("user@example.com")));
         assertThat(payment.toString(), not(containsString("last_digits_card_number")));

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -116,6 +116,7 @@ public class PaymentsResourceCreatePaymentTest {
                 URI.create(PAYMENT_URI + "/cancel"),
                 URI.create(PAYMENT_URI + "/refunds"),
                 URI.create(PAYMENT_URI + "/capture"),
+                URI.create(PAYMENT_URI + "/auth"),
                 null,
                 null,
                 "providerId",

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -167,7 +167,7 @@ public class CreatePaymentServiceTest {
 
         PaymentWithAllLinks paymentResponse = createPaymentService.create(account, requestPayload);
         CardPayment payment = (CardPayment) paymentResponse.getPayment();
-        assertThat(paymentResponse.getLinks().getAuthUrlPost(), is(new PostLink("https://connector/v1/api/charges/authorise", "POST", "application/json", Collections.singletonMap("one_time_token", "token_1234567asdf"))));
+        assertThat(paymentResponse.getLinks().getAuthUrlPost(), is(new PostLink("http://publicapi.test.localhost/v1/auth", "POST", "application/json", Collections.singletonMap("one_time_token", "token_1234567asdf"))));
         assertThat(payment.getPaymentId(), is("ch_123abc456def"));
         assertThat(payment.getAuthorisationMode(), is(AuthorisationMode.MOTO_API));
     }

--- a/src/test/java/uk/gov/pay/api/service/GetPaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentServiceTest.java
@@ -157,6 +157,6 @@ public class GetPaymentServiceTest {
         assertThat(paymentResponse.getLinks().getSelf().getMethod(), is("GET"));
         assertThat(paymentResponse.getLinks().getRefunds().getHref(), containsString("v1/payments/" + CHARGE_ID + "/refunds"));
         assertThat(paymentResponse.getLinks().getRefunds().getMethod(), is("GET"));
-        assertThat(paymentResponse.getLinks().getAuthUrlPost(), is(new PostLink("https://connector/v1/api/charges/authorise", "POST", "application/json", Collections.singletonMap("one_time_token", "token_1234567asdf"))));
+        assertThat(paymentResponse.getLinks().getAuthUrlPost(), is(new PostLink("http://publicapi.test.localhost/v1/auth", "POST", "application/json", Collections.singletonMap("one_time_token", "token_1234567asdf"))));
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Updated the `PaymentWithAllLinks` class to construct responses with the correct payment authorisation URI when creating or retrieving payment requests