### PR TITLE
PP-10441 Return AgreementSearchResults when searching agreements

### DIFF
--- a/openapi/publicapi_spec.json
+++ b/openapi/publicapi_spec.json
@@ -1378,6 +1378,7 @@
       },
       "Agreement" : {
         "type" : "object",
+        "description" : "Contains information about a user's agreement for recurring payments. An agreement represents an understanding between you and your paying user that you'll use their card to make ongoing payments for a service.",
         "properties" : {
           "agreement_id" : {
             "type" : "string",
@@ -2680,32 +2681,6 @@
           },
           "self" : {
             "$ref" : "#/components/schemas/Link"
-          }
-        }
-      },
-      "SearchResultsAgreement" : {
-        "type" : "object",
-        "properties" : {
-          "_links" : {
-            "$ref" : "#/components/schemas/SearchNavigationLinks"
-          },
-          "count" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "page" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "results" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/Agreement"
-            }
-          },
-          "total" : {
-            "type" : "integer",
-            "format" : "int32"
           }
         }
       },

--- a/src/main/java/uk/gov/pay/api/agreement/model/Agreement.java
+++ b/src/main/java/uk/gov/pay/api/agreement/model/Agreement.java
@@ -13,6 +13,8 @@ import java.util.Optional;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Schema(description = "Contains information about a user's agreement for recurring payments. " +
+        "An agreement represents an understanding between you and your paying user that you'll use their card to make ongoing payments for a service.")
 public class Agreement {
     private String externalId;
     private String reference;

--- a/src/main/java/uk/gov/pay/api/agreement/model/AgreementSearchResults.java
+++ b/src/main/java/uk/gov/pay/api/agreement/model/AgreementSearchResults.java
@@ -1,11 +1,15 @@
 package uk.gov.pay.api.agreement.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.links.SearchNavigationLinks;
 import uk.gov.pay.api.model.search.SearchPagination;
 
 import java.util.List;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class AgreementSearchResults implements SearchPagination {
 
     @Schema(name = "total", example = "100", description = "Total number of agreements matching your search criteria.")
@@ -18,9 +22,18 @@ public class AgreementSearchResults implements SearchPagination {
                     "To view other pages, make this request again using the `page` parameter.")
     private int page;
     private List<Agreement> results;
+    @JsonProperty("_links")
     @Schema(name = "_links")
     SearchNavigationLinks links;
 
+    public AgreementSearchResults(int total, int count, int page, List<Agreement> results, SearchNavigationLinks links) {
+        this.total = total;
+        this.count = count;
+        this.page = page;
+        this.results = results;
+        this.links = links;
+    }
+    
     @Override
     public int getTotal() {
         return total;
@@ -37,7 +50,7 @@ public class AgreementSearchResults implements SearchPagination {
     }
 
     @Schema(name = "results", description = "Contains agreements matching your search criteria.")
-    public List<Agreement> getAgreements() {
+    public List<Agreement> getResults() {
         return results;
     }
 

--- a/src/main/java/uk/gov/pay/api/agreement/resource/AgreementsApiResource.java
+++ b/src/main/java/uk/gov/pay/api/agreement/resource/AgreementsApiResource.java
@@ -166,7 +166,7 @@ public class AgreementsApiResource {
                             content = @Content(schema = @Schema(implementation = RequestError.class)))
             }
     )
-    public SearchResults<Agreement> getAgreements(@Parameter(hidden = true) @Auth Account account, @BeanParam AgreementSearchParams searchParams) {
+    public AgreementSearchResults getAgreements(@Parameter(hidden = true) @Auth Account account, @BeanParam AgreementSearchParams searchParams) {
         return searchAgreementsService.searchLedgerAgreements(account, searchParams);
     }
 

--- a/src/main/java/uk/gov/pay/api/service/SearchAgreementsService.java
+++ b/src/main/java/uk/gov/pay/api/service/SearchAgreementsService.java
@@ -2,6 +2,7 @@ package uk.gov.pay.api.service;
 
 import uk.gov.pay.api.agreement.model.Agreement;
 import uk.gov.pay.api.agreement.model.AgreementLedgerResponse;
+import uk.gov.pay.api.agreement.model.AgreementSearchResults;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.ledger.model.AgreementSearchParams;
 import uk.gov.pay.api.ledger.model.SearchResults;
@@ -23,13 +24,13 @@ public class SearchAgreementsService {
         this.paginationDecorator = paginationDecorator;
     }
 
-    public SearchResults<Agreement> searchLedgerAgreements(Account account, AgreementSearchParams params) {
+    public AgreementSearchResults searchLedgerAgreements(Account account, AgreementSearchParams params) {
         SearchResults<AgreementLedgerResponse> ledgerResponse = ledgerService.searchAgreements(account, params);
         return processLedgerResponse(ledgerResponse);
     }
 
-    private SearchResults<Agreement> processLedgerResponse(SearchResults<AgreementLedgerResponse> searchResults) {
-        return new SearchResults<>(searchResults.getTotal(),
+    private AgreementSearchResults processLedgerResponse(SearchResults<AgreementLedgerResponse> searchResults) {
+        return new AgreementSearchResults(searchResults.getTotal(),
                 searchResults.getCount(),
                 searchResults.getPage(),
                 searchResults.getResults().stream().map(Agreement::from).collect(Collectors.toUnmodifiableList()),

--- a/src/test/java/uk/gov/pay/api/service/SearchAgreementsServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/SearchAgreementsServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.api.agreement.model.Agreement;
+import uk.gov.pay.api.agreement.model.AgreementSearchResults;
 import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
@@ -56,7 +57,7 @@ public class SearchAgreementsServiceTest {
     public void searchWithPageAndDisplaySize_shouldReturnCorrectPageAndPaginationLinks() {
         AgreementSearchParams params = new AgreementSearchParams(null, null, "2", "1");
         Account account = new Account("777", TokenPaymentType.CARD, "a-token-link");
-        SearchResults<Agreement> results = searchAgreementsService.searchLedgerAgreements(account, params);
+        AgreementSearchResults results = searchAgreementsService.searchLedgerAgreements(account, params);
 
         assertThat(results.getResults().size(), is(1));
         assertThat(results.getCount(), is(1));


### PR DESCRIPTION
- previous updates to the openapi spec involved creating an AgreementSearchResults class purely
for the openapi spec
- update search agreements endpoint to return AgreementSearchResults instead of generic SearchResults
- correct naming and whitespace in AgreementSearchResults