### PR TITLE
PP-10485 Include pagination links for search agreements

### DIFF
--- a/src/main/java/uk/gov/pay/api/agreement/resource/AgreementsApiResource.java
+++ b/src/main/java/uk/gov/pay/api/agreement/resource/AgreementsApiResource.java
@@ -6,13 +6,13 @@ import io.swagger.v3.oas.annotations.Parameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.agreement.model.Agreement;
-import uk.gov.pay.api.agreement.model.AgreementLedgerResponse;
 import uk.gov.pay.api.agreement.model.CreateAgreementRequest;
 import uk.gov.pay.api.agreement.service.AgreementService;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.ledger.model.AgreementSearchParams;
 import uk.gov.pay.api.ledger.model.SearchResults;
 import uk.gov.pay.api.service.LedgerService;
+import uk.gov.pay.api.service.SearchAgreementsService;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -24,7 +24,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
-import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.http.HttpStatus.SC_CREATED;
@@ -37,11 +36,15 @@ public class AgreementsApiResource {
 
     private final AgreementService agreementService;
     private final LedgerService ledgerService;
+    private final SearchAgreementsService searchAgreementsService;
 
     @Inject
-    public AgreementsApiResource(AgreementService agreementService, LedgerService ledgerService) {
+    public AgreementsApiResource(AgreementService agreementService,
+                                 LedgerService ledgerService, 
+                                 SearchAgreementsService searchAgreementsService) {
         this.agreementService = agreementService;
         this.ledgerService = ledgerService;
+        this.searchAgreementsService = searchAgreementsService;
     }
 
     @POST
@@ -76,9 +79,7 @@ public class AgreementsApiResource {
     @Path("/v1/agreements")
     @Produces(APPLICATION_JSON)
     public SearchResults<Agreement> getAgreements(@Auth Account account, @BeanParam AgreementSearchParams searchParams) {
-        SearchResults<AgreementLedgerResponse> searchResults = ledgerService.searchAgreements(account, searchParams);
-        return new SearchResults<>(searchResults.getTotal(), searchResults.getCount(),
-                searchResults.getPage(), searchResults.getResults().stream().map(Agreement::from).collect(Collectors.toUnmodifiableList()), null);
+        return searchAgreementsService.searchLedgerAgreements(account, searchParams);
     }
 
     @POST

--- a/src/main/java/uk/gov/pay/api/service/SearchAgreementsService.java
+++ b/src/main/java/uk/gov/pay/api/service/SearchAgreementsService.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.api.service;
+
+import uk.gov.pay.api.agreement.model.Agreement;
+import uk.gov.pay.api.agreement.model.AgreementLedgerResponse;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.ledger.model.AgreementSearchParams;
+import uk.gov.pay.api.ledger.model.SearchResults;
+import uk.gov.pay.api.model.search.PaginationDecorator;
+
+import javax.inject.Inject;
+import java.util.stream.Collectors;
+
+public class SearchAgreementsService {
+
+    private static final String AGREEMENTS_PATH = "/v1/agreements";
+    private final LedgerService ledgerService;
+    private final PaginationDecorator paginationDecorator;
+
+    @Inject
+    public SearchAgreementsService(LedgerService ledgerService,
+                                   PaginationDecorator paginationDecorator) {
+        this.ledgerService = ledgerService;
+        this.paginationDecorator = paginationDecorator;
+    }
+
+    public SearchResults<Agreement> searchLedgerAgreements(Account account, AgreementSearchParams params) {
+        SearchResults<AgreementLedgerResponse> ledgerResponse = ledgerService.searchAgreements(account, params);
+        return processLedgerResponse(ledgerResponse);
+    }
+
+    private SearchResults<Agreement> processLedgerResponse(SearchResults<AgreementLedgerResponse> searchResults) {
+        return new SearchResults<>(searchResults.getTotal(),
+                searchResults.getCount(),
+                searchResults.getPage(),
+                searchResults.getResults().stream().map(Agreement::from).collect(Collectors.toUnmodifiableList()),
+                paginationDecorator.transformLinksToPublicApiUri(searchResults.getLinks(), AGREEMENTS_PATH));
+    }
+}

--- a/src/test/java/uk/gov/pay/api/it/AgreementsIT.java
+++ b/src/test/java/uk/gov/pay/api/it/AgreementsIT.java
@@ -10,6 +10,7 @@ import uk.gov.pay.api.utils.mocks.LedgerMockClient;
 
 import static io.restassured.RestAssured.given;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
@@ -94,6 +95,11 @@ public class AgreementsIT extends PaymentResourceITestBase {
                 .body("total", is(9))
                 .body("count", is(2))
                 .body("page", is(3))
+                .body("_links.self.href", containsString("/v1/agreements?page=3"))
+                .body("_links.first_page.href", containsString("/v1/agreements?page=1"))
+                .body("_links.last_page.href", containsString("/v1/agreements?page=5"))
+                .body("_links.prev_page.href", containsString("/v1/agreements?page=2"))
+                .body("_links.next_page.href", containsString("/v1/agreements?page=4"))
                 .body("results.size()", is(2))
                 .body("results[0].agreement_id", is(agreementWithPaymentInstrument.getExternalId()))
                 .body("results[0].reference", is(agreementWithPaymentInstrument.getReference()))

--- a/src/test/java/uk/gov/pay/api/service/SearchAgreementsServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/SearchAgreementsServiceTest.java
@@ -1,0 +1,71 @@
+package uk.gov.pay.api.service;
+
+import au.com.dius.pact.consumer.PactVerification;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.api.agreement.model.Agreement;
+import uk.gov.pay.api.app.RestClientFactory;
+import uk.gov.pay.api.app.config.PublicApiConfig;
+import uk.gov.pay.api.app.config.RestClientConfig;
+import uk.gov.pay.api.auth.Account;
+import uk.gov.pay.api.ledger.model.AgreementSearchParams;
+import uk.gov.pay.api.ledger.model.SearchResults;
+import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
+import uk.gov.pay.api.model.TokenPaymentType;
+import uk.gov.pay.api.model.search.PaginationDecorator;
+import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
+import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+
+import javax.ws.rs.client.Client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SearchAgreementsServiceTest {
+    @Rule
+    public PactProviderRule ledgerRule = new PactProviderRule("ledger", this);
+    @Mock
+    private PublicApiConfig mockConfiguration;
+
+    private SearchAgreementsService searchAgreementsService;
+
+    private static final String PUBLIC_API_URL = "http://publicapi.test.localhost/";
+
+    @Before
+    public void setUp() {
+        when(mockConfiguration.getLedgerUrl()).thenReturn(ledgerRule.getUrl());
+        when(mockConfiguration.getBaseUrl()).thenReturn(PUBLIC_API_URL);
+
+        Client client = RestClientFactory.buildClient(new RestClientConfig(false));
+        LedgerUriGenerator ledgerUriGenerator = new LedgerUriGenerator(mockConfiguration);
+
+        searchAgreementsService = new SearchAgreementsService(
+                new LedgerService(client, ledgerUriGenerator),
+                new PaginationDecorator(mockConfiguration));
+    }
+
+    @Test
+    @PactVerification({"ledger"})
+    @Pacts(pacts = {"publicapi-ledger-search-agreements-with-page-and-display-size"})
+    public void searchWithPageAndDisplaySize_shouldReturnCorrectPageAndPaginationLinks() {
+        AgreementSearchParams params = new AgreementSearchParams(null, null, "2", "1");
+        Account account = new Account("777", TokenPaymentType.CARD, "a-token-link");
+        SearchResults<Agreement> results = searchAgreementsService.searchLedgerAgreements(account, params);
+
+        assertThat(results.getResults().size(), is(1));
+        assertThat(results.getCount(), is(1));
+        assertThat(results.getTotal(), is(3));
+        assertThat(results.getPage(), is(2));
+        assertThat(results.getLinks().getSelf().getHref(), is(PUBLIC_API_URL + "v1/agreements?display_size=1&page=2"));
+        assertThat(results.getLinks().getFirstPage().getHref(), is(PUBLIC_API_URL + "v1/agreements?display_size=1&page=1"));
+        assertThat(results.getLinks().getLastPage().getHref(), is(PUBLIC_API_URL + "v1/agreements?display_size=1&page=3"));
+        assertThat(results.getLinks().getPrevPage().getHref(), is(PUBLIC_API_URL + "v1/agreements?display_size=1&page=1"));
+        assertThat(results.getLinks().getNextPage().getHref(), is(PUBLIC_API_URL + "v1/agreements?display_size=1&page=3"));
+    }
+}

--- a/src/test/resources/pacts/publicapi-ledger-search-agreements-with-page-and-display-size.json
+++ b/src/test/resources/pacts/publicapi-ledger-search-agreements-with-page-and-display-size.json
@@ -1,0 +1,163 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "ledger"
+  },
+  "interactions": [
+    {
+      "description": "search agreements with page and display size params",
+      "providerStates": [
+        {
+          "name": "3 agreements exist for account",
+          "params": {
+            "account_id": "777"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/agreement",
+        "query": {
+          "page": [
+            "2"
+          ],
+          "display_size": [
+            "1"
+          ],
+          "account_id": ["777"],
+          "exact_reference_match": ["true"],
+          "status_version": ["1"]
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "page": 2,
+          "total": 3,
+          "count": 1,
+          "results": [
+            {
+              "external_id": "5f8cgoad1k3q216rul5v2m3v0c",
+              "service_id": "bbd0591e01dc4410839978a6ef5a8a81",
+              "reference": "ref",
+              "description": "descr",
+              "status": "CREATED",
+              "created_date": "2023-01-10T11:09:17.443Z"
+            }
+          ],
+          "_links": {
+            "self": {
+              "href": "http://ledger.service.backend/v1/agreements?account_id=777&display_size=1&page=2"
+            },
+            "first_page": {
+              "href": "http://ledger.service.backend/v1/agreements?account_id=777&display_size=1&page=1"
+            },
+            "last_page": {
+              "href": "http://ledger.service.backend/v1/agreements?account_id=777&display_size=1&page=3"
+            },
+            "prev_page": {
+              "href": "http://ledger.service.backend/v1/agreements?account_id=777&display_size=1&page=1"
+            },
+            "next_page": {
+              "href": "http://ledger.service.backend/v1/agreements?account_id=777&display_size=1&page=3"
+            }
+          }
+        },
+        "matchingRules": {
+          "body": {
+            "$.results[*].external_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].service_id": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].reference": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].description": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].status": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*].created_date": {
+              "matchers": [
+                {
+                  "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+                }
+              ]
+            },
+            "$._links.self.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/agreement\\?account_id=777&page=2&display_size=1"
+                }
+              ]
+            },
+            "$._links.first_page.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/agreement\\?account_id=777&page=1&display_size=1"
+                }
+              ]
+            },
+            "$._links.last_page.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/agreement\\?account_id=777&page=3&display_size=1"
+                }
+              ]
+            },
+            "$._links.prev_page.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/agreement\\?account_id=777&page=1&display_size=1"
+                }
+              ]
+            },
+            "$._links.next_page.href": {
+              "matchers": [
+                {
+                  "regex": "http.*:\/\/.*\/v1\/agreement\\?account_id=777&page=3&display_size=1"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
- Add SearchAgreementsService to call ledger to search agreements and transform the response to the Public API response. When the response is converted, convert the pagination links returned by ledger into public API links.
- Add pact test for getting agreements from ledger that checks that we transform the pagination links correctly. 