### PR TITLE
PP-9498 Update error codes for agreements API calls

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CancelAgreementExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CancelAgreementExceptionMapper.java
@@ -13,7 +13,7 @@ import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static uk.gov.pay.api.model.RequestError.Code.CANCEL_AGREEMENT_CONNECTOR_BAD_REQUEST_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.CANCEL_AGREEMENT_CONNECTOR_ERROR;
-import static uk.gov.pay.api.model.RequestError.Code.CANCEL_PAYMENT_NOT_FOUND_ERROR;
+import static uk.gov.pay.api.model.RequestError.Code.CANCEL_AGREEMENT_NOT_FOUND_ERROR;
 import static uk.gov.pay.api.model.RequestError.aRequestError;
 
 public class CancelAgreementExceptionMapper implements ExceptionMapper<CancelAgreementException> {
@@ -28,7 +28,7 @@ public class CancelAgreementExceptionMapper implements ExceptionMapper<CancelAgr
         Response.Status status;
 
         if (errorStatus == NOT_FOUND.getStatusCode()) {
-            requestError = aRequestError(CANCEL_PAYMENT_NOT_FOUND_ERROR);
+            requestError = aRequestError(CANCEL_AGREEMENT_NOT_FOUND_ERROR);
             status = NOT_FOUND;
         } else if (errorStatus == BAD_REQUEST.getStatusCode()) {
             requestError = aRequestError(CANCEL_AGREEMENT_CONNECTOR_BAD_REQUEST_ERROR);

--- a/src/main/java/uk/gov/pay/api/exception/mapper/SearchAgreementsExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/SearchAgreementsExceptionMapper.java
@@ -11,7 +11,7 @@ import javax.ws.rs.ext.ExceptionMapper;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static uk.gov.pay.api.model.RequestError.Code.SEARCH_AGREEMENTS_LEDGER_ERROR;
-import static uk.gov.pay.api.model.RequestError.Code.SEARCH_PAYMENTS_NOT_FOUND;
+import static uk.gov.pay.api.model.RequestError.Code.SEARCH_AGREEMENTS_NOT_FOUND;
 import static uk.gov.pay.api.model.RequestError.aRequestError;
 
 public class SearchAgreementsExceptionMapper implements ExceptionMapper<SearchAgreementsException> {
@@ -22,10 +22,9 @@ public class SearchAgreementsExceptionMapper implements ExceptionMapper<SearchAg
         if (exception.getErrorStatus() == NOT_FOUND.getStatusCode()) {
             return Response
                     .status(NOT_FOUND)
-                    .entity(aRequestError(SEARCH_PAYMENTS_NOT_FOUND))
+                    .entity(aRequestError(SEARCH_AGREEMENTS_NOT_FOUND))
                     .build();
-        }
-        else {
+        } else {
             RequestError requestError = aRequestError(SEARCH_AGREEMENTS_LEDGER_ERROR);
             final Response.Status status = INTERNAL_SERVER_ERROR;
             LOGGER.error("Ledger response was {}.\n Returning http status {} with error body {}", exception.getMessage(), status, requestError);

--- a/src/main/java/uk/gov/pay/api/model/RequestError.java
+++ b/src/main/java/uk/gov/pay/api/model/RequestError.java
@@ -84,14 +84,19 @@ public class RequestError {
         AUTHORISATION_ONE_TIME_TOKEN_ALREADY_USED_ERROR("P1212", "%s"),
         AUTHORISATION_ONE_TIME_TOKEN_INVALID_ERROR("P1211", "%s"),
 
-        CREATE_AGREEMENT_CONNECTOR_ERROR("P0198", "Downstream system error"),
-        CREATE_AGREEMENT_PARSING_ERROR("P0197", "Unable to parse JSON"),
+        CREATE_AGREEMENT_CONNECTOR_ERROR("P2198", "Downstream system error"),
+        CREATE_AGREEMENT_PARSING_ERROR("P2197", "Unable to parse JSON"),
 
-        GET_AGREEMENT_NOT_FOUND_ERROR("P0200", "Not found"),
-        GET_AGREEMENT_LEDGER_ERROR("P0298", "Downstream system error"),
+        CREATE_AGREEMENT_MISSING_FIELD_ERROR("P2101", "Missing mandatory attribute: %s"),
+        CREATE_AGREEMENT_VALIDATION_ERROR("P2102", "Invalid attribute value: %s. %s"),
 
-        CANCEL_AGREEMENT_CONNECTOR_BAD_REQUEST_ERROR("P0501", "Cancellation of agreement failed"),
-        CANCEL_AGREEMENT_CONNECTOR_ERROR("P0198", "Downstream system error"),
+        GET_AGREEMENT_NOT_FOUND_ERROR("P2200", "Not found"),
+        GET_AGREEMENT_LEDGER_ERROR("P2298", "Downstream system error"),
+
+        CANCEL_AGREEMENT_NOT_FOUND_ERROR("P2500", "Not found"),
+        CANCEL_AGREEMENT_CONNECTOR_BAD_REQUEST_ERROR("P2501", "Cancellation of agreement failed"),
+        CANCEL_AGREEMENT_CONNECTOR_ERROR("P2598", "Downstream system error"),
+        
         SEARCH_DISPUTES_VALIDATION_ERROR("P0401", "Invalid parameters: %s. See Public API documentation for the correct data formats"),
         GET_DISPUTE_LEDGER_ERROR("P0498", "Downstream system error"),
         SEARCH_DISPUTES_NOT_FOUND("P0402", "Page not found");

--- a/src/main/java/uk/gov/pay/api/validation/AgreementSearchValidator.java
+++ b/src/main/java/uk/gov/pay/api/validation/AgreementSearchValidator.java
@@ -21,14 +21,13 @@ import static uk.gov.pay.api.common.SearchConstants.REFERENCE_KEY;
 import static uk.gov.pay.api.common.SearchConstants.STATUS_KEY;
 import static uk.gov.pay.api.model.CreateCardPaymentRequest.REFERENCE_MAX_LENGTH;
 import static uk.gov.pay.api.model.RequestError.Code.SEARCH_AGREEMENTS_VALIDATION_ERROR;
-import static uk.gov.pay.api.model.RequestError.Code.SEARCH_PAYMENTS_VALIDATION_ERROR;
 import static uk.gov.pay.api.model.RequestError.aRequestError;
 import static uk.gov.pay.api.validation.MaxLengthValidator.isInvalid;
 import static uk.gov.pay.api.validation.SearchValidator.validateDisplaySizeIfNotNull;
 import static uk.gov.pay.api.validation.SearchValidator.validatePageIfNotNull;
 
 public class AgreementSearchValidator {
-    
+
     private static final Set<String> SUPPORTED_SEARCH_PARAMS = Set.of(REFERENCE_KEY, STATUS_KEY, PAGE, DISPLAY_SIZE);
 
     public static void validateSearchParameters(AgreementSearchParams searchParams) {

--- a/src/test/java/uk/gov/pay/api/it/AgreementsIT.java
+++ b/src/test/java/uk/gov/pay/api/it/AgreementsIT.java
@@ -55,7 +55,7 @@ public class AgreementsIT extends PaymentResourceITestBase {
                 .then()
                 .statusCode(404)
                 .contentType(ContentType.JSON)
-                .body("code", is("P0200"))
+                .body("code", is("P2200"))
                 .body("description", is("Not found"));
     }
 

--- a/src/test/java/uk/gov/pay/api/it/CreateAgreementIT.java
+++ b/src/test/java/uk/gov/pay/api/it/CreateAgreementIT.java
@@ -63,7 +63,7 @@ public class CreateAgreementIT extends PaymentResourceITestBase {
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .contentType(JSON)
                 .body("field", is("reference"))
-                .body("code", is("P0101"))
+                .body("code", is("P2101"))
                 .body("description", is("Missing mandatory attribute: reference"));
     }
 
@@ -75,7 +75,7 @@ public class CreateAgreementIT extends PaymentResourceITestBase {
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .contentType(JSON)
                 .body("field", is("reference"))
-                .body("code", is("P0101"))
+                .body("code", is("P2101"))
                 .body("description", is("Missing mandatory attribute: reference"));
     }
 
@@ -87,7 +87,7 @@ public class CreateAgreementIT extends PaymentResourceITestBase {
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .contentType(JSON)
                 .body("field", is("description"))
-                .body("code", is("P0101"))
+                .body("code", is("P2101"))
                 .body("description", is("Missing mandatory attribute: description"));
     }
 
@@ -99,7 +99,7 @@ public class CreateAgreementIT extends PaymentResourceITestBase {
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .contentType(JSON)
                 .body("field", is("description"))
-                .body("code", is("P0101"))
+                .body("code", is("P2101"))
                 .body("description", is("Missing mandatory attribute: description"));
     }
 
@@ -188,7 +188,7 @@ public class CreateAgreementIT extends PaymentResourceITestBase {
        postAgreementRequest(agreementPayload(createAgreementRequestParams))
                .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
                 .contentType(JSON)
-               .body("code",is("P0198"))
+               .body("code",is("P2198"))
                .body("description", is("Downstream system error"));
       
         connectorMockClient.verifyCreateAgreementConnectorRequest(GATEWAY_ACCOUNT_ID, createAgreementRequestParams);

--- a/src/test/java/uk/gov/pay/api/json/CreateAgreementRequestDeserializerTest.java
+++ b/src/test/java/uk/gov/pay/api/json/CreateAgreementRequestDeserializerTest.java
@@ -41,7 +41,7 @@ public class CreateAgreementRequestDeserializerTest {
         String invalidJson = "{\"reference\": \"Some reference\"";
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> deserializer.deserialize(jsonFactory.createParser(invalidJson), ctx));
-        assertThat(badRequestException, aBadRequestExceptionWithError("P0197", "Unable to parse JSON"));
+        assertThat(badRequestException, aBadRequestExceptionWithError("P2197", "Unable to parse JSON"));
     }
 
     @Test
@@ -49,7 +49,7 @@ public class CreateAgreementRequestDeserializerTest {
         String invalidJson = "{}";
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> deserializer.deserialize(jsonFactory.createParser(invalidJson), ctx));
-        assertThat(badRequestException, aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: reference"));
+        assertThat(badRequestException, aBadRequestExceptionWithError("P2101", "Missing mandatory attribute: reference"));
     }
     
     @Test
@@ -57,7 +57,7 @@ public class CreateAgreementRequestDeserializerTest {
         String json = "{ \"reference\": null}";
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
-        assertThat(badRequestException, aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: reference"));
+        assertThat(badRequestException, aBadRequestExceptionWithError("P2101", "Missing mandatory attribute: reference"));
     }
 
     @Test
@@ -65,7 +65,7 @@ public class CreateAgreementRequestDeserializerTest {
         String json = "{ \"reference\": \"\"}";
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> deserializer.deserialize(jsonFactory.createParser(json), ctx));
-        assertThat(badRequestException, aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: reference"));
+        assertThat(badRequestException, aBadRequestExceptionWithError("P2101", "Missing mandatory attribute: reference"));
     }
 
     @Test
@@ -73,7 +73,7 @@ public class CreateAgreementRequestDeserializerTest {
         String invalidJson = "{\"reference\": \"Some reference\"}";
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> deserializer.deserialize(jsonFactory.createParser(invalidJson), ctx));
-        assertThat(badRequestException, aBadRequestExceptionWithError("P0101", "Missing mandatory attribute: description"));
+        assertThat(badRequestException, aBadRequestExceptionWithError("P2101", "Missing mandatory attribute: description"));
     }
 
     @Test
@@ -81,7 +81,7 @@ public class CreateAgreementRequestDeserializerTest {
         String jsonWithNumericReference = "{\"reference\": 123}";
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> deserializer.deserialize(jsonFactory.createParser(jsonWithNumericReference), ctx));
-        assertThat(badRequestException, aBadRequestExceptionWithError("P0102",
+        assertThat(badRequestException, aBadRequestExceptionWithError("P2102",
                 "Invalid attribute value: reference. Must be a valid string format"));
     }
     


### PR DESCRIPTION
Update the error codes for agreements API calls to match those we’ve agreed upon (which is essentially the same as the equivalent P0xxx error code for payments but P2xxx instead).