### PR TITLE
PP-10713 implement idempotency key header violation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -136,7 +136,7 @@
         "filename": "src/main/java/uk/gov/pay/api/resources/PaymentsResource.java",
         "hashed_secret": "0ca33fee4444c18265ffce030b9e327b54f05ae0",
         "is_verified": false,
-        "line_number": 238
+        "line_number": 240
       }
     ],
     "src/test/java/uk/gov/pay/api/filter/AuthorizationValidationFilterTest.java": [
@@ -183,5 +183,5 @@
       }
     ]
   },
-  "generated_at": "2023-02-08T16:03:13Z"
+  "generated_at": "2023-04-18T13:38:29Z"
 }

--- a/openapi/publicapi_spec.json
+++ b/openapi/publicapi_spec.json
@@ -660,6 +660,13 @@
       "post" : {
         "description" : "You can use this endpoint to [create a new payment](https://docs.payments.service.gov.uk/making_payments/).",
         "operationId" : "Create a payment",
+        "parameters" : [ {
+          "in" : "header",
+          "name" : "Idempotency-Key",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -2660,6 +2667,11 @@
             "type" : "string",
             "description" : "The parameter in your request that's causing the error.",
             "example" : "amount"
+          },
+          "header" : {
+            "type" : "string",
+            "description" : "The header in your request that's causing the error.",
+            "example" : "Idempotency-Key"
           }
         }
       },

--- a/src/main/java/uk/gov/pay/api/exception/mapper/ViolationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/ViolationExceptionMapper.java
@@ -3,6 +3,7 @@ package uk.gov.pay.api.exception.mapper;
 import com.google.common.base.CaseFormat;
 import io.dropwizard.jersey.validation.JerseyViolationException;
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.validator.constraints.Length;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.model.RequestError;
@@ -15,35 +16,55 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_HEADER_VALIDATION_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_MISSING_FIELD_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_VALIDATION_ERROR;
 import static uk.gov.pay.api.model.RequestError.aRequestError;
+import static uk.gov.pay.api.model.RequestError.aHeaderRequestError;
 
 @Priority(1)
 public class ViolationExceptionMapper implements ExceptionMapper<JerseyViolationException> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ViolationExceptionMapper.class);
+    private static final Pattern HEADER_VIOLATION_EXCEPTION_MESSAGE = Pattern.compile("Header \\[(.*)\\] .*");
 
     @Override
     public Response toResponse(JerseyViolationException exception) {
         LOGGER.info(exception.getMessage());
         ConstraintViolation<?> firstException = exception.getConstraintViolations().iterator().next();
-        String fieldName = getApiFieldName(firstException.getPropertyPath());
-        
+
         RequestError requestError;
-        if (firstException.getConstraintDescriptor() != null &&
-                firstException.getConstraintDescriptor().getAnnotation() != null &&
-                firstException.getConstraintDescriptor().getAnnotation().annotationType() == NotBlank.class ||
-                firstException.getConstraintDescriptor().getAnnotation().annotationType() == NotEmpty.class ||
-                firstException.getConstraintDescriptor().getAnnotation().annotationType() == NotNull.class) {
-            requestError = aRequestError(fieldName, CREATE_PAYMENT_MISSING_FIELD_ERROR);
+        Matcher matcher = HEADER_VIOLATION_EXCEPTION_MESSAGE.matcher(firstException.getMessage());
+        if (matcher.matches() && isLengthViolation(firstException)) {
+            String header = matcher.group(1);
+            requestError = aHeaderRequestError(header, CREATE_PAYMENT_HEADER_VALIDATION_ERROR, firstException.getMessage());
         } else {
-            requestError = aRequestError(fieldName, CREATE_PAYMENT_VALIDATION_ERROR, StringUtils.capitalize(firstException.getMessage()));
+            requestError = getFieldNameRequestError(firstException);
         }
         
         return Response.status(422)
                 .entity(requestError)
                 .build();
+    }
+
+    private static boolean isLengthViolation(ConstraintViolation<?> firstException) {
+        return  firstException.getConstraintDescriptor() != null &&
+                firstException.getConstraintDescriptor().getAnnotation() != null &&
+                firstException.getConstraintDescriptor().getAnnotation().annotationType() == Length.class;
+    }
+
+    private RequestError getFieldNameRequestError(ConstraintViolation<?> firstException) {
+        String fieldName = getApiFieldName(firstException.getPropertyPath());
+        if (firstException.getConstraintDescriptor() != null &&
+                firstException.getConstraintDescriptor().getAnnotation() != null &&
+                firstException.getConstraintDescriptor().getAnnotation().annotationType() == NotBlank.class ||
+                firstException.getConstraintDescriptor().getAnnotation().annotationType() == NotEmpty.class ||
+                firstException.getConstraintDescriptor().getAnnotation().annotationType() == NotNull.class) {
+            return aRequestError(fieldName, CREATE_PAYMENT_MISSING_FIELD_ERROR);
+        }
+        return aRequestError(fieldName, CREATE_PAYMENT_VALIDATION_ERROR, StringUtils.capitalize(firstException.getMessage()));
     }
 
     private String getApiFieldName(Path path) {

--- a/src/main/java/uk/gov/pay/api/model/RequestError.java
+++ b/src/main/java/uk/gov/pay/api/model/RequestError.java
@@ -27,6 +27,7 @@ public class RequestError {
         CREATE_PAYMENT_MISSING_FIELD_ERROR("P0101", "Missing mandatory attribute: %s"),
         CREATE_PAYMENT_UNEXPECTED_FIELD_ERROR("P0104", "Unexpected attribute: %s"),
         CREATE_PAYMENT_VALIDATION_ERROR("P0102", "Invalid attribute value: %s. %s"),
+        CREATE_PAYMENT_HEADER_VALIDATION_ERROR("P0102", "%s"),
 
         GET_PAYMENT_NOT_FOUND_ERROR("P0200", "Not found"),
         GET_PAYMENT_CONNECTOR_ERROR("P0298", "Downstream system error"),
@@ -119,6 +120,7 @@ public class RequestError {
     }
 
     private String field;
+    private String header;
     private final Code code;
     private final String description;
 
@@ -127,7 +129,11 @@ public class RequestError {
     }
 
     public static RequestError aRequestError(String fieldName, Code code, Object... parameters) {
-        return new RequestError(fieldName, code, parameters);
+        return new RequestError(null, fieldName, code, parameters);
+    }
+
+    public static RequestError aHeaderRequestError(String header, Code code, Object... parameters) {
+        return new RequestError(header, null, code, parameters);
     }
 
     private RequestError(Code code, Object... parameters) {
@@ -135,10 +141,11 @@ public class RequestError {
         this.description = format(code.getFormat(), parameters);
     }
 
-    private RequestError(String fieldName, Code code, Object... parameters) {
+    private RequestError(String header, String fieldName, Code code, Object... parameters) {
+        this.header = header;
         this.field = fieldName;
         this.code = code;
-        this.description = format(code.getFormat(), concat(fieldName, parameters));
+        this.description = format(code.getFormat(), fieldName != null ? concat(fieldName, parameters) : parameters);
     }
 
     @Schema(example = "amount", description = "The parameter in your request that's causing the error.")
@@ -146,7 +153,12 @@ public class RequestError {
         return field;
     }
 
-    @Schema(example = "P0102", 
+    @Schema(example = "Idempotency-Key", description = "The header in your request that's causing the error.")
+    public String getHeader() {
+        return header;
+    }
+
+    @Schema(example = "P0102",
             description = "An [API error code](https://docs.payments.service.gov.uk/api_reference/#gov-uk-pay-api-error-codes)" +
                     "that explains why the payment failed.<br><br>`code` only appears if the payment failed.")
     public String getCode() {

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -10,14 +10,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.http.HttpStatus;
+import org.hibernate.validator.constraints.Length;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CaptureChargeException;
 import uk.gov.pay.api.model.CreateCardPaymentRequest;
 import uk.gov.pay.api.model.CreatePaymentResult;
-import uk.gov.pay.api.model.RequestError;
 import uk.gov.pay.api.model.PaymentEventsResponse;
+import uk.gov.pay.api.model.RequestError;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 import uk.gov.pay.api.model.search.card.GetPaymentResult;
 import uk.gov.pay.api.model.search.card.PaymentSearchResults;
@@ -31,6 +32,7 @@ import uk.gov.pay.api.service.PaymentSearchParams;
 import uk.gov.pay.api.service.PaymentSearchService;
 import uk.gov.pay.api.service.PublicApiUriGenerator;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
@@ -293,7 +295,8 @@ public class PaymentsResource {
     )
     public Response createNewPayment(@Parameter(hidden = true) @Auth Account account,
                                      @Parameter(required = true, description = "requestPayload")
-                                     @Valid CreateCardPaymentRequest createCardPaymentRequest) {
+                                     @Valid CreateCardPaymentRequest createCardPaymentRequest,
+                                     @Nullable @Length(min = 1, max = 255, message = "Header [Idempotency-Key] can have a size between 1 and 255") @HeaderParam("Idempotency-Key") String idempotencyKey) {
         logger.info("Payment create request parsed to {}", createCardPaymentRequest);
 
         PaymentWithAllLinks createdPayment = createPaymentService.create(account, createCardPaymentRequest);

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -86,7 +86,7 @@ public class PaymentsResourceCreatePaymentTest {
 
         when(createPaymentService.create(account, createPaymentRequest)).thenReturn(injectedResponse);
 
-        Response newPayment = paymentsResource.createNewPayment(account, createPaymentRequest);
+        Response newPayment = paymentsResource.createNewPayment(account, createPaymentRequest, null);
 
         assertThat(newPayment.getHeaderString(PRAGMA), is("no-cache"));
         assertThat(newPayment.getHeaderString(CACHE_CONTROL), is("no-store"));


### PR DESCRIPTION
## WHAT YOU DID
- implement checking the length of the Idempotency-Key header if present.
- refactor RequestError to include a `header` field
- refactor ViolationExceptionMapper to handle this violation
- add header param to PaymentsResource create payment
- add/update relevant tests

with @alexbishop1
