### PR TITLE
PP-9407 Don't require Authorisation header for auth API

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -125,7 +125,7 @@
         "filename": "src/test/java/uk/gov/pay/api/filter/AuthorizationValidationFilterTest.java",
         "hashed_secret": "a0936a38d2c31ad225d670f529a82319fc5bb915",
         "is_verified": false,
-        "line_number": 79
+        "line_number": 87
       }
     ],
     "src/test/resources/config/empty-elevated-accounts-test-config.yaml": [
@@ -156,5 +156,5 @@
       }
     ]
   },
-  "generated_at": "2021-11-24T12:04:57Z"
+  "generated_at": "2022-04-29T11:26:11Z"
 }

--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -59,6 +59,7 @@ import uk.gov.service.payments.logging.LoggingFilter;
 import uk.gov.service.payments.logging.LogstashConsoleAppenderFactory;
 import uk.gov.pay.api.exception.mapper.CreateAgreementExceptionMapper;
 import javax.net.ssl.HttpsURLConnection;
+import javax.servlet.FilterRegistration;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.EnumSet.of;
@@ -110,9 +111,10 @@ public class PublicApi extends Application<PublicApiConfig> {
 
         environment.servlets().addFilter("LoggingFilter", injector.getInstance(LoggingFilter.class))
                 .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
-        
-        environment.servlets().addFilter("AuthorizationValidationFilter", injector.getInstance(AuthorizationValidationFilter.class))
-                .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
+
+        FilterRegistration.Dynamic authorizationValidationFilter = environment.servlets().addFilter("AuthorizationValidationFilter", injector.getInstance(AuthorizationValidationFilter.class));
+        authorizationValidationFilter.setInitParameter("excludedUrls", "/v1/auth");
+        authorizationValidationFilter.addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
 
         /*
            Turn off 'FilteringJacksonJaxbJsonProvider' which overrides dropwizard JacksonMessageBodyProvider.

--- a/src/test/java/uk/gov/pay/api/filter/AuthorizationValidationFilterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/AuthorizationValidationFilterTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.pay.api.utils.ApiKeyGenerator.apiKeyValueOf;
 
 @ExtendWith(MockitoExtension.class)
-public class AuthorizationValidationFilterTest {
+class AuthorizationValidationFilterTest {
 
     private static final String SECRET_KEY = "mysupersecret";
     private AuthorizationValidationFilter authorizationValidationFilter;
@@ -50,7 +50,7 @@ public class AuthorizationValidationFilterTest {
     ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         Logger logger = (Logger) LoggerFactory.getLogger(AuthorizationValidationFilter.class);
         logger.setLevel(Level.WARN);
         logger.addAppender(mockAppender);
@@ -61,11 +61,12 @@ public class AuthorizationValidationFilterTest {
     }
 
     @Test
-    public void shouldProcessFilterChain_whenAuthorizationHeaderIsValid() throws Exception {
+    void shouldProcessFilterChain_whenAuthorizationHeaderIsValid() throws Exception {
 
         String validToken = "asdfghdasd";
         String authorization = "Bearer " + apiKeyValueOf(validToken, SECRET_KEY);
 
+        when(mockRequest.getRequestURI()).thenReturn("/v1/payments");
         when(mockRequest.getHeader("Authorization")).thenReturn(authorization);
 
         authorizationValidationFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
@@ -74,11 +75,19 @@ public class AuthorizationValidationFilterTest {
     }
 
     @Test
-    public void shouldRejectRequest_with401ResponseError_whenAuthorizationHeaderIsInvalid() throws Exception {
+    void shouldProcessFilterChain_whenUrlIsAuthURLAndNoAuthorisationHeaderPresent() throws Exception {
+        when(mockRequest.getRequestURI()).thenReturn("/v1/auth");
+        authorizationValidationFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
+        verify(mockFilterChain).doFilter(mockRequest, mockResponse);
+    }
+
+    @Test
+    void shouldRejectRequest_with401ResponseError_whenAuthorizationHeaderIsInvalid() throws Exception {
 
         String invalidApiKey = "asdfghdasdakjshdkjwhdjweghrhjgwerguweurweruhiweuiweriuui";
         String authorization = "Bearer " + invalidApiKey;
 
+        when(mockRequest.getRequestURI()).thenReturn("/v1/payments");
         when(mockRequest.getHeader("Authorization")).thenReturn(authorization);
 
         authorizationValidationFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
@@ -93,8 +102,9 @@ public class AuthorizationValidationFilterTest {
     }
 
     @Test
-    public void shouldRejectRequest_with401ResponseError_whenAuthorizationHeaderIsNotPresent() throws Exception {
+    void shouldRejectRequest_with401ResponseError_whenAuthorizationHeaderIsNotPresent() throws Exception {
 
+        when(mockRequest.getRequestURI()).thenReturn("/v1/payments");
         when(mockRequest.getHeader("Authorization")).thenReturn(null);
 
         authorizationValidationFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
@@ -104,11 +114,12 @@ public class AuthorizationValidationFilterTest {
     }
 
     @Test
-    public void shouldRejectRequest_with401ResponseError_whenAuthorizationHeaderHasInvalidFormat() throws Exception {
+    void shouldRejectRequest_with401ResponseError_whenAuthorizationHeaderHasInvalidFormat() throws Exception {
 
         String validToken = "asdfghdasd";
         String authorization = "Bearer" + apiKeyValueOf(validToken, SECRET_KEY);
 
+        when(mockRequest.getRequestURI()).thenReturn("/v1/payments");
         when(mockRequest.getHeader("Authorization")).thenReturn(authorization);
 
         authorizationValidationFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
@@ -118,11 +129,12 @@ public class AuthorizationValidationFilterTest {
     }
 
     @Test
-    public void shouldRejectRequest_with401ResponseError_whenAuthorizationHeaderHasNotMinimumLengthExpected() throws Exception {
+    void shouldRejectRequest_with401ResponseError_whenAuthorizationHeaderHasNotMinimumLengthExpected() throws Exception {
 
         String apiKey = RandomStringUtils.randomAlphanumeric(32);
         String authorization = "Bearer " + apiKey;
 
+        when(mockRequest.getRequestURI()).thenReturn("/v1/payments");
         when(mockRequest.getHeader("Authorization")).thenReturn(authorization);
 
         authorizationValidationFilter.doFilter(mockRequest, mockResponse, mockFilterChain);

--- a/src/test/java/uk/gov/pay/api/resources/AuthorisationResourceIT.java
+++ b/src/test/java/uk/gov/pay/api/resources/AuthorisationResourceIT.java
@@ -162,7 +162,6 @@ public class AuthorisationResourceIT extends PaymentResourceITestBase {
                 .body(payload)
                 .accept(JSON)
                 .contentType(JSON)
-                .header(AUTHORIZATION, "Bearer " + API_KEY)
                 .post(AUTH_PATH)
                 .then();
     }


### PR DESCRIPTION
The MOTO payments authorisation API should not require an Authorisation header with the bearer token to be present. We instead require a one_time_token in the request body to authorise the request.

Add an exclusion to the filter that checks for Authorisation header for the URL "/v1/auth". It is not possible to add this exclusion in the URL pattern we provide for the filter when registering it in the app module, so instead hardcode this exclusion into the filter.