### PR TITLE
PP-10713 Pact test for idempotency key create matching payment

### DIFF
--- a/src/test/resources/pacts/publicapi-connector-create-payment-with-idempotency-key-200-response.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment-with-idempotency-key-200-response.json
@@ -1,0 +1,110 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "a create charge request with idempotency key and same request body",
+      "providerStates": [
+        {
+          "name": "a gateway account with external id and recurring payment enabled exists",
+          "params": {
+            "gateway_account_id": "123456"
+          }
+        },
+        {
+          "name": "an active agreement exists",
+          "params": {
+            "agreement_external_id": "abcdefghijklmnopqrstuvwxyz",
+            "gateway_account_id": "123456"
+          }
+        },
+        {
+          "name": "a charge created with an idempotency key for an agreement exists",
+          "params": {
+            "created": "2023-04-20T13:30:00.000Z",
+            "gateway_account_id": "123456",
+            "agreement_external_id": "abcdefghijklmnopqrstuvwxyz",
+            "charge_external_id": "chargeable",
+            "idempotency_key": "Ida the idempotency key",
+            "amount": "2046",
+            "reference": "referential",
+            "description": "describable"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/v1/api/accounts/123456/charges",
+        "headers" : {
+          "Idempotency-Key": "Ida the idempotency key"
+        },
+        "body": {
+          "amount": 2046,
+          "reference": "referential",
+          "description": "describable",
+          "agreement_id": "abcdefghijklmnopqrstuvwxyz",
+          "authorisation_mode": "agreement"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "charge_id": "chargeable",
+          "amount": 2046,
+          "reference": "referential",
+          "description": "describable",
+          "state": {
+            "status": "created",
+            "finished": false
+          },
+          "payment_provider": "sandbox",
+          "created_date": "2023-04-20T13:30:00.000Z",
+          "agreement_id": "abcdefghijklmnopqrstuvwxyz",
+          "authorisation_mode": "agreement",
+          "links": [
+            {
+              "href": "http://connector.service.backend/v1/api/accounts/123456/charges/chargeable",
+              "rel": "self",
+              "method": "GET"
+            },
+            {
+              "rel": "refunds",
+              "href": "url"
+            }
+          ]
+        },
+        "matchingRules": {
+          "body": {
+            "$.links[0].href": {
+              "matchers": [
+                {
+                  "regex": "https*:\/\/.*\/v1\/api\/accounts\/123456\/charges\/[a-z0-9]*"
+                }
+              ]
+            },
+            "$.links[1].href": {
+              "matchers": [
+                {"match": "type"}
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}

--- a/src/test/resources/pacts/publicapi-connector-create-payment-with-idempotency-key-409-response.json
+++ b/src/test/resources/pacts/publicapi-connector-create-payment-with-idempotency-key-409-response.json
@@ -1,0 +1,73 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "connector"
+  },
+  "interactions": [
+    {
+      "description": "a create charge request with idempotency key and different request body",
+      "providerStates": [
+        {
+          "name": "a gateway account with external id and recurring payment enabled exists",
+          "params": {
+            "gateway_account_id": "123456"
+          }
+        },
+        {
+          "name": "an active agreement exists",
+          "params": {
+            "agreement_external_id": "abcdefghijklmnopqrstuvwxyz",
+            "gateway_account_id": "123456"
+          }
+        },
+        {
+          "name": "a charge created with an idempotency key for an agreement exists",
+          "params": {
+            "created": "2023-04-20T13:30:00.000Z",
+            "gateway_account_id": "123456",
+            "agreement_external_id": "abcdefghijklmnopqrstuvwxyz",
+            "charge_external_id": "chargeable",
+            "idempotency_key": "Ida the idempotency key",
+            "amount": "2046",
+            "reference": "referential",
+            "description": "describable"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "path": "/v1/api/accounts/123456/charges",
+        "headers" : {
+          "Idempotency-Key": "Ida the idempotency key"
+        },
+        "body": {
+          "amount": 2046,
+          "reference": "different referential",
+          "description": "describable",
+          "agreement_id": "abcdefghijklmnopqrstuvwxyz",
+          "authorisation_mode": "agreement"
+        }
+      },
+      "response": {
+        "status": 409,
+        "headers": {
+          "Content-Type": "application/json",
+        },
+        "body": {
+          "message": ["The Idempotency-Key has already been used to create a payment"],
+          "error_identifier": "IDEMPOTENCY_KEY_USED"
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
## WHAT YOU DID

Add a Pact test to test the scenario where a second request is received to create a payment with an idempotency key and request body that matches that of an existing payment, which causes connector to return the original payment with a 200 response.

with @SandorArpa
