### PR TITLE
PP-9498 Handle connector incorrect auth mode for set up agreement

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -12,6 +12,7 @@ import javax.ws.rs.ext.ExceptionMapper;
 
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static uk.gov.pay.api.model.CreateCardPaymentRequest.SET_UP_AGREEMENT_FIELD_NAME;
 import static uk.gov.pay.api.model.RequestError.Code.ACCOUNT_DISABLED;
 import static uk.gov.pay.api.model.RequestError.Code.ACCOUNT_NOT_LINKED_WITH_PSP;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_ACCOUNT_ERROR;
@@ -19,6 +20,7 @@ import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_AGREEMENT_ID
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_AUTHORISATION_API_NOT_ENABLED;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_CONNECTOR_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_MOTO_NOT_ENABLED;
+import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_UNEXPECTED_FIELD_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_VALIDATION_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.GENERIC_MISSING_FIELD_ERROR_MESSAGE_FROM_CONNECTOR;
 import static uk.gov.pay.api.model.RequestError.Code.GENERIC_UNEXPECTED_FIELD_ERROR_MESSAGE_FROM_CONNECTOR;
@@ -86,6 +88,10 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
                 case UNEXPECTED_ATTRIBUTE:
                     statusCode = HttpStatus.BAD_REQUEST_400;
                     requestError = aRequestError(GENERIC_UNEXPECTED_FIELD_ERROR_MESSAGE_FROM_CONNECTOR, exception.getConnectorErrorMessage());
+                    break;
+                case INCORRECT_AUTHORISATION_MODE_FOR_SAVE_PAYMENT_INSTRUMENT_TO_AGREEMENT:
+                    statusCode = HttpStatus.BAD_REQUEST_400;
+                    requestError = aRequestError(CREATE_PAYMENT_UNEXPECTED_FIELD_ERROR, SET_UP_AGREEMENT_FIELD_NAME);
                     break;
                 case INVALID_ATTRIBUTE_VALUE:
                     statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;

--- a/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
+++ b/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.api.exception.mapper;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -12,15 +13,18 @@ import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import javax.ws.rs.core.Response;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.when;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.ACCOUNT_DISABLED;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.ACCOUNT_NOT_LINKED_WITH_PSP;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.AGREEMENT_NOT_ACTIVE;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.AGREEMENT_NOT_FOUND;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.AUTHORISATION_API_NOT_ALLOWED;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.INCORRECT_AUTHORISATION_MODE_FOR_SAVE_PAYMENT_INSTRUMENT_TO_AGREEMENT;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.INVALID_ATTRIBUTE_VALUE;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.MISSING_MANDATORY_ATTRIBUTE;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.MOTO_NOT_ALLOWED;
@@ -36,24 +40,8 @@ class CreateChargeExceptionMapperTest {
 
     private final CreateChargeExceptionMapper mapper = new CreateChargeExceptionMapper();
 
-    static Object[] parametersForMapping() {
-        return new Object[] {
-                new Object[]{ZERO_AMOUNT_NOT_ALLOWED, false, "Invalid attribute value: amount. Must be greater than or equal to 1", 422, "P0102"},
-                new Object[]{MOTO_NOT_ALLOWED, false, "MOTO payments are not enabled for this account. Please contact support if you would like to process MOTO payments - https://www.payments.service.gov.uk/support/ .", 422, "P0196"},
-                new Object[]{ACCOUNT_DISABLED, false, "GOV.UK Pay has disabled payment and refund creation on this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ .", 403, "P0941"},
-                new Object[]{TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED, false, "Access to this resource is not enabled for this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ .", 403, "P0930"},
-                new Object[]{ACCOUNT_NOT_LINKED_WITH_PSP, false, "Account is not fully configured. Please refer to documentation to setup your account or contact support with your error code - https://www.payments.service.gov.uk/support/ .", 403, "P0940"},
-                new Object[]{AUTHORISATION_API_NOT_ALLOWED, false, "Using authorisation_mode of moto_api is not allowed for this account", 422, "P0195"},
-                new Object[]{MISSING_MANDATORY_ATTRIBUTE, true, "An error message from connector", 400, "P0101"},
-                new Object[]{UNEXPECTED_ATTRIBUTE, true, "An error message from connector", 400, "P0104"},
-                new Object[]{AGREEMENT_NOT_FOUND, false, "Invalid attribute value: agreement_id. Agreement does not exist", 400, "P0102"},
-                new Object[]{AGREEMENT_NOT_ACTIVE, false, "Invalid attribute value: agreement_id. Agreement must be active", 400, "P0102"},
-                new Object[]{INVALID_ATTRIBUTE_VALUE, true, "An error message from connector", 422, "P0102"}
-        };
-    }
-    
     @ParameterizedTest
-    @MethodSource("parametersForMapping")
+    @MethodSource
     void testExceptionMapping(ErrorIdentifier errorIdentifier, boolean messageFromConnector, String expectedDescription, int expectedStatusCode, String expectedErrorCode) {
         List<String> connectorErrorMessages = messageFromConnector ? List.of(expectedDescription) : List.of();
         when(mockResponse.readEntity(ConnectorErrorResponse.class))
@@ -66,4 +54,22 @@ class CreateChargeExceptionMapperTest {
         assertThat(returnedError.getDescription(), is(expectedDescription));
         assertThat(returnedError.getCode(), is(expectedErrorCode));
     }
+
+    static Stream<Arguments> testExceptionMapping() {
+        return Stream.of(
+                arguments(ZERO_AMOUNT_NOT_ALLOWED, false, "Invalid attribute value: amount. Must be greater than or equal to 1", 422, "P0102"),
+                arguments(MOTO_NOT_ALLOWED, false, "MOTO payments are not enabled for this account. Please contact support if you would like to process MOTO payments - https://www.payments.service.gov.uk/support/ .", 422, "P0196"),
+                arguments(ACCOUNT_DISABLED, false, "GOV.UK Pay has disabled payment and refund creation on this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ .", 403, "P0941"),
+                arguments(TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED, false, "Access to this resource is not enabled for this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ .", 403, "P0930"),
+                arguments(ACCOUNT_NOT_LINKED_WITH_PSP, false, "Account is not fully configured. Please refer to documentation to setup your account or contact support with your error code - https://www.payments.service.gov.uk/support/ .", 403, "P0940"),
+                arguments(AUTHORISATION_API_NOT_ALLOWED, false, "Using authorisation_mode of moto_api is not allowed for this account", 422, "P0195"),
+                arguments(MISSING_MANDATORY_ATTRIBUTE, true, "An error message from connector", 400, "P0101"),
+                arguments(UNEXPECTED_ATTRIBUTE, true, "An error message from connector", 400, "P0104"),
+                arguments(INCORRECT_AUTHORISATION_MODE_FOR_SAVE_PAYMENT_INSTRUMENT_TO_AGREEMENT, true, "Unexpected attribute: set_up_agreement", 400, "P0104"),
+                arguments(AGREEMENT_NOT_FOUND, false, "Invalid attribute value: agreement_id. Agreement does not exist", 400, "P0102"),
+                arguments(AGREEMENT_NOT_ACTIVE, false, "Invalid attribute value: agreement_id. Agreement must be active", 400, "P0102"),
+                arguments(INVALID_ATTRIBUTE_VALUE, true, "An error message from connector", 422, "P0102")
+        );
+    }
+
 }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -57,6 +57,7 @@ import static uk.gov.service.payments.commons.model.ErrorIdentifier.AGREEMENT_NO
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.AGREEMENT_NOT_FOUND;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.AUTHORISATION_API_NOT_ALLOWED;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.GENERIC;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.INCORRECT_AUTHORISATION_MODE_FOR_SAVE_PAYMENT_INSTRUMENT_TO_AGREEMENT;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.MOTO_NOT_ALLOWED;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.REFUND_NOT_AVAILABLE;
@@ -386,8 +387,12 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
         mockCreateAgreement(gatewayAccountId, withStatusAndErrorMessage(BAD_REQUEST_400, errorMsg, GENERIC));
     }
 
-    public void respondBadRequest_whenCreateChargeWithAgreementNotFound(String gatewayAccountId, String agreementId, String errorMsg) {
+    public void respondAgreementNotFound_whenCreateCharge(String gatewayAccountId, String agreementId, String errorMsg) {
         mockCreateCharge(gatewayAccountId, withStatusAndErrorMessage(NOT_FOUND_404, format(errorMsg, agreementId), AGREEMENT_NOT_FOUND));
+    }
+
+    public void respondIncorrectAuthorisationModeForSavePaymentInstrumentToAgreement_whenCreateCharge(String gatewayAccountId, String agreementId, String errorMsg) {
+        mockCreateCharge(gatewayAccountId, withStatusAndErrorMessage(BAD_REQUEST_400, format(errorMsg, agreementId), INCORRECT_AUTHORISATION_MODE_FOR_SAVE_PAYMENT_INSTRUMENT_TO_AGREEMENT));
     }
 
     public void respondPreconditionFailed_whenCreateRefund(String gatewayAccountId, String errorMsg, String chargeId) {


### PR DESCRIPTION
Handle connector returning an `INCORRECT_AUTHORISATION_MODE_FOR_SAVE_PAYMENT_INSTRUMENT_TO_AGREEMENT` error when creating a payment. This happens if we send connector `"save_payment_instrument_to_agreement": true`, `"authorisation_mode": "agreement"` and an `"agreement_id"`.

Public API will send a request like this to connector if it receives a request with `"authorisation_mode": "agreement"` and `"set_up_agreement"` (with or without `"agreement_id"`).

Public API will respond with a 400 response with the error code P0104 and the message ‘Unexpected attribute: set_up_agreement‘.