### PR TITLE
PP-9671 Return error for refund unavailable for disputed payment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <jackson.version>2.13.3</jackson.version>
         <logback.version>1.2.11</logback.version>
         <docker-client.version>8.16.0</docker-client.version>
-        <pay-java-commons.version>1.0.20220720153401</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20220722152412</pay-java-commons.version>
         <junit5.version>5.8.2</junit5.version>
         <pact.version>3.6.15</pact.version>
         <swagger.lib.version>2.2.2</swagger.lib.version>

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapper.java
@@ -18,6 +18,7 @@ import static uk.gov.pay.api.model.RequestError.Code.ACCOUNT_DISABLED;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_REFUND_AMOUNT_AVAILABLE_MISMATCH;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_REFUND_CONNECTOR_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_REFUND_NOT_AVAILABLE;
+import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_REFUND_NOT_AVAILABLE_DUE_TO_DISPUTE;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_REFUND_NOT_FOUND_ERROR;
 import static uk.gov.pay.api.model.RequestError.aRequestError;
 
@@ -53,6 +54,11 @@ public class CreateRefundExceptionMapper implements ExceptionMapper<CreateRefund
                         requestError = aRequestError(CREATE_PAYMENT_REFUND_CONNECTOR_ERROR);
                         status = INTERNAL_SERVER_ERROR;
                     }
+                    break;
+                }
+                case REFUND_NOT_AVAILABLE_DUE_TO_DISPUTE: {
+                    requestError = aRequestError(CREATE_PAYMENT_REFUND_NOT_AVAILABLE_DUE_TO_DISPUTE);
+                    status = BAD_REQUEST;
                     break;
                 }
                 case REFUND_AMOUNT_AVAILABLE_MISMATCH: {

--- a/src/main/java/uk/gov/pay/api/model/RequestError.java
+++ b/src/main/java/uk/gov/pay/api/model/RequestError.java
@@ -54,6 +54,7 @@ public class RequestError {
         CREATE_PAYMENT_REFUND_MISSING_FIELD_ERROR("P0601", "Missing mandatory attribute: %s"),
         CREATE_PAYMENT_REFUND_VALIDATION_ERROR("P0602", "Invalid attribute value: %s. %s"),
         CREATE_PAYMENT_REFUND_NOT_AVAILABLE("P0603", "The payment is not available for refund. Payment refund status: %s"),
+        CREATE_PAYMENT_REFUND_NOT_AVAILABLE_DUE_TO_DISPUTE("P0603", "The payment is disputed and cannot be refunded"),
         CREATE_PAYMENT_REFUND_AMOUNT_AVAILABLE_MISMATCH("P0604", "Refund amount available mismatch."),
 
         GET_PAYMENT_REFUND_NOT_FOUND_ERROR("P0700", "Not found"),

--- a/src/test/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapperTest.java
+++ b/src/test/java/uk/gov/pay/api/exception/mapper/CreateRefundExceptionMapperTest.java
@@ -21,6 +21,7 @@ import static uk.gov.service.payments.commons.model.ErrorIdentifier.ACCOUNT_DISA
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.GENERIC;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.REFUND_NOT_AVAILABLE;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.REFUND_NOT_AVAILABLE_DUE_TO_DISPUTE;
 
 @ExtendWith(MockitoExtension.class)
 class CreateRefundExceptionMapperTest {
@@ -36,6 +37,7 @@ class CreateRefundExceptionMapperTest {
                 new Object[]{REFUND_AMOUNT_AVAILABLE_MISMATCH, null, "Refund amount available mismatch.", 412, "P0604"},
                 new Object[]{REFUND_NOT_AVAILABLE, "This is a reason", "The payment is not available for refund. Payment refund status: This is a reason", 400, "P0603"},
                 new Object[]{REFUND_NOT_AVAILABLE, null, "Downstream system error", 500, "P0698"},
+                new Object[]{REFUND_NOT_AVAILABLE_DUE_TO_DISPUTE, null, "The payment is disputed and cannot be refunded", 400, "P0603"},
                 new Object[]{GENERIC, null, "Downstream system error", 500, "P0698"},
         };
     }


### PR DESCRIPTION
Handle an error response returned by connector with identifier REFUND_NOT_AVAILABLE_DUE_TO_DISPUTE when attempting to create a refund to return a specific error.