### PR TITLE
PP-10437 Map agreement user identifier now sent from ledger

### DIFF
--- a/src/main/java/uk/gov/pay/api/agreement/model/Agreement.java
+++ b/src/main/java/uk/gov/pay/api/agreement/model/Agreement.java
@@ -19,6 +19,7 @@ public class Agreement {
     private String status;
     private String createdDate;
     private PaymentInstrument paymentInstrument;
+    private String userIdentifier;
 
     @JsonProperty("agreement_id")
     public String getExternalId() {
@@ -41,17 +42,22 @@ public class Agreement {
         return createdDate;
     }
 
+    public String getUserIdentifier() {
+        return userIdentifier;
+    }
+
     public PaymentInstrument getPaymentInstrument() {
         return paymentInstrument;
     }
 
-    public Agreement(String externalId, String reference, String description, String status, String createdDate, PaymentInstrument paymentInstrument) {
+    public Agreement(String externalId, String reference, String description, String status, String createdDate, PaymentInstrument paymentInstrument, String userIdentifier) {
         this.externalId = externalId;
         this.reference = reference;
         this.description = description;
         this.status = status;
         this.createdDate = createdDate;
         this.paymentInstrument = paymentInstrument;
+        this.userIdentifier = userIdentifier;
     }
 
     public static Agreement from(AgreementLedgerResponse agreementLedgerResponse) {
@@ -61,8 +67,8 @@ public class Agreement {
                 agreementLedgerResponse.getDescription(),
                 agreementLedgerResponse.getStatus(),
                 agreementLedgerResponse.getCreatedDate(),
-                Optional.ofNullable(agreementLedgerResponse.getPaymentInstrument()).map(PaymentInstrument::from).orElse(null)
-        );
+                Optional.ofNullable(agreementLedgerResponse.getPaymentInstrument()).map(PaymentInstrument::from).orElse(null),
+                agreementLedgerResponse.getUserIdentifier());
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/uk/gov/pay/api/agreement/model/AgreementLedgerResponse.java
+++ b/src/main/java/uk/gov/pay/api/agreement/model/AgreementLedgerResponse.java
@@ -18,6 +18,7 @@ public class AgreementLedgerResponse {
     private String status;
     private String createdDate;
     private PaymentInstrumentLedgerResponse paymentInstrument;
+    private String userIdentifier;
 
     @JsonProperty("external_id")
     public void setExternalId(String externalId) {
@@ -51,6 +52,10 @@ public class AgreementLedgerResponse {
 
     public PaymentInstrumentLedgerResponse getPaymentInstrument() {
         return paymentInstrument;
+    }
+
+    public String getUserIdentifier() {
+        return userIdentifier;
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/test/java/uk/gov/pay/api/it/AgreementsIT.java
+++ b/src/test/java/uk/gov/pay/api/it/AgreementsIT.java
@@ -47,7 +47,8 @@ public class AgreementsIT extends PaymentResourceITestBase {
                 .body("reference", is(fixture.getReference()))
                 .body("description", is(fixture.getDescription()))
                 .body("status", is(fixture.getStatus().toLowerCase()))
-                .body("created_date", is(fixture.getCreatedDate()));
+                .body("created_date", is(fixture.getCreatedDate()))
+                .body("$", not(hasKey("user_identifier")));
     }
 
     @Test
@@ -67,6 +68,7 @@ public class AgreementsIT extends PaymentResourceITestBase {
     public void searchAgreementsFromLedger() throws JsonProcessingException {
         var agreementWithPaymentInstrument = anAgreementFromLedgerWithPaymentInstrumentFixture()
                 .withExternalId(agreementId)
+                .withUserIdentifier("a-valid-user-identifier")
                 .build();
 
         var agreementWithoutPaymentInstrument = anAgreementFromLedgerWithoutPaymentInstrumentFixture()
@@ -96,6 +98,7 @@ public class AgreementsIT extends PaymentResourceITestBase {
                 .body("results[0].agreement_id", is(agreementWithPaymentInstrument.getExternalId()))
                 .body("results[0].reference", is(agreementWithPaymentInstrument.getReference()))
                 .body("results[0].description", is(agreementWithPaymentInstrument.getDescription()))
+                .body("results[0].user_identifier", is(agreementWithPaymentInstrument.getUserIdentifier()))
                 .body("results[0].status", is(agreementWithPaymentInstrument.getStatus().toLowerCase()))
                 .body("results[0].created_date", is(agreementWithPaymentInstrument.getCreatedDate()))
                 .body("results[0].payment_instrument.type", is(agreementWithPaymentInstrument.getPaymentInstrument().getType()))

--- a/src/test/java/uk/gov/pay/api/utils/mocks/AgreementFromLedgerFixture.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/AgreementFromLedgerFixture.java
@@ -20,6 +20,7 @@ public class AgreementFromLedgerFixture {
     private final String status;
     private final String createdDate;
     private final AgreementLedgerResponse.PaymentInstrumentLedgerResponse paymentInstrument;
+    private String userIdentifier;
 
     private AgreementFromLedgerFixture(AgreementFromLedgerFixtureBuilder builder) {
         this.externalId = builder.externalId;
@@ -29,6 +30,7 @@ public class AgreementFromLedgerFixture {
         this.status = builder.status;
         this.createdDate = builder.createdDate;
         this.paymentInstrument = builder.paymentInstrument;
+        this.userIdentifier = builder.userIdentifier;
     }
 
     public String getExternalId() {
@@ -59,6 +61,10 @@ public class AgreementFromLedgerFixture {
         return paymentInstrument;
     }
 
+    public String getUserIdentifier() {
+        return userIdentifier;
+    }
+
     public static final class AgreementFromLedgerFixtureBuilder {
         private String externalId = "agreement-external-id";
         private String serviceId = "a-service-id";
@@ -67,6 +73,7 @@ public class AgreementFromLedgerFixture {
         private String status = "CREATED";
         private String createdDate = ISO_INSTANT_MILLISECOND_PRECISION.format(ZonedDateTime.parse("2022-07-20T11:01:00.132012345Z"));
         private AgreementLedgerResponse.PaymentInstrumentLedgerResponse paymentInstrument;
+        private String userIdentifier;
 
         private AgreementFromLedgerFixtureBuilder() {
             paymentInstrument = new AgreementLedgerResponse.PaymentInstrumentLedgerResponse.Builder()
@@ -120,6 +127,11 @@ public class AgreementFromLedgerFixture {
         
         public AgreementFromLedgerFixtureBuilder withPaymentInstrument(AgreementLedgerResponse.PaymentInstrumentLedgerResponse paymentInstrument) {
             this.paymentInstrument = paymentInstrument;
+            return this;
+        }
+
+        public AgreementFromLedgerFixtureBuilder withUserIdentifier(String userIdentifier) {
+            this.userIdentifier = userIdentifier;
             return this;
         }
         


### PR DESCRIPTION
Include the `user_identifier` attribute on the agreement endpoint (search and get one).