### PR TITLE
PP-9389 remove `return_url` from connector auth api pact tests

### DIFF
--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -159,7 +159,6 @@ public class CreatePaymentServiceTest {
         Account account = new Account("123456", TokenPaymentType.CARD, "a-token-link");
         var requestPayload = CreateCardPaymentRequestBuilder.builder()
                 .amount(100)
-                .returnUrl("https://somewhere.gov.uk/rainbow/1")
                 .reference("a reference")
                 .description("a description")
                 .authorisationMode(AuthorisationMode.MOTO_API)
@@ -179,7 +178,6 @@ public class CreatePaymentServiceTest {
         Account account = new Account("667", TokenPaymentType.CARD, "a-token-link");
         var requestPayload = CreateCardPaymentRequestBuilder.builder()
                 .amount(100)
-                .returnUrl("https://somewhere.gov.uk/rainbow/1")
                 .reference("a reference")
                 .description("a description")
                 .authorisationMode(AuthorisationMode.MOTO_API)

--- a/src/test/resources/pacts/publicapi-connector-create-payment-with-authorisation-mode-moto-api-not-allowed.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment-with-authorisation-mode-moto-api-not-allowed.json
@@ -23,7 +23,6 @@
           "amount": 100,
           "reference": "a reference",
           "description": "a description",
-          "return_url": "https://somewhere.gov.uk/rainbow/1",
           "authorisation_mode": "moto_api"
         }
       },

--- a/src/test/resources/pacts/publicapi-connector-create-payment-with-authorisation-mode-moto-api.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment-with-authorisation-mode-moto-api.json
@@ -29,7 +29,6 @@
           "amount": 100,
           "reference": "a reference",
           "description": "a description",
-          "return_url": "https://somewhere.gov.uk/rainbow/1",
           "authorisation_mode": "moto_api"
         }
       },
@@ -102,9 +101,6 @@
               "matchers": [{"match": "type"}]
             },
             "$.state.status": {
-              "matchers": [{"match": "type"}]
-            },
-            "$.return_url": {
               "matchers": [{"match": "type"}]
             },
             "$.payment_provider": {


### PR DESCRIPTION
## WHAT YOU DID
Remove the `return_url` check on auth API Pact tests as this is not required for this type of request