### PR TITLE
PP-9545 Assert that we do not send "payment_instrument": null

### DIFF
--- a/src/main/java/uk/gov/pay/api/agreement/model/AgreementLedgerResponse.java
+++ b/src/main/java/uk/gov/pay/api/agreement/model/AgreementLedgerResponse.java
@@ -56,12 +56,25 @@ public class AgreementLedgerResponse {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonIgnoreProperties(ignoreUnknown = true)
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public class PaymentInstrumentLedgerResponse {
+    public static class PaymentInstrumentLedgerResponse {
+
         private String externalId;
         private String agreementExternalId;
         private CardDetails cardDetails;
         private String createdDate;
         private String type;
+
+        public PaymentInstrumentLedgerResponse() {
+            // Janet Jackson
+        }
+        
+        private PaymentInstrumentLedgerResponse(Builder builder) {
+            this.externalId = builder.externalId;
+            this.agreementExternalId = builder.agreementExternalId;
+            this.cardDetails = builder.cardDetails;
+            this.createdDate = builder.createdDate;
+            this.type = builder.type;
+        }
 
         public String getExternalId() {
             return externalId;
@@ -82,5 +95,45 @@ public class AgreementLedgerResponse {
         public String getType() {
             return type;
         }
+
+        public static class Builder {
+            private String externalId;
+            private String agreementExternalId;
+            private CardDetails cardDetails;
+            private String createdDate;
+            private String type;
+
+            public PaymentInstrumentLedgerResponse build() {
+                return new PaymentInstrumentLedgerResponse(this);
+            }
+
+            public Builder withExternalId(String externalId) {
+                this.externalId = externalId;
+                return this;
+            }
+
+            public Builder withAgreementExternalId(String agreementExternalId) {
+                this.agreementExternalId = agreementExternalId;
+                return this;
+            }
+
+            public Builder withCardDetails(CardDetails cardDetails) {
+                this.cardDetails = cardDetails;
+                return this;
+            }
+
+            public Builder withCreatedDate(String createdDate) {
+                this.createdDate = createdDate;
+                return this;
+            }
+
+            public Builder withType(String type) {
+                this.type = type;
+                return this;
+            }
+
+        }
+
     }
+
 }

--- a/src/test/java/uk/gov/pay/api/it/CreateAgreementIT.java
+++ b/src/test/java/uk/gov/pay/api/it/CreateAgreementIT.java
@@ -18,7 +18,7 @@ import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.apache.commons.lang3.RandomStringUtils.random;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
-import static uk.gov.pay.api.utils.mocks.AgreementFromLedgerFixture.AgreementFromLedgerFixtureBuilder.anAgreementFromLedgerFixture;
+import static uk.gov.pay.api.utils.mocks.AgreementFromLedgerFixture.AgreementFromLedgerFixtureBuilder.anAgreementFromLedgerWithoutPaymentInstrumentFixture;
 import static uk.gov.pay.api.utils.mocks.CreateAgreementRequestParams.CreateAgreementRequestParamsBuilder.aCreateAgreementRequestParams;
 
 public class CreateAgreementIT extends PaymentResourceITestBase {
@@ -39,8 +39,9 @@ public class CreateAgreementIT extends PaymentResourceITestBase {
                 .withDescription(DESCRIPTION)
                 .withUserIdentifier(USER_IDENTIFIER)
                 .build();
-        var agreementFixture = anAgreementFromLedgerFixture()
+        var agreementFixture = anAgreementFromLedgerWithoutPaymentInstrumentFixture()
                 .withExternalId(VALID_AGREEMENT_ID)
+                .withPaymentInstrument(null)
                 .build();
         connectorMockClient.respondOk_whenCreateAgreement(GATEWAY_ACCOUNT_ID, createAgreementRequestParams);
         ledgerMockClient.respondWithAgreement(VALID_AGREEMENT_ID, agreementFixture);
@@ -117,8 +118,9 @@ public class CreateAgreementIT extends PaymentResourceITestBase {
 
     @Test
     public void shouldReturn201WhenWhenOptionalUserIdentifierIsNull() throws JsonProcessingException {
-        var agreementFixture = anAgreementFromLedgerFixture()
+        var agreementFixture = anAgreementFromLedgerWithoutPaymentInstrumentFixture()
                 .withExternalId(VALID_AGREEMENT_ID)
+                .withPaymentInstrument(null)
                 .build();
         publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, CARD);
 

--- a/src/test/java/uk/gov/pay/api/utils/mocks/AgreementFromLedgerFixture.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/AgreementFromLedgerFixture.java
@@ -3,6 +3,8 @@ package uk.gov.pay.api.utils.mocks;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.api.agreement.model.AgreementLedgerResponse;
+import uk.gov.pay.api.model.Address;
+import uk.gov.pay.api.model.CardDetails;
 
 import java.time.ZonedDateTime;
 
@@ -58,7 +60,7 @@ public class AgreementFromLedgerFixture {
     }
 
     public static final class AgreementFromLedgerFixtureBuilder {
-        private String externalId = "an-external-id";
+        private String externalId = "agreement-external-id";
         private String serviceId = "a-service-id";
         private String reference = "valid-reference";
         private String description = "An agreement description";
@@ -67,10 +69,23 @@ public class AgreementFromLedgerFixture {
         private AgreementLedgerResponse.PaymentInstrumentLedgerResponse paymentInstrument;
 
         private AgreementFromLedgerFixtureBuilder() {
+            paymentInstrument = new AgreementLedgerResponse.PaymentInstrumentLedgerResponse.Builder()
+                    .withExternalId("payment-instrument-external-id")
+                    .withAgreementExternalId("agreement-external-id")
+                    .withCreatedDate("2022-08-02T15:20:00.000Z")
+                    .withType("card")
+                    .withCardDetails(new CardDetails("1234", "123456", "Rio Curring", "12/27",
+                            new Address("Line 1", "Line 2", "E1 8QS", "London", "GB"),
+                            "Mastercard", "debit"))
+                    .build();
         }
 
-        public static AgreementFromLedgerFixtureBuilder anAgreementFromLedgerFixture() {
+        public static AgreementFromLedgerFixtureBuilder anAgreementFromLedgerWithPaymentInstrumentFixture() {
             return new AgreementFromLedgerFixtureBuilder();
+        }
+
+        public static AgreementFromLedgerFixtureBuilder anAgreementFromLedgerWithoutPaymentInstrumentFixture() {
+            return new AgreementFromLedgerFixtureBuilder().withPaymentInstrument(null);
         }
 
         public AgreementFromLedgerFixtureBuilder withExternalId(String externalId) {

--- a/src/test/java/uk/gov/pay/api/utils/mocks/LedgerMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/LedgerMockClient.java
@@ -205,7 +205,7 @@ public class LedgerMockClient {
                         .withBody(body)));
     }
 
-    public void respondWithSearchAgreements(String gatewayAccountId, AgreementFromLedgerFixture... agreements) {
+    public void respondWithSearchAgreements(String gatewayAccountId, AgreementFromLedgerFixture... agreements) throws JsonProcessingException {
         var links = Map.of(
                 "first_page", new Link("http://server:port/first-link?page=1"),
                 "prev_page", new Link("http://server:port/prev-link?page=2"),
@@ -214,12 +214,12 @@ public class LedgerMockClient {
                 "next_page", new Link("http://server:port/next-link?page=4")
         );
 
-        var jsonStringBuilder = new JsonStringBuilder()
-                .add("total", 9)
-                .add("count", 2)
-                .add("page", 3)
-                .add("results", List.copyOf(Arrays.asList(agreements)))
-                .add("_links", links);
+        var responseBody = new HashMap<String, Object>();
+        responseBody.put("total", 9);
+        responseBody.put("count", 2);
+        responseBody.put("page", 3);
+        responseBody.put("results", List.copyOf(Arrays.asList(agreements)));
+        responseBody.put("_links", links);
 
         ledgerMock.stubFor(get(urlPathEqualTo("/v1/agreement"))
                 .withQueryParam("page", equalTo("3"))
@@ -230,7 +230,7 @@ public class LedgerMockClient {
                 .willReturn(aResponse()
                         .withStatus(OK_200)
                         .withHeader(CONTENT_TYPE, APPLICATION_JSON)
-                        .withBody(jsonStringBuilder.build())));
+                        .withBody(mapper.writeValueAsString(responseBody))));
     }
 
     public void respondAgreementNotFound(String agreementId) {


### PR DESCRIPTION
It’s possible for an agreement to not have a payment instrument yet. We have unintentionally flip-flopped between including
`"payment_instrument": null` or nothing in the agreement response if this is the case.

We have now decided to not include `"payment_instrument": null` when there is no payment instrument for the agreement. The rationale for including it was it alerts services that there may sometimes be a payment instrument. However, we wish to use the agreements model for other kinds of recurring payments in the future and our crystal balls are not good enough to rule out the possibility that we may one day have a kind of agreement that never has a payment instrument. If this happens, always including `"payment_instrument": null` will be undesirable.

Update integration tests to ensure we keep this desired behaviour of agreements only including `"payment_instrument"` if there is a payment instrument.