### PR TITLE
PP-10713 Implement passing idempotency key to connector

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -136,7 +136,7 @@
         "filename": "src/main/java/uk/gov/pay/api/resources/PaymentsResource.java",
         "hashed_secret": "0ca33fee4444c18265ffce030b9e327b54f05ae0",
         "is_verified": false,
-        "line_number": 240
+        "line_number": 241
       }
     ],
     "src/test/java/uk/gov/pay/api/filter/AuthorizationValidationFilterTest.java": [
@@ -183,5 +183,5 @@
       }
     ]
   },
-  "generated_at": "2023-04-18T13:38:29Z"
+  "generated_at": "2023-04-20T10:24:52Z"
 }

--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -19,6 +19,7 @@ import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_ACCOUNT_ERRO
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_AGREEMENT_ID_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_AUTHORISATION_API_NOT_ENABLED;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_CONNECTOR_ERROR;
+import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_IDEMPOTENCY_KEY_ALREADY_USED;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_MOTO_NOT_ENABLED;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_UNEXPECTED_FIELD_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_VALIDATION_ERROR;
@@ -101,6 +102,10 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
                 case RECURRING_CARD_PAYMENTS_NOT_ALLOWED:
                     statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
                     requestError = aRequestError(RECURRING_CARD_PAYMENTS_NOT_ALLOWED_ERROR);
+                    break;
+                case IDEMPOTENCY_KEY_USED:
+                    statusCode = HttpStatus.CONFLICT_409;
+                    requestError = aRequestError(CREATE_PAYMENT_IDEMPOTENCY_KEY_ALREADY_USED);
                     break;
                 default:
                     requestError = aRequestError(CREATE_PAYMENT_CONNECTOR_ERROR);

--- a/src/main/java/uk/gov/pay/api/model/CreatedPaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/CreatedPaymentWithAllLinks.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.api.model;
+
+import uk.gov.pay.api.model.links.PaymentWithAllLinks;
+
+public class CreatedPaymentWithAllLinks {
+
+    public enum WhenCreated {
+        BRAND_NEW,
+        EXISTING
+    }
+
+    private final PaymentWithAllLinks payment;
+    private final WhenCreated whenCreated;
+
+    private CreatedPaymentWithAllLinks(PaymentWithAllLinks payment, WhenCreated whenCreated) {
+        this.payment = payment;
+        this.whenCreated = whenCreated;
+    }
+
+    public static CreatedPaymentWithAllLinks of(PaymentWithAllLinks payment, WhenCreated whenCreated) {
+        return new CreatedPaymentWithAllLinks(payment, whenCreated);
+    }
+
+    public PaymentWithAllLinks getPayment() {
+        return payment;
+    }
+
+    public WhenCreated getWhenCreated() {
+        return whenCreated;
+    }
+}

--- a/src/main/java/uk/gov/pay/api/model/RequestError.java
+++ b/src/main/java/uk/gov/pay/api/model/RequestError.java
@@ -28,6 +28,7 @@ public class RequestError {
         CREATE_PAYMENT_UNEXPECTED_FIELD_ERROR("P0104", "Unexpected attribute: %s"),
         CREATE_PAYMENT_VALIDATION_ERROR("P0102", "Invalid attribute value: %s. %s"),
         CREATE_PAYMENT_HEADER_VALIDATION_ERROR("P0102", "%s"),
+        CREATE_PAYMENT_IDEMPOTENCY_KEY_ALREADY_USED("P0191", "The `Idempotency-Key` you sent in the request header has already been used to create a payment."),
 
         GET_PAYMENT_NOT_FOUND_ERROR("P0200", "Not found"),
         GET_PAYMENT_CONNECTOR_ERROR("P0298", "Downstream system error"),

--- a/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
+++ b/src/main/java/uk/gov/pay/api/service/CreatePaymentService.java
@@ -6,15 +6,22 @@ import uk.gov.pay.api.exception.CreateChargeException;
 import uk.gov.pay.api.model.Charge;
 import uk.gov.pay.api.model.ChargeFromResponse;
 import uk.gov.pay.api.model.CreateCardPaymentRequest;
+import uk.gov.pay.api.model.CreatedPaymentWithAllLinks;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 
 import javax.inject.Inject;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
+import java.util.Optional;
+
 import static javax.ws.rs.client.Entity.json;
+import static uk.gov.pay.api.model.CreatedPaymentWithAllLinks.WhenCreated.BRAND_NEW;
+import static uk.gov.pay.api.model.CreatedPaymentWithAllLinks.WhenCreated.EXISTING;
 
 public class CreatePaymentService {
 
@@ -29,19 +36,22 @@ public class CreatePaymentService {
         this.connectorUriGenerator = connectorUriGenerator;
     }
 
-    public PaymentWithAllLinks create(Account account, CreateCardPaymentRequest createCardPaymentRequest) {
-        Response connectorResponse = createCharge(account, createCardPaymentRequest);
+    public CreatedPaymentWithAllLinks create(Account account, CreateCardPaymentRequest createCardPaymentRequest, String idempotencyKey) {
+        Response connectorResponse = createCharge(account, createCardPaymentRequest, idempotencyKey);
 
-        if (!createdSuccessfully(connectorResponse)) {
-            throw new CreateChargeException(connectorResponse);
+        if (connectorCreatedNewPayment(connectorResponse)) {
+            ChargeFromResponse chargeFromResponse = connectorResponse.readEntity(ChargeFromResponse.class);
+            return CreatedPaymentWithAllLinks.of(buildResponseModel(Charge.from(chargeFromResponse)), BRAND_NEW);
         }
 
-        ChargeFromResponse chargeFromResponse = connectorResponse.readEntity(ChargeFromResponse.class);
-        
-        return buildResponseModel(Charge.from(chargeFromResponse));
-    }
+        if (connectorReturnedExistingPayment(connectorResponse)) {
+            ChargeFromResponse chargeFromResponse = connectorResponse.readEntity(ChargeFromResponse.class);
+            return CreatedPaymentWithAllLinks.of(buildResponseModel(Charge.from(chargeFromResponse)), EXISTING);
+        }
 
-    private PaymentWithAllLinks buildResponseModel(Charge chargeFromResponse) {
+        throw new CreateChargeException(connectorResponse);
+    }
+   private PaymentWithAllLinks buildResponseModel(Charge chargeFromResponse) {
         return PaymentWithAllLinks.getPaymentWithLinks(
                 chargeFromResponse,
                 publicApiUriGenerator.getPaymentURI(chargeFromResponse.getChargeId()),
@@ -52,14 +62,25 @@ public class CreatePaymentService {
                 publicApiUriGenerator.getPaymentAuthorisationURI());
     }
 
-    private boolean createdSuccessfully(Response connectorResponse) {
+    private boolean connectorCreatedNewPayment(Response connectorResponse) {
         return connectorResponse.getStatus() == HttpStatus.SC_CREATED;
     }
 
-    private Response createCharge(Account account, CreateCardPaymentRequest createCardPaymentRequest) {
+    private boolean connectorReturnedExistingPayment(Response connectorResponse) {
+        return connectorResponse.getStatus() == HttpStatus.SC_OK;
+    }
+
+
+    private Response createCharge(Account account, CreateCardPaymentRequest createCardPaymentRequest, String idempotencyKey) {
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+
+        Optional.ofNullable(idempotencyKey)
+                .ifPresent(key -> headers.add("Idempotency-Key", idempotencyKey));
+
         return client
                 .target(connectorUriGenerator.chargesURI(account))
                 .request()
+                .headers(headers)
                 .accept(MediaType.APPLICATION_JSON)
                 .post(buildChargeRequestPayload(createCardPaymentRequest));
     }

--- a/src/test/java/uk/gov/pay/api/it/AgreementsApiResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/api/it/AgreementsApiResourceCreateIT.java
@@ -43,7 +43,7 @@ public class AgreementsApiResourceCreateIT extends PaymentResourceITestBase {
                 .withExternalId(VALID_AGREEMENT_ID)
                 .withPaymentInstrument(null)
                 .build();
-        connectorMockClient.respondOk_whenCreateAgreement(GATEWAY_ACCOUNT_ID, createAgreementRequestParams);
+        connectorMockClient.respondCreated_whenCreateAgreement(GATEWAY_ACCOUNT_ID, createAgreementRequestParams);
         ledgerMockClient.respondWithAgreement(VALID_AGREEMENT_ID, agreementFixture);
         postAgreementRequest(agreementPayload(createAgreementRequestParams))
                 .statusCode(HttpStatus.SC_CREATED)
@@ -129,7 +129,7 @@ public class AgreementsApiResourceCreateIT extends PaymentResourceITestBase {
                 .withDescription(DESCRIPTION)
                 .withUserIdentifier(null)
                 .build();
-        connectorMockClient.respondOk_whenCreateAgreement(GATEWAY_ACCOUNT_ID, params);
+        connectorMockClient.respondCreated_whenCreateAgreement(GATEWAY_ACCOUNT_ID, params);
         ledgerMockClient.respondWithAgreement(VALID_AGREEMENT_ID, agreementFixture);
         postAgreementRequest(agreementPayload(params))
                 .statusCode(HttpStatus.SC_CREATED)

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceCreateIT.java
@@ -2,7 +2,6 @@ package uk.gov.pay.api.it;
 
 import com.jayway.jsonassert.JsonAssert;
 import io.restassured.response.ValidatableResponse;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -81,7 +80,7 @@ public class PaymentsResourceCreateIT extends PaymentResourceITestBase {
                 .add("metadata", Map.of())
                 .build();
 
-        connectorMockClient.respondOk_whenCreateCharge(GATEWAY_ACCOUNT_ID, aCreateChargeRequestParams()
+        connectorMockClient.respondCreated_whenCreateCharge(GATEWAY_ACCOUNT_ID, aCreateChargeRequestParams()
                 .withAmount(100)
                 .withDescription(DESCRIPTION)
                 .withReference(REFERENCE)
@@ -105,7 +104,7 @@ public class PaymentsResourceCreateIT extends PaymentResourceITestBase {
                 .withReturnUrl(RETURN_URL)
                 .withMetadata(Map.of("reconciled", true, "ledger_code", 123, "fuh", "fuh you"))
                 .build();
-        connectorMockClient.respondOk_whenCreateCharge(GATEWAY_ACCOUNT_ID, createChargeRequestParams);
+        connectorMockClient.respondCreated_whenCreateCharge(GATEWAY_ACCOUNT_ID, createChargeRequestParams);
 
         postPaymentResponse(paymentPayload(createChargeRequestParams))
                 .statusCode(201)
@@ -128,7 +127,7 @@ public class PaymentsResourceCreateIT extends PaymentResourceITestBase {
                 .withReturnUrl(RETURN_URL)
                 .withSetUpAgreement(VALID_AGREEMENT_ID)
                 .build();
-        connectorMockClient.respondOk_whenCreateCharge(GATEWAY_ACCOUNT_ID, createChargeRequestParams);
+        connectorMockClient.respondCreated_whenCreateCharge(GATEWAY_ACCOUNT_ID, createChargeRequestParams);
 
         postPaymentResponse(paymentPayload(createChargeRequestParams))
                 .statusCode(HttpStatus.SC_CREATED)
@@ -287,7 +286,7 @@ public class PaymentsResourceCreateIT extends PaymentResourceITestBase {
                 .withAddressCity("address city")
                 .withAddressCountry("GB")
                 .build();
-        connectorMockClient.respondOk_whenCreateCharge(GATEWAY_ACCOUNT_ID, createChargeRequestParams);
+        connectorMockClient.respondCreated_whenCreateCharge(GATEWAY_ACCOUNT_ID, createChargeRequestParams);
 
         postPaymentResponse(paymentPayload(createChargeRequestParams))
                 .statusCode(201)
@@ -333,7 +332,7 @@ public class PaymentsResourceCreateIT extends PaymentResourceITestBase {
                 .withAddressCity("address city")
                 .withAddressCountry("GB")
                 .build();
-        connectorMockClient.respondOk_whenCreateCharge(GATEWAY_ACCOUNT_ID, createChargeRequestParams);
+        connectorMockClient.respondCreated_whenCreateCharge(GATEWAY_ACCOUNT_ID, createChargeRequestParams);
 
         postPaymentResponse(paymentPayload(createChargeRequestParams))
                 .statusCode(HttpStatus.SC_CREATED)
@@ -352,7 +351,7 @@ public class PaymentsResourceCreateIT extends PaymentResourceITestBase {
     public void createCardPayment() {
         publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, CARD);
 
-        connectorMockClient.respondOk_whenCreateCharge(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
+        connectorMockClient.respondCreated_whenCreateCharge(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
                 .withAmount(AMOUNT)
                 .withChargeId(CHARGE_ID)
                 .withState(CREATED)
@@ -421,7 +420,7 @@ public class PaymentsResourceCreateIT extends PaymentResourceITestBase {
 
         publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
-        connectorMockClient.respondOk_whenCreateCharge(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
+        connectorMockClient.respondCreated_whenCreateCharge(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
                 .withAmount(minimumAmount)
                 .withChargeId(CHARGE_ID)
                 .withState(CREATED)
@@ -464,7 +463,7 @@ public class PaymentsResourceCreateIT extends PaymentResourceITestBase {
 
         publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
-        connectorMockClient.respondOk_whenCreateCharge(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
+        connectorMockClient.respondCreated_whenCreateCharge(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
                 .withAmount(amount)
                 .withChargeId(CHARGE_ID)
                 .withState(CREATED)
@@ -510,7 +509,7 @@ public class PaymentsResourceCreateIT extends PaymentResourceITestBase {
 
         publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
-        connectorMockClient.respondOk_whenCreateCharge_withAuthorisationMode_MotoApi(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
+        connectorMockClient.respondCreated_whenCreateCharge_withAuthorisationMode_MotoApi(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
                 .withAmount(amount)
                 .withChargeId(CHARGE_ID)
                 .withState(CREATED)
@@ -559,7 +558,7 @@ public class PaymentsResourceCreateIT extends PaymentResourceITestBase {
 
         publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
-        connectorMockClient.respondOk_whenCreateCharge_withAuthorisationMode_Agreement(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
+        connectorMockClient.respondCreated_whenCreateCharge_withAuthorisationMode_Agreement(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
                 .withAmount(amount)
                 .withChargeId(CHARGE_ID)
                 .withState(CREATED)
@@ -611,7 +610,7 @@ public class PaymentsResourceCreateIT extends PaymentResourceITestBase {
 
         publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
-        connectorMockClient.respondOk_whenCreateCharge(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
+        connectorMockClient.respondCreated_whenCreateCharge(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
                 .withAmount(amount)
                 .withChargeId(CHARGE_ID)
                 .withState(CREATED)
@@ -752,30 +751,6 @@ public class PaymentsResourceCreateIT extends PaymentResourceITestBase {
     }
 
     @Test
-    public void createPayment_responseWith422_whenIdempotencyKeyIsEmpty() {
-        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-
-        postPaymentResponseWithIdempotencyKey(SUCCESS_PAYLOAD, "")
-                .statusCode(422)
-                .contentType(JSON)
-                .body("code", is("P0102"))
-                .body("header", is("Idempotency-Key"))
-                .body("description", is("Header [Idempotency-Key] can have a size between 1 and 255"));
-    }
-
-    @Test
-    public void createPayment_responseWith422_whenIdempotencyKeyIsTooLength() {
-        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
-
-        postPaymentResponseWithIdempotencyKey(SUCCESS_PAYLOAD, RandomStringUtils.randomAlphanumeric(256))
-                .statusCode(422)
-                .contentType(JSON)
-                .body("code", is("P0102"))
-                .body("header", is("Idempotency-Key"))
-                .body("description", is("Header [Idempotency-Key] can have a size between 1 and 255"));
-    }
-
-    @Test
     public void createPayment_Returns401_WhenUnauthorised() {
         publicAuthMockClient.respondUnauthorised();
         postPaymentResponse(SUCCESS_PAYLOAD).statusCode(401);
@@ -811,7 +786,7 @@ public class PaymentsResourceCreateIT extends PaymentResourceITestBase {
                 .withReturnUrl(RETURN_URL)
                 .withSource(CARD_PAYMENT_LINK)
                 .build();
-        connectorMockClient.respondOk_whenCreateCharge(GATEWAY_ACCOUNT_ID, createChargeRequestParams);
+        connectorMockClient.respondCreated_whenCreateCharge(GATEWAY_ACCOUNT_ID, createChargeRequestParams);
 
         postPaymentResponse(paymentPayload(createChargeRequestParams))
                 .statusCode(201)
@@ -877,17 +852,6 @@ public class PaymentsResourceCreateIT extends PaymentResourceITestBase {
                 .accept(JSON)
                 .contentType(JSON)
                 .header(AUTHORIZATION, "Bearer " + PaymentResourceITestBase.API_KEY)
-                .post(PAYMENTS_PATH)
-                .then();
-    }
-
-    protected ValidatableResponse postPaymentResponseWithIdempotencyKey(String payload, String idempotencyKey) {
-        return given().port(app.getLocalPort())
-                .body(payload)
-                .accept(JSON)
-                .contentType(JSON)
-                .header(AUTHORIZATION, "Bearer " + PaymentResourceITestBase.API_KEY)
-                .header("Idempotency-Key", idempotencyKey)
                 .post(PAYMENTS_PATH)
                 .then();
     }

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceCreateWithIdempotencyKeyIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceCreateWithIdempotencyKeyIT.java
@@ -1,0 +1,202 @@
+package uk.gov.pay.api.it;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+import io.restassured.response.ValidatableResponse;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
+import uk.gov.pay.api.model.Address;
+import uk.gov.pay.api.model.CardDetails;
+import uk.gov.pay.api.model.PaymentState;
+import uk.gov.pay.api.model.RefundSummary;
+import uk.gov.pay.api.utils.JsonStringBuilder;
+import uk.gov.pay.api.utils.PublicAuthMockClient;
+import uk.gov.pay.api.utils.mocks.ChargeResponseFromConnector;
+import uk.gov.pay.api.utils.mocks.ConnectorMockClient;
+import uk.gov.pay.api.utils.mocks.CreateChargeRequestParams;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.validation.DateTimeUtils;
+
+import java.time.ZonedDateTime;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.api.model.TokenPaymentType.CARD;
+import static uk.gov.pay.api.utils.mocks.ChargeResponseFromConnector.ChargeResponseFromConnectorBuilder.aCreateOrGetChargeResponseFromConnector;
+import static uk.gov.pay.api.utils.mocks.CreateChargeRequestParams.CreateChargeRequestParamsBuilder.aCreateChargeRequestParams;
+import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
+
+public class PaymentsResourceCreateWithIdempotencyKeyIT extends PaymentResourceITestBase {
+
+    private static final ZonedDateTime TIMESTAMP = DateTimeUtils.toUTCZonedDateTime("2016-01-01T12:00:00Z").get();
+    private static final int AMOUNT = 9999999;
+    private static final String CHARGE_ID = "ch_ab2341da231434l";
+    private static final String CHARGE_TOKEN_ID = "token_1234567asdf";
+    private static final PaymentState CREATED = new PaymentState("created", false, null, null);
+    private static final RefundSummary REFUND_SUMMARY = new RefundSummary("pending", 100L, 50L);
+    private static final String PAYMENT_PROVIDER = "Sandbox";
+    private static final String CARD_BRAND_LABEL = "Mastercard";
+    private static final String CARD_TYPE = "credit";
+    private static final String RETURN_URL = "https://somewhere.gov.uk/rainbow/1";
+    private static final String REFERENCE = "Some reference";
+    private static final String DESCRIPTION = "Some description";
+    private static final String CREATED_DATE = ISO_INSTANT_MILLISECOND_PRECISION.format(TIMESTAMP);
+    private static final Address BILLING_ADDRESS = new Address("line1", "line2", "NR2 5 6EG", "city", "UK");
+    private static final CardDetails CARD_DETAILS = new CardDetails("1234", "123456", "Mr. Payment", "12/19", BILLING_ADDRESS, CARD_BRAND_LABEL, CARD_TYPE);
+    public static final String VALID_AGREEMENT_ID = "12345678901234567890123456";
+    private static final String SUCCESS_PAYLOAD = paymentPayload(aCreateChargeRequestParams()
+            .withAmount(AMOUNT)
+            .withDescription(DESCRIPTION)
+            .withReference(REFERENCE)
+            .withReturnUrl(RETURN_URL).build());
+    private static final String GATEWAY_TRANSACTION_ID = "gateway-tx-123456";
+    private static final String IDEMPOTENCY_KEY = "an-idempotency-key";
+    private ConnectorMockClient connectorMockClient = new ConnectorMockClient(connectorMock);
+    private PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
+
+    @Test
+    public void createCardPaymentWithIdempotencyKeyReturns201() {
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, CARD);
+
+        CreateChargeRequestParams createChargeRequestParams = aCreateChargeRequestParams()
+                .withAmount(100)
+                .withDescription(DESCRIPTION)
+                .withReference(REFERENCE)
+                .withReturnUrl(RETURN_URL)
+                .withAgreementId(VALID_AGREEMENT_ID)
+                .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .build();
+        connectorMockClient.respondCreated_whenCreateCharge(GATEWAY_ACCOUNT_ID, createChargeRequestParams);
+
+        StringValuePattern idempotencyKeyMatcher = WireMock.equalTo(IDEMPOTENCY_KEY);
+
+        postPaymentResponseWithIdempotencyKey(paymentPayload(createChargeRequestParams), IDEMPOTENCY_KEY)
+                .statusCode(201)
+                .contentType(JSON);
+
+        connectorMockClient.verifyCreateChargeConnectorRequestWithHeader(GATEWAY_ACCOUNT_ID, paymentPayload(createChargeRequestParams), idempotencyKeyMatcher);
+    }
+
+    @Test
+    public void createPaymentShouldReturn200_whenConnectorReturns200() {
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, CARD);
+        CreateChargeRequestParams createChargeRequestParams = aCreateChargeRequestParams()
+                .withAmount(100)
+                .withDescription(DESCRIPTION)
+                .withReference(REFERENCE)
+                .withReturnUrl(RETURN_URL)
+                .withAgreementId(VALID_AGREEMENT_ID)
+                .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .build();
+        connectorMockClient.respondOK_whenCreateChargeIdempotencyKey(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, getConnectorCharge()
+                .build());
+
+        StringValuePattern idempotencyKeyMatcher = WireMock.equalTo(IDEMPOTENCY_KEY);
+
+        postPaymentResponseWithIdempotencyKey(paymentPayload(createChargeRequestParams), IDEMPOTENCY_KEY)
+                .statusCode(200)
+                .contentType(JSON);
+
+        connectorMockClient.verifyCreateChargeConnectorRequestWithHeader(GATEWAY_ACCOUNT_ID, paymentPayload(createChargeRequestParams), idempotencyKeyMatcher);
+    }
+
+    @Test
+    public void createPaymentShouldReturn409_whenConnectorReturns409() {
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, CARD);
+        CreateChargeRequestParams createChargeRequestParams = aCreateChargeRequestParams()
+                .withAmount(100)
+                .withDescription(DESCRIPTION)
+                .withReference(REFERENCE)
+                .withReturnUrl(RETURN_URL)
+                .withAgreementId(VALID_AGREEMENT_ID)
+                .withAuthorisationMode(AuthorisationMode.AGREEMENT)
+                .build();
+        connectorMockClient.respondConflict_whenCreateChargeAndIdempotencyKeyUSed(GATEWAY_ACCOUNT_ID);
+
+        StringValuePattern idempotencyKeyMatcher = WireMock.equalTo(IDEMPOTENCY_KEY);
+
+        postPaymentResponseWithIdempotencyKey(paymentPayload(createChargeRequestParams), IDEMPOTENCY_KEY)
+                .statusCode(409)
+                .contentType(JSON)
+                .body("code", is("P0191"))
+                .body("description", is("The `Idempotency-Key` you sent in the request header has already been used to create a payment."));
+
+        connectorMockClient.verifyCreateChargeConnectorRequestWithHeader(GATEWAY_ACCOUNT_ID, paymentPayload(createChargeRequestParams), idempotencyKeyMatcher);
+    }
+
+    @Test
+    public void createPayment_responseWith422_whenIdempotencyKeyIsEmpty() {
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+
+        postPaymentResponseWithIdempotencyKey(SUCCESS_PAYLOAD, "")
+                .statusCode(422)
+                .contentType(JSON)
+                .body("code", is("P0102"))
+                .body("header", is("Idempotency-Key"))
+                .body("description", is("Header [Idempotency-Key] can have a size between 1 and 255"));
+    }
+
+    @Test
+    public void createPayment_responseWith422_whenIdempotencyKeyIsTooLong() {
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+
+        postPaymentResponseWithIdempotencyKey(SUCCESS_PAYLOAD, RandomStringUtils.randomAlphanumeric(256))
+                .statusCode(422)
+                .contentType(JSON)
+                .body("code", is("P0102"))
+                .body("header", is("Idempotency-Key"))
+                .body("description", is("Header [Idempotency-Key] can have a size between 1 and 255"));
+    }
+
+
+    private static String paymentPayload(CreateChargeRequestParams params) {
+        JsonStringBuilder payload = new JsonStringBuilder()
+                .add("amount", params.getAmount())
+                .add("reference", params.getReference())
+                .add("description", params.getDescription())
+                .add("return_url", params.getReturnUrl());
+
+        if (!params.getMetadata().isEmpty()) {
+            payload.add("metadata", params.getMetadata());
+        }
+
+        params.getSource().ifPresent(source -> payload.addToNestedMap("source", source, "internal"));
+        params.getSetUpAgreement().ifPresent(setUpAgreement -> payload.add("set_up_agreement", setUpAgreement));
+        params.getAgreementId().ifPresent(agreementId -> payload.add("agreement_id", agreementId));
+        params.getAuthorisationMode().ifPresent(authorisationMode -> payload.add("authorisation_mode", authorisationMode));
+
+        return payload.build();
+    }
+
+    private ChargeResponseFromConnector.ChargeResponseFromConnectorBuilder getConnectorCharge() {
+        return aCreateOrGetChargeResponseFromConnector()
+                .withAmount(AMOUNT)
+                .withChargeId(CHARGE_ID)
+                .withState(CREATED)
+                .withReturnUrl(RETURN_URL)
+                .withDescription(DESCRIPTION)
+                .withReference(REFERENCE)
+                .withPaymentProvider(PAYMENT_PROVIDER)
+                .withCreatedDate(CREATED_DATE)
+                .withLanguage(SupportedLanguage.ENGLISH)
+                .withDelayedCapture(true)
+                .withMoto(false)
+                .withRefundSummary(REFUND_SUMMARY)
+                .withCardDetails(CARD_DETAILS)
+                .withGatewayTransactionId(GATEWAY_TRANSACTION_ID);
+    }
+
+    private ValidatableResponse postPaymentResponseWithIdempotencyKey(String payload, String idempotencyKey) {
+        return given().port(app.getLocalPort())
+                .body(payload)
+                .accept(JSON)
+                .contentType(JSON)
+                .header(AUTHORIZATION, "Bearer " + PaymentResourceITestBase.API_KEY)
+                .header("Idempotency-Key", idempotencyKey)
+                .post(PAYMENTS_PATH)
+                .then();
+    }
+}

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterLocalRateLimiterIT.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterLocalRateLimiterIT.java
@@ -89,7 +89,7 @@ public class ResourcesFilterLocalRateLimiterIT {
 
         publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
 
-        connectorMockClient.respondOk_whenCreateCharge(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
+        connectorMockClient.respondCreated_whenCreateCharge(CHARGE_TOKEN_ID, GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
                 .withAmount(AMOUNT)
                 .withChargeId(CHARGE_ID)
                 .withState(CREATED)

--- a/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterIT.java
+++ b/src/test/java/uk/gov/pay/api/it/ResourcesFilterRateLimiterIT.java
@@ -43,7 +43,7 @@ public class ResourcesFilterRateLimiterIT extends ResourcesFilterITestBase {
         logger.setLevel(Level.INFO);
         logger.addAppender(mockAppender);
 
-        connectorMockClient.respondOk_whenCreateCharge("token_1234567asdf", GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
+        connectorMockClient.respondCreated_whenCreateCharge("token_1234567asdf", GATEWAY_ACCOUNT_ID, aCreateOrGetChargeResponseFromConnector()
                 .withAmount(AMOUNT)
                 .withChargeId(CHARGE_ID)
                 .withState(CREATED)

--- a/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentWithHttpReturnUrlIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentWithHttpReturnUrlIT.java
@@ -71,7 +71,7 @@ public class CreatePaymentWithHttpReturnUrlIT {
                 .add("metadata", Map.of())
                 .build();
 
-        connectorMockClient.respondOk_whenCreateCharge(GATEWAY_ACCOUNT_ID, aCreateChargeRequestParams()
+        connectorMockClient.respondCreated_whenCreateCharge(GATEWAY_ACCOUNT_ID, aCreateChargeRequestParams()
                 .withAmount(100)
                 .withDescription("desc")
                 .withReference("ref")
@@ -91,7 +91,7 @@ public class CreatePaymentWithHttpReturnUrlIT {
                 .add("metadata", Map.of())
                 .build();
 
-        connectorMockClient.respondOk_whenCreateCharge(GATEWAY_ACCOUNT_ID, aCreateChargeRequestParams()
+        connectorMockClient.respondCreated_whenCreateCharge(GATEWAY_ACCOUNT_ID, aCreateChargeRequestParams()
                 .withAmount(100)
                 .withDescription("desc")
                 .withReference("ref")

--- a/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentWithPrefilledCardholderDetailsValidationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentWithPrefilledCardholderDetailsValidationIT.java
@@ -71,7 +71,7 @@ public class CreatePaymentWithPrefilledCardholderDetailsValidationIT extends Pay
         payload.add("prefilled_cardholder_details", Map.of("billing_address",
                 Map.of("country", "")));
 
-        connectorMockClient.respondOk_whenCreateCharge(GATEWAY_ACCOUNT_ID, aCreateChargeRequestParams()
+        connectorMockClient.respondCreated_whenCreateCharge(GATEWAY_ACCOUNT_ID, aCreateChargeRequestParams()
                 .withAmount(100)
                 .withDescription("hi")
                 .withReference("Ref")

--- a/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceLanguageValidationIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/PaymentsResourceLanguageValidationIT.java
@@ -37,7 +37,7 @@ public class PaymentsResourceLanguageValidationIT extends PaymentResourceITestBa
                         "email", "dorothy@rainbow.com",
                         "language", language));
 
-        connectorMockClient.respondOk_whenCreateCharge(GATEWAY_ACCOUNT_ID, aCreateChargeRequestParams()
+        connectorMockClient.respondCreated_whenCreateCharge(GATEWAY_ACCOUNT_ID, aCreateChargeRequestParams()
                 .withAmount(100)
                 .withDescription("hi")
                 .withReference("Some ref")

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -11,6 +11,7 @@ import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.Address;
 import uk.gov.pay.api.model.CardDetails;
 import uk.gov.pay.api.model.CreateCardPaymentRequestBuilder;
+import uk.gov.pay.api.model.CreatedPaymentWithAllLinks;
 import uk.gov.pay.api.model.PaymentSettlementSummary;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
@@ -37,6 +38,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.api.model.CreatedPaymentWithAllLinks.WhenCreated.BRAND_NEW;
 
 @ExtendWith(MockitoExtension.class)
 public class PaymentsResourceCreatePaymentTest {
@@ -83,8 +85,9 @@ public class PaymentsResourceCreatePaymentTest {
                 .build();
 
         PaymentWithAllLinks injectedResponse = aSuccessfullyCreatedPayment();
+        CreatedPaymentWithAllLinks payment = CreatedPaymentWithAllLinks.of(injectedResponse, BRAND_NEW);
 
-        when(createPaymentService.create(account, createPaymentRequest)).thenReturn(injectedResponse);
+        when(createPaymentService.create(account, createPaymentRequest, null)).thenReturn(payment);
 
         Response newPayment = paymentsResource.createNewPayment(account, createPaymentRequest, null);
 

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServiceTest.java
@@ -15,6 +15,7 @@ import uk.gov.pay.api.exception.CreateChargeException;
 import uk.gov.pay.api.model.Address;
 import uk.gov.pay.api.model.CardPayment;
 import uk.gov.pay.api.model.CreateCardPaymentRequestBuilder;
+import uk.gov.pay.api.model.CreatedPaymentWithAllLinks;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.links.Link;
@@ -74,7 +75,8 @@ public class CreatePaymentServiceTest {
                 .description("a description")
                 .build();
 
-        PaymentWithAllLinks paymentResponse = createPaymentService.create(account, requestPayload);
+        CreatedPaymentWithAllLinks createdPaymentWithAllLinks = createPaymentService.create(account, requestPayload, null);
+        PaymentWithAllLinks paymentResponse = createdPaymentWithAllLinks.getPayment();
         CardPayment payment = (CardPayment) paymentResponse.getPayment();
 
         assertThat(payment.getPaymentId(), is("ch_ab2341da231434l"));
@@ -121,7 +123,8 @@ public class CreatePaymentServiceTest {
                 .country("GB")
                 .build();
 
-        PaymentWithAllLinks paymentResponse = createPaymentService.create(account, requestPayload);
+        CreatedPaymentWithAllLinks paymentWithAllLinks = createPaymentService.create(account, requestPayload, null);
+        PaymentWithAllLinks paymentResponse = paymentWithAllLinks.getPayment();
         CardPayment payment = (CardPayment) paymentResponse.getPayment();
 
         assertThat(payment.getPaymentId(), is("ch_ab2341da231434l"));
@@ -164,7 +167,7 @@ public class CreatePaymentServiceTest {
                 .build();
 
         try {
-            createPaymentService.create(account, requestPayload);
+            createPaymentService.create(account, requestPayload, null);
             fail("Expected CreateChargeException to be thrown");
         } catch (CreateChargeException e) {
             assertThat(e.getErrorIdentifier(), is(ErrorIdentifier.ACCOUNT_DISABLED));
@@ -183,7 +186,8 @@ public class CreatePaymentServiceTest {
                 .authorisationMode(AuthorisationMode.MOTO_API)
                 .build();
 
-        PaymentWithAllLinks paymentResponse = createPaymentService.create(account, requestPayload);
+        CreatedPaymentWithAllLinks paymentWithAllLinks = createPaymentService.create(account, requestPayload, null);
+        PaymentWithAllLinks paymentResponse = paymentWithAllLinks.getPayment();
         CardPayment payment = (CardPayment) paymentResponse.getPayment();
         assertThat(paymentResponse.getLinks().getAuthUrlPost(), is(new PostLink("http://publicapi.test.localhost/v1/auth", "POST", "application/json", Collections.singletonMap("one_time_token", "token_1234567asdf"))));
         assertThat(payment.getPaymentId(), is("ch_123abc456def"));
@@ -202,7 +206,7 @@ public class CreatePaymentServiceTest {
                 .authorisationMode(AuthorisationMode.MOTO_API)
                 .build();
         try {
-            createPaymentService.create(account, requestPayload);
+            createPaymentService.create(account, requestPayload, null);
             fail("Expected CreateChargeException to be thrown");
         } catch (CreateChargeException e) {
             assertThat(e.getErrorIdentifier(), is(ErrorIdentifier.AUTHORISATION_API_NOT_ALLOWED));
@@ -221,7 +225,7 @@ public class CreatePaymentServiceTest {
                 .build();
 
         try {
-            createPaymentService.create(account, requestPayload);
+            createPaymentService.create(account, requestPayload, null);
             fail("Expected CreateChargeException to be thrown");
         } catch (CreateChargeException e) {
             assertThat(e.getErrorIdentifier(), is(ErrorIdentifier.ZERO_AMOUNT_NOT_ALLOWED));
@@ -241,7 +245,7 @@ public class CreatePaymentServiceTest {
                 .build();
 
         try {
-            createPaymentService.create(account, requestPayload);
+            createPaymentService.create(account, requestPayload, null);
             fail("Expected CreateChargeException to be thrown");
         } catch (CreateChargeException e) {
             assertThat(e.getErrorIdentifier(), is(ErrorIdentifier.MOTO_NOT_ALLOWED));
@@ -261,7 +265,7 @@ public class CreatePaymentServiceTest {
                 .build();
 
         try {
-            createPaymentService.create(account, requestPayload);
+            createPaymentService.create(account, requestPayload, null);
             fail("Expected CreateChargeException to be thrown");
         } catch (CreateChargeException e) {
             assertThat(e.getErrorIdentifier(), is(ErrorIdentifier.ACCOUNT_NOT_LINKED_WITH_PSP));
@@ -281,7 +285,7 @@ public class CreatePaymentServiceTest {
                 .build();
 
         try {
-            createPaymentService.create(account, requestPayload);
+            createPaymentService.create(account, requestPayload, null);
             fail("Expected CreateChargeException to be thrown");
         } catch (CreateChargeException e) {
             assertThat(e.getErrorIdentifier(), is(ErrorIdentifier.INVALID_ATTRIBUTE_VALUE));
@@ -301,7 +305,7 @@ public class CreatePaymentServiceTest {
                 .build();
 
         try {
-            createPaymentService.create(account, requestPayload);
+            createPaymentService.create(account, requestPayload, null);
             fail("Expected CreateChargeException to be thrown");
         } catch (CreateChargeException e) {
             assertThat(e.getErrorIdentifier(), is(ErrorIdentifier.MISSING_MANDATORY_ATTRIBUTE));

--- a/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
@@ -3,6 +3,7 @@ package uk.gov.pay.api.utils.mocks;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import uk.gov.pay.api.utils.JsonStringBuilder;
@@ -137,6 +138,14 @@ public abstract class BaseConnectorMockClient {
         wireMockClassRule.verify(1,
                 postRequestedFor(urlEqualTo(format(CONNECTOR_MOCK_CHARGES_PATH, gatewayAccountId)))
                         .withRequestBody(equalToJson(payload, true, true)));
+    }
+
+    public void verifyCreateChargeConnectorRequestWithHeader(String gatewayAccountId, String payload, StringValuePattern idempotencyKey) {
+        wireMockClassRule.getAllServeEvents();
+        wireMockClassRule.verify(1,
+                postRequestedFor(urlEqualTo(format(CONNECTOR_MOCK_CHARGES_PATH, gatewayAccountId)))
+                        .withRequestBody(equalToJson(payload, true, true))
+                        .withHeader("Idempotency-Key", idempotencyKey));
     }
     
     public void verifyCreateAgreementConnectorRequest(String gatewayAccountId, CreateAgreementRequestParams createChargeRequestParams) {


### PR DESCRIPTION
## WHAT YOU DID
- add idempotency key header to endpoint
- add idempotency key validations
- pass idempotency key to connector client
- call connector with idempotency key if applicable
- handle responses from connector
- implement tests for happy path and not so happy path
- refactor a few things as needed

with @alexbishop1
