### PR TITLE
BAU Fix readonly field in OpenAPI spec

### DIFF
--- a/openapi/publicapi_spec.json
+++ b/openapi/publicapi_spec.json
@@ -1816,8 +1816,7 @@
             "description" : "Amount in pence. Total amount still available before issuing the refund",
             "example" : 200000,
             "maximum" : 10000000,
-            "minimum" : 1,
-            "readOnly" : true
+            "minimum" : 1
           }
         },
         "required" : [ "amount" ]

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentRefundRequest.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentRefundRequest.java
@@ -5,8 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Optional;
 
-import static io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY;
-
 @Schema(name = "PaymentRefundRequest", description = "The Payment Refund Request Payload")
 public class CreatePaymentRefundRequest {
 
@@ -18,7 +16,7 @@ public class CreatePaymentRefundRequest {
     private int amount;
     @JsonProperty("refund_amount_available")
     @Schema(description = "Amount in pence. Total amount still available before issuing the refund", required = false,
-            example = "200000", accessMode = READ_ONLY, minimum = "1", maximum = "10000000")
+            example = "200000", minimum = "1", maximum = "10000000")
     private Integer refundAmountAvailable;
 
     public CreatePaymentRefundRequest() {


### PR DESCRIPTION
The refund_amount_available field on the create refund request was marked as readonly. As this is a field on a request, it should not be marked as readonly. This was causing issues for a user generating a request library using the file.