### PR TITLE
PP-9784 Add cancel agreement endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/api/agreement/resource/AgreementsApiResource.java
+++ b/src/main/java/uk/gov/pay/api/agreement/resource/AgreementsApiResource.java
@@ -4,19 +4,22 @@ import io.dropwizard.auth.Auth;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.api.agreement.model.CreateAgreementRequest;
 import uk.gov.pay.api.agreement.model.AgreementResponse;
+import uk.gov.pay.api.agreement.model.CreateAgreementRequest;
 import uk.gov.pay.api.agreement.service.AgreementService;
 import uk.gov.pay.api.auth.Account;
+
 import javax.inject.Inject;
 import javax.validation.Valid;
-import javax.ws.rs.Path;
-import javax.ws.rs.POST;
-import javax.ws.rs.Produces;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
 import static org.apache.http.HttpStatus.SC_CREATED;
+import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 
 @Path("/")
 public class AgreementsApiResource {
@@ -35,11 +38,19 @@ public class AgreementsApiResource {
     @Produces("application/json")
     @Consumes("application/json")
     public Response createAgreement(@Parameter(hidden = true) @Auth Account account,
-            @Valid CreateAgreementRequest createAgreementRequest
-    ) {
+            @Valid CreateAgreementRequest createAgreementRequest) {
         LOGGER.info("Creating new agreement for reference {} and gateway accountID {}", 
                 createAgreementRequest.getReference(), account.getAccountId());
         AgreementResponse agreementResponse = agreementService.create(account, createAgreementRequest);
        return Response.status(SC_CREATED).entity(agreementResponse).build();
     }
+
+    @POST
+    @Path("/v1/agreements/{agreementId}/cancel")
+    @Consumes("application/json")
+    public Response createAgreement(@Parameter(hidden = true) @Auth Account account, @PathParam("agreementId") String agreementId) {
+        agreementService.cancel(account, agreementId);
+        return Response.status(SC_NO_CONTENT).build();
+    }
+
 }

--- a/src/main/java/uk/gov/pay/api/agreement/service/AgreementService.java
+++ b/src/main/java/uk/gov/pay/api/agreement/service/AgreementService.java
@@ -8,11 +8,13 @@ import uk.gov.pay.api.agreement.model.builder.AgreementResponseBuilder;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CreateAgreementException;
 import uk.gov.pay.api.service.ConnectorUriGenerator;
+
 import javax.inject.Inject;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
 import static javax.ws.rs.client.Entity.json;
 
 public class AgreementService {
@@ -34,10 +36,17 @@ public class AgreementService {
         }
         
         AgreementResponse agreementResponse = connectorResponse.readEntity(AgreementResponse.class);
-        return buildResponseModel(Agreement.from(agreementResponse));
+        return buildCreateAgreementResponseModel(Agreement.from(agreementResponse));
     }
-    
-    private AgreementResponse buildResponseModel(Agreement agreementFromConnector) {
+
+    public Response cancel(Account account, String agreementId) {
+        return client
+                .target(connectorUriGenerator.cancelAgreementURI(account, agreementId))
+                .request()
+                .post(null);
+    }
+
+    private AgreementResponse buildCreateAgreementResponseModel(Agreement agreementFromConnector) {
         return new AgreementResponseBuilder().
                 withAgreementId(agreementFromConnector.getAgreementId())
                 .withReference(agreementFromConnector.getReference())
@@ -53,10 +62,10 @@ public class AgreementService {
                 .target(connectorUriGenerator.getAgreementURI(account))
                 .request()
                 .accept(MediaType.APPLICATION_JSON)
-                .post(buildAgreementCreateRequestPayload(agreementCreateRequest));
+                .post(buildCreateAgreementRequestPayload(agreementCreateRequest));
     }
 
-    private Entity buildAgreementCreateRequestPayload(CreateAgreementRequest requestPayload) {
+    private Entity buildCreateAgreementRequestPayload(CreateAgreementRequest requestPayload) {
         return json(requestPayload.toConnectorPayload());
     }
 }

--- a/src/main/java/uk/gov/pay/api/exception/CancelAgreementException.java
+++ b/src/main/java/uk/gov/pay/api/exception/CancelAgreementException.java
@@ -1,0 +1,11 @@
+package uk.gov.pay.api.exception;
+
+import javax.ws.rs.core.Response;
+
+public class CancelAgreementException extends ConnectorResponseErrorException {
+
+    public CancelAgreementException(Response response) {
+        super(response);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CancelAgreementExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CancelAgreementExceptionMapper.java
@@ -1,0 +1,50 @@
+package uk.gov.pay.api.exception.mapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.api.exception.CancelAgreementException;
+import uk.gov.pay.api.model.RequestError;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static uk.gov.pay.api.model.RequestError.Code.CANCEL_AGREEMENT_CONNECTOR_BAD_REQUEST_ERROR;
+import static uk.gov.pay.api.model.RequestError.Code.CANCEL_AGREEMENT_CONNECTOR_ERROR;
+import static uk.gov.pay.api.model.RequestError.Code.CANCEL_PAYMENT_NOT_FOUND_ERROR;
+import static uk.gov.pay.api.model.RequestError.aRequestError;
+
+public class CancelAgreementExceptionMapper implements ExceptionMapper<CancelAgreementException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CancelAgreementExceptionMapper.class);
+
+    @Override
+    public Response toResponse(CancelAgreementException exception) {
+
+        int errorStatus = exception.getErrorStatus();
+        RequestError requestError;
+        Response.Status status;
+
+        if (errorStatus == NOT_FOUND.getStatusCode()) {
+            requestError = aRequestError(CANCEL_PAYMENT_NOT_FOUND_ERROR);
+            status = NOT_FOUND;
+        } else if (errorStatus == BAD_REQUEST.getStatusCode()) {
+            requestError = aRequestError(CANCEL_AGREEMENT_CONNECTOR_BAD_REQUEST_ERROR);
+            status = BAD_REQUEST;
+        } else {
+            requestError = aRequestError(CANCEL_AGREEMENT_CONNECTOR_ERROR);
+            status = INTERNAL_SERVER_ERROR;
+        }
+
+        if (status == INTERNAL_SERVER_ERROR) {
+            LOGGER.error("Connector invalid response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, requestError);
+        }
+        return Response
+                .status(status)
+                .entity(requestError)
+                .build();
+    }
+
+}

--- a/src/main/java/uk/gov/pay/api/model/RequestError.java
+++ b/src/main/java/uk/gov/pay/api/model/RequestError.java
@@ -13,15 +13,12 @@ public class RequestError {
 
     public enum Code {
 
-        CREATE_PAYMENT_AGREEMENT_ID_ERROR("P0103", "Invalid attribute value: set_up_agreement. Agreement ID does not exist"),
-
         CREATE_PAYMENT_ACCOUNT_ERROR("P0199", "There is an error with this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ ."),
         CREATE_PAYMENT_CONNECTOR_ERROR("P0198", "Downstream system error"),
-        CREATE_AGREEMENT_CONNECTOR_ERROR("P0198", "Downstream system error"),
         CREATE_PAYMENT_PARSING_ERROR("P0197", "Unable to parse JSON"),
-        CREATE_AGREEMENT_PARSING_ERROR("P0197", "Unable to parse JSON"),
         CREATE_PAYMENT_MOTO_NOT_ENABLED("P0196", "MOTO payments are not enabled for this account. Please contact support if you would like to process MOTO payments - https://www.payments.service.gov.uk/support/ ."),
         CREATE_PAYMENT_AUTHORISATION_API_NOT_ENABLED("P0195","Using authorisation_mode of moto_api is not allowed for this account"),
+        CREATE_PAYMENT_AGREEMENT_ID_ERROR("P0103", "Invalid attribute value: set_up_agreement. Agreement ID does not exist"),
 
         GENERIC_MISSING_FIELD_ERROR_MESSAGE_FROM_CONNECTOR("P0101", "%s"),
         GENERIC_VALIDATION_EXCEPTION_MESSAGE_FROM_CONNECTOR("P0102", "%s"),
@@ -80,8 +77,13 @@ public class RequestError {
         AUTHORISATION_ERROR("P0050", "%s"),
         AUTHORISATION_TIMEOUT_ERROR("P0050", "%s"),
         AUTHORISATION_ONE_TIME_TOKEN_ALREADY_USED_ERROR("P1212", "%s"),
-        AUTHORISATION_ONE_TIME_TOKEN_INVALID_ERROR("P1211", "%s");
+        AUTHORISATION_ONE_TIME_TOKEN_INVALID_ERROR("P1211", "%s"),
 
+        CREATE_AGREEMENT_CONNECTOR_ERROR("P0198", "Downstream system error"),
+        CREATE_AGREEMENT_PARSING_ERROR("P0197", "Unable to parse JSON"),
+
+        CANCEL_AGREEMENT_CONNECTOR_BAD_REQUEST_ERROR("P0501", "Cancellation of agreement failed"),
+        CANCEL_AGREEMENT_CONNECTOR_ERROR("P0198", "Downstream system error");
 
         private String value;
         private String format;

--- a/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.api.service;
 
-import com.google.common.collect.Maps;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 
@@ -35,16 +34,11 @@ public class ConnectorUriGenerator {
 
     String cancelURI(Account account, String paymentId) {
         String path = format("/v1/api/accounts/%s/charges/%s/cancel", account.getAccountId(), paymentId);
-        return buildConnectorUri(path, Maps.newHashMap());
+        return buildConnectorUri(path, Collections.emptyMap());
     }
 
     public String telephoneChargesURI(Account account) {
         return buildConnectorUri(format("/v1/api/accounts/%s/telephone-charges", account.getAccountId()));
-    }
-
-    public String getAgreementURI(Account account) {
-        String path = format("/v1/api/accounts/%s/agreements", account.getAccountId());
-        return buildConnectorUri(path);
     }
 
     String captureURI(Account account, String chargeId) {
@@ -66,7 +60,17 @@ public class ConnectorUriGenerator {
         String path = "/v1/api/charges/authorise";
         return buildConnectorUri(path);
     }
-    
+
+    public String getAgreementURI(Account account) {
+        String path = format("/v1/api/accounts/%s/agreements", account.getAccountId());
+        return buildConnectorUri(path);
+    }
+
+    public String cancelAgreementURI(Account account, String agreementId) {
+        String path = format("/v1/api/accounts/%s/agreements/%s/cancel", account.getAccountId(), agreementId);
+        return buildConnectorUri(path, Collections.emptyMap());
+    }
+
     private String buildConnectorUri(String path) {
         return buildConnectorUri(path, Collections.emptyMap());
     }

--- a/src/test/java/uk/gov/pay/api/service/AgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/AgreementServiceTest.java
@@ -13,6 +13,7 @@ import uk.gov.pay.api.agreement.service.AgreementService;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.CreateAgreementRequestBuilder;
 import uk.gov.pay.api.utils.mocks.CreateAgreementRequestParams;
+
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
@@ -21,6 +22,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import static javax.ws.rs.client.Entity.json;
+import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
@@ -28,11 +30,13 @@ import static uk.gov.pay.api.it.CreateAgreementIT.agreementPayload;
 import static uk.gov.pay.api.utils.mocks.CreateAgreementRequestParams.CreateAgreementRequestParamsBuilder.aCreateAgreementRequestParams;
 
 @ExtendWith(MockitoExtension.class)
-class CreateAgreementServiceTest {
+class AgreementServiceTest {
+
     private static final String REFERENCE_ID = "test";
-    private static final String DESCRIPTION = "a valid description";
     private static final String AGREEMENT_ID = "12345678901234567890123456";
-    private static final String AGREEMENTS_CONNECTOR_URI = "/v1/api/accounts/GATEWAY_ACCOUNT_ID/agreements";
+    private static final String AGREEMENTS_CONNECTOR_URI = "/v1/api/accounts/GATEWAY_ACCOUNT_ID/agreements"; // pragma: allowlist secret
+    private static final String AGREEMENT_CONNECTOR_CANCEL_URI = AGREEMENTS_CONNECTOR_URI + '/' + AGREEMENT_ID + "/cancel";
+
     private AgreementService service;
     @Mock
     private Client client;
@@ -46,23 +50,23 @@ class CreateAgreementServiceTest {
     private Invocation.Builder builder;
     @Mock
     private Response connectorResponse;
-    private AgreementResponse agreementResponse;
 
     @BeforeEach
     void setUp() {
-        agreementResponse = new AgreementResponseBuilder()
-                .withReference(REFERENCE_ID)
-                .withAgreementId(AGREEMENT_ID).build();
+
         service = new AgreementService(client, connectorUriGenerator);
     }
 
     @Test
-    void shouldCreateAnAgreement() {
+    void shouldCreateAgreement() {
         CreateAgreementRequestParams createAgreementRequestParams = aCreateAgreementRequestParams()
                 .withReference(REFERENCE_ID)
                 .build();
         String payloadToConnector = agreementPayload(createAgreementRequestParams);
         Entity<String> payloadEntity = json(payloadToConnector);
+        var agreementResponse = new AgreementResponseBuilder()
+                .withReference(REFERENCE_ID)
+                .withAgreementId(AGREEMENT_ID).build();
         when(connectorUriGenerator.getAgreementURI(account)).thenReturn(AGREEMENTS_CONNECTOR_URI);
         when(connectorResponse.getStatus()).thenReturn(HttpStatus.SC_CREATED);
         when(target.request()).thenReturn(builder);
@@ -72,8 +76,24 @@ class CreateAgreementServiceTest {
         when(connectorResponse.readEntity(AgreementResponse.class)).thenReturn(agreementResponse);
         CreateAgreementRequest agreementCreateRequest = new CreateAgreementRequest(CreateAgreementRequestBuilder
                 .builder().reference(REFERENCE_ID));
+
         AgreementResponse agreementResponseFromService = service.create(account, agreementCreateRequest);
+
         assertThat(agreementResponseFromService.getAgreementId(), is(AGREEMENT_ID));
         assertThat(agreementResponseFromService.getReference(), is(REFERENCE_ID));
     }
+
+    @Test
+    void shouldCancelAgreement() {
+        when(connectorUriGenerator.cancelAgreementURI(account, AGREEMENT_ID)).thenReturn(AGREEMENT_CONNECTOR_CANCEL_URI);
+        when(connectorResponse.getStatus()).thenReturn(HttpStatus.SC_NO_CONTENT);
+        when(target.request()).thenReturn(builder);
+        when(builder.post(null)).thenReturn(connectorResponse);
+        when(client.target(AGREEMENT_CONNECTOR_CANCEL_URI)).thenReturn(target);
+
+        Response response = service.cancel(account, AGREEMENT_ID);
+
+        assertThat(response.getStatus(), is(NO_CONTENT.getStatusCode()));
+    }
+
 }


### PR DESCRIPTION
Add cancel agreement endpoint at `/v1/agreements/AGREEMENT_ID/cancel` that takes an empty POST body and, if successful, returns a 204.

with @sfount