### PR TITLE
PP-9812  "authorisation_mode": "agreement" requires "agreement_id"

### DIFF
--- a/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
+++ b/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
 import static uk.gov.pay.api.agreement.model.CreateAgreementRequest.USER_IDENTIFIER_FIELD;
+import static uk.gov.pay.api.model.CreateCardPaymentRequest.AGREEMENT_ID_FIELD_NAME;
 import static uk.gov.pay.api.model.CreateCardPaymentRequest.AMOUNT_FIELD_NAME;
 import static uk.gov.pay.api.model.CreateCardPaymentRequest.AUTHORISATION_MODE;
 import static uk.gov.pay.api.model.CreateCardPaymentRequest.DELAYED_CAPTURE_FIELD_NAME;
@@ -65,7 +66,7 @@ import static uk.gov.service.payments.commons.model.Source.CARD_PAYMENT_LINK;
 class RequestJsonParser {
 
     private static final Set<Source> ALLOWED_SOURCES = EnumSet.of(CARD_PAYMENT_LINK, CARD_AGENT_INITIATED_MOTO);
-    public static final Set<AuthorisationMode> ALLOWED_AUTHORISATION_MODES = EnumSet.of(AuthorisationMode.WEB, AuthorisationMode.MOTO_API);
+    public static final Set<AuthorisationMode> ALLOWED_AUTHORISATION_MODES = EnumSet.of(AuthorisationMode.WEB, AuthorisationMode.MOTO_API, AuthorisationMode.AGREEMENT);
 
     private static ObjectMapper objectMapper = new ObjectMapper();
     private static final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
@@ -95,6 +96,13 @@ class RequestJsonParser {
 
         if(paymentRequest.has(SET_UP_AGREEMENT_FIELD_NAME)) {
             builder.setUpAgreement(validateAndGetSetUpAgreement(paymentRequest));
+        }
+
+        if(paymentRequest.has(AGREEMENT_ID_FIELD_NAME)) {
+            builder.agreementId(validateSkipNullValueAndGetString(
+                   paymentRequest.get(AGREEMENT_ID_FIELD_NAME),
+                   aRequestError(AGREEMENT_ID_FIELD_NAME, CREATE_PAYMENT_VALIDATION_ERROR, "Must be a valid string format")
+            ));
         }
 
         if (paymentRequest.has(LANGUAGE_FIELD_NAME)) {

--- a/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
+++ b/src/main/java/uk/gov/pay/api/json/RequestJsonParser.java
@@ -57,6 +57,7 @@ import static uk.gov.pay.api.model.CreatePaymentRefundRequest.REFUND_AMOUNT_AVAI
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_MISSING_FIELD_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_REFUND_MISSING_FIELD_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_REFUND_VALIDATION_ERROR;
+import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_UNEXPECTED_FIELD_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_VALIDATION_ERROR;
 import static uk.gov.pay.api.model.RequestError.aRequestError;
 import static uk.gov.service.payments.commons.model.Source.CARD_AGENT_INITIATED_MOTO;
@@ -98,11 +99,21 @@ class RequestJsonParser {
             builder.setUpAgreement(validateAndGetSetUpAgreement(paymentRequest));
         }
 
-        if(paymentRequest.has(AGREEMENT_ID_FIELD_NAME)) {
-            builder.agreementId(validateSkipNullValueAndGetString(
-                   paymentRequest.get(AGREEMENT_ID_FIELD_NAME),
-                   aRequestError(AGREEMENT_ID_FIELD_NAME, CREATE_PAYMENT_VALIDATION_ERROR, "Must be a valid string format")
-            ));
+        AuthorisationMode authorisationMode = null;
+        if (paymentRequest.has(AUTHORISATION_MODE)) {
+            authorisationMode = validateAndGetAuthorisationMode(paymentRequest);
+            builder.authorisationMode(authorisationMode);
+        }
+
+        if (paymentRequest.has(AGREEMENT_ID_FIELD_NAME)) {
+            if (AuthorisationMode.AGREEMENT == authorisationMode) {
+                builder.agreementId(validateAndGetString(
+                        paymentRequest.get(AGREEMENT_ID_FIELD_NAME),
+                        aRequestError(AGREEMENT_ID_FIELD_NAME, CREATE_PAYMENT_VALIDATION_ERROR, "Must be a valid string format"),
+                        aRequestError(AGREEMENT_ID_FIELD_NAME, CREATE_PAYMENT_MISSING_FIELD_ERROR)));
+            } else {
+                throw new BadRequestException(aRequestError(CREATE_PAYMENT_UNEXPECTED_FIELD_ERROR, AGREEMENT_ID_FIELD_NAME));
+            }
         }
 
         if (paymentRequest.has(LANGUAGE_FIELD_NAME)) {
@@ -126,10 +137,6 @@ class RequestJsonParser {
 
         if (paymentRequest.has(METADATA)) {
             builder.metadata(validateAndGetMetadata(paymentRequest));
-        }
-
-        if (paymentRequest.has(AUTHORISATION_MODE)) {
-            builder.authorisationMode(validateAndGetAuthorisationMode(paymentRequest));
         }
 
         builder.source(validateAndGetSource(paymentRequest));

--- a/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
@@ -41,6 +41,7 @@ public class CreateCardPaymentRequest {
     public static final String DELAYED_CAPTURE_FIELD_NAME = "delayed_capture";
     public static final String MOTO_FIELD_NAME = "moto";
     public static final String SET_UP_AGREEMENT_FIELD_NAME = "set_up_agreement";
+    public static final String AGREEMENT_ID_FIELD_NAME = "agreement_id";
     public static final String SOURCE_FIELD_NAME = "source";
     public static final String METADATA = "metadata";
     public static final String INTERNAL = "internal";
@@ -110,6 +111,7 @@ public class CreateCardPaymentRequest {
         this.internal = builder.getInternal();
         this.setUpAgreement = builder.getSetUpAgreement();
         this.authorisationMode = builder.getAuthorisationMode();
+        this.agreementId = builder.getAgreementId();
     }
     
     @Schema(description = "amount in pence", required = true, minimum = "1", maximum = "10000000", example = "12000")

--- a/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequest.java
@@ -87,6 +87,10 @@ public class CreateCardPaymentRequest {
     @Size(min=26, max=26, message = "Field [set_up_agreement] length must be 26")
     private String setUpAgreement;
 
+    @JsonProperty("agreement_id")
+    @Size(min=26, max=26, message = "Field [agreement_id] length must be 26")
+    private String agreementId;
+
     @Valid
     private final PrefilledCardholderDetails prefilledCardholderDetails;
 
@@ -175,9 +179,15 @@ public class CreateCardPaymentRequest {
     }
 
     @JsonProperty("set_up_agreement")
-    @Schema(description = "agreement ID", required = false, example = "abcefghjklmnopqr1234567890", hidden = true)
-    public String getSetUpAgreement() {
-        return setUpAgreement;
+    @Schema(description = "ID of agreement to save card details to", required = false, example = "abcefghjklmnopqr1234567890", hidden = true)
+    public Optional<String> getSetUpAgreement() {
+        return Optional.ofNullable(setUpAgreement);
+    }
+
+    @JsonProperty("agreement_id")
+    @Schema(description = "ID of agreement to take payment from (requires \"authorisation_mode\": \"agreement\")", required = false, example = "abcefghjklmnopqr1234567890", hidden = true)
+    public Optional<String> getAgreementId() {
+        return Optional.ofNullable(agreementId);
     }
 
     @JsonProperty("authorisation_mode")
@@ -198,8 +208,13 @@ public class CreateCardPaymentRequest {
         getMetadata().ifPresent(metadata -> request.add("metadata", metadata.getMetadata()));
         getEmail().ifPresent(email -> request.add("email", email));
         getInternal().flatMap(Internal::getSource).ifPresent(source -> request.add("source", source));
-        getAuthorisationMode().ifPresent((authorisationMode -> request.add("authorisation_mode", authorisationMode.getName())));
-        
+        getAuthorisationMode().ifPresent(authorisationMode -> request.add("authorisation_mode", authorisationMode.getName()));
+        getAgreementId().ifPresent(agreementId -> request.add("agreement_id", agreementId));
+        getSetUpAgreement().ifPresent(setUpAgreement -> {
+            request.add("agreement_id", setUpAgreement);
+            request.add("save_payment_instrument_to_agreement", true);
+        });
+
         getPrefilledCardholderDetails().ifPresent(prefilledDetails -> {
             prefilledDetails.getCardholderName().ifPresent(name -> request.addToMap(PREFILLED_CARDHOLDER_DETAILS, "cardholder_name", name));
             prefilledDetails.getBillingAddress().ifPresent(address -> {
@@ -210,11 +225,6 @@ public class CreateCardPaymentRequest {
                 request.addToNestedMap("country", address.getCountry(), PREFILLED_CARDHOLDER_DETAILS, BILLING_ADDRESS);
             });
         });
-        
-        if (this.getSetUpAgreement() != null) {
-            request.add("agreement_id", this.getSetUpAgreement())
-                    .add("save_payment_instrument_to_agreement", true);
-        }
 
         return request.build();
     }
@@ -235,11 +245,10 @@ public class CreateCardPaymentRequest {
         getDelayedCapture().ifPresent(value -> joiner.add("delayed_capture: " + value));
         getMoto().ifPresent(value -> joiner.add("moto: " + value));
         getMetadata().ifPresent(value -> joiner.add("metadata: " + value));
-        
-        if (this.getSetUpAgreement() != null) {
-            joiner.add("set_up_agreement: " + this.getSetUpAgreement());
-        }
-        
+        getAuthorisationMode().ifPresent(authorisationMode -> joiner.add("authorisation_mode: " + authorisationMode));
+        getSetUpAgreement().ifPresent(setUpAgreement -> joiner.add("set_up_agreement: " + setUpAgreement));
+        getAgreementId().ifPresent(agreementId -> joiner.add("agreement_id: " + agreementId));
+
         return joiner.toString();
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/api/model/CreateCardPaymentRequestBuilder.java
@@ -26,6 +26,7 @@ public class CreateCardPaymentRequestBuilder {
     private Internal internal;
     private String setUpAgreement;
     private AuthorisationMode authorisationMode;
+    private String agreementId;
 
     public static CreateCardPaymentRequestBuilder builder() {
         return new CreateCardPaymentRequestBuilder();
@@ -117,6 +118,11 @@ public class CreateCardPaymentRequestBuilder {
     
     public CreateCardPaymentRequestBuilder authorisationMode(AuthorisationMode authorisationMode) {
         this.authorisationMode = authorisationMode;
+        return this;
+    }
+
+    public CreateCardPaymentRequestBuilder agreementId(String agreementId) {
+        this.agreementId = agreementId;
         return this;
     }
 
@@ -215,5 +221,9 @@ public class CreateCardPaymentRequestBuilder {
 
     public String getSetUpAgreement() {
         return setUpAgreement;
+    }
+
+    public String getAgreementId() {
+        return agreementId;
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/RequestError.java
+++ b/src/main/java/uk/gov/pay/api/model/RequestError.java
@@ -28,6 +28,7 @@ public class RequestError {
         GENERIC_UNEXPECTED_FIELD_ERROR_MESSAGE_FROM_CONNECTOR("P0104", "%s"),
         
         CREATE_PAYMENT_MISSING_FIELD_ERROR("P0101", "Missing mandatory attribute: %s"),
+        CREATE_PAYMENT_UNEXPECTED_FIELD_ERROR("P0104", "Unexpected attribute: %s"),
         CREATE_PAYMENT_VALIDATION_ERROR("P0102", "Invalid attribute value: %s. %s"),
 
         GET_PAYMENT_NOT_FOUND_ERROR("P0200", "Not found"),

--- a/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
@@ -35,7 +35,7 @@ public class CreatePaymentService {
         if (!createdSuccessfully(connectorResponse)) {
             throw new CreateChargeException(connectorResponse);
         }
-        
+
         ChargeFromResponse chargeFromResponse = connectorResponse.readEntity(ChargeFromResponse.class);
         
         return buildResponseModel(Charge.from(chargeFromResponse));

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
@@ -137,7 +137,7 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
     }
 
     @Test
-    public void shouldReturn422WhencreateAChargeIsCalledWithTooShortAgreementId() {
+    public void shouldReturn422WhenCreateAChargeIsCalledWithTooShortAgreementId() {
         publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, CARD);
 
         CreateChargeRequestParams createChargeRequestParams = aCreateChargeRequestParams()
@@ -531,7 +531,7 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
                 .withAmount(amount)
                 .withDescription(DESCRIPTION)
                 .withReference(REFERENCE)
-                .withAuthorisationMode(AuthorisationMode.MOTO_API)
+                .withAuthorisationMode(AuthorisationMode.AGREEMENT)
                 .build();
 
         postPaymentResponse(paymentPayload(params))
@@ -545,7 +545,7 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
                 .body("description", is(DESCRIPTION))
                 .body("payment_provider", is(PAYMENT_PROVIDER))
                 .body("created_date", is(CREATED_DATE))
-                .body("moto", is(true))
+                .body("moto", is(false))
                 .body("authorisation_mode", is(AuthorisationMode.AGREEMENT.getName()));
 
         connectorMockClient.verifyCreateChargeConnectorRequest(GATEWAY_ACCOUNT_ID, params);
@@ -736,7 +736,6 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
                 .withDescription(DESCRIPTION)
                 .withReference(REFERENCE)
                 .withReturnUrl(RETURN_URL)
-                .withReturnUrl(RETURN_URL)
                 .withSource(CARD_PAYMENT_LINK)
                 .build();
         connectorMockClient.respondOk_whenCreateCharge(GATEWAY_ACCOUNT_ID, createChargeRequestParams);
@@ -767,29 +766,29 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
             payload.add("moto", params.isMoto());
         }
 
-        if (params.getCardholderName().isPresent()) {
-            payload.addToNestedMap("cardholder_name", params.getCardholderName().get(), "prefilled_cardholder_details");
-        }
+        params.getCardholderName().ifPresent(cardholderName -> {
+            payload.addToNestedMap("cardholder_name", cardholderName, "prefilled_cardholder_details");
+        });
 
-        if (params.getAddressLine1().isPresent()) {
-            payload.addToNestedMap("line1", params.getAddressLine1().get(), "prefilled_cardholder_details", "billing_address");
-        }
+        params.getAddressLine1().ifPresent(addressLine1 -> {
+            payload.addToNestedMap("line1", addressLine1, "prefilled_cardholder_details", "billing_address");
+        });
 
-        if (params.getAddressLine2().isPresent()) {
-            payload.addToNestedMap("line2", params.getAddressLine2().get(), "prefilled_cardholder_details", "billing_address");
-        }
+        params.getAddressLine1().ifPresent(addressLine2 -> {
+            payload.addToNestedMap("line2", addressLine2, "prefilled_cardholder_details", "billing_address");
+        });
 
-        if (params.getAddressPostcode().isPresent()) {
-            payload.addToNestedMap("postcode", params.getAddressPostcode().get(), "prefilled_cardholder_details", "billing_address");
-        }
+        params.getAddressPostcode().ifPresent(addressPostcode -> {
+            payload.addToNestedMap("postcode", addressPostcode, "prefilled_cardholder_details", "billing_address");
+        });
 
-        if (params.getAddressCity().isPresent()) {
-            payload.addToNestedMap("city", params.getAddressCity().get(), "prefilled_cardholder_details", "billing_address");
-        }
+        params.getAddressCity().ifPresent(addressCity -> {
+            payload.addToNestedMap("city", addressCity, "prefilled_cardholder_details", "billing_address");
+        });
 
-        if (params.getAddressCountry().isPresent()) {
-            payload.addToNestedMap("country", params.getAddressCountry().get(), "prefilled_cardholder_details", "billing_address");
-        }
+        params.getAddressCountry().ifPresent(addressCountry -> {
+                payload.addToNestedMap("country", addressCountry, "prefilled_cardholder_details", "billing_address");
+        });
 
         params.getSource().ifPresent(source -> {
             payload.addToNestedMap("source", source, "internal");

--- a/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
+++ b/src/test/java/uk/gov/pay/api/it/CreatePaymentIT.java
@@ -525,6 +525,7 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
                 .withRefundSummary(REFUND_SUMMARY)
                 .withCardDetails(CARD_DETAILS)
                 .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .withAgreementId(VALID_AGREEMENT_ID)
                 .build());
 
         CreateChargeRequestParams params = aCreateChargeRequestParams()
@@ -532,6 +533,7 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
                 .withDescription(DESCRIPTION)
                 .withReference(REFERENCE)
                 .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .withAgreementId(VALID_AGREEMENT_ID)
                 .build();
 
         postPaymentResponse(paymentPayload(params))
@@ -774,7 +776,7 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
             payload.addToNestedMap("line1", addressLine1, "prefilled_cardholder_details", "billing_address");
         });
 
-        params.getAddressLine1().ifPresent(addressLine2 -> {
+        params.getAddressLine2().ifPresent(addressLine2 -> {
             payload.addToNestedMap("line2", addressLine2, "prefilled_cardholder_details", "billing_address");
         });
 
@@ -796,6 +798,14 @@ public class CreatePaymentIT extends PaymentResourceITestBase {
 
         if (params.getSetUpAgreement() != null) {
             payload.add("set_up_agreement", params.getSetUpAgreement());
+        }
+
+        if (params.getAgreementId() != null) {
+            payload.add("agreement_id", params.getAgreementId());
+        }
+
+        if (params.getAuthorisationMode() != null) {
+            payload.add("authorisation_mode", params.getAuthorisationMode().getName());
         }
 
         return payload.build();

--- a/src/test/java/uk/gov/pay/api/json/RequestJsonParserTest.java
+++ b/src/test/java/uk/gov/pay/api/json/RequestJsonParserTest.java
@@ -582,7 +582,7 @@ class RequestJsonParserTest {
 
         PaymentValidationException paymentValidationException = assertThrows(PaymentValidationException.class, () -> parsePaymentRequest(jsonNode));
         assertThat(paymentValidationException.getRequestError().getCode(), is("P0102"));
-        assertThat(paymentValidationException.getRequestError().getDescription(), is("Invalid attribute value: authorisation_mode. Must be one of web, moto_api"));
+        assertThat(paymentValidationException.getRequestError().getDescription(), is("Invalid attribute value: authorisation_mode. Must be one of web, moto_api, agreement"));
     }
 
     @Test
@@ -600,6 +600,6 @@ class RequestJsonParserTest {
 
         PaymentValidationException paymentValidationException = assertThrows(PaymentValidationException.class, () -> parsePaymentRequest(jsonNode));
         assertThat(paymentValidationException.getRequestError().getCode(), is("P0102"));
-        assertThat(paymentValidationException.getRequestError().getDescription(), is("Invalid attribute value: authorisation_mode. Must be one of web, moto_api"));
+        assertThat(paymentValidationException.getRequestError().getDescription(), is("Invalid attribute value: authorisation_mode. Must be one of web, moto_api, agreement"));
     }
 }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
@@ -110,6 +110,14 @@ public abstract class BaseConnectorMockClient {
             payload.add("save_payment_instrument_to_agreement", true);
         }
 
+        if (params.getAgreementId() != null) {
+            payload.add("agreement_id", params.getAgreementId());
+        }
+
+        if (params.getAuthorisationMode() != null) {
+            payload.add("authorisation_mode", params.getAuthorisationMode().getName());
+        }
+
         payload.add("source", params.getSource().orElse(CARD_API));
 
         return payload.build();

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -12,6 +12,7 @@ import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.links.Link;
 import uk.gov.pay.api.model.telephone.CreateTelephonePaymentRequest;
 import uk.gov.pay.api.utils.JsonStringBuilder;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
@@ -322,7 +323,7 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
 
     public void respondOk_whenCreateCharge_withAuthorisationMode_Agreement(String chargeTokenId, String gatewayAccountId, ChargeResponseFromConnector responseFromConnector) {
         ChargeResponseFromConnector build = aCreateOrGetChargeResponseFromConnector(responseFromConnector)
-                .withMoto(true)
+                .withAuthorisationMode(AuthorisationMode.AGREEMENT)
                 .withLink(validGetLink(chargeLocation(gatewayAccountId, responseFromConnector.getChargeId()), "self"))
                 .build();
 

--- a/src/test/java/uk/gov/pay/api/utils/mocks/CreateChargeRequestParams.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/CreateChargeRequestParams.java
@@ -26,6 +26,7 @@ public class CreateChargeRequestParams {
     private final Source source;
     private final String setUpAgreement;
     private final AuthorisationMode authorisationMode;
+    private final String agreementId;
 
     private CreateChargeRequestParams(CreateChargeRequestParamsBuilder builder) {
         this.amount = builder.amount;
@@ -45,6 +46,7 @@ public class CreateChargeRequestParams {
         this.source = builder.source;
         this.setUpAgreement = builder.setUpAgreement;
         this.authorisationMode = builder.authorisationMode;
+        this.agreementId = builder.agreementId;
     }
 
     public int getAmount() {
@@ -115,6 +117,10 @@ public class CreateChargeRequestParams {
         return authorisationMode;
     }
 
+    public String getAgreementId() {
+        return agreementId;
+    }
+
     public static final class CreateChargeRequestParamsBuilder {
         private Integer amount;
         private String returnUrl;
@@ -133,6 +139,7 @@ public class CreateChargeRequestParams {
         private Source source;
         public String setUpAgreement;
         public AuthorisationMode authorisationMode;
+        public String agreementId;
 
         private CreateChargeRequestParamsBuilder() {
         }
@@ -228,6 +235,11 @@ public class CreateChargeRequestParams {
         
         public CreateChargeRequestParamsBuilder withAuthorisationMode(AuthorisationMode authorisationMode) {
             this.authorisationMode = authorisationMode;
+            return this;
+        }
+
+        public CreateChargeRequestParamsBuilder withAgreementId(String agreementId) {
+            this.agreementId = agreementId;
             return this;
         }
     }


### PR DESCRIPTION
When creating a new payment, if `"authorisation_mode": "agreement"`, require an `"agreement_id"` (which must have a string value).

Conversely, if any other `"authorisation_mode"` is specified (or none at all), reject the request if it contains an `"agreement_id"`.

(The latter change will prevent surprising things happening if both `"set_up_agreement"` and `"agreement_id"` are specified.)

with @sfount

Depends on #1507 