### PR TITLE
PP-10004 M1 support for integration tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,6 +32,6 @@ jobs:
           key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}-pacts
       - name: Pull docker image dependencies
         run: |
-          docker pull redis:latest
+          docker pull redis:5.0.6
       - name: Run unit and integration tests
         run: mvn clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.17.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
             <version>${dropwizard.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
         <hamcrest.version>2.2</hamcrest.version>
         <jackson.version>2.13.4</jackson.version>
         <logback.version>1.2.11</logback.version>
-        <docker-client.version>8.16.0</docker-client.version>
         <pay-java-commons.version>1.0.20221024133103</pay-java-commons.version>
         <junit5.version>5.9.1</junit5.version>
         <pact.version>3.6.15</pact.version>
@@ -230,12 +229,6 @@
             <groupId>au.com.dius</groupId>
             <artifactId>pact-jvm-consumer-junit_2.12</artifactId>
             <version>${pact.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.spotify</groupId>
-            <artifactId>docker-client</artifactId>
-            <version>${docker-client.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- swagger -->

--- a/src/test/java/uk/gov/pay/api/it/CreateAgreementIT.java
+++ b/src/test/java/uk/gov/pay/api/it/CreateAgreementIT.java
@@ -18,6 +18,7 @@ import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.apache.commons.lang3.RandomStringUtils.random;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
+import static uk.gov.pay.api.utils.Payloads.agreementPayload;
 import static uk.gov.pay.api.utils.mocks.AgreementFromLedgerFixture.AgreementFromLedgerFixtureBuilder.anAgreementFromLedgerWithoutPaymentInstrumentFixture;
 import static uk.gov.pay.api.utils.mocks.CreateAgreementRequestParams.CreateAgreementRequestParamsBuilder.aCreateAgreementRequestParams;
 
@@ -213,16 +214,6 @@ public class CreateAgreementIT extends PaymentResourceITestBase {
                 .withReference(REFERENCE)
                 .build();
         postAgreementRequest(agreementPayload(createAgreementRequestParams)).statusCode(503);
-    }
-    
-    public static String agreementPayload(CreateAgreementRequestParams params) {
-        var stringBuilder = new JsonStringBuilder()
-                .add("reference", params.getReference())
-                .add("description", params.getDescription());
-        if (params.getUserIdentifier() != null) {
-            stringBuilder.add("user_identifier", params.getUserIdentifier());
-        }
-        return stringBuilder.build();
     }
 
     protected ValidatableResponse postAgreementRequest(String payload) {

--- a/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentResourceITestBase.java
@@ -3,7 +3,6 @@ package uk.gov.pay.api.it;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.spotify.docker.client.exceptions.DockerException;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import io.restassured.response.ValidatableResponse;
 import org.junit.Before;
@@ -35,15 +34,7 @@ public abstract class PaymentResourceITestBase {
     protected static final String CONNECTOR_ONLY_STRATEGY = "connector-only";
 
     @ClassRule
-    public static RedisDockerRule redisDockerRule;
-
-    static {
-        try {
-            redisDockerRule = new RedisDockerRule();
-        } catch (DockerException e) {
-            e.printStackTrace();
-        }
-    }
+    public static RedisDockerRule redisDockerRule = new RedisDockerRule();
 
     private static final int CONNECTOR_PORT = findFreePort();
     private static final int PUBLIC_AUTH_PORT = findFreePort();

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterITestBase.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterITestBase.java
@@ -2,7 +2,6 @@ package uk.gov.pay.api.it;
 
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.google.common.collect.ImmutableMap;
-import com.spotify.docker.client.exceptions.DockerException;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -60,18 +59,10 @@ abstract public class ResourcesFilterITestBase {
     private static final int PUBLIC_AUTH_PORT = findFreePort();
     private static final int LEDGER_PORT = findFreePort();
 
-    private ExecutorService executor = Executors.newFixedThreadPool(2);
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
 
     @ClassRule
-    public static RedisDockerRule redisDockerRule;
-
-    static {
-        try {
-            redisDockerRule = new RedisDockerRule();
-        } catch (DockerException e) {
-            e.printStackTrace();
-        }
-    }
+    public static RedisDockerRule redisDockerRule = new RedisDockerRule();
 
     @ClassRule
     public static WireMockClassRule connectorMock = new WireMockClassRule(CONNECTOR_PORT);
@@ -94,7 +85,7 @@ abstract public class ResourcesFilterITestBase {
             config("rateLimiter.noOfReqForPost", "1")
     );
 
-    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+    private final PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
 
     @Before
     public void setupApiKey() {

--- a/src/test/java/uk/gov/pay/api/it/rule/RedisContainer.java
+++ b/src/test/java/uk/gov/pay/api/it/rule/RedisContainer.java
@@ -21,13 +21,13 @@ public class RedisContainer {
                     .waitingFor(Wait.forLogMessage(".*Ready to accept connections.*", 1));
 
             REDIS_CONTAINER.start();
-            logger.info(format("Redis container started, mapped %o to host port %o", PORT, REDIS_CONTAINER.getMappedPort(6379)));
+            logger.info(format("Redis container started, mapped %o to host port %o", PORT, REDIS_CONTAINER.getMappedPort(PORT)));
         }
         return REDIS_CONTAINER;
     }
     
     static String getConnectionUrl() {
-        return format("%s:%s", REDIS_CONTAINER.getHost(), REDIS_CONTAINER.getMappedPort(6379)) ;
+        return format("%s:%s", REDIS_CONTAINER.getHost(), REDIS_CONTAINER.getMappedPort(PORT)) ;
     }
 
     static void clearRedisCache() {

--- a/src/test/java/uk/gov/pay/api/it/rule/RedisContainer.java
+++ b/src/test/java/uk/gov/pay/api/it/rule/RedisContainer.java
@@ -1,139 +1,41 @@
 package uk.gov.pay.api.it.rule;
 
-import com.google.common.base.Stopwatch;
-import com.spotify.docker.client.DockerClient;
-import com.spotify.docker.client.LogStream;
-import com.spotify.docker.client.exceptions.DockerException;
-import com.spotify.docker.client.messages.ContainerConfig;
-import com.spotify.docker.client.messages.ContainerInfo;
-import com.spotify.docker.client.messages.HostConfig;
-import com.spotify.docker.client.messages.LogConfig;
-import com.spotify.docker.client.messages.PortBinding;
 import io.lettuce.core.RedisClient;
-import io.lettuce.core.api.StatefulRedisConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 
-import java.io.IOException;
-import java.util.Objects;
-import java.util.concurrent.TimeUnit;
-
-import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 
-class RedisContainer {
+public class RedisContainer {
 
     private static final Logger logger = LoggerFactory.getLogger(RedisContainer.class);
+    private static GenericContainer<?> REDIS_CONTAINER;
+    private static final int PORT = 6379;
+    
+    static GenericContainer<?> getOrCreateRedisContainer() {
+        if (REDIS_CONTAINER == null) {
+            REDIS_CONTAINER = new GenericContainer<>("redis:5.0.6") // elasticache engine version
+                    .withExposedPorts(PORT)
+                    .waitingFor(Wait.forLogMessage(".*Ready to accept connections.*", 1));
 
-    private final String containerId;
-    private final int port;
-    private DockerClient docker;
-    private String host;
-    private volatile boolean stopped = false;
-    private static StatefulRedisConnection<String, String> redisConnection;
-
-    private static final int DB_TIMEOUT_SEC = 10;
-    private static final String REDIS_IMAGE = "redis:latest";
-    private static final String INTERNAL_PORT = "6379";
-
-    RedisContainer(DockerClient docker, String host) throws DockerException, InterruptedException {
-
-        this.docker = docker;
-        this.host = host;
-
-        failsafeDockerPull(docker);
-        docker.listImages(DockerClient.ListImagesParam.create("name", REDIS_IMAGE));
-
-        final HostConfig hostConfig = HostConfig.builder().logConfig(LogConfig.create("json-file")).publishAllPorts(true).build();
-        ContainerConfig containerConfig = ContainerConfig.builder()
-                .image(REDIS_IMAGE)
-                .hostConfig(hostConfig)
-                .build();
-        containerId = docker.createContainer(containerConfig).id();
-        docker.startContainer(containerId);
-        port = hostPortNumber(docker.inspectContainer(containerId));
-        registerShutdownHook();
-        waitForRedisToStart();
-    }
-
-    private void failsafeDockerPull(DockerClient docker) {
-        try {
-            docker.pull(REDIS_IMAGE);
-        } catch (Exception e) {
-            logger.error("Docker image " + REDIS_IMAGE + " could not be pulled from DockerHub", e);
+            REDIS_CONTAINER.start();
+            logger.info(format("Redis container started, mapped %o to host port %o", PORT, REDIS_CONTAINER.getMappedPort(6379)));
         }
+        return REDIS_CONTAINER;
+    }
+    
+    static String getConnectionUrl() {
+        return format("%s:%s", REDIS_CONTAINER.getHost(), REDIS_CONTAINER.getMappedPort(6379)) ;
     }
 
-    String getConnectionUrl() {
-        return host + ":" + port;
-    }
-
-    private static int hostPortNumber(ContainerInfo containerInfo) {
-        String redisPortSpec = INTERNAL_PORT + "/tcp";
-        PortBinding portBinding;
-        try {
-            portBinding = Objects.requireNonNull(containerInfo
-                    .networkSettings()
-                    .ports())
-                    .get(redisPortSpec)
-                    .get(0);
-            logger.info("Redis host port: {}", portBinding.hostPort());
-            return parseInt(portBinding.hostPort());
-        } catch (NullPointerException e) {
-            logger.error("Unable to find host port mapping for {} in container {}", redisPortSpec, containerInfo.id());
-            throw e;
-        }
-    }
-
-    private void registerShutdownHook() {
-        Runtime.getRuntime().addShutdownHook(new Thread(this::stop));
-    }
-
-    private void waitForRedisToStart() throws InterruptedException {
-        Stopwatch timer = Stopwatch.createStarted();
-        boolean succeeded = false;
-        while (!succeeded && timer.elapsed(TimeUnit.SECONDS) < DB_TIMEOUT_SEC) {
-            Thread.sleep(300);
-            succeeded = checkRedisConnection();
-        }
-        if (!succeeded) {
-            throw new RuntimeException("Redis did not start in " + DB_TIMEOUT_SEC + " seconds.");
-        }
-        logger.info("Redis docker container started in {}.", timer.elapsed(TimeUnit.MILLISECONDS));
-    }
-
-    private boolean checkRedisConnection() {
-        RedisClient redisClient = RedisClient.create(format("redis://%s:%s", host, port));
-        try {
-            redisConnection = redisClient.connect();
-            return true;
-        } catch (Exception except) {
-            return false;
-        }
-    }
-
-    void stop() {
-        if (stopped) {
-            return;
-        }
-        try {
-            stopped = true;
-            System.err.println("Killing redis container with ID: " + containerId);
-            LogStream logs = docker.logs(containerId, DockerClient.LogsParam.stdout(), DockerClient.LogsParam.stderr());
-            System.err.println("Killed container logs:\n");
-            logs.attach(System.err, System.err);
-            docker.stopContainer(containerId, 5);
-            docker.removeContainer(containerId);
-        } catch (DockerException | InterruptedException | IOException e) {
-            System.err.println("Could not shutdown " + containerId);
-            e.printStackTrace();
-        }
-    }
-
-    public void clearRedisCache() {
-        String response = redisConnection.sync().flushall();
-        if (!response.equals("OK")) {
-            logger.warn("Unexpected response from redis flushAll command: " + response);
+    static void clearRedisCache() {
+        try (RedisClient redisClient = RedisClient.create(format("redis://%s", getConnectionUrl()))) {
+            String response = redisClient.connect().sync().flushall();
+            if (!response.equals("OK")) {
+                logger.warn("Unexpected response from redis flushAll command: " + response);
+            }
         }
     }
 }

--- a/src/test/java/uk/gov/pay/api/it/telephone/TelephonePaymentResourceITBase.java
+++ b/src/test/java/uk/gov/pay/api/it/telephone/TelephonePaymentResourceITBase.java
@@ -3,7 +3,6 @@ package uk.gov.pay.api.it.telephone;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.spotify.docker.client.exceptions.DockerException;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import io.restassured.response.ValidatableResponse;
 import org.junit.Before;
@@ -34,15 +33,7 @@ public abstract class TelephonePaymentResourceITBase {
     protected static final CreateTelephonePaymentRequest.Builder createTelephonePaymentRequest = new CreateTelephonePaymentRequest.Builder();
 
     @ClassRule
-    public static RedisDockerRule redisDockerRule;
-
-    static {
-        try {
-            redisDockerRule = new RedisDockerRule();
-        } catch (DockerException e) {
-            e.printStackTrace();
-        }
-    }
+    public static RedisDockerRule redisDockerRule = new RedisDockerRule();
 
     private static final int CONNECTOR_PORT = findFreePort();
     private static final int PUBLIC_AUTH_PORT = findFreePort();

--- a/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentWithHttpReturnUrlIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentWithHttpReturnUrlIT.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.api.it.validation;
 
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
-import com.spotify.docker.client.exceptions.DockerException;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import io.restassured.response.ValidatableResponse;
 import org.junit.Before;
@@ -33,15 +32,7 @@ public class CreatePaymentWithHttpReturnUrlIT {
     private static final String PAYMENTS_PATH = "/v1/payments/";
 
     @ClassRule
-    public static RedisDockerRule redisDockerRule;
-
-    static {
-        try {
-            redisDockerRule = new RedisDockerRule();
-        } catch (DockerException e) {
-            e.printStackTrace();
-        }
-    }
+    public static RedisDockerRule redisDockerRule = new RedisDockerRule();
 
     private static final int CONNECTOR_PORT = findFreePort();
     private static final int PUBLIC_AUTH_PORT = findFreePort();
@@ -62,8 +53,8 @@ public class CreatePaymentWithHttpReturnUrlIT {
             config("allowHttpForReturnUrl", "true")
     );
 
-    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
-    private ConnectorMockClient connectorMockClient = new ConnectorMockClient(connectorMock);
+    private final PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+    private final ConnectorMockClient connectorMockClient = new ConnectorMockClient(connectorMock);
     
     @Before
     public void setup() {

--- a/src/test/java/uk/gov/pay/api/service/AgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/AgreementServiceTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.api.it.CreateAgreementIT.agreementPayload;
+import static uk.gov.pay.api.utils.Payloads.agreementPayload;
 import static uk.gov.pay.api.utils.mocks.CreateAgreementRequestParams.CreateAgreementRequestParamsBuilder.aCreateAgreementRequestParams;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,11 +51,11 @@ class AgreementServiceTest {
     @Mock
     private Response mockConnectorResponse;
 
-    private AgreementService service;
+    private AgreementService underTest;
 
     @BeforeEach
     void setUp() {
-        service = new AgreementService(mockClient, mockConnectorUriGenerator);
+        underTest = new AgreementService(mockClient, mockConnectorUriGenerator);
     }
 
     @Test
@@ -77,7 +77,7 @@ class AgreementServiceTest {
 
         CreateAgreementRequest agreementCreateRequest = new CreateAgreementRequest(CreateAgreementRequestBuilder
                 .builder().reference(REFERENCE_ID));
-        AgreementCreatedResponse agreementResponseFromService = service.create(mockAccount, agreementCreateRequest);
+        AgreementCreatedResponse agreementResponseFromService = underTest.create(mockAccount, agreementCreateRequest);
 
         assertThat(agreementResponseFromService.getAgreementId(), is(AGREEMENT_ID));
     }
@@ -90,7 +90,7 @@ class AgreementServiceTest {
         when(mockInvocationBuilder.post(null)).thenReturn(mockConnectorResponse);
         when(mockConnectorResponse.getStatus()).thenReturn(HttpStatus.SC_NO_CONTENT);
 
-        Response response = service.cancel(mockAccount, AGREEMENT_ID);
+        Response response = underTest.cancel(mockAccount, AGREEMENT_ID);
 
         assertThat(response.getStatus(), is(NO_CONTENT.getStatusCode()));
 
@@ -105,7 +105,7 @@ class AgreementServiceTest {
         when(mockInvocationBuilder.post(null)).thenReturn(mockConnectorResponse);
         when(mockConnectorResponse.getStatus()).thenReturn(HttpStatus.SC_BAD_REQUEST);
 
-        assertThrows(CancelAgreementException.class, () -> service.cancel(mockAccount, AGREEMENT_ID));
+        assertThrows(CancelAgreementException.class, () -> underTest.cancel(mockAccount, AGREEMENT_ID));
 
         verify(mockConnectorResponse).close();
     }

--- a/src/test/java/uk/gov/pay/api/utils/Payloads.java
+++ b/src/test/java/uk/gov/pay/api/utils/Payloads.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.api.utils;
 
+import uk.gov.pay.api.utils.mocks.CreateAgreementRequestParams;
+
 public class Payloads {
 
     public static String aSuccessfulPaymentPayload() {
@@ -17,5 +19,15 @@ public class Payloads {
                 .add("description", description)
                 .add("return_url", returnUrl)
                 .build();
+    }
+
+    public static String agreementPayload(CreateAgreementRequestParams params) {
+        var stringBuilder = new JsonStringBuilder()
+                .add("reference", params.getReference())
+                .add("description", params.getDescription());
+        if (params.getUserIdentifier() != null) {
+            stringBuilder.add("user_identifier", params.getUserIdentifier());
+        }
+        return stringBuilder.build();
     }
 }


### PR DESCRIPTION
## WHAT YOU DID

- updated int tests to use testcontainers over now EOL docker client
- changed redis version to match engine version in use on elasticache
- updated GHA to use correct redis image
- moved static method to utility class, this fixes a unit test failure in CI environments where no docker engine was available
- removed Docker Client dependency, this is no longer needed as TestContainers instruments all ephemeral test dependencies
