### PR TITLE
BAU fix if statement

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/ViolationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/ViolationExceptionMapper.java
@@ -59,9 +59,9 @@ public class ViolationExceptionMapper implements ExceptionMapper<JerseyViolation
         String fieldName = getApiFieldName(firstException.getPropertyPath());
         if (firstException.getConstraintDescriptor() != null &&
                 firstException.getConstraintDescriptor().getAnnotation() != null &&
-                firstException.getConstraintDescriptor().getAnnotation().annotationType() == NotBlank.class ||
+                (firstException.getConstraintDescriptor().getAnnotation().annotationType() == NotBlank.class ||
                 firstException.getConstraintDescriptor().getAnnotation().annotationType() == NotEmpty.class ||
-                firstException.getConstraintDescriptor().getAnnotation().annotationType() == NotNull.class) {
+                firstException.getConstraintDescriptor().getAnnotation().annotationType() == NotNull.class)) {
             return aRequestError(fieldName, CREATE_PAYMENT_MISSING_FIELD_ERROR);
         }
         return aRequestError(fieldName, CREATE_PAYMENT_VALIDATION_ERROR, StringUtils.capitalize(firstException.getMessage()));


### PR DESCRIPTION
## WHAT YOU DID
- the if statement in ViolationExceptionMapper.getFieldNameRequestError needs an extra bracket: && has higher precedence than ||
So if we have A && B && C || D || E then it effectively becomes (A && B && C) || D || E
