### PR TITLE
PP-9545 Make TransactionSearchResults generic

### DIFF
--- a/src/main/java/uk/gov/pay/api/ledger/model/SearchResults.java
+++ b/src/main/java/uk/gov/pay/api/ledger/model/SearchResults.java
@@ -5,24 +5,23 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.api.model.links.SearchNavigationLinks;
 import uk.gov.pay.api.model.search.SearchPagination;
-import uk.gov.pay.api.model.search.card.PaymentForSearchResult;
 
 import java.util.List;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class TransactionSearchResults implements SearchPagination {
+public class SearchResults<E> implements SearchPagination {
 
     private int total;
     private int count;
     private int page;
-    private List<PaymentForSearchResult> results;
+    private List<E> results;
     SearchNavigationLinks links;
 
-    public TransactionSearchResults() {
+    public SearchResults() {
     }
 
-    public TransactionSearchResults(int total, int count, int page, List<PaymentForSearchResult> results,
-                                    SearchNavigationLinks links) {
+    public SearchResults(int total, int count, int page, List<E> results,
+                         SearchNavigationLinks links) {
         this.total = total;
         this.count = count;
         this.page = page;
@@ -47,7 +46,7 @@ public class TransactionSearchResults implements SearchPagination {
     }
 
     @JsonProperty("results")
-    public List<PaymentForSearchResult> getResults() {
+    public List<E> getResults() {
         return results;
     }
 

--- a/src/main/java/uk/gov/pay/api/ledger/resource/TransactionsResource.java
+++ b/src/main/java/uk/gov/pay/api/ledger/resource/TransactionsResource.java
@@ -3,9 +3,10 @@ package uk.gov.pay.api.ledger.resource;
 import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.auth.Auth;
 import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.ledger.model.SearchResults;
 import uk.gov.pay.api.ledger.model.TransactionSearchParams;
-import uk.gov.pay.api.ledger.model.TransactionSearchResults;
 import uk.gov.pay.api.ledger.service.TransactionSearchService;
+import uk.gov.pay.api.model.search.card.PaymentForSearchResult;
 
 import javax.inject.Inject;
 import javax.ws.rs.BeanParam;
@@ -30,9 +31,7 @@ public class TransactionsResource {
     @Timed
     @Path("/v1/transactions")
     @Produces(APPLICATION_JSON)
-    public TransactionSearchResults getTransactions(@Auth Account account,
-                                                    @BeanParam TransactionSearchParams searchParams) {
-        
+    public SearchResults<PaymentForSearchResult> getTransactions(@Auth Account account, @BeanParam TransactionSearchParams searchParams) {
         return transactionSearchService.doSearch(account, searchParams);
     }
 }

--- a/src/main/java/uk/gov/pay/api/ledger/service/TransactionSearchService.java
+++ b/src/main/java/uk/gov/pay/api/ledger/service/TransactionSearchService.java
@@ -9,8 +9,8 @@ import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.BadRequestException;
 import uk.gov.pay.api.exception.SearchPaymentsException;
 import uk.gov.pay.api.exception.SearchTransactionsException;
+import uk.gov.pay.api.ledger.model.SearchResults;
 import uk.gov.pay.api.ledger.model.TransactionSearchParams;
-import uk.gov.pay.api.ledger.model.TransactionSearchResults;
 import uk.gov.pay.api.model.RequestError;
 import uk.gov.pay.api.model.TransactionResponse;
 import uk.gov.pay.api.model.links.Link;
@@ -67,7 +67,7 @@ public class TransactionSearchService {
         this.baseUrl = configuration.getBaseUrl();
     }
 
-    public TransactionSearchResults doSearch(Account account, TransactionSearchParams searchParams) {
+    public SearchResults<PaymentForSearchResult> doSearch(Account account, TransactionSearchParams searchParams) {
         validateSearchParameters(searchParams.getState(), searchParams.getReference(),
                 searchParams.getEmail(), searchParams.getCardBrand(), searchParams.getFromDate(),
                 searchParams.getToDate(), searchParams.getPageNumber(), searchParams.getDisplaySize(),
@@ -89,10 +89,10 @@ public class TransactionSearchService {
         throw new SearchTransactionsException(ledgerResponse);
     }
 
-    private TransactionSearchResults processResponse(Response connectorResponse) {
+    private SearchResults<PaymentForSearchResult> processResponse(Response connectorResponse) {
         PaymentSearchResponse<TransactionResponse> response;
         try {
-            response = connectorResponse.readEntity(new GenericType<PaymentSearchResponse<TransactionResponse>>() {
+            response = connectorResponse.readEntity(new GenericType<>() {
             });
         } catch (ProcessingException ex) {
             throw new SearchTransactionsException(ex);
@@ -103,7 +103,7 @@ public class TransactionSearchService {
                 .map(this::getPaymentForSearchResult)
                 .collect(toList());
 
-        return new TransactionSearchResults(
+        return new SearchResults<>(
                 response.getTotal(),
                 response.getCount(),
                 response.getPage(),

--- a/src/test/java/uk/gov/pay/api/ledger/service/TransactionSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/ledger/service/TransactionSearchServiceTest.java
@@ -12,8 +12,8 @@ import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.BadRequestException;
+import uk.gov.pay.api.ledger.model.SearchResults;
 import uk.gov.pay.api.ledger.model.TransactionSearchParams;
-import uk.gov.pay.api.ledger.model.TransactionSearchResults;
 import uk.gov.pay.api.model.Address;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.TokenPaymentType;
@@ -78,8 +78,7 @@ public class TransactionSearchServiceTest {
         Account account = new Account(ACCOUNT_ID, TokenPaymentType.CARD, "a-token-link");
         TransactionSearchParams searchParams = new TransactionSearchParams();
 
-        TransactionSearchResults searchResults = transactionSearchService.doSearch(account,
-                searchParams);
+        SearchResults<PaymentForSearchResult> searchResults = transactionSearchService.doSearch(account, searchParams);
 
         PaymentForSearchResult payment = searchResults.getResults().get(0);
 


### PR DESCRIPTION
Transmogrify `TransactionSearchResults` into `SearchResults<E>` so we can use it for other kinds of search results.

with @sfount