### PR TITLE
PP-9662 Query payment refunds by transaction_type

### DIFF
--- a/src/main/java/uk/gov/pay/api/ledger/service/LedgerUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/ledger/service/LedgerUriGenerator.java
@@ -58,9 +58,12 @@ public class LedgerUriGenerator {
         );
     }
 
-    public String transactionsForTransactionURI(String gatewayAccountId, String paymentId) {
+    public String transactionsForTransactionURI(String gatewayAccountId, String paymentId, String transactionType) {
         String path = format("/v1/transaction/%s/transaction", paymentId);
-        return buildLedgerUri(path, Map.of("gateway_account_id", gatewayAccountId));
+        return buildLedgerUri(path,
+                Map.of("gateway_account_id", gatewayAccountId,
+                        "transaction_type", transactionType)
+        );
     }
 
     public String agreementURI(Account account, String agreementId) {

--- a/src/main/java/uk/gov/pay/api/service/LedgerService.java
+++ b/src/main/java/uk/gov/pay/api/service/LedgerService.java
@@ -88,7 +88,7 @@ public class LedgerService {
 
     public RefundsFromLedger getPaymentRefunds(String accountId, String paymentId) {
         Response response = client
-                .target(ledgerUriGenerator.transactionsForTransactionURI(accountId, paymentId))
+                .target(ledgerUriGenerator.transactionsForTransactionURI(accountId, paymentId, REFUND_TRANSACTION_TYPE))
                 .request()
                 .get();
 

--- a/src/test/resources/pacts/publicapi-ledger-get-payment-refunds.json
+++ b/src/test/resources/pacts/publicapi-ledger-get-payment-refunds.json
@@ -23,6 +23,9 @@
         "query": {
           "gateway_account_id": [
             "123456"
+          ],
+          "transaction_type": [
+            "REFUND"
           ]
         }
       },


### PR DESCRIPTION
## WHAT YOU DID
- Query payment refunds by transaction_type as the ledger endpoint /v1/transaction/{externalId}/transaction without query params will return refunds as well as disputes
