### PR TITLE
PP-9758: Add no cache directive

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -47,6 +47,8 @@ import javax.ws.rs.core.UriInfo;
 
 import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.apache.http.HttpHeaders.CACHE_CONTROL;
+import static org.apache.http.HttpHeaders.PRAGMA;
 
 @Path("/")
 @Tag(name = "Card payments")
@@ -115,7 +117,10 @@ public class PaymentsResource {
         PaymentWithAllLinks payment = strategy.validateAndExecute();
 
         logger.info("Payment returned - [ {} ]", payment);
-        return Response.ok(payment).build();
+        return Response.ok(payment)
+                .header(PRAGMA, "no-cache")
+                .header(CACHE_CONTROL, "no-store")
+                .build();
     }
 
     @GET
@@ -275,6 +280,8 @@ public class PaymentsResource {
         Response response = Response
                 .created(publicApiUriGenerator.getPaymentURI(createdPayment.getPayment().getPaymentId()))
                 .entity(createdPayment)
+                .header(PRAGMA, "no-cache")
+                .header(CACHE_CONTROL, "no-store")
                 .build();
 
         logger.info("Payment returned (created): [ {} ]", createdPayment);

--- a/src/main/java/uk/gov/pay/api/service/PaymentSearchService.java
+++ b/src/main/java/uk/gov/pay/api/service/PaymentSearchService.java
@@ -12,6 +12,8 @@ import javax.ws.rs.core.Response;
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.http.HttpHeaders.CACHE_CONTROL;
+import static org.apache.http.HttpHeaders.PRAGMA;
 import static uk.gov.pay.api.validation.PaymentSearchValidator.validateSearchParameters;
 
 public class PaymentSearchService {
@@ -56,6 +58,8 @@ public class PaymentSearchService {
                 .addProperty("results", chargeFromResponses);
 
         return Response.ok()
+                .header(PRAGMA, "no-cache")
+                .header(CACHE_CONTROL, "no-store")
                 .entity(paginationDecorator
                         .decoratePagination(halRepresentation, paymentSearchResponse, PAYMENTS_PATH)
                         .build()

--- a/src/test/java/uk/gov/pay/api/it/GetPaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/GetPaymentIT.java
@@ -32,6 +32,8 @@ import java.util.function.Consumer;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.apache.http.HttpHeaders.CACHE_CONTROL;
+import static org.apache.http.HttpHeaders.PRAGMA;
 import static org.apache.http.HttpStatus.SC_NOT_ACCEPTABLE;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -96,6 +98,7 @@ public class GetPaymentIT extends PaymentResourceITestBase {
 
         ValidatableResponse response = getPaymentResponse(CHARGE_ID);
 
+        response.header(PRAGMA, "no-cache").header(CACHE_CONTROL, "no-store");
         assertCommonPaymentFields(response);
         assertConnectorOnlyPaymentFields(response);
         assertPaymentWithMetadata(response);
@@ -110,6 +113,7 @@ public class GetPaymentIT extends PaymentResourceITestBase {
 
         ValidatableResponse response = getPaymentResponse(CHARGE_ID, LEDGER_ONLY_STRATEGY);
 
+        response.header(PRAGMA, "no-cache").header(CACHE_CONTROL, "no-store");
         assertCommonPaymentFields(response);
         assertPaymentWithMetadata(response);
     }

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceSearchIT.java
@@ -27,6 +27,8 @@ import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.apache.http.HttpHeaders.CACHE_CONTROL;
+import static org.apache.http.HttpHeaders.PRAGMA;
 import static org.eclipse.jetty.http.HttpStatus.OK_200;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -87,8 +89,11 @@ public class PaymentResourceSearchIT extends PaymentResourceITestBase {
 
         ledgerMockClient.respondOk_whenSearchCharges(payments);
 
-        searchPayments(Map.of()).statusCode(200)
-                .contentType(JSON).log().body()
+        searchPayments(Map.of())
+                .statusCode(200)
+                .header(PRAGMA, "no-cache")
+                .header(CACHE_CONTROL, "no-store")
+                .contentType(JSON)
                 .body("results[0].metadata.reconciled", is(true))
                 .body("results[0].metadata.ledger_code", is(123))
                 .body("results[0].metadata.fuh", is("fuh you"))

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -30,6 +30,8 @@ import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.Collections;
 
+import static org.apache.http.HttpHeaders.CACHE_CONTROL;
+import static org.apache.http.HttpHeaders.PRAGMA;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -86,6 +88,8 @@ public class PaymentsResourceCreatePaymentTest {
 
         Response newPayment = paymentsResource.createNewPayment(account, createPaymentRequest);
 
+        assertThat(newPayment.getHeaderString(PRAGMA), is("no-cache"));
+        assertThat(newPayment.getHeaderString(CACHE_CONTROL), is("no-store"));
         assertThat(newPayment.getStatus(), is(201));
         assertThat(newPayment.getLocation(), is(URI.create(PAYMENT_URI)));
         assertThat(newPayment.getEntity(), sameInstance(injectedResponse));


### PR DESCRIPTION
As per the IT health check (ITHC) report, add no cache directives for endpoints that
return sensitive data.

The ITHC report recommends to add `Cache-control: no-store` and `Pragma: no-cache` to `/v1/payments` and `/v1/payments/{paymentId}` (see JIRA ticket).