### PR TITLE
PP-10977 remove expired status from agreement

### DIFF
--- a/openapi/publicapi_spec.json
+++ b/openapi/publicapi_spec.json
@@ -34,7 +34,7 @@
           "name" : "status",
           "schema" : {
             "type" : "string",
-            "enum" : [ "created", "active", "cancelled", "expired" ]
+            "enum" : [ "created", "active", "cancelled", "inactive" ]
           }
         }, {
           "description" : "Returns a specific page of results. Defaults to `1`. You can [read about search pagination](https://docs.payments.service.gov.uk/api_reference/#pagination)",
@@ -1414,7 +1414,7 @@
           "status" : {
             "type" : "string",
             "description" : "The status of this agreement. You can [read more about the meanings of each agreement status.](https://docs.payments.service.gov.uk/recurring_payments/#understanding-agreement-status)",
-            "enum" : [ "created", "active", "cancelled", "expired", "inactive" ]
+            "enum" : [ "created", "active", "cancelled", "inactive" ]
           },
           "user_identifier" : {
             "type" : "string",

--- a/src/main/java/uk/gov/pay/api/agreement/model/Agreement.java
+++ b/src/main/java/uk/gov/pay/api/agreement/model/Agreement.java
@@ -45,7 +45,7 @@ public class Agreement {
 
     @Schema(description = "The status of this agreement. " +
             "You can [read more about the meanings of each agreement status.](https://docs.payments.service.gov.uk/recurring_payments/#understanding-agreement-status)",
-            allowableValues = {"created", "active", "cancelled", "expired", "inactive"})
+            allowableValues = {"created", "active", "cancelled", "inactive"})
     public String getStatus() {
         return Optional.ofNullable(status).map(String::toLowerCase).orElse(null);
     }

--- a/src/main/java/uk/gov/pay/api/ledger/model/AgreementSearchParams.java
+++ b/src/main/java/uk/gov/pay/api/ledger/model/AgreementSearchParams.java
@@ -26,7 +26,7 @@ public class AgreementSearchParams {
             "`status` reflects where an agreement is in its lifecycle. " +
             "You can [read more about the meanings of the different agreement status values]" +
             "(https://docs.payments.service.gov.uk/recurring_payments/#understanding-agreement-status).",
-            schema = @Schema(allowableValues = {"created", "active", "cancelled", "expired"}))
+            schema = @Schema(allowableValues = {"created", "active", "cancelled", "inactive"}))
     private String status;
 
     @QueryParam("page")


### PR DESCRIPTION
## WHAT YOU DID

We don’t have any process/code that sets the payment_instrucment/agreement status to expired. Also, we don’t have any plans to set payment instruments to expired status.

- remove `EXPIRED` from agreements status
- replace `expired` with `inactive` (it was forgotten in PP-10949)
