### PR TITLE
PP-9498 Make cancel agreement handle error conditions

### DIFF
--- a/src/main/java/uk/gov/pay/api/agreement/resource/AgreementsApiResource.java
+++ b/src/main/java/uk/gov/pay/api/agreement/resource/AgreementsApiResource.java
@@ -83,7 +83,7 @@ public class AgreementsApiResource {
 
     @POST
     @Path("/v1/agreements/{agreementId}/cancel")
-    @Consumes("application/json")
+    @Produces(APPLICATION_JSON)
     public Response createAgreement(@Parameter(hidden = true) @Auth Account account, @PathParam("agreementId") String agreementId) {
         agreementService.cancel(account, agreementId);
         return Response.status(SC_NO_CONTENT).build();

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CancelAgreementExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CancelAgreementExceptionMapper.java
@@ -22,7 +22,6 @@ public class CancelAgreementExceptionMapper implements ExceptionMapper<CancelAgr
 
     @Override
     public Response toResponse(CancelAgreementException exception) {
-
         int errorStatus = exception.getErrorStatus();
         RequestError requestError;
         Response.Status status;

--- a/src/test/java/uk/gov/pay/api/exception/mapper/CancelAgreementExceptionMapperTest.java
+++ b/src/test/java/uk/gov/pay/api/exception/mapper/CancelAgreementExceptionMapperTest.java
@@ -1,0 +1,58 @@
+package uk.gov.pay.api.exception.mapper;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.api.exception.CancelAgreementException;
+import uk.gov.pay.api.exception.ConnectorResponseErrorException.ConnectorErrorResponse;
+import uk.gov.pay.api.model.RequestError;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.when;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.AGREEMENT_NOT_ACTIVE;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.AGREEMENT_NOT_FOUND;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.GENERIC;
+
+@ExtendWith(MockitoExtension.class)
+class CancelAgreementExceptionMapperTest {
+
+    @Mock
+    private Response mockResponse;
+
+    private final CancelAgreementExceptionMapper mapper = new CancelAgreementExceptionMapper();
+
+    @ParameterizedTest
+    @MethodSource
+    void testExceptionMapping(int statusCodeFromConnector, ErrorIdentifier errorIdentifierFromConnector,
+                              int expectedStatusCode, String expectedErrorCode, String expectedDescription) {
+        when(mockResponse.getStatus()).thenReturn(statusCodeFromConnector);
+        when(mockResponse.readEntity(ConnectorErrorResponse.class)).thenReturn(new ConnectorErrorResponse(errorIdentifierFromConnector, List.of()));
+
+        Response returnedResponse = mapper.toResponse(new CancelAgreementException(mockResponse));
+
+        assertThat(returnedResponse.getStatus(), is(expectedStatusCode));
+
+        RequestError returnedError = (RequestError) returnedResponse.getEntity();
+        assertThat(returnedError.getDescription(), is(expectedDescription));
+        assertThat(returnedError.getCode(), is(expectedErrorCode));
+    }
+
+    static Stream<Arguments> testExceptionMapping() {
+        return Stream.of(
+                arguments(404, AGREEMENT_NOT_FOUND, 404, "P2500", "Not found"),
+                arguments(400, AGREEMENT_NOT_ACTIVE, 400, "P2501", "Cancellation of agreement failed"),
+                arguments(500, GENERIC, 500, "P2598", "Downstream system error")
+        );
+    }
+
+}

--- a/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
@@ -25,7 +25,8 @@ public abstract class BaseConnectorMockClient {
     static String CONNECTOR_MOCK_CHARGES_PATH = CONNECTOR_MOCK_ACCOUNTS_PATH + "/charges";
     static String CONNECTOR_MOCK_TELEPHONE_CHARGES_PATH = CONNECTOR_MOCK_ACCOUNTS_PATH + "/telephone-charges";
     static String CONNECTOR_MOCK_CHARGE_PATH = CONNECTOR_MOCK_CHARGES_PATH + "/%s";
-    static String CONNECTOR_MOCK_AGREEMENT_PATH = CONNECTOR_MOCK_ACCOUNTS_PATH + "/agreements";
+    static String CONNECTOR_MOCK_AGREEMENTS_PATH = CONNECTOR_MOCK_ACCOUNTS_PATH + "/agreements";
+    static String CONNECTOR_MOCK_AGREEMENT_PATH = CONNECTOR_MOCK_AGREEMENTS_PATH + "/%s";
     static String CONNECTOR_MOCK_AUTHORISATION_PATH = "/v1/api/charges/authorise";
 
     WireMockClassRule wireMockClassRule;
@@ -145,7 +146,7 @@ public abstract class BaseConnectorMockClient {
     public void verifyCreateAgreementConnectorRequest(String gatewayAccountId, String payload) {
         wireMockClassRule.getAllServeEvents();
         wireMockClassRule.verify(1,
-                postRequestedFor(urlEqualTo(format(CONNECTOR_MOCK_AGREEMENT_PATH, gatewayAccountId)))
+                postRequestedFor(urlEqualTo(format(CONNECTOR_MOCK_AGREEMENTS_PATH, gatewayAccountId)))
                         .withRequestBody(equalToJson(payload, true, true)));
     }
 }


### PR DESCRIPTION
Correctly handle connector returning 404, 400 and 500 appropriately when cancelling an agreement and add tests to prove this.