### PR TITLE
PP-10265 Responses As Constants for PaymentResource

### DIFF
--- a/openapi/publicapi_spec.json
+++ b/openapi/publicapi_spec.json
@@ -1440,7 +1440,7 @@
           "authorisation_mode" : {
             "type" : "string",
             "description" : "How the payment will be authorised. Payments created in `web` mode require the paying user to visit the `next_url` to complete the payment.",
-            "enum" : [ "web", "moto_api", "external" ]
+            "enum" : [ "web", "moto_api", "agreement", "external" ]
           },
           "authorisation_summary" : {
             "$ref" : "#/components/schemas/AuthorisationSummary"
@@ -1578,7 +1578,7 @@
           "authorisation_mode" : {
             "type" : "string",
             "description" : "How the payment will be authorised. Payments created in `web` mode require the paying user to visit the `next_url` to complete the payment.",
-            "enum" : [ "web", "moto_api", "external" ]
+            "enum" : [ "web", "moto_api", "agreement", "external" ]
           },
           "authorisation_summary" : {
             "$ref" : "#/components/schemas/AuthorisationSummary"

--- a/openapi/publicapi_spec.json
+++ b/openapi/publicapi_spec.json
@@ -1440,7 +1440,7 @@
           "authorisation_mode" : {
             "type" : "string",
             "description" : "How the payment will be authorised. Payments created in `web` mode require the paying user to visit the `next_url` to complete the payment.",
-            "enum" : [ "web", "moto_api", "agreement", "external" ]
+            "enum" : [ "web", "moto_api", "external" ]
           },
           "authorisation_summary" : {
             "$ref" : "#/components/schemas/AuthorisationSummary"
@@ -1578,7 +1578,7 @@
           "authorisation_mode" : {
             "type" : "string",
             "description" : "How the payment will be authorised. Payments created in `web` mode require the paying user to visit the `next_url` to complete the payment.",
-            "enum" : [ "web", "moto_api", "agreement", "external" ]
+            "enum" : [ "web", "moto_api", "external" ]
           },
           "authorisation_summary" : {
             "$ref" : "#/components/schemas/AuthorisationSummary"

--- a/src/main/java/uk/gov/pay/api/common/ResponseConstants.java
+++ b/src/main/java/uk/gov/pay/api/common/ResponseConstants.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.api.common;
+
+public final class ResponseConstants {
+    
+    public static final String RESPONSE_200_DESCRIPTION = "OK";
+    public static final String RESPONSE_400_DESCRIPTION = "Bad request";
+    public static final String RESPONSE_401_DESCRIPTION = "Credentials are required to access this resource";
+    public static final String RESPONSE_404_DESCRIPTION = "Not found";
+    public static final String RESPONSE_409_DESCRIPTION = "Conflict";
+    public static final String RESPONSE_429_DESCRIPTION = "Too many requests";
+    public static final String RESPONSE_500_DESCRIPTION = "Downstream system error";
+}

--- a/src/main/java/uk/gov/pay/api/model/CardPayment.java
+++ b/src/main/java/uk/gov/pay/api/model/CardPayment.java
@@ -199,7 +199,8 @@ public class CardPayment extends Payment {
         return agreementId;
     }
 
-    @Schema(description = "How the payment will be authorised. Payments created in `web` mode require the paying user to visit the `next_url` to complete the payment.")
+    @Schema(type = "String", description = "How the payment will be authorised. Payments created in `web` mode require the paying user to visit the `next_url` to complete the payment.",
+        allowableValues = {"web", "moto_api", "external"})
     public AuthorisationMode getAuthorisationMode() {
         return authorisationMode;
     }

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -49,6 +49,13 @@ import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.http.HttpHeaders.CACHE_CONTROL;
 import static org.apache.http.HttpHeaders.PRAGMA;
+import static uk.gov.pay.api.common.ResponseConstants.RESPONSE_200_DESCRIPTION;
+import static uk.gov.pay.api.common.ResponseConstants.RESPONSE_400_DESCRIPTION;
+import static uk.gov.pay.api.common.ResponseConstants.RESPONSE_401_DESCRIPTION;
+import static uk.gov.pay.api.common.ResponseConstants.RESPONSE_404_DESCRIPTION;
+import static uk.gov.pay.api.common.ResponseConstants.RESPONSE_409_DESCRIPTION;
+import static uk.gov.pay.api.common.ResponseConstants.RESPONSE_429_DESCRIPTION;
+import static uk.gov.pay.api.common.ResponseConstants.RESPONSE_500_DESCRIPTION;
 
 @Path("/")
 @Tag(name = "Card payments")
@@ -93,15 +100,15 @@ public class PaymentsResource {
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "OK",
+                    @ApiResponse(responseCode = "200", description = RESPONSE_200_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = GetPaymentResult.class))),
                     @ApiResponse(responseCode = "401",
-                            description = "Credentials are required to access this resource"),
-                    @ApiResponse(responseCode = "404", description = "Not found",
+                            description = RESPONSE_401_DESCRIPTION),
+                    @ApiResponse(responseCode = "404", description = RESPONSE_404_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = RequestError.class))),
-                    @ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = RESPONSE_429_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = RESPONSE_500_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = RequestError.class)))
             }
     )
@@ -134,15 +141,15 @@ public class PaymentsResource {
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "OK",
+                    @ApiResponse(responseCode = "200", description = RESPONSE_200_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = PaymentEventsResponse.class))),
                     @ApiResponse(responseCode = "401",
-                            description = "Credentials are required to access this resource"),
-                    @ApiResponse(responseCode = "404", description = "Not found",
+                            description = RESPONSE_401_DESCRIPTION),
+                    @ApiResponse(responseCode = "404", description = RESPONSE_404_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = RequestError.class))),
-                    @ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = RESPONSE_429_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = RESPONSE_500_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = RequestError.class)))
             }
     )
@@ -173,16 +180,16 @@ public class PaymentsResource {
                     "The Authorisation token needs to be specified in the 'authorization' header " +
                     "as 'authorization: Bearer YOUR_API_KEY_HERE'",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "OK",
+                    @ApiResponse(responseCode = "200", description = RESPONSE_200_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = PaymentSearchResults.class))),
                     @ApiResponse(responseCode = "401",
-                            description = "Credentials are required to access this resource"),
+                            description = RESPONSE_401_DESCRIPTION),
                     @ApiResponse(responseCode = "422",
                             description = "Invalid parameters: from_date, to_date, status, display_size. See Public API documentation for the correct data formats",
                             content = @Content(schema = @Schema(implementation = RequestError.class))),
-                    @ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = RESPONSE_429_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = RESPONSE_500_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = RequestError.class)))
             }
     )
@@ -257,16 +264,16 @@ public class PaymentsResource {
             responses = {
                     @ApiResponse(responseCode = "201", description = "Created",
                             content = @Content(schema = @Schema(implementation = CreatePaymentResult.class))),
-                    @ApiResponse(responseCode = "400", description = "Bad request",
+                    @ApiResponse(responseCode = "400", description = RESPONSE_400_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = RequestError.class))),
                     @ApiResponse(responseCode = "401",
-                            description = "Credentials are required to access this resource"),
+                            description = RESPONSE_401_DESCRIPTION),
                     @ApiResponse(responseCode = "422",
                             description = "Invalid attribute value: description. Must be less than or equal to 255 characters length",
                             content = @Content(schema = @Schema(implementation = RequestError.class))),
-                    @ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = RESPONSE_429_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = RESPONSE_500_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = RequestError.class)))
             }
     )
@@ -304,14 +311,14 @@ public class PaymentsResource {
                     @ApiResponse(responseCode = "400", description = "Cancellation of payment failed",
                             content = @Content(schema = @Schema(implementation = RequestError.class))),
                     @ApiResponse(responseCode = "401",
-                            description = "Credentials are required to access this resource"),
-                    @ApiResponse(responseCode = "404", description = "Not found",
+                            description = RESPONSE_401_DESCRIPTION),
+                    @ApiResponse(responseCode = "404", description = RESPONSE_404_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = RequestError.class))),
-                    @ApiResponse(responseCode = "409", description = "Conflict",
+                    @ApiResponse(responseCode = "409", description = RESPONSE_409_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = RequestError.class))),
-                    @ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = RESPONSE_429_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = RESPONSE_500_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = RequestError.class)))
             }
     )
@@ -341,14 +348,14 @@ public class PaymentsResource {
                     @ApiResponse(responseCode = "400", description = "Capture of payment failed",
                             content = @Content(schema = @Schema(implementation = RequestError.class))),
                     @ApiResponse(responseCode = "401",
-                            description = "Credentials are required to access this resource"),
-                    @ApiResponse(responseCode = "404", description = "Not found",
+                            description = RESPONSE_401_DESCRIPTION),
+                    @ApiResponse(responseCode = "404", description = RESPONSE_404_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = RequestError.class))),
-                    @ApiResponse(responseCode = "409", description = "Conflict",
+                    @ApiResponse(responseCode = "409", description = RESPONSE_409_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = RequestError.class))),
-                    @ApiResponse(responseCode = "429", description = "Too many requests",
+                    @ApiResponse(responseCode = "429", description = RESPONSE_429_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-                    @ApiResponse(responseCode = "500", description = "Downstream system error",
+                    @ApiResponse(responseCode = "500", description = RESPONSE_500_DESCRIPTION,
                             content = @Content(schema = @Schema(implementation = RequestError.class)))
             }
     )


### PR DESCRIPTION
Context
- OpenApi spec is being updated to better reflect Pay API documentation
- One aspect of this is Response descriptions which are currently
defined in each endpoint as string literals, with lots of duplication.
- This is being refactored to facilitate changes to the descriptions.
- created ResourceConstants class with commonly-occurring response descriptions
- pointed PaymentResource response descriptions to the constants where appropriate
- where descriptions differed, these were left as string literals.
- this particular change is refactoring only, not affecting the openapi spec.
- other Resource classes will be dealt with in subsequent PRs.
