### PR TITLE
PP-10486 Map RCP error response from connector

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -25,6 +25,7 @@ import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_VALIDATION_E
 import static uk.gov.pay.api.model.RequestError.Code.GENERIC_MISSING_FIELD_ERROR_MESSAGE_FROM_CONNECTOR;
 import static uk.gov.pay.api.model.RequestError.Code.GENERIC_UNEXPECTED_FIELD_ERROR_MESSAGE_FROM_CONNECTOR;
 import static uk.gov.pay.api.model.RequestError.Code.GENERIC_VALIDATION_EXCEPTION_MESSAGE_FROM_CONNECTOR;
+import static uk.gov.pay.api.model.RequestError.Code.RECURRING_CARD_PAYMENTS_NOT_ALLOWED_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.RESOURCE_ACCESS_FORBIDDEN;
 import static uk.gov.pay.api.model.RequestError.aRequestError;
 
@@ -96,6 +97,10 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
                 case INVALID_ATTRIBUTE_VALUE:
                     statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
                     requestError = aRequestError(GENERIC_VALIDATION_EXCEPTION_MESSAGE_FROM_CONNECTOR, exception.getConnectorErrorMessage());
+                    break;
+                case RECURRING_CARD_PAYMENTS_NOT_ALLOWED:
+                    statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
+                    requestError = aRequestError(RECURRING_CARD_PAYMENTS_NOT_ALLOWED_ERROR);
                     break;
                 default:
                     requestError = aRequestError(CREATE_PAYMENT_CONNECTOR_ERROR);

--- a/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
+++ b/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
@@ -28,6 +28,7 @@ import static uk.gov.service.payments.commons.model.ErrorIdentifier.INCORRECT_AU
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.INVALID_ATTRIBUTE_VALUE;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.MISSING_MANDATORY_ATTRIBUTE;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.MOTO_NOT_ALLOWED;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.RECURRING_CARD_PAYMENTS_NOT_ALLOWED;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.UNEXPECTED_ATTRIBUTE;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.ZERO_AMOUNT_NOT_ALLOWED;
@@ -68,7 +69,8 @@ class CreateChargeExceptionMapperTest {
                 arguments(INCORRECT_AUTHORISATION_MODE_FOR_SAVE_PAYMENT_INSTRUMENT_TO_AGREEMENT, true, "Unexpected attribute: set_up_agreement", 400, "P0104"),
                 arguments(AGREEMENT_NOT_FOUND, false, "Invalid attribute value: agreement_id. Agreement does not exist", 400, "P0102"),
                 arguments(AGREEMENT_NOT_ACTIVE, false, "Invalid attribute value: agreement_id. Agreement must be active", 400, "P0102"),
-                arguments(INVALID_ATTRIBUTE_VALUE, true, "An error message from connector", 422, "P0102")
+                arguments(INVALID_ATTRIBUTE_VALUE, true, "An error message from connector", 422, "P0102"),
+                arguments(RECURRING_CARD_PAYMENTS_NOT_ALLOWED, true, "Recurring card payments are currently disabled for this service. Contact support with your error code - https://www.payments.service.gov.uk/support/", 422, "P0942")
         );
     }
 


### PR DESCRIPTION
Context: In the event of a setup agreement or recurring payment request from a service which does not have RCP enabled, connector will return a RECURRING_CARD_PAYMENTS_NOT_ALLOWED error response

- Map RCP error response from connector to error code P0942.