### PR TITLE
BAU fix flaky tests

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -300,7 +300,7 @@ public class PaymentsResource {
                                      @Valid CreateCardPaymentRequest createCardPaymentRequest,
                                      @Nullable 
                                      @Length(min = 1, max = 255, message = "Header [Idempotency-Key] can have a size between 1 and 255") 
-                                     @Pattern(regexp = "^[a-zA-Z0-9-]+$", message = "Header [Idempotency-Key] can only contain alphanumeric characters and hyphens") 
+                                     @Pattern(regexp = "^$|^[a-zA-Z0-9-]+$", message = "Header [Idempotency-Key] can only contain alphanumeric characters and hyphens")
                                      @HeaderParam("Idempotency-Key") 
                                      String idempotencyKey) {
         logger.info("Payment create request parsed to {}", createCardPaymentRequest);


### PR DESCRIPTION
## WHAT YOU DID
The Idempotency-Key pattern matcher validataion is sometimes executed before the length check. This leads to a false error where the error `Header [Idempotency-Key] can only contain alphanumeric characters and hyphens` is returned.

- add allow empty string to regex
