### PR TITLE
PP-9587 Include link to support page in error responses

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/RequestError.java
+++ b/src/main/java/uk/gov/pay/api/model/RequestError.java
@@ -15,12 +15,12 @@ public class RequestError {
 
         CREATE_PAYMENT_AGREEMENT_ID_ERROR("P0103", "Invalid attribute value: set_up_agreement. Agreement ID does not exist"),
 
-        CREATE_PAYMENT_ACCOUNT_ERROR("P0199", "There is an error with this account. Please contact support"),
+        CREATE_PAYMENT_ACCOUNT_ERROR("P0199", "There is an error with this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ ."),
         CREATE_PAYMENT_CONNECTOR_ERROR("P0198", "Downstream system error"),
         CREATE_AGREEMENT_CONNECTOR_ERROR("P0198", "Downstream system error"),
         CREATE_PAYMENT_PARSING_ERROR("P0197", "Unable to parse JSON"),
         CREATE_AGREEMENT_PARSING_ERROR("P0197", "Unable to parse JSON"),
-        CREATE_PAYMENT_MOTO_NOT_ENABLED("P0196", "MOTO payments are not enabled for this account. Please contact support if you would like to process MOTO payments"),
+        CREATE_PAYMENT_MOTO_NOT_ENABLED("P0196", "MOTO payments are not enabled for this account. Please contact support if you would like to process MOTO payments - https://www.payments.service.gov.uk/support/ ."),
         CREATE_PAYMENT_AUTHORISATION_API_NOT_ENABLED("P0195","Using authorisation_mode of moto_api is not allowed for this account"),
 
         GENERIC_MISSING_FIELD_ERROR_MESSAGE_FROM_CONNECTOR("P0101", "%s"),
@@ -66,9 +66,9 @@ public class RequestError {
 
         TOO_MANY_REQUESTS_ERROR("P0900", "Too many requests"),
         REQUEST_DENIED_ERROR("P0920", "Request blocked by security rules. Please consult API documentation for more information."),
-        RESOURCE_ACCESS_FORBIDDEN("P0930", "Access to this resource is not enabled for this account. Please contact support."),
-        ACCOUNT_NOT_LINKED_WITH_PSP("P0940", "Account is not fully configured. Please refer to documentation to setup your account or contact support."),
-        ACCOUNT_DISABLED("P0941", "GOV.UK Pay has disabled payment and refund creation on this account. Contact support with your error code."),
+        RESOURCE_ACCESS_FORBIDDEN("P0930", "Access to this resource is not enabled for this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ ."),
+        ACCOUNT_NOT_LINKED_WITH_PSP("P0940", "Account is not fully configured. Please refer to documentation to setup your account or contact support with your error code - https://www.payments.service.gov.uk/support/ ."),
+        ACCOUNT_DISABLED("P0941", "GOV.UK Pay has disabled payment and refund creation on this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ ."),
 
         SEARCH_REFUNDS_VALIDATION_ERROR("P1101", "Invalid parameters: %s. See Public API documentation for the correct data formats"),
         SEARCH_REFUNDS_NOT_FOUND("P1100", "Page not found"),

--- a/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
+++ b/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
@@ -37,10 +37,10 @@ class CreateChargeExceptionMapperTest {
     static Object[] parametersForMapping() {
         return new Object[] {
                 new Object[]{ZERO_AMOUNT_NOT_ALLOWED, false, "Invalid attribute value: amount. Must be greater than or equal to 1", 422, "P0102"},
-                new Object[]{MOTO_NOT_ALLOWED, false, "MOTO payments are not enabled for this account. Please contact support if you would like to process MOTO payments", 422, "P0196"},
-                new Object[]{ACCOUNT_DISABLED, false, "GOV.UK Pay has disabled payment and refund creation on this account. Contact support with your error code.", 403, "P0941"},
-                new Object[]{TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED, false, "Access to this resource is not enabled for this account. Please contact support.", 403, "P0930"},
-                new Object[]{ACCOUNT_NOT_LINKED_WITH_PSP, false, "Account is not fully configured. Please refer to documentation to setup your account or contact support.", 403, "P0940"},
+                new Object[]{MOTO_NOT_ALLOWED, false, "MOTO payments are not enabled for this account. Please contact support if you would like to process MOTO payments - https://www.payments.service.gov.uk/support/ .", 422, "P0196"},
+                new Object[]{ACCOUNT_DISABLED, false, "GOV.UK Pay has disabled payment and refund creation on this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ .", 403, "P0941"},
+                new Object[]{TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED, false, "Access to this resource is not enabled for this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ .", 403, "P0930"},
+                new Object[]{ACCOUNT_NOT_LINKED_WITH_PSP, false, "Account is not fully configured. Please refer to documentation to setup your account or contact support with your error code - https://www.payments.service.gov.uk/support/ .", 403, "P0940"},
                 new Object[]{AUTHORISATION_API_NOT_ALLOWED, false, "Using authorisation_mode of moto_api is not allowed for this account", 422, "P0195"},
                 new Object[]{MISSING_MANDATORY_ATTRIBUTE, true, "An error message from connector", 400, "P0101"},
                 new Object[]{UNEXPECTED_ATTRIBUTE, true, "An error message from connector", 400, "P0104"},

--- a/src/test/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapperTest.java
+++ b/src/test/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapperTest.java
@@ -32,7 +32,7 @@ class CreateRefundExceptionMapperTest {
 
     static Object[] parametersForMapping() {
         return new Object[] {
-                new Object[]{ACCOUNT_DISABLED, null, "GOV.UK Pay has disabled payment and refund creation on this account. Contact support with your error code.", 403, "P0941"},
+                new Object[]{ACCOUNT_DISABLED, null, "GOV.UK Pay has disabled payment and refund creation on this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ .", 403, "P0941"},
                 new Object[]{REFUND_AMOUNT_AVAILABLE_MISMATCH, null, "Refund amount available mismatch.", 412, "P0604"},
                 new Object[]{REFUND_NOT_AVAILABLE, "This is a reason", "The payment is not available for refund. Payment refund status: This is a reason", 400, "P0603"},
                 new Object[]{REFUND_NOT_AVAILABLE, null, "Downstream system error", 500, "P0698"},

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
@@ -589,7 +589,7 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
                 .statusCode(500)
                 .contentType(JSON)
                 .body("code", is("P0199"))
-                .body("description", is("There is an error with this account. Please contact support"));
+                .body("description", is("There is an error with this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ ."));
 
         connectorMockClient.verifyCreateChargeConnectorRequest(notFoundGatewayAccountId, SUCCESS_PAYLOAD);
     }
@@ -612,7 +612,7 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
                 .statusCode(422)
                 .contentType(JSON)
                 .body("code", is("P0196"))
-                .body("description", is("MOTO payments are not enabled for this account. Please contact support if you would like to process MOTO payments"));
+                .body("description", is("MOTO payments are not enabled for this account. Please contact support if you would like to process MOTO payments - https://www.payments.service.gov.uk/support/ ."));
 
         connectorMockClient.verifyCreateChargeConnectorRequest(GATEWAY_ACCOUNT_ID, createMotoPaymentPayload);
     }
@@ -670,7 +670,7 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
                 .statusCode(403)
                 .contentType(JSON)
                 .body("code", is("P0940"))
-                .body("description", is("Account is not fully configured. Please refer to documentation to setup your account or contact support."));
+                .body("description", is("Account is not fully configured. Please refer to documentation to setup your account or contact support with your error code - https://www.payments.service.gov.uk/support/ ."));
 
         connectorMockClient.verifyCreateChargeConnectorRequest(GATEWAY_ACCOUNT_ID, SUCCESS_PAYLOAD);
     }

--- a/src/test/java/uk/gov/pay/api/it/telephone/CreateTelephonePaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/telephone/CreateTelephonePaymentIT.java
@@ -155,6 +155,6 @@ public class CreateTelephonePaymentIT extends TelephonePaymentResourceITBase {
                 .statusCode(403)
                 .contentType(JSON)
                 .body("code", is("P0930"))
-                .body("description", is("Access to this resource is not enabled for this account. Please contact support."));
+                .body("description", is("Access to this resource is not enabled for this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ ."));
     }
 }

--- a/src/test/java/uk/gov/pay/api/model/RequestErrorTest.java
+++ b/src/test/java/uk/gov/pay/api/model/RequestErrorTest.java
@@ -11,7 +11,7 @@ public class RequestErrorTest {
     @Test
     void shouldGetExpectedValuesWhenToStringIsCalled() {
         RequestError requestError = aRequestError(RequestError.Code.CREATE_PAYMENT_ACCOUNT_ERROR);
-        assertThat(requestError.toString(), is("RequestError{field=null, code=P0199, name=CREATE_PAYMENT_ACCOUNT_ERROR, description='There is an error with this account. Please contact support'}"));
+        assertThat(requestError.toString(), is("RequestError{field=null, code=P0199, name=CREATE_PAYMENT_ACCOUNT_ERROR, description='There is an error with this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ .'}"));
     }
 
     @Test


### PR DESCRIPTION
In API error responses, where the message instructs to contact support, include a link to the support webpage.