### PR TITLE
PP-9812 Handle connector response for recurring payment request

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -71,6 +71,14 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
                     statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
                     requestError = aRequestError(CREATE_PAYMENT_AUTHORISATION_API_NOT_ENABLED);
                     break;
+                case AGREEMENT_NOT_FOUND:
+                    statusCode = HttpStatus.BAD_REQUEST_400;
+                    requestError = aRequestError("agreement_id", CREATE_PAYMENT_VALIDATION_ERROR, "Agreement does not exist");
+                    break;
+                case AGREEMENT_NOT_ACTIVE:
+                    statusCode = HttpStatus.BAD_REQUEST_400;
+                    requestError = aRequestError("agreement_id", CREATE_PAYMENT_VALIDATION_ERROR, "Agreement must be active");
+                    break;
                 case MISSING_MANDATORY_ATTRIBUTE:
                     statusCode = HttpStatus.BAD_REQUEST_400;
                     requestError = aRequestError(GENERIC_MISSING_FIELD_ERROR_MESSAGE_FROM_CONNECTOR, exception.getConnectorErrorMessage());

--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -2,12 +2,12 @@ package uk.gov.pay.api.model.links;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
-import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 import uk.gov.pay.api.model.AuthorisationSummary;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.CardPayment;
 import uk.gov.pay.api.model.Charge;
 import uk.gov.pay.api.model.Payment;
+import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 import uk.gov.pay.api.model.PaymentSettlementSummary;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
@@ -48,7 +48,7 @@ public class PaymentWithAllLinks {
         this.links.addEvents(paymentEventsUri.toString());
         this.links.addRefunds(paymentRefundsUri.toString());
 
-        if (!state.isFinished()) {
+        if (!state.isFinished() && authorisationMode != AuthorisationMode.AGREEMENT) {
             this.links.addCancel(paymentCancelUri.toString());
         }
 

--- a/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
@@ -2,10 +2,10 @@ package uk.gov.pay.api.model.search.card;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 import uk.gov.pay.api.model.AuthorisationSummary;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.CardPayment;
+import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 import uk.gov.pay.api.model.PaymentSettlementSummary;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
@@ -38,7 +38,7 @@ public class PaymentForSearchResult extends CardPayment {
         this.links.addEvents(paymentEventsLink.toString());
         this.links.addRefunds(paymentRefundsLink.toString());
 
-        if (!state.isFinished()) {
+        if (!state.isFinished() && authorisationMode != AuthorisationMode.AGREEMENT) {
             this.links.addCancel(paymentCancelLink.toString());
         }
         if (links.stream().anyMatch(link -> "capture".equals(link.getRel()))) {

--- a/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
+++ b/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
@@ -18,6 +18,8 @@ import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.ACCOUNT_DISABLED;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.ACCOUNT_NOT_LINKED_WITH_PSP;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.AGREEMENT_NOT_ACTIVE;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.AGREEMENT_NOT_FOUND;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.AUTHORISATION_API_NOT_ALLOWED;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.INVALID_ATTRIBUTE_VALUE;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.MISSING_MANDATORY_ATTRIBUTE;
@@ -44,6 +46,8 @@ class CreateChargeExceptionMapperTest {
                 new Object[]{AUTHORISATION_API_NOT_ALLOWED, false, "Using authorisation_mode of moto_api is not allowed for this account", 422, "P0195"},
                 new Object[]{MISSING_MANDATORY_ATTRIBUTE, true, "An error message from connector", 400, "P0101"},
                 new Object[]{UNEXPECTED_ATTRIBUTE, true, "An error message from connector", 400, "P0104"},
+                new Object[]{AGREEMENT_NOT_FOUND, false, "Invalid attribute value: agreement_id. Agreement does not exist", 400, "P0102"},
+                new Object[]{AGREEMENT_NOT_ACTIVE, false, "Invalid attribute value: agreement_id. Agreement must be active", 400, "P0102"},
                 new Object[]{INVALID_ATTRIBUTE_VALUE, true, "An error message from connector", 422, "P0102"}
         };
     }

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
@@ -505,6 +505,52 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
         connectorMockClient.verifyCreateChargeConnectorRequest(GATEWAY_ACCOUNT_ID, params);
     }
 
+    @Test
+    public void createPaymentWithAuthorisationModeAgreement() {
+        int amount = 1;
+
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+
+        connectorMockClient.respondOk_whenCreateCharge_withAuthorisationMode_Agreement(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
+                .withAmount(amount)
+                .withChargeId(CHARGE_ID)
+                .withState(CREATED)
+                .withDescription(DESCRIPTION)
+                .withReference(REFERENCE)
+                .withPaymentProvider(PAYMENT_PROVIDER)
+                .withGatewayTransactionId(GATEWAY_TRANSACTION_ID)
+                .withCreatedDate(CREATED_DATE)
+                .withLanguage(SupportedLanguage.ENGLISH)
+                .withDelayedCapture(false)
+                .withRefundSummary(REFUND_SUMMARY)
+                .withCardDetails(CARD_DETAILS)
+                .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .build());
+
+        CreateChargeRequestParams params = aCreateChargeRequestParams()
+                .withAmount(amount)
+                .withDescription(DESCRIPTION)
+                .withReference(REFERENCE)
+                .withAuthorisationMode(AuthorisationMode.MOTO_API)
+                .build();
+
+        postPaymentResponse(paymentPayload(params))
+                .statusCode(201)
+                .contentType(JSON)
+                .body("$", not(hasKey("return_url")))
+                .body("$_links", not(hasKey("cancel")))
+                .body("payment_id", is(CHARGE_ID))
+                .body("amount", is(amount))
+                .body("reference", is(REFERENCE))
+                .body("description", is(DESCRIPTION))
+                .body("payment_provider", is(PAYMENT_PROVIDER))
+                .body("created_date", is(CREATED_DATE))
+                .body("moto", is(true))
+                .body("authorisation_mode", is(AuthorisationMode.AGREEMENT.getName()));
+
+        connectorMockClient.verifyCreateChargeConnectorRequest(GATEWAY_ACCOUNT_ID, params);
+    }
+
 
     @Test
     public void createPayment_withAllFieldsUpToMaxLengthBoundaries_shouldBeAccepted() {

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -319,6 +319,19 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
                         .withHeader(LOCATION, chargeLocation(gatewayAccountId, responseFromConnector.getChargeId()))
                         .withBody(buildChargeResponse(build)));
     }
+
+    public void respondOk_whenCreateCharge_withAuthorisationMode_Agreement(String chargeTokenId, String gatewayAccountId, ChargeResponseFromConnector responseFromConnector) {
+        ChargeResponseFromConnector build = aCreateOrGetChargeResponseFromConnector(responseFromConnector)
+                .withMoto(true)
+                .withLink(validGetLink(chargeLocation(gatewayAccountId, responseFromConnector.getChargeId()), "self"))
+                .build();
+
+        mockCreateCharge(gatewayAccountId,
+                aResponse().withStatus(CREATED_201)
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                        .withHeader(LOCATION, chargeLocation(gatewayAccountId, responseFromConnector.getChargeId()))
+                        .withBody(buildChargeResponse(build)));
+    }
     
     public void respondOk_whenCreateAgreement(String gatewayAccountId, CreateAgreementRequestParams requestParams) {
         var responseFromConnector = aCreateAgreementResponseFromConnector()


### PR DESCRIPTION
When public API is handling a recurring payment request (`"authorisation_mode": "agreement"` and an `"agreement_id"`), we need to handle a couple of things differently depending on the response from connector.

If the payment is created successfully, we need to not include a cancel link in the public API response.

If connector responds with an error with the error identifier `AGREEMENT_NOT_FOUND`, public API needs to return a 400 response like this:

```json
{
  "field": "agreement_id",
  "code": "P0102",
  "description": "Invalid attribute value: agreement_id. Agreement does not exist"
}
```

If connector responds with an error with the error identifier `AGREEMENT_NOT_ACTIVE`, public API needs to return a 400 response like this:

```json
{
  "field": "agreement_id",
  "code": "P0102",
  "description": "Invalid attribute value: agreement_id. Agreement must be active"
}
```

with @sfount