### PR TITLE
Mirror the full format returned by the API in open api spec

### DIFF
--- a/openapi/publicapi_spec.json
+++ b/openapi/publicapi_spec.json
@@ -220,14 +220,14 @@
             "type" : "string"
           }
         }, {
-          "description" : "From date of payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z",
+          "description" : "From date of payments to be searched (this date is inclusive). Example=2015-08-13T12:35:00.000Z",
           "in" : "query",
           "name" : "from_date",
           "schema" : {
             "type" : "string"
           }
         }, {
-          "description" : "To date of payments to be searched (this date is exclusive). Example=2015-08-14T12:35:00Z",
+          "description" : "To date of payments to be searched (this date is exclusive). Example=2015-08-14T12:35:00.000Z",
           "in" : "query",
           "name" : "to_date",
           "schema" : {
@@ -919,14 +919,14 @@
         "description" : "Search refunds by 'from' and 'to' date. The Authorisation token needs to be specified in the 'authorization' header as 'authorization: Bearer YOUR_API_KEY_HERE'",
         "operationId" : "Search refunds",
         "parameters" : [ {
-          "description" : "From date of refunds to be searched (this date is inclusive). Example=2015-08-13T12:35:00Z",
+          "description" : "From date of refunds to be searched (this date is inclusive). Example=2015-08-13T12:35:00.000Z",
           "in" : "query",
           "name" : "from_date",
           "schema" : {
             "type" : "string"
           }
         }, {
-          "description" : "To date of refunds to be searched (this date is exclusive). Example=2015-08-14T12:35:00Z",
+          "description" : "To date of refunds to be searched (this date is exclusive). Example=2015-08-14T12:35:00.000Z",
           "in" : "query",
           "name" : "to_date",
           "schema" : {
@@ -1211,7 +1211,7 @@
           "created_date" : {
             "type" : "string",
             "description" : "The date you created the payment.",
-            "example" : "2016-01-21T17:15:00Z"
+            "example" : "2016-01-21T17:15:00.000Z"
           },
           "delayed_capture" : {
             "type" : "boolean",
@@ -1295,7 +1295,7 @@
           "created_date" : {
             "type" : "string",
             "description" : "The date and time the user's bank told GOV.UK Pay about this dispute.",
-            "example" : "2022-07-28T16:43:000Z",
+            "example" : "2022-07-28T16:43:00.000Z",
             "readOnly" : true
           },
           "dispute_id" : {
@@ -1307,7 +1307,7 @@
           "evidence_due_date" : {
             "type" : "string",
             "description" : "The deadline for submitting your supporting evidence. This value uses Coordinated Universal Time (UTC) and ISO 8601 format",
-            "example" : "2022-07-28T16:43:000Z",
+            "example" : "2022-07-28T16:43:00.000Z",
             "readOnly" : true
           },
           "fee" : {
@@ -1463,7 +1463,7 @@
           },
           "created_date" : {
             "type" : "string",
-            "example" : "2016-01-21T17:15:000Z",
+            "example" : "2016-01-21T17:15:00.000Z",
             "readOnly" : true
           },
           "delayed_capture" : {
@@ -1601,7 +1601,7 @@
           },
           "created_date" : {
             "type" : "string",
-            "example" : "2016-01-21T17:15:000Z",
+            "example" : "2016-01-21T17:15:00.000Z",
             "readOnly" : true
           },
           "delayed_capture" : {
@@ -1857,7 +1857,7 @@
           "capture_submit_time" : {
             "type" : "string",
             "description" : "Date and time capture request has been submitted. May be null if capture request was not immediately acknowledged by payment gateway.",
-            "example" : "2016-01-21T17:15:000Z",
+            "example" : "2016-01-21T17:15:00.000Z",
             "readOnly" : true
           },
           "captured_date" : {


### PR DESCRIPTION
## WHAT YOU DID
We're currently integrating with Gov UK Pay for a new service and we're using the open API spec as a seed for a mock service to run integration tests against using Stoplight Prism mock server. During development, I encountered a discrepancy regarding the date formats defined in the open API spec. The dates in the spec are in the format `2015-08-14T12:35:00Z` but when they are returned by the real API they're in the format `2022-09-29T12:20:03.873Z` (see sample JSON below)

```json
{
  "amount": 8200,
  "description": "A payment",
  "reference": "abc",
  "language": "en",
  "email": "a@b.com",
  "state": {
    "status": "created",
    "finished": false
  },
  "payment_id": "xxx",
  "payment_provider": "sandbox",
  "created_date": "2022-09-29T12:20:03.873Z",
  "refund_summary": {
    "status": "pending",
    "amount_available": 8200,
    "amount_submitted": 0
  },
  "settlement_summary": {},
  "delayed_capture": false,
  "moto": false,
  "return_url": "http://localhost:5050/payment-confirmation",
  "authorisation_mode": "web",
  "_links": {
    "self": {
      "href": "https://publicapi.payments.service.gov.uk/v1/payments/xxx",
      "method": "GET"
    },
    "next_url": {
      "href": "https://www.payments.service.gov.uk/secure/xxx",
      "method": "GET"
    },
    "next_url_post": {
      "type": "application/x-www-form-urlencoded",
      "params": {
        "chargeTokenId": "xxx"
      },
      "href": "https://www.payments.service.gov.uk/secure",
      "method": "POST"
    },
    "events": {
      "href": "https://publicapi.payments.service.gov.uk/v1/payments/xxx/events",
      "method": "GET"
    },
    "refunds": {
      "href": "https://publicapi.payments.service.gov.uk/v1/payments/xxx/refunds",
      "method": "GET"
    },
    "cancel": {
      "href": "https://publicapi.payments.service.gov.uk/v1/payments/xxx/cancel",
      "method": "POST"
    }
  }
}
```

Usually, this isn't a huge deal but Golang is pretty strict regarding the parsing dates and the date format we define needs to match exactly the format provided. Using the date format from the real API this matches up to [RFC3339Nano](https://pkg.go.dev/time#pkg-constants). It's possible to do some string manipulation to get it to match but ideally, we'd like to take the unedited value.

Given that the spec isn't 100% representative of real life I'm hoping this change won't be too controversial but happy to discuss it further.