### PR TITLE
BAU: Exclude Github Actions/Dependabot from post-merge workflow

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '.github/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
See ADR: https://github.com/alphagov/pay-architecture/pull/49/files

This means that for PRs where the only changes are files in the `.github` folder, merging will not trigger the post-merge workflow (release and tag) or subsequent Concourse builds.