### PR TITLE
PP-9675 implement search disputes endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/PublicApi.java
+++ b/src/main/java/uk/gov/pay/api/app/PublicApi.java
@@ -41,6 +41,7 @@ import uk.gov.pay.api.exception.mapper.JsonProcessingExceptionMapper;
 import uk.gov.pay.api.exception.mapper.PaymentValidationExceptionMapper;
 import uk.gov.pay.api.exception.mapper.RefundsValidationExceptionMapper;
 import uk.gov.pay.api.exception.mapper.SearchChargesExceptionMapper;
+import uk.gov.pay.api.exception.mapper.SearchDisputeExceptionMapper;
 import uk.gov.pay.api.exception.mapper.SearchRefundsExceptionMapper;
 import uk.gov.pay.api.exception.mapper.ViolationExceptionMapper;
 import uk.gov.pay.api.filter.AuthorizationValidationFilter;
@@ -55,6 +56,7 @@ import uk.gov.pay.api.resources.HealthCheckResource;
 import uk.gov.pay.api.resources.PaymentRefundsResource;
 import uk.gov.pay.api.resources.PaymentsResource;
 import uk.gov.pay.api.resources.RequestDeniedResource;
+import uk.gov.pay.api.resources.SearchDisputesResource;
 import uk.gov.pay.api.resources.SearchRefundsResource;
 import uk.gov.pay.api.resources.SecuritytxtResource;
 import uk.gov.pay.api.resources.telephone.TelephonePaymentNotificationResource;
@@ -106,6 +108,7 @@ public class PublicApi extends Application<PublicApiConfig> {
         environment.jersey().register(new InjectingValidationFeature(injector));
         environment.jersey().register(injector.getInstance(SecuritytxtResource.class));
         environment.jersey().register(injector.getInstance(AuthorisationResource.class));
+        environment.jersey().register(injector.getInstance(SearchDisputesResource.class));
 
         environment.jersey().register(injector.getInstance(RateLimiterFilter.class));
         environment.jersey().register(injector.getInstance(LoggingMDCRequestFilter.class));
@@ -178,6 +181,7 @@ public class PublicApi extends Application<PublicApiConfig> {
         jersey.register(AuthorisationRequestExceptionMapper.class);
         jersey.register(InternalServerExceptionMapper.class);
         jersey.register(DisputeValidationExceptionMapper.class);
+        jersey.register(SearchDisputeExceptionMapper.class);
     }
 
     private void initialiseMetrics(PublicApiConfig configuration, Environment environment) {

--- a/src/main/java/uk/gov/pay/api/exception/mapper/SearchDisputeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/SearchDisputeExceptionMapper.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.api.exception.mapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.api.exception.SearchDisputeException;
+import uk.gov.pay.api.model.RequestError;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static uk.gov.pay.api.model.RequestError.Code.GET_DISPUTE_LEDGER_ERROR;
+import static uk.gov.pay.api.model.RequestError.Code.SEARCH_DISPUTES_NOT_FOUND;
+import static uk.gov.pay.api.model.RequestError.aRequestError;
+
+public class SearchDisputeExceptionMapper implements ExceptionMapper<SearchDisputeException> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SearchDisputeExceptionMapper.class);
+
+    @Override
+    public Response toResponse(SearchDisputeException exception) {
+        if (exception.getErrorStatus() == NOT_FOUND.getStatusCode()) {
+            return buildResponse(exception, SEARCH_DISPUTES_NOT_FOUND, NOT_FOUND);
+        }
+        return buildResponse(exception, GET_DISPUTE_LEDGER_ERROR, INTERNAL_SERVER_ERROR);
+    }
+
+    private Response buildResponse(SearchDisputeException exception, RequestError.Code connectorError, Response.Status status) {
+        RequestError requestError = aRequestError(connectorError);
+        LOGGER.info("Ledger response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, requestError);
+        return Response
+                .status(status)
+                .entity(requestError)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/api/model/RequestError.java
+++ b/src/main/java/uk/gov/pay/api/model/RequestError.java
@@ -88,7 +88,9 @@ public class RequestError {
 
         CANCEL_AGREEMENT_CONNECTOR_BAD_REQUEST_ERROR("P0501", "Cancellation of agreement failed"),
         CANCEL_AGREEMENT_CONNECTOR_ERROR("P0198", "Downstream system error"),
-        SEARCH_DISPUTES_VALIDATION_ERROR("P0401", "Invalid parameters: %s. See Public API documentation for the correct data formats");
+        SEARCH_DISPUTES_VALIDATION_ERROR("P0401", "Invalid parameters: %s. See Public API documentation for the correct data formats"),
+        GET_DISPUTE_LEDGER_ERROR("P0498", "Downstream system error"),
+        SEARCH_DISPUTES_NOT_FOUND("P0402", "Page not found");
 
         private String value;
         private String format;

--- a/src/main/java/uk/gov/pay/api/resources/SearchDisputesResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchDisputesResource.java
@@ -1,0 +1,64 @@
+package uk.gov.pay.api.resources;
+
+import com.codahale.metrics.annotation.Timed;
+import io.dropwizard.auth.Auth;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.model.search.dispute.DisputeSearchResults;
+import uk.gov.pay.api.service.DisputesSearchParams;
+import uk.gov.pay.api.service.SearchDisputesService;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+
+import static java.lang.String.format;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.pay.api.validation.DisputeSearchValidator.validateDisputeParameters;
+
+@Path("/")
+@Produces({"application/json"})
+public class SearchDisputesResource {
+    private static final Logger logger = LoggerFactory.getLogger(SearchDisputesResource.class);
+    private final SearchDisputesService searchDisputesService;
+
+    @Inject
+    public SearchDisputesResource(SearchDisputesService searchDisputesService) {
+        this.searchDisputesService = searchDisputesService;
+    }
+
+    @GET
+    @Timed
+    @Path("/v1/disputes")
+    @Produces(APPLICATION_JSON)
+    public DisputeSearchResults searchDisputes(@Auth Account account,
+                                               @QueryParam("from_date") String fromDate,
+                                               @QueryParam("to_date") String toDate,
+                                               @QueryParam("from_settled_date") String fromSettledDate,
+                                               @QueryParam("to_settled_date") String toSettledDate,
+                                               @QueryParam("status") String status,
+                                               @QueryParam("page") String pageNumber,
+                                               @QueryParam("display_size") String displaySize) {
+        logger.info("Disputes search request - [ {} ]",
+                format("from_date: %s, to_date: %s, from_settled_date: %s, to_settled_date: %s, " +
+                                "status: s, page: %s, display_size: %s",
+                        fromDate, toDate, fromSettledDate, toSettledDate, status, pageNumber, displaySize));
+
+        DisputesSearchParams params = new DisputesSearchParams.Builder()
+                .withFromDate(fromDate)
+                .withToDate(toDate)
+                .withFromSettledDate(fromSettledDate)
+                .withToSettledDate(toSettledDate)
+                .withStatus(status)
+                .withPage(pageNumber)
+                .withDisplaySize(displaySize)
+                .build();
+
+        validateDisputeParameters(params);
+
+        return searchDisputesService.searchDisputes(account, params);
+    }
+}

--- a/src/main/java/uk/gov/pay/api/service/DisputesSearchParams.java
+++ b/src/main/java/uk/gov/pay/api/service/DisputesSearchParams.java
@@ -4,7 +4,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
-public class DisputesParams {
+public class DisputesSearchParams {
 
     private static final String PAGE = "page";
     private static final String DISPLAY_SIZE = "display_size";
@@ -14,7 +14,7 @@ public class DisputesParams {
     private static final String TO_DATE = "to_date";
     private static final String FROM_SETTLED_DATE = "from_settled_date";
     private static final String TO_SETTLED_DATE = "to_settled_date";
-    private static final String STATE = "state";
+    private static final String STATUS = "status";
 
     private String fromDate;
     private String toDate;
@@ -24,14 +24,14 @@ public class DisputesParams {
     private String toSettledDate;
     private String state;
 
-    private DisputesParams(Builder builder) {
+    private DisputesSearchParams(Builder builder) {
         this.fromDate = builder.fromDate;
         this.toDate = builder.toDate;
         this.page = builder.page;
         this.displaySize = builder.displaySize;
         this.fromSettledDate = builder.fromSettledDate;
         this.toSettledDate = builder.toSettledDate;
-        this.state = builder.state;
+        this.state = builder.status;
     }
 
     public Map<String, String> getParamsAsMap() {
@@ -42,7 +42,7 @@ public class DisputesParams {
         params.put(DISPLAY_SIZE, Optional.ofNullable(displaySize).orElse(DEFAULT_DISPLAY_SIZE));
         params.put(FROM_SETTLED_DATE, fromSettledDate);
         params.put(TO_SETTLED_DATE, toSettledDate);
-        params.put(STATE, state);
+        params.put(STATUS, state);
         
         return params;
     }
@@ -82,13 +82,13 @@ public class DisputesParams {
         private String displaySize;
         private String fromSettledDate;
         private String toSettledDate;
-        private String state;
+        private String status;
 
         public Builder() {
         }
 
-        public DisputesParams build() {
-            return new DisputesParams(this);
+        public DisputesSearchParams build() {
+            return new DisputesSearchParams(this);
         }
 
         public Builder withFromDate(String fromDate) {
@@ -121,8 +121,8 @@ public class DisputesParams {
             return this;
         }
 
-        public Builder withState(String state) {
-            this.state = state;
+        public Builder withStatus(String status) {
+            this.status = status;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/api/service/LedgerService.java
+++ b/src/main/java/uk/gov/pay/api/service/LedgerService.java
@@ -121,9 +121,13 @@ public class LedgerService {
         throw new SearchRefundsException(response);
     }
 
-    public SearchDisputeResponseFromLedger searchDispute(Account account, Map<String, String> paramsAsMap) {
+    public SearchDisputeResponseFromLedger searchDisputes(Account account, Map<String, String> paramsAsMap) {
         paramsAsMap.put(PARAM_ACCOUNT_ID, account.getAccountId());
         paramsAsMap.put(PARAM_TRANSACTION_TYPE, DISPUTE_TRANSACTION_TYPE);
+
+        if (paramsAsMap.containsKey("status")) {
+            paramsAsMap.put("state", paramsAsMap.remove("status"));
+        }
 
         Response response = client
                 .target(ledgerUriGenerator.transactionsURIWithParams(paramsAsMap))

--- a/src/main/java/uk/gov/pay/api/validation/DisputeSearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/DisputeSearchValidator.java
@@ -2,7 +2,7 @@ package uk.gov.pay.api.validation;
 
 import com.google.common.collect.ImmutableList;
 import uk.gov.pay.api.exception.DisputesValidationException;
-import uk.gov.pay.api.service.DisputesParams;
+import uk.gov.pay.api.service.DisputesSearchParams;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -23,7 +23,7 @@ public class DisputeSearchValidator {
     private static final List<String> VALID_DISPUTE_STATES = ImmutableList.of("created", "needs_response",
             "under_review", "lost", "won");
 
-    public static void validateDisputeParameters(DisputesParams params) {
+    public static void validateDisputeParameters(DisputesSearchParams params) {
         String pageNumber = params.getPage();
         String displaySize = params.getDisplaySize();
         String fromSettledDate = params.getFromSettledDate();

--- a/src/test/java/uk/gov/pay/api/it/SearchDisputesResourceIT.java
+++ b/src/test/java/uk/gov/pay/api/it/SearchDisputesResourceIT.java
@@ -1,0 +1,123 @@
+package uk.gov.pay.api.it;
+
+import io.restassured.response.ValidatableResponse;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.api.model.ledger.DisputeSettlementSummary;
+import uk.gov.pay.api.model.ledger.TransactionState;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
+import uk.gov.pay.api.utils.mocks.LedgerMockClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.api.utils.mocks.DisputeTransactionFromLedgerFixture.DisputeTransactionFromLedgerBuilder.aDisputeTransactionFromLedgerFixture;
+
+public class SearchDisputesResourceIT extends PaymentResourceITestBase {
+
+    private static final String SEARCH_PATH = "/v1/disputes";
+    private LedgerMockClient ledgerMockClient = new LedgerMockClient(ledgerMock);
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+
+    @Before
+    public void setUp() {
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+    }
+
+    @Test
+    public void searchDisputes_shouldReturnValidResponse() {
+        var dispute = aDisputeTransactionFromLedgerFixture()
+                .withTransactionId("a-transaction-id")
+                .withAmount(1000L)
+                .withCreatedDate("2022-05-20T19:05:00.000Z")
+                .withEvidenceDueDate("2022-05-27T19:05:00.000Z")
+                .withFee(1500L)
+                .withNetAmount(-2500L)
+                .withParentTransactionId("a-parent-transaction-id")
+                .withReason("fraudulent")
+                .withSettlementSummary(new DisputeSettlementSummary("2022-05-27"))
+                .withState(new TransactionState("lost", true))
+                .build();
+
+        ledgerMockClient.respondWithSearchDisputes(dispute);
+
+        searchDisputes(Map.of())
+                .statusCode(200)
+                .contentType(JSON)
+                .body("page", is(1))
+                .body("total", is(1))
+                .body("count", is(1))
+                .body("links.self.href", containsString("/v1/disputes"))
+                .body("links.first_page.href", containsString("/v1/disputes"))
+                .body("links.last_page.href", containsString("/v1/disputes"))
+
+                .body("results[0].amount", is(1000))
+                .body("results[0].fee", is(1500))
+                .body("results[0].reason", is("fraudulent"))
+                .body("results[0].status", is("lost"))
+                .body("results[0].created_date", is("2022-05-20T19:05:00.000Z"))
+                .body("results[0].dispute_id", is("a-transaction-id"))
+                .body("results[0].evidence_due_date", is("2022-05-27T19:05:00.000Z"))
+                .body("results[0].net_amount", is(-2500))
+                .body("results[0].payment_id", is("a-parent-transaction-id"))
+                .body("results[0].settlement_summary.settled_date", is("2022-05-27"))
+                .body("results[0]._links.payment.href", containsString("/v1/payments/a-parent-transaction-id"))
+                .body("results[0]._links.payment.method", is("GET"));
+    }
+
+    @Test
+    public void shouldError_whenInvalidSearchParams() {
+        Map<String, String> queryParams = Map.of(
+                "from_date", "27th of July, 2022, 11:23",
+                "to_date", "27th of July, 2022, 13:05",
+                "from_settled_date", "3rd of July",
+                "to_settled_date", "30th of July",
+                "status", "disputed",
+                "page", "second",
+                "display_size", "short"
+        );
+
+        searchDisputes(queryParams)
+                .statusCode(422)
+                .contentType(JSON)
+                .body("code", is("P0401"))
+                .body("description", is("Invalid parameters: from_date, to_date, from_settled_date, to_settled_date, page, display_size, state. See Public API documentation for the correct data formats"));
+    }
+
+    @Test
+    public void searchDisputesShouldReturnPageNotFound_whenLedgerRespondsWith404() {
+        ledgerMockClient.respondWithSearchDisputesNotFound();
+
+        searchDisputes(Map.of(
+                "status", "lost",
+                "page", "2"))
+                .statusCode(404)
+                .contentType(JSON)
+                .body("code", is ("P0402"))
+                .body("description", is("Page not found"));
+    }
+
+    @Test
+    public void searchDisputes_shouldReturns401WhenUnauthorised() {
+        publicAuthMockClient.respondUnauthorised();
+
+        searchDisputes(Map.of())
+                .statusCode(401);
+    }
+
+    private ValidatableResponse searchDisputes(Map<String, String> queryParams) {
+        return given().port(app.getLocalPort())
+                .accept(JSON)
+                .contentType(JSON)
+                .header(AUTHORIZATION, "Bearer " + PaymentResourceITestBase.API_KEY)
+                .queryParams(queryParams)
+                .get(SEARCH_PATH)
+                .then();
+    }
+}

--- a/src/test/java/uk/gov/pay/api/service/SearchDisputesServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/SearchDisputesServiceTest.java
@@ -11,7 +11,6 @@ import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
-import uk.gov.pay.api.exception.DisputesValidationException;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.search.PaginationDecorator;
@@ -24,7 +23,6 @@ import javax.ws.rs.client.Client;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -57,20 +55,20 @@ public class SearchDisputesServiceTest {
     @PactVerification({"ledger"})
     @Pacts(pacts = {"publicapi-ledger-search-disputes_by_settled_dates"})
     public void searchDisputesBySettledDatesShouldReturnFromLedger() {
-        DisputesParams.Builder paramsBuilder = new DisputesParams.Builder();
-        DisputesParams params = paramsBuilder
+        DisputesSearchParams.Builder paramsBuilder = new DisputesSearchParams.Builder();
+        DisputesSearchParams params = paramsBuilder
                 .withFromSettledDate("2022-05-27")
                 .withToSettledDate("2022-05-27")
                 .build();
         Account account = new Account(accountId, TokenPaymentType.CARD, tokenLink);
-        DisputeSearchResults results = service.validateAndSearchDisputes(account, params);
+        DisputeSearchResults results = service.searchDisputes(account, params);
         assertThat(results.getResults().size(), is(1));
         assertThat(results.getCount(), is(1));
         assertThat(results.getPage(), is(1));
         assertThat(results.getTotal(), is(1));
-        assertThat(results.getLinks().getSelf().getHref(), is("http://publicapi.test.localhost/v1/disputes/?from_settled_date=2022-05-27&to_settled_date=2022-05-27&display_size=500&page=1"));
-        assertThat(results.getLinks().getFirstPage().getHref(), is("http://publicapi.test.localhost/v1/disputes/?from_settled_date=2022-05-27&to_settled_date=2022-05-27&display_size=500&page=1"));
-        assertThat(results.getLinks().getLastPage().getHref(), is("http://publicapi.test.localhost/v1/disputes/?from_settled_date=2022-05-27&to_settled_date=2022-05-27&display_size=500&page=1"));
+        assertThat(results.getLinks().getSelf().getHref(), is("http://publicapi.test.localhost/v1/disputes?from_settled_date=2022-05-27&to_settled_date=2022-05-27&display_size=500&page=1"));
+        assertThat(results.getLinks().getFirstPage().getHref(), is("http://publicapi.test.localhost/v1/disputes?from_settled_date=2022-05-27&to_settled_date=2022-05-27&display_size=500&page=1"));
+        assertThat(results.getLinks().getLastPage().getHref(), is("http://publicapi.test.localhost/v1/disputes?from_settled_date=2022-05-27&to_settled_date=2022-05-27&display_size=500&page=1"));
 
         DisputeForSearchResult dispute = results.getResults().get(0);
         assertThat(dispute.getDisputeId(), is("dispute97837509646393e3C"));
@@ -87,20 +85,34 @@ public class SearchDisputesServiceTest {
     }
 
     @Test
-    public void getSearchResponse_shouldThrowDisputesValidationExceptionWhenParamsAreInvalid() {
-        Account account = new Account(accountId, TokenPaymentType.CARD, tokenLink);
-        String invalid = "invalid_param";
-        DisputesParams.Builder builder = new DisputesParams.Builder();
-        DisputesParams params = builder
-                .withDisplaySize(invalid)
-                .withPage(invalid)
-                .withToSettledDate(invalid)
+    @PactVerification({"ledger"})
+    @Pacts(pacts = {"publicapi-ledger-search-disputes_by_state"})
+    public void searchDisputesByStatus_ShouldReturnFromLedger_andShouldRewriteQueryParamsAndLinks() {
+        DisputesSearchParams.Builder paramsBuilder = new DisputesSearchParams.Builder();
+        DisputesSearchParams params = paramsBuilder
+                .withStatus("lost")
                 .build();
+        Account account = new Account(accountId, TokenPaymentType.CARD, tokenLink);
+        DisputeSearchResults results = service.searchDisputes(account, params);
+        assertThat(results.getResults().size(), is(1));
+        assertThat(results.getCount(), is(1));
+        assertThat(results.getPage(), is(1));
+        assertThat(results.getTotal(), is(1));
+        assertThat(results.getLinks().getSelf().getHref(), is("http://publicapi.test.localhost/v1/disputes?display_size=500&page=1&status=lost"));
+        assertThat(results.getLinks().getFirstPage().getHref(), is("http://publicapi.test.localhost/v1/disputes?display_size=500&page=1&status=lost"));
+        assertThat(results.getLinks().getLastPage().getHref(), is("http://publicapi.test.localhost/v1/disputes?display_size=500&page=1&status=lost"));
 
-        DisputesValidationException disputesValidationException = assertThrows(DisputesValidationException.class,
-                () -> service.validateAndSearchDisputes(account, builder.build()));
-
-        assertThat(disputesValidationException.getRequestError().getCode(), is("P0401"));
-        assertThat(disputesValidationException.getRequestError().getDescription(), is("Invalid parameters: to_settled_date, page, display_size. See Public API documentation for the correct data formats"));
+        DisputeForSearchResult dispute = results.getResults().get(0);
+        assertThat(dispute.getDisputeId(), is("dispute97837509646393e3C"));
+        assertThat(dispute.getReason(), is("fraudulent"));
+        assertThat(dispute.getAmount(), is(1000L));
+        assertThat(dispute.getFee(), is(1500L));
+        assertThat(dispute.getNetAmount(), is(-2500L));
+        assertThat(dispute.getPaymentId(), is("parent-abcde-12345"));
+        assertThat(dispute.getCreatedDate(), is("2022-05-20T19:05:00.000Z"));
+        assertThat(dispute.getEvidenceDueDate(), is("2022-05-27T19:05:00.000Z"));
+        assertThat(dispute.getSettlementSummary().getSettledDate(), is("2022-05-27"));
+        assertThat(dispute.getStatus(), is("lost"));
+        assertThat(dispute.getLinks().getPayment().getHref(), is("http://publicapi.test.localhost/v1/payments/parent-abcde-12345"));
     }
 }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/DisputeTransactionFromLedgerFixture.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/DisputeTransactionFromLedgerFixture.java
@@ -1,0 +1,161 @@
+package uk.gov.pay.api.utils.mocks;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.api.model.ledger.DisputeSettlementSummary;
+import uk.gov.pay.api.model.ledger.TransactionState;
+
+public class DisputeTransactionFromLedgerFixture {
+    @JsonProperty("amount")
+    private Long amount;
+    @JsonProperty("created_date")
+    private String createdDate;
+    @JsonProperty("transaction_id")
+    private String transactionId;
+    @JsonProperty("evidence_due_date")
+    private String evidenceDueDate;
+    @JsonProperty("fee")
+    private Long fee;
+    @JsonProperty("net_amount")
+    private Long netAmount;
+    @JsonProperty("parent_transaction_id")
+    private String parentTransactionId;
+    @JsonProperty("reason")
+    private String reason;
+    @JsonProperty("settlement_summary")
+    private DisputeSettlementSummary settlementSummary;
+    @JsonProperty("state")
+    private TransactionState state;
+    @JsonProperty("transaction_type")
+    private String transActionType = "DISPUTE";
+
+    public DisputeTransactionFromLedgerFixture(DisputeTransactionFromLedgerBuilder builder) {
+        this.amount = builder.amount;
+        this.createdDate = builder.createdDate;
+        this.transactionId = builder.transactionId;
+        this.evidenceDueDate = builder.evidenceDueDate;
+        this.fee = builder.fee;
+        this.netAmount = builder.netAmount;
+        this.parentTransactionId = builder.parentTransactionId;
+        this.reason = builder.reason;
+        this.settlementSummary = builder.settlementSummary;
+        this.state = builder.state;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public String getCreatedDate() {
+        return createdDate;
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public String getEvidenceDueDate() {
+        return evidenceDueDate;
+    }
+
+    public Long getFee() {
+        return fee;
+    }
+
+    public Long getNetAmount() {
+        return netAmount;
+    }
+
+    public String getParentTransactionId() {
+        return parentTransactionId;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public DisputeSettlementSummary getSettlementSummary() {
+        return settlementSummary;
+    }
+
+    public TransactionState getState() {
+        return state;
+    }
+
+    public String getTransActionType() {
+        return transActionType;
+    }
+
+    public static final class DisputeTransactionFromLedgerBuilder {
+        private Long amount;
+        private String createdDate;
+        private String transactionId;
+        private String evidenceDueDate;
+        private Long fee;
+        private Long netAmount;
+        private String parentTransactionId;
+        private String reason;
+        private DisputeSettlementSummary settlementSummary;
+        private TransactionState state;
+
+        private DisputeTransactionFromLedgerBuilder() {
+        }
+
+        public static DisputeTransactionFromLedgerBuilder aDisputeTransactionFromLedgerFixture() {
+            return new DisputeTransactionFromLedgerBuilder();
+        }
+
+        public DisputeTransactionFromLedgerBuilder withAmount(Long amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        public DisputeTransactionFromLedgerBuilder withCreatedDate(String createdDate) {
+            this.createdDate = createdDate;
+            return this;
+        }
+
+        public DisputeTransactionFromLedgerBuilder withTransactionId(String transactionId) {
+            this.transactionId = transactionId;
+            return this;
+        }
+
+        public DisputeTransactionFromLedgerBuilder withEvidenceDueDate(String evidenceDueDate) {
+            this.evidenceDueDate = evidenceDueDate;
+            return this;
+        }
+
+        public DisputeTransactionFromLedgerBuilder withFee(Long fee) {
+            this.fee = fee;
+            return this;
+        }
+
+        public DisputeTransactionFromLedgerBuilder withNetAmount(Long netAmount) {
+            this.netAmount = netAmount;
+            return this;
+        }
+
+        public DisputeTransactionFromLedgerBuilder withParentTransactionId(String parentTransactionId) {
+            this.parentTransactionId = parentTransactionId;
+            return this;
+        }
+
+        public DisputeTransactionFromLedgerBuilder withReason(String reason) {
+            this.reason = reason;
+            return this;
+        }
+
+        public DisputeTransactionFromLedgerBuilder withSettlementSummary(DisputeSettlementSummary settlementSummary) {
+            this.settlementSummary = settlementSummary;
+            return this;
+        }
+
+        public DisputeTransactionFromLedgerBuilder withState(TransactionState state) {
+            this.state = state;
+            return this;
+        }
+
+        public DisputeTransactionFromLedgerFixture build() {
+            return new DisputeTransactionFromLedgerFixture(this);
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/api/utils/mocks/LedgerMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/LedgerMockClient.java
@@ -101,7 +101,35 @@ public class LedgerMockClient {
                         .withBody(jsonStringBuilder.build())));
     }
 
+    public void respondWithSearchDisputes(DisputeTransactionFromLedgerFixture... disputes) {
+
+        Map<String, Link> links = (ImmutableMap.of(
+                "first_page", new Link("http://server:port/first-link?page=1"),
+                "self", new Link("http://server:port/self-link?page=1"),
+                "last_page", new Link("http://server:port/last-link?page=1")));
+
+        JsonStringBuilder jsonStringBuilder = new JsonStringBuilder()
+                .add("total", 1)
+                .add("count", 1)
+                .add("page", 1)
+                .add("results", Arrays.asList(disputes))
+                .add("_links", links);
+
+        ledgerMock.stubFor(get(urlPathEqualTo("/v1/transaction"))
+                .willReturn(aResponse()
+                        .withStatus(OK_200)
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                        .withBody(jsonStringBuilder.build())));
+    }
+
     public void respondWithSearchRefundsNotFound() {
+        ledgerMock.stubFor(get(urlPathEqualTo("/v1/transaction"))
+                .willReturn(aResponse()
+                        .withStatus(NOT_FOUND_404)
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)));
+    }
+
+    public void respondWithSearchDisputesNotFound() {
         ledgerMock.stubFor(get(urlPathEqualTo("/v1/transaction"))
                 .willReturn(aResponse()
                         .withStatus(NOT_FOUND_404)

--- a/src/test/java/uk/gov/pay/api/validation/DisputeSearchValidatorTest.java
+++ b/src/test/java/uk/gov/pay/api/validation/DisputeSearchValidatorTest.java
@@ -2,7 +2,7 @@ package uk.gov.pay.api.validation;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.api.exception.DisputesValidationException;
-import uk.gov.pay.api.service.DisputesParams;
+import uk.gov.pay.api.service.DisputesSearchParams;
 
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.is;
@@ -14,14 +14,14 @@ class DisputeSearchValidatorTest {
     private static String VALIDATION_EXCEPTION_MESSAGE = "Invalid parameters: %s. See Public API documentation for the correct data formats";
     @Test
     void validateSearchParameters_shouldSuccessValidation() {
-        DisputesParams params = new DisputesParams.Builder()
+        DisputesSearchParams params = new DisputesSearchParams.Builder()
                 .withFromDate("2022-07-22T11:23:55Z")
                 .withToDate("2022-07-22T12:23:55Z")
                 .withDisplaySize("1")
                 .withFromSettledDate("2022-07-20")
                 .withToSettledDate("2022-07-21")
                 .withPage("1")
-                .withState("won")
+                .withStatus("won")
                 .build();
 
         validateDisputeParameters(params);
@@ -29,21 +29,21 @@ class DisputeSearchValidatorTest {
 
     @Test
     void validateParams_shouldNotGiveAnErrorValidation_ForMissingPageDisplaySize() {
-        DisputesParams params = new DisputesParams.Builder()
+        DisputesSearchParams params = new DisputesSearchParams.Builder()
                 .withFromDate("2022-07-22T11:23:55Z")
                 .withToDate("2022-07-22T12:23:55Z")
                 .withDisplaySize(null)
                 .withFromSettledDate("2022-07-20")
                 .withToSettledDate("2022-07-21")
                 .withPage(null)
-                .withState("lost")
+                .withStatus("lost")
                 .build();
         validateDisputeParameters(params);
     }
 
     @Test
     void validateSearchParameters_shouldGiveAValidationError_ForNonValidToDate() {
-        DisputesParams params = new DisputesParams.Builder()
+        DisputesSearchParams params = new DisputesSearchParams.Builder()
                 .withToDate("alpha")
                 .build();
         DisputesValidationException validationException = assertThrows(DisputesValidationException.class,
@@ -54,7 +54,7 @@ class DisputeSearchValidatorTest {
 
     @Test
     void validateSearchParameters_shouldGiveAValidationError_ForNonValidFromDate() {
-        DisputesParams params = new DisputesParams.Builder()
+        DisputesSearchParams params = new DisputesSearchParams.Builder()
                 .withFromDate("bravo")
                 .build();
         DisputesValidationException validationException = assertThrows(DisputesValidationException.class,
@@ -65,7 +65,7 @@ class DisputeSearchValidatorTest {
 
     @Test
     void validateSearchParameters_shouldGiveAValidationError_ForNonNumericPageAndSize() {
-        DisputesParams params = new DisputesParams.Builder()
+        DisputesSearchParams params = new DisputesSearchParams.Builder()
                 .withDisplaySize("charlie")
                 .withPage("delta")
                 .build();
@@ -77,7 +77,7 @@ class DisputeSearchValidatorTest {
 
     @Test
     void validateParams_shouldGiveAnErrorValidation_forZeroPageDisplay() {
-        DisputesParams params = new DisputesParams.Builder()
+        DisputesSearchParams params = new DisputesSearchParams.Builder()
                 .withDisplaySize("0")
                 .withPage("0")
                 .build();
@@ -89,7 +89,7 @@ class DisputeSearchValidatorTest {
 
     @Test
     void validateParams_shouldGiveAnErrorValidation_forMaxedOutValuesPageDisplaySize() {
-        DisputesParams params = new DisputesParams.Builder()
+        DisputesSearchParams params = new DisputesSearchParams.Builder()
                 .withDisplaySize(String.valueOf(Integer.MAX_VALUE + 1))
                 .withPage(String.valueOf(Integer.MAX_VALUE + 1))
                 .build();
@@ -101,7 +101,7 @@ class DisputeSearchValidatorTest {
 
     @Test
     void validateParams_shouldGiveAnErrorValidation_forTooLargeDisplaySize() {
-        DisputesParams params = new DisputesParams.Builder()
+        DisputesSearchParams params = new DisputesSearchParams.Builder()
                 .withDisplaySize("501")
                 .build();
         DisputesValidationException validationException = assertThrows(DisputesValidationException.class,
@@ -112,7 +112,7 @@ class DisputeSearchValidatorTest {
 
     @Test
     void validateSearchParameters_shouldGiveAValidationError_ForNonValidToSettledDate() {
-        DisputesParams params = new DisputesParams.Builder()
+        DisputesSearchParams params = new DisputesSearchParams.Builder()
                 .withToSettledDate("January 7")
                 .build();
         DisputesValidationException validationException = assertThrows(DisputesValidationException.class,
@@ -123,7 +123,7 @@ class DisputeSearchValidatorTest {
 
     @Test
     void validateSearchParameters_shouldGiveAValidationError_ForNonValidFromSettledDate() {
-        DisputesParams params = new DisputesParams.Builder()
+        DisputesSearchParams params = new DisputesSearchParams.Builder()
                 .withFromSettledDate("19th September")
                 .build();
         DisputesValidationException validationException = assertThrows(DisputesValidationException.class,
@@ -134,8 +134,8 @@ class DisputeSearchValidatorTest {
 
     @Test
     void validateSearchParameters_shouldGiveAValidationError_ForNonExistentStatus() {
-        DisputesParams params = new DisputesParams.Builder()
-                .withState("blew it")
+        DisputesSearchParams params = new DisputesSearchParams.Builder()
+                .withStatus("blew it")
                 .build();
         DisputesValidationException validationException = assertThrows(DisputesValidationException.class,
                 () -> validateDisputeParameters(params));

--- a/src/test/resources/pacts/publicapi-ledger-search-disputes_by_state.json
+++ b/src/test/resources/pacts/publicapi-ledger-search-disputes_by_state.json
@@ -7,7 +7,7 @@
   },
   "interactions": [
     {
-      "description": "Search disputes by settled dates",
+      "description": "search disputes by state",
       "providerStates": [
         {
           "name": "a dispute lost transaction exists",
@@ -24,8 +24,7 @@
         "query": {
           "page": ["1"],
           "display_size": ["500"],
-          "from_settled_date": ["2022-05-27"],
-          "to_settled_date": ["2022-05-27"],
+          "state": ["lost"],
           "account_id": ["123456"],
           "transaction_type": ["DISPUTE"],
           "status_version": ["1"]
@@ -62,13 +61,13 @@
           ],
           "_links": {
             "self": {
-              "href": "http://ledger.service.backend/v1/transaction?account_id=1234566&transaction_type=DISPUTE&from_settled_date=2022-05-27&to_settled_date=2022-05-27&page=1&display_size=500"
+              "href": "http://ledger.service.backend/v1/transaction?account_id=123456&state=lost&transaction_type=DISPUTE&page=1&display_size=500"
             },
             "last_page": {
-              "href": "http://ledger.service.backend/v1/transaction?account_id=1234566&transaction_type=DISPUTE&from_settled_date=2022-05-27&to_settled_date=2022-05-27&page=1&display_size=500"
+              "href": "http://ledger.service.backend/v1/transaction?account_id=123456&state=lost&transaction_type=DISPUTE&page=1&display_size=500"
             },
             "first_page": {
-              "href": "http://ledger.service.backend/v1/transaction?account_id=1234566&transaction_type=DISPUTE&from_settled_date=2022-05-27&to_settled_date=2022-05-27&page=1&display_size=500"
+              "href": "http://ledger.service.backend/v1/transaction?account_id=123456&state=lost&transaction_type=DISPUTE&page=1&display_size=500"
             }
           }
         },
@@ -157,21 +156,21 @@
             "$._links.self.href": {
               "matchers": [
                 {
-                  "regex": "http.*:\/\/.*\/v1\/transaction\\?account_id=123456&transaction_type=DISPUTE&from_settled_date=2022-05-27&to_settled_date=2022-05-27&page=1&display_size=500"
+                  "regex": "http.*:\/\/.*\/v1\/transaction\\?account_id=123456&state=lost&transaction_type=DISPUTE&page=1&display_size=500"
                 }
               ]
             },
             "$._links.last_page.href": {
               "matchers": [
                 {
-                  "regex": "http.*:\/\/.*\/v1\/transaction\\?account_id=123456&transaction_type=DISPUTE&from_settled_date=2022-05-27&to_settled_date=2022-05-27&page=1&display_size=500"
+                  "regex": "http.*:\/\/.*\/v1\/transaction\\?account_id=123456&state=lost&transaction_type=DISPUTE&page=1&display_size=500"
                 }
               ]
             },
             "$._links.first_page.href": {
               "matchers": [
                 {
-                  "regex": "http.*:\/\/.*\/v1\/transaction\\?account_id=123456&transaction_type=DISPUTE&from_settled_date=2022-05-27&to_settled_date=2022-05-27&page=1&display_size=500"
+                  "regex": "http.*:\/\/.*\/v1\/transaction\\?account_id=123456&state=lost&transaction_type=DISPUTE&page=1&display_size=500"
                 }
               ]
             }


### PR DESCRIPTION
## WHAT YOU DID
- add a new resource endpoint `/v1/disputes`
- implement endpoint to use SearchDisputesService
- there is double re-writing of the incoming data. we need to re-write incoming query param `status` to `state` as that is what Ledger expecting. also re-write the return data from Ledger, the links  changed from `state` to `status`
- add tests
