### PR TITLE
PP-9587: Re-instate pact tests relating to disabled accounts

### DIFF
--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -154,6 +154,25 @@ public class CreatePaymentServiceTest {
 
     @Test
     @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector-create-payment-for-disabled-account"})
+    public void creating_payment_for_disabled_account_should_return_403() {
+        var requestPayload = CreateCardPaymentRequestBuilder.builder()
+                .amount(100)
+                .returnUrl("https://somewhere.gov.uk/rainbow/1")
+                .reference("a reference")
+                .description("a description")
+                .build();
+
+        try {
+            createPaymentService.create(account, requestPayload);
+            fail("Expected CreateChargeException to be thrown");
+        } catch (CreateChargeException e) {
+            assertThat(e.getErrorIdentifier(), is(ErrorIdentifier.ACCOUNT_DISABLED));
+        }
+    }
+
+    @Test
+    @PactVerification({"connector"})
     @Pacts(pacts = {"publicapi-connector-create-payment-with-authorisation-mode-moto-api"})
     public void testCreatePaymentWithAuthorisationModeMotoApi() {
         Account account = new Account("123456", TokenPaymentType.CARD, "a-token-link");

--- a/src/test/java/uk/gov/pay/api/service/CreateRefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreateRefundServiceTest.java
@@ -1,0 +1,68 @@
+package uk.gov.pay.api.service;
+
+import au.com.dius.pact.consumer.PactVerification;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.api.app.RestClientFactory;
+import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.app.config.RestClientConfig;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.exception.CreateRefundException;
+import uk.gov.pay.api.model.CreatePaymentRefundRequest;
+import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
+import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+
+import javax.ws.rs.client.Client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CreateRefundServiceTest {
+    
+    private CreateRefundService createRefundService;
+
+    @Rule
+    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+
+    @Mock
+    private PublicApiConfig configuration;
+    
+    @Mock
+    private GetPaymentService getPaymentService;
+
+    private Account account;
+
+    @Before
+    public void setup() {
+        when(configuration.getConnectorUrl()).thenReturn(connectorRule.getUrl()); // We will actually send real requests here, which will be intercepted by pact
+        when(configuration.getBaseUrl()).thenReturn("http://publicapi.test.localhost/");
+
+        Client client = RestClientFactory.buildClient(new RestClientConfig(false));
+        
+        createRefundService = new CreateRefundService(getPaymentService, client, configuration);
+        account = new Account("123456", TokenPaymentType.CARD, "a-token-link");
+    }
+
+    @Test
+    @PactVerification({"connector"})
+    @Pacts(pacts = {"publicapi-connector-create-refund-for-disabled-account"})
+    public void creating_refund_for_disabled_account_should_return_403() {
+        var requestPayload = new CreatePaymentRefundRequest(100, 100);
+
+        try {
+            createRefundService.createRefund(account,"654321" , requestPayload);
+            fail("Expected CreateRefundException to be thrown");
+        } catch (CreateRefundException e) {
+            assertThat(e.getErrorIdentifier(), is(ErrorIdentifier.ACCOUNT_DISABLED));
+        }
+    }
+}

--- a/src/test/resources/pacts/publicapi-connector-create-payment-for-disabled-account.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment-for-disabled-account.json
@@ -1,0 +1,54 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "a create charge request for disabled account",
+      "providerStates": [
+        {
+          "name": "a gateway account with external id exists",
+          "params": {
+            "gateway_account_id": "123456"
+          }
+        },
+        {
+          "name": "the gateway account is disabled",
+          "params": {
+            "gateway_account_id": "123456"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/v1/api/accounts/123456/charges",
+        "body": {
+          "amount": 100,
+          "reference": "a reference",
+          "description": "a description",
+          "return_url": "https://somewhere.gov.uk/rainbow/1"
+        }
+      },
+      "response": {
+        "status": 403,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "error_identifier": "ACCOUNT_DISABLED"
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}

--- a/src/test/resources/pacts/publicapi-connector-create-refund-for-disabled-account.json
+++ b/src/test/resources/pacts/publicapi-connector-create-refund-for-disabled-account.json
@@ -1,0 +1,53 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "a create refund request for disabled account",
+      "providerStates": [
+        {
+          "name": "a charge exists",
+          "params": {
+            "gateway_account_id": "123456",
+            "charge_id": "654321"
+          }
+        },
+        {
+          "name": "the gateway account is disabled",
+          "params": {
+            "gateway_account_id": "123456"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/v1/api/accounts/123456/charges/654321/refunds",
+        "body": {
+          "amount": 100,
+          "refund_amount_available": 100
+        }
+      },
+      "response": {
+        "status": 403,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "error_identifier": "ACCOUNT_DISABLED"
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
* Connector now returns 403 status code instead of 422
* Re-instate removed tests and update their status codes accordingly