### PR TITLE
PP-10485 Search transactions by recurring payment agreement

### DIFF
--- a/openapi/publicapi_spec.json
+++ b/openapi/publicapi_spec.json
@@ -286,6 +286,13 @@
           "schema" : {
             "type" : "string"
           }
+        }, {
+          "description" : "Returns payments that were authorised using the agreement with this `agreement_id`. Must be an exact match.",
+          "in" : "query",
+          "name" : "agreement_id",
+          "schema" : {
+            "type" : "string"
+          }
         } ],
         "responses" : {
           "200" : {

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -233,14 +233,17 @@ public class PaymentsResource {
                                            "Date must be in ISO 8601 format to date-level accuracy - `YYYY-MM-DD`. " +
                                            "Payments are settled when your payment service provider sends funds to your bank account.")
                                    @QueryParam("to_settled_date") String toSettledDate,
+                                   @Parameter(description = "Returns payments that were authorised using the agreement with this `agreement_id`. " + 
+                                           "Must be an exact match.")
+                                   @QueryParam("agreement_id") String agreementId,
                                    @Context UriInfo uriInfo) {
 
         logger.info("Payments search request - [ {} ]",
                 format("reference:%s, email: %s, status: %s, card_brand %s, fromDate: %s, toDate: %s, page: %s, " +
                                 "display_size: %s, cardholder_name: %s, first_digits_card_number: %s, " +
-                                "last_digits_card_number: %s, from_settled_date: %s, to_settled_date: %s",
+                                "last_digits_card_number: %s, from_settled_date: %s, to_settled_date: %s, agreement_id: %s",
                         reference, email, state, cardBrand, fromDate, toDate, pageNumber, displaySize,
-                        cardHolderName, firstDigitsCardNumber, lastDigitsCardNumber, fromSettledDate, toSettledDate));
+                        cardHolderName, firstDigitsCardNumber, lastDigitsCardNumber, fromSettledDate, toSettledDate, agreementId));
 
         var paymentSearchParams = new PaymentSearchParams.Builder()
                 .withReference(reference)
@@ -256,6 +259,7 @@ public class PaymentsResource {
                 .withLastDigitsCardNumber(lastDigitsCardNumber)
                 .withFromSettledDate(fromSettledDate)
                 .withToSettledDate(toSettledDate)
+                .withAgreementId(agreementId)
                 .build();
 
         return paymentSearchService.searchLedgerPayments(account, paymentSearchParams);

--- a/src/main/java/uk/gov/pay/api/service/PaymentSearchParams.java
+++ b/src/main/java/uk/gov/pay/api/service/PaymentSearchParams.java
@@ -20,6 +20,7 @@ public class PaymentSearchParams {
     public static final String DISPLAY_SIZE = "display_size";
     public static final String FROM_SETTLED_DATE = "from_settled_date";
     public static final String TO_SETTLED_DATE = "to_settled_date";
+    public static final String AGREEMENT_ID = "agreement_id";
 
     private String reference;
     private String email;
@@ -34,6 +35,7 @@ public class PaymentSearchParams {
     private String lastDigitsCardNumber;
     private String fromSettledDate;
     private String toSettledDate;
+    private String agreementId;
 
     public PaymentSearchParams(Builder builder) {
         this.reference = builder.reference;
@@ -49,6 +51,7 @@ public class PaymentSearchParams {
         this.lastDigitsCardNumber = builder.lastDigitsCardNumber;
         this.fromSettledDate = builder.fromSettledDate;
         this.toSettledDate = builder.toSettledDate;
+        this.agreementId = builder.agreementId;
     }
 
     public Map<String, String> getParamsAsMap() {
@@ -66,6 +69,7 @@ public class PaymentSearchParams {
         params.put(DISPLAY_SIZE, displaySize);
         params.put(FROM_SETTLED_DATE, fromSettledDate);
         params.put(TO_SETTLED_DATE, toSettledDate);
+        params.put(AGREEMENT_ID, agreementId);
 
         return params;
     }
@@ -118,6 +122,10 @@ public class PaymentSearchParams {
         return toSettledDate;
     }
 
+    public String getAgreementId() {
+        return agreementId;
+    }
+
     public static class Builder {
         private String reference;
         private String email;
@@ -132,6 +140,7 @@ public class PaymentSearchParams {
         private String lastDigitsCardNumber;
         private String fromSettledDate;
         private String toSettledDate;
+        private String agreementId;
 
         public Builder() {
         }
@@ -207,6 +216,11 @@ public class PaymentSearchParams {
 
         public Builder withToSettledDate(String toSettledDate) {
             this.toSettledDate = toSettledDate;
+            return this;
+        }
+
+        public Builder withAgreementId(String agreementId) {
+            this.agreementId = agreementId;
             return this;
         }
     }

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceSearchIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceSearchIT.java
@@ -348,7 +348,8 @@ public class PaymentsResourceSearchIT extends PaymentResourceITestBase {
                 "email", TEST_EMAIL,
                 "state", TEST_STATE,
                 "from_date", TEST_FROM_DATE,
-                "to_date", TEST_TO_DATE))
+                "to_date", TEST_TO_DATE,
+                "agreement_id", "does_not_exist"))
                 .statusCode(200)
                 .contentType(JSON)
                 .body("results.size()", is(0))

--- a/src/test/resources/pacts/publicapi-ledger-search-payment-by-agreement-id.json
+++ b/src/test/resources/pacts/publicapi-ledger-search-payment-by-agreement-id.json
@@ -1,0 +1,175 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "ledger"
+  },
+  "interactions": [
+    {
+      "description": "search payment by agreement id",
+      "providerStates": [
+        {
+          "name": "a recurring card payment exists for agreement",
+          "params": {
+            "account_id": "123456",
+            "agreement_id": "agreement-1"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/transaction",
+        "query": {
+          "agreement_id": [
+            "agreement-1"
+          ],
+          "status_version": [
+            "1"
+          ],
+          "page": [
+            "1"
+          ],
+          "exact_reference_match": [
+            "true"
+          ],
+          "display_size": [
+            "500"
+          ],
+          "transaction_type": [
+            "PAYMENT"
+          ],
+          "account_id": [
+            "123456"
+          ]
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "page": 1,
+          "total": 1,
+          "count": 1,
+          "results": [
+            {
+              "amount": 1000,
+              "state": {
+                "finished": true,
+                "status": "created"
+              },
+              "description": "Test description",
+              "reference": "aReference",
+              "transaction_id": "charge97837509646393e3C",
+              "payment_provider": "sandbox",
+              "created_date": "2018-09-22T10:13:16.067Z",
+              "authorisation_mode": "agreement"
+            }
+          ],
+          "_links": {
+            "self": {
+              "href": "http://ledger.service.backend/v1/transaction?account_id=123456&transaction_type=PAYMENT&agreement_id=agreement-1&page=1&display_size=500"
+            },
+            "last_page": {
+              "href": "http://ledger.service.backend/v1/transaction?account_id=123456&transaction_type=PAYMENT&agreement_id=agreement-1&page=1&display_size=500"
+            },
+            "first_page": {
+              "href": "http://ledger.service.backend/v1/transaction?account_id=123456&transaction_type=PAYMENT&agreement_id=agreement-1&page=1&display_size=500"
+            }
+          }
+        },
+        "matchingRules": {
+          "body": {
+            "$._links.self.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/transaction\\?account_id=123456&transaction_type=PAYMENT&agreement_id=agreement-1&page=1&display_size=500"
+                }
+              ]
+            },
+            "$._links.last_page.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/transaction\\?account_id=123456&transaction_type=PAYMENT&agreement_id=agreement-1&page=1&display_size=500"
+                }
+              ]
+            },
+            "$._links.first_page.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/transaction\\?account_id=123456&transaction_type=PAYMENT&agreement_id=agreement-1&page=1&display_size=500"
+                }
+              ]
+            },
+            "$.results[*].transaction_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].amount": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].reference": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].description": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].state.status": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].state.finished": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].payment_provider": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].created_date": {
+              "matchers": [
+                {
+                  "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
Ledger already supports filtering transactions by agreement, allow the
agreement ID to be passed through.

Use the open api specs and description from the public docs.