### PR TITLE
BAU correct swagger examples to the right format

### DIFF
--- a/openapi/publicapi_spec.json
+++ b/openapi/publicapi_spec.json
@@ -1211,7 +1211,7 @@
           "created_date" : {
             "type" : "string",
             "description" : "The date you created the payment.",
-            "example" : "2016-01-21T17:15:00Z"
+            "example" : "2016-01-21T17:15:00.000Z"
           },
           "delayed_capture" : {
             "type" : "boolean",
@@ -1295,7 +1295,7 @@
           "created_date" : {
             "type" : "string",
             "description" : "The date and time the user's bank told GOV.UK Pay about this dispute.",
-            "example" : "2022-07-28T16:43:000Z",
+            "example" : "2022-07-28T16:43:00.000Z",
             "readOnly" : true
           },
           "dispute_id" : {
@@ -1307,7 +1307,7 @@
           "evidence_due_date" : {
             "type" : "string",
             "description" : "The deadline for submitting your supporting evidence. This value uses Coordinated Universal Time (UTC) and ISO 8601 format",
-            "example" : "2022-07-28T16:43:000Z",
+            "example" : "2022-07-28T16:43:00.000Z",
             "readOnly" : true
           },
           "fee" : {
@@ -1463,7 +1463,7 @@
           },
           "created_date" : {
             "type" : "string",
-            "example" : "2016-01-21T17:15:000Z",
+            "example" : "2016-01-21T17:15:00.000Z",
             "readOnly" : true
           },
           "delayed_capture" : {
@@ -1601,7 +1601,7 @@
           },
           "created_date" : {
             "type" : "string",
-            "example" : "2016-01-21T17:15:000Z",
+            "example" : "2016-01-21T17:15:00.000Z",
             "readOnly" : true
           },
           "delayed_capture" : {
@@ -1857,7 +1857,7 @@
           "capture_submit_time" : {
             "type" : "string",
             "description" : "Date and time capture request has been submitted. May be null if capture request was not immediately acknowledged by payment gateway.",
-            "example" : "2016-01-21T17:15:000Z",
+            "example" : "2016-01-21T17:15:00.000Z",
             "readOnly" : true
           },
           "captured_date" : {

--- a/src/main/java/uk/gov/pay/api/model/CreatePaymentResult.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatePaymentResult.java
@@ -46,7 +46,7 @@ public class CreatePaymentResult {
     private String returnUrl;
 
     @JsonProperty
-    @Schema(name = "created_date", description = "The date you created the payment.", example = "2016-01-21T17:15:00Z")
+    @Schema(name = "created_date", description = "The date you created the payment.", example = "2016-01-21T17:15:00.000Z")
     private String createdDate;
 
     @JsonProperty

--- a/src/main/java/uk/gov/pay/api/model/Payment.java
+++ b/src/main/java/uk/gov/pay/api/model/Payment.java
@@ -43,7 +43,7 @@ public abstract class Payment {
         this.createdDate = createdDate;
     }
 
-    @Schema(example = "2016-01-21T17:15:000Z", accessMode = READ_ONLY)
+    @Schema(example = "2016-01-21T17:15:00.000Z", accessMode = READ_ONLY)
     public String getCreatedDate() {
         return createdDate;
     }

--- a/src/main/java/uk/gov/pay/api/model/PaymentSettlementSummary.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentSettlementSummary.java
@@ -30,7 +30,7 @@ public class PaymentSettlementSummary {
     }
 
     @Schema(description = "Date and time capture request has been submitted. May be null if capture request was not immediately acknowledged by payment gateway.",
-            example = "2016-01-21T17:15:000Z", accessMode = READ_ONLY)
+            example = "2016-01-21T17:15:00.000Z", accessMode = READ_ONLY)
     public String getCaptureSubmitTime() {
         return captureSubmitTime;
     }

--- a/src/main/java/uk/gov/pay/api/model/search/dispute/DisputeForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/dispute/DisputeForSearchResult.java
@@ -60,7 +60,7 @@ public class DisputeForSearchResult {
         return amount;
     }
 
-    @Schema(example = "2022-07-28T16:43:000Z", description = "The date and time the user's bank told GOV.UK Pay about this dispute.", accessMode = READ_ONLY)
+    @Schema(example = "2022-07-28T16:43:00.000Z", description = "The date and time the user's bank told GOV.UK Pay about this dispute.", accessMode = READ_ONLY)
     public String getCreatedDate() {
         return createdDate;
     }
@@ -70,7 +70,7 @@ public class DisputeForSearchResult {
         return disputeId;
     }
 
-    @Schema(example = "2022-07-28T16:43:000Z", description = "The deadline for submitting your supporting evidence. This value uses Coordinated Universal Time (UTC) and ISO 8601 format", accessMode = READ_ONLY)
+    @Schema(example = "2022-07-28T16:43:00.000Z", description = "The deadline for submitting your supporting evidence. This value uses Coordinated Universal Time (UTC) and ISO 8601 format", accessMode = READ_ONLY)
     public String getEvidenceDueDate() {
         return evidenceDueDate;
     }


### PR DESCRIPTION
## WHAT YOU DID
- there is a  discrepancy regarding the date formats defined in the open API spec. The dates in the spec are in the format 2015-08-14T12:35:00Z but when they are returned by the API they're in the format 2022-09-29T12:20:03.873Z
