### PR TITLE
PP-10486 Make RCP error code more generic

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapper.java
@@ -27,7 +27,7 @@ public class CreateAgreementExceptionMapper implements ExceptionMapper<CreateAgr
         
         if (exception.getErrorIdentifier() == ErrorIdentifier.RECURRING_CARD_PAYMENTS_NOT_ALLOWED) {
             statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
-            requestError = aRequestError(RequestError.Code.CREATE_AGREEMENT_RECURRING_CARD_PAYMENTS_NOT_ALLOWED_ERROR);
+            requestError = aRequestError(RequestError.Code.RECURRING_CARD_PAYMENTS_NOT_ALLOWED_ERROR);
         }
         else {
             requestError = aRequestError(CREATE_AGREEMENT_CONNECTOR_ERROR);

--- a/src/main/java/uk/gov/pay/api/model/RequestError.java
+++ b/src/main/java/uk/gov/pay/api/model/RequestError.java
@@ -72,6 +72,7 @@ public class RequestError {
         RESOURCE_ACCESS_FORBIDDEN("P0930", "Access to this resource is not enabled for this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ ."),
         ACCOUNT_NOT_LINKED_WITH_PSP("P0940", "Account is not fully configured. Please refer to documentation to setup your account or contact support with your error code - https://www.payments.service.gov.uk/support/ ."),
         ACCOUNT_DISABLED("P0941", "GOV.UK Pay has disabled payment and refund creation on this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ ."),
+        RECURRING_CARD_PAYMENTS_NOT_ALLOWED_ERROR("P0942", "Recurring card payments are currently disabled for this service. Contact support with your error code - https://www.payments.service.gov.uk/support/"),
 
         SEARCH_REFUNDS_VALIDATION_ERROR("P1101", "Invalid parameters: %s. See Public API documentation for the correct data formats"),
         SEARCH_REFUNDS_NOT_FOUND("P1100", "Page not found"),
@@ -89,7 +90,6 @@ public class RequestError {
 
         CREATE_AGREEMENT_MISSING_FIELD_ERROR("P2101", "Missing mandatory attribute: %s"),
         CREATE_AGREEMENT_VALIDATION_ERROR("P2102", "Invalid attribute value: %s. %s"),
-        CREATE_AGREEMENT_RECURRING_CARD_PAYMENTS_NOT_ALLOWED_ERROR("P2103", "Recurring card payments are currently disabled for this service. Contact support with your error code - https://www.payments.service.gov.uk/support/"),
         GET_AGREEMENT_NOT_FOUND_ERROR("P2200", "Not found"),
         GET_AGREEMENT_LEDGER_ERROR("P2298", "Downstream system error"),
 

--- a/src/test/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapperTest.java
+++ b/src/test/java/uk/gov/pay/api/exception/mapper/CreateAgreementExceptionMapperTest.java
@@ -44,7 +44,7 @@ class CreateAgreementExceptionMapperTest {
                 .thenReturn(new ConnectorErrorResponse(ErrorIdentifier.RECURRING_CARD_PAYMENTS_NOT_ALLOWED, null, null));
         Response returnedResponse = mapper.toResponse(new CreateAgreementException(mockResponse));
         RequestError returnedError = (RequestError) returnedResponse.getEntity();
-        RequestError expectedError = aRequestError(RequestError.Code.CREATE_AGREEMENT_RECURRING_CARD_PAYMENTS_NOT_ALLOWED_ERROR);
+        RequestError expectedError = aRequestError(RequestError.Code.RECURRING_CARD_PAYMENTS_NOT_ALLOWED_ERROR);
         assertThat(returnedResponse.getStatus(), is(SC_UNPROCESSABLE_ENTITY));
         assertThat(returnedError.getDescription(),
                 is(expectedError.getDescription()));


### PR DESCRIPTION
- Context: If RCP is not enabled for a gateway account, error code P0942 should be returned for any request to create agreement, setup agreement or take recurring payment
- Remove specific error for create agreement, replace with P0942
- Update associated unit test accordingly
- A separate PR will cover applying this error code to setting up agreements and taking recurring payments.