### PR TITLE
PP-9587: Map account disabled error from Connector for refunds

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -46,10 +46,6 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
         } else {
             ErrorIdentifier errorIdentifier = exception.getErrorIdentifier();
             switch (errorIdentifier) {
-                case ACCOUNT_DISABLED:
-                    statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
-                    requestError = aRequestError(ACCOUNT_DISABLED);
-                    break;
                 case ZERO_AMOUNT_NOT_ALLOWED:
                     statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
                     requestError = aRequestError("amount", CREATE_PAYMENT_VALIDATION_ERROR,
@@ -58,6 +54,10 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
                 case MOTO_NOT_ALLOWED:
                     statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
                     requestError = aRequestError(CREATE_PAYMENT_MOTO_NOT_ENABLED);
+                    break;
+                case ACCOUNT_DISABLED:
+                    statusCode = HttpStatus.FORBIDDEN_403;
+                    requestError = aRequestError(ACCOUNT_DISABLED);
                     break;
                 case TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED:
                     statusCode = HttpStatus.FORBIDDEN_403;

--- a/src/main/java/uk/gov/pay/api/service/CreateRefundService.java
+++ b/src/main/java/uk/gov/pay/api/service/CreateRefundService.java
@@ -48,10 +48,11 @@ public class CreateRefundService {
 
         Integer refundAmountAvailable = createPaymentRefundRequest.getRefundAmountAvailable()
                 .orElseGet(() -> getRefundAmountAvailableFromPayment(strategy));
-        
-        ImmutableMap<String, Object> payloadMap = ImmutableMap.of("amount", createPaymentRefundRequest.getAmount(), "refund_amount_available", refundAmountAvailable);
-        String connectorPayload = new GsonBuilder().create().toJson(
-                payloadMap);
+
+        ImmutableMap<String, Object> payloadMap = ImmutableMap.of(
+                "amount", createPaymentRefundRequest.getAmount(),
+                "refund_amount_available", refundAmountAvailable);
+        String connectorPayload = new GsonBuilder().create().toJson(payloadMap);
 
         Response connectorResponse = client
                 .target(getConnectorUrl(format("/v1/api/accounts/%s/charges/%s/refunds", account.getAccountId(), paymentId)))
@@ -61,7 +62,7 @@ public class CreateRefundService {
         if (connectorResponse.getStatus() != ACCEPTED.getStatusCode()) {
             throw new CreateRefundException(connectorResponse);
         }
-        
+
         RefundFromConnector refundFromConnector = connectorResponse.readEntity(RefundFromConnector.class);
         logger.debug("created refund returned - [ {} ]", refundFromConnector);
         return RefundResponse.valueOf(refundFromConnector, paymentId, baseUrl);

--- a/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
+++ b/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
@@ -36,9 +36,9 @@ class CreateChargeExceptionMapperTest {
 
     static Object[] parametersForMapping() {
         return new Object[] {
-                new Object[]{ACCOUNT_DISABLED, false, "GOV.UK Pay has disabled payment and refund creation on this account. Contact support with your error code.", 422, "P0941"},
                 new Object[]{ZERO_AMOUNT_NOT_ALLOWED, false, "Invalid attribute value: amount. Must be greater than or equal to 1", 422, "P0102"},
                 new Object[]{MOTO_NOT_ALLOWED, false, "MOTO payments are not enabled for this account. Please contact support if you would like to process MOTO payments", 422, "P0196"},
+                new Object[]{ACCOUNT_DISABLED, false, "GOV.UK Pay has disabled payment and refund creation on this account. Contact support with your error code.", 403, "P0941"},
                 new Object[]{TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED, false, "Access to this resource is not enabled for this account. Please contact support.", 403, "P0930"},
                 new Object[]{ACCOUNT_NOT_LINKED_WITH_PSP, false, "Account is not fully configured. Please refer to documentation to setup your account or contact support.", 403, "P0940"},
                 new Object[]{AUTHORISATION_API_NOT_ALLOWED, false, "Using authorisation_mode of moto_api is not allowed for this account", 422, "P0195"},

--- a/src/test/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapperTest.java
+++ b/src/test/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapperTest.java
@@ -1,0 +1,57 @@
+package uk.gov.pay.api.exception.mapper;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.api.exception.ConnectorResponseErrorException;
+import uk.gov.pay.api.exception.CreateRefundException;
+import uk.gov.pay.api.model.RequestError;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+
+import javax.ws.rs.core.Response;
+
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.when;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.ACCOUNT_DISABLED;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.GENERIC;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.REFUND_NOT_AVAILABLE;
+
+@ExtendWith(MockitoExtension.class)
+class CreateRefundExceptionMapperTest {
+
+    @Mock
+    private Response mockResponse;
+
+    private final CreateRefundExceptionMapper mapper = new CreateRefundExceptionMapper();
+
+    static Object[] parametersForMapping() {
+        return new Object[] {
+                new Object[]{ACCOUNT_DISABLED, null, "GOV.UK Pay has disabled payment and refund creation on this account. Contact support with your error code.", 403, "P0941"},
+                new Object[]{REFUND_AMOUNT_AVAILABLE_MISMATCH, null, "Refund amount available mismatch.", 412, "P0604"},
+                new Object[]{REFUND_NOT_AVAILABLE, "This is a reason", "The payment is not available for refund. Payment refund status: This is a reason", 400, "P0603"},
+                new Object[]{REFUND_NOT_AVAILABLE, null, "Downstream system error", 500, "P0698"},
+                new Object[]{GENERIC, null, "Downstream system error", 500, "P0698"},
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("parametersForMapping")
+    void testExceptionMapping(ErrorIdentifier errorIdentifier, String reason, String expectedDescription, int expectedStatusCode, String expectedErrorCode) {
+        when(mockResponse.readEntity(ConnectorResponseErrorException.ConnectorErrorResponse.class))
+                .thenReturn(new ConnectorResponseErrorException.ConnectorErrorResponse(errorIdentifier, reason, Collections.emptyList()));
+
+        Response returnedResponse = mapper.toResponse(new CreateRefundException(mockResponse));
+        RequestError returnedError = (RequestError) returnedResponse.getEntity();
+
+        assertThat(returnedResponse.getStatus(), is(expectedStatusCode));
+        assertThat(returnedError.getDescription(), is(expectedDescription));
+        assertThat(returnedError.getCode(), is(expectedErrorCode));
+    }
+    
+}

--- a/src/test/java/uk/gov/pay/api/service/CreateRefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreateRefundServiceTest.java
@@ -1,0 +1,68 @@
+package uk.gov.pay.api.service;
+
+import au.com.dius.pact.consumer.PactVerification;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.api.app.RestClientFactory;
+import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.app.config.RestClientConfig;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.exception.CreateRefundException;
+import uk.gov.pay.api.model.CreatePaymentRefundRequest;
+import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
+import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+
+import javax.ws.rs.client.Client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CreateRefundServiceTest {
+    
+    private CreateRefundService createRefundService;
+
+    @Rule
+    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+
+    @Mock
+    private PublicApiConfig configuration;
+    
+    @Mock
+    private GetPaymentService getPaymentService;
+
+    private Account account;
+
+    @Before
+    public void setup() {
+        when(configuration.getConnectorUrl()).thenReturn(connectorRule.getUrl()); // We will actually send real requests here, which will be intercepted by pact
+        when(configuration.getBaseUrl()).thenReturn("http://publicapi.test.localhost/");
+
+        Client client = RestClientFactory.buildClient(new RestClientConfig(false));
+        
+        createRefundService = new CreateRefundService(getPaymentService, client, configuration);
+        account = new Account("123456", TokenPaymentType.CARD, "a-token-link");
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector-create-refund-for-disabled-account"})
+    public void creating_refund_for_disabled_account_should_return_422() {
+        var requestPayload = new CreatePaymentRefundRequest(100, 100);
+
+        try {
+            createRefundService.createRefund(account,"654321" , requestPayload);
+            fail("Expected CreateRefundException to be thrown");
+        } catch (CreateRefundException e) {
+            assertThat(e.getErrorIdentifier(), is(ErrorIdentifier.ACCOUNT_DISABLED));
+        }
+    }
+}

--- a/src/test/resources/pacts/publicapi-connector-create-refund-for-disabled-account.json
+++ b/src/test/resources/pacts/publicapi-connector-create-refund-for-disabled-account.json
@@ -1,0 +1,53 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "a create refund request for disabled account",
+      "providerStates": [
+        {
+          "name": "a charge exists",
+          "params": {
+            "gateway_account_id": "123456",
+            "charge_id": "654321"
+          }
+        },
+        {
+          "name": "the gateway account is disabled",
+          "params": {
+            "gateway_account_id": "123456"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/v1/api/accounts/123456/charges/654321/refunds",
+        "body": {
+          "amount": 100,
+          "refund_amount_available": 100
+        }
+      },
+      "response": {
+        "status": 422,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "error_identifier": "ACCOUNT_DISABLED"
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
* New CreateChargeException mapping
* New pact test
* Uses same message and error code as used for create payment request when account is disabled