### PR TITLE
PP-10439 Handle 422 Recurring Payments Not Allowed response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <jackson.version>2.14.1</jackson.version>
         <logback.version>1.2.11</logback.version>
-        <pay-java-commons.version>1.0.20221205115218</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20221220092453</pay-java-commons.version>
         <junit5.version>5.9.1</junit5.version>
         <pact.version>3.6.15</pact.version>
         <swagger.lib.version>2.2.7</swagger.lib.version>

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapper.java
@@ -1,15 +1,19 @@
 package uk.gov.pay.api.exception.mapper;
 
+import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.exception.CreateAgreementException;
 import uk.gov.pay.api.model.RequestError;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static uk.gov.pay.api.model.RequestError.Code.CREATE_AGREEMENT_CONNECTOR_ERROR;
+import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_CONNECTOR_ERROR;
 import static uk.gov.pay.api.model.RequestError.aRequestError;
 
 public class CreateAgreementExceptionMapper implements ExceptionMapper<CreateAgreementException> {
@@ -18,13 +22,19 @@ public class CreateAgreementExceptionMapper implements ExceptionMapper<CreateAgr
    
     @Override
     public Response toResponse(CreateAgreementException exception) {
-        RequestError requestError = aRequestError(RequestError.Code.CREATE_AGREEMENT_CONNECTOR_ERROR);
-        LOGGER.info("Connector invalid response was {}.\n Returning http status {} with error body {}",
-                exception.getMessage(), INTERNAL_SERVER_ERROR, requestError);
-        LOGGER.info(exception.getMessage());
-        return Response.status(INTERNAL_SERVER_ERROR)
-                .entity(requestError)
-                .type(APPLICATION_JSON)
-                .build();
+        RequestError requestError;
+        int statusCode = HttpStatus.INTERNAL_SERVER_ERROR_500;
+        
+        if (exception.getErrorIdentifier() == ErrorIdentifier.RECURRING_CARD_PAYMENTS_NOT_ALLOWED) {
+            statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
+            requestError = aRequestError(RequestError.Code.CREATE_AGREEMENT_RECURRING_CARD_PAYMENTS_NOT_ALLOWED_ERROR);
+        }
+        else {
+            requestError = aRequestError(CREATE_AGREEMENT_CONNECTOR_ERROR);
+            LOGGER.info("Connector invalid response was {}.\n Returning http status {} with error body {}",
+                    exception.getMessage(), INTERNAL_SERVER_ERROR, requestError);
+        }
+        
+        return Response.status(statusCode).entity(requestError).build();
     }
 }

--- a/src/main/java/uk/gov/pay/api/model/RequestError.java
+++ b/src/main/java/uk/gov/pay/api/model/RequestError.java
@@ -89,7 +89,7 @@ public class RequestError {
 
         CREATE_AGREEMENT_MISSING_FIELD_ERROR("P2101", "Missing mandatory attribute: %s"),
         CREATE_AGREEMENT_VALIDATION_ERROR("P2102", "Invalid attribute value: %s. %s"),
-        CREATE_AGREEMENT_RECURRING_CARD_PAYMENTS_NOT_ALLOWED_ERROR("P2103", "Recurring Card Payment agreements are not enabled for this account"),
+        CREATE_AGREEMENT_RECURRING_CARD_PAYMENTS_NOT_ALLOWED_ERROR("P2103", "Recurring card payments are currently disabled for this service. Contact support with your error code - https://www.payments.service.gov.uk/support/"),
         GET_AGREEMENT_NOT_FOUND_ERROR("P2200", "Not found"),
         GET_AGREEMENT_LEDGER_ERROR("P2298", "Downstream system error"),
 

--- a/src/main/java/uk/gov/pay/api/model/RequestError.java
+++ b/src/main/java/uk/gov/pay/api/model/RequestError.java
@@ -89,7 +89,7 @@ public class RequestError {
 
         CREATE_AGREEMENT_MISSING_FIELD_ERROR("P2101", "Missing mandatory attribute: %s"),
         CREATE_AGREEMENT_VALIDATION_ERROR("P2102", "Invalid attribute value: %s. %s"),
-
+        CREATE_AGREEMENT_RECURRING_CARD_PAYMENTS_NOT_ALLOWED_ERROR("P2103", "Recurring Card Payment agreements are not enabled for this account"),
         GET_AGREEMENT_NOT_FOUND_ERROR("P2200", "Not found"),
         GET_AGREEMENT_LEDGER_ERROR("P2298", "Downstream system error"),
 

--- a/src/test/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapperTest.java
+++ b/src/test/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapperTest.java
@@ -12,6 +12,7 @@ import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import javax.ws.rs.core.Response;
 
 import static org.apache.hc.core5.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static org.apache.hc.core5.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
@@ -32,6 +33,19 @@ class CreateAgreementExceptionMapperTest {
         RequestError returnedError = (RequestError) returnedResponse.getEntity();
         RequestError expectedError = aRequestError(RequestError.Code.valueOf("CREATE_AGREEMENT_CONNECTOR_ERROR"));
         assertThat(returnedResponse.getStatus(), is(SC_INTERNAL_SERVER_ERROR));
+        assertThat(returnedError.getDescription(),
+                is(expectedError.getDescription()));
+        assertThat(returnedError.getCode(), is(expectedError.getCode()));
+    }
+    
+    @Test
+    void testExceptionMappingForRecurringCardPaymentsNotAllowed() {
+        when(mockResponse.readEntity(ConnectorErrorResponse.class))
+                .thenReturn(new ConnectorErrorResponse(ErrorIdentifier.valueOf("RECURRING_CARD_PAYMENTS_NOT_ALLOWED"), null, null));
+        Response returnedResponse = mapper.toResponse(new CreateAgreementException(mockResponse));
+        RequestError returnedError = (RequestError) returnedResponse.getEntity();
+        RequestError expectedError = aRequestError(RequestError.Code.valueOf("CREATE_AGREEMENT_RECURRING_CARD_PAYMENTS_NOT_ALLOWED_ERROR"));
+        assertThat(returnedResponse.getStatus(), is(SC_UNPROCESSABLE_ENTITY));
         assertThat(returnedError.getDescription(),
                 is(expectedError.getDescription()));
         assertThat(returnedError.getCode(), is(expectedError.getCode()));

--- a/src/test/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapperTest.java
+++ b/src/test/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapperTest.java
@@ -28,10 +28,10 @@ class CreateAgreementExceptionMapperTest {
     @Test
     void testExceptionMapping() {
         when(mockResponse.readEntity(ConnectorErrorResponse.class))
-                .thenReturn(new ConnectorErrorResponse(ErrorIdentifier.valueOf("GENERIC"), null, null));
+                .thenReturn(new ConnectorErrorResponse(ErrorIdentifier.GENERIC, null, null));
         Response returnedResponse = mapper.toResponse(new CreateAgreementException(mockResponse));
         RequestError returnedError = (RequestError) returnedResponse.getEntity();
-        RequestError expectedError = aRequestError(RequestError.Code.valueOf("CREATE_AGREEMENT_CONNECTOR_ERROR"));
+        RequestError expectedError = aRequestError(RequestError.Code.CREATE_AGREEMENT_CONNECTOR_ERROR);
         assertThat(returnedResponse.getStatus(), is(SC_INTERNAL_SERVER_ERROR));
         assertThat(returnedError.getDescription(),
                 is(expectedError.getDescription()));
@@ -41,10 +41,10 @@ class CreateAgreementExceptionMapperTest {
     @Test
     void testExceptionMappingForRecurringCardPaymentsNotAllowed() {
         when(mockResponse.readEntity(ConnectorErrorResponse.class))
-                .thenReturn(new ConnectorErrorResponse(ErrorIdentifier.valueOf("RECURRING_CARD_PAYMENTS_NOT_ALLOWED"), null, null));
+                .thenReturn(new ConnectorErrorResponse(ErrorIdentifier.RECURRING_CARD_PAYMENTS_NOT_ALLOWED, null, null));
         Response returnedResponse = mapper.toResponse(new CreateAgreementException(mockResponse));
         RequestError returnedError = (RequestError) returnedResponse.getEntity();
-        RequestError expectedError = aRequestError(RequestError.Code.valueOf("CREATE_AGREEMENT_RECURRING_CARD_PAYMENTS_NOT_ALLOWED_ERROR"));
+        RequestError expectedError = aRequestError(RequestError.Code.CREATE_AGREEMENT_RECURRING_CARD_PAYMENTS_NOT_ALLOWED_ERROR);
         assertThat(returnedResponse.getStatus(), is(SC_UNPROCESSABLE_ENTITY));
         assertThat(returnedError.getDescription(),
                 is(expectedError.getDescription()));


### PR DESCRIPTION
Context: If connector receives a create agreement request from public_api for a gateway account that does not have recurring payments enabled, it will return a 422 response with the error_identifier RECURRING_CARD_PAYMENTS_NOT_ALLOWED

- Update CreateAgreementExceptionMapper to handle the 422 response from connector, sending a 422 response with the error identifier CREATE_AGREEMENT_RECURRING_CARD_PAYMENTS_NOT_ALLOWED
- Add unit tests