### PR TITLE
PP-10982 add can_retry to external transaction state

### DIFF
--- a/openapi/publicapi_spec.json
+++ b/openapi/publicapi_spec.json
@@ -2390,6 +2390,12 @@
         "type" : "object",
         "description" : "A structure representing the current state of the payment in its lifecycle.",
         "properties" : {
+          "can_retry" : {
+            "type" : "boolean",
+            "description" : "If `can_retry` is `true`, you can use this agreement to try to take another recurring payment. If `can_retry` is `false`, you cannot take another recurring payment with this agreement. `can_retry` only appears on failed payments that were attempted using an agreement for recurring payments.",
+            "nullable" : true,
+            "readOnly" : true
+          },
           "code" : {
             "type" : "string",
             "description" : "An [API error code](https://docs.payments.service.gov.uk/api_reference/#gov-uk-pay-api-error-codes)that explains why the payment failed. `code` only appears if the payment failed.",

--- a/src/main/java/uk/gov/pay/api/model/PaymentState.java
+++ b/src/main/java/uk/gov/pay/api/model/PaymentState.java
@@ -25,14 +25,18 @@ public class PaymentState {
 
     @JsonProperty("code")
     private String code;
-    
+
+    @JsonProperty("can_retry")
+    private Boolean canRetry;
+
 
     public static PaymentState createPaymentState(JsonNode node) {
         return new PaymentState(
                 node.get("status").asText(),
                 node.get("finished").asBoolean(),
                 node.has("message") ? node.get("message").asText() : null,
-                node.has("code") ? node.get("code").asText() : null
+                node.has("code") ? node.get("code").asText() : null,
+                node.has("can_retry") ? node.get("can_retry").asBoolean() : null
         );
     }
 
@@ -44,10 +48,15 @@ public class PaymentState {
     }
 
     public PaymentState(String status, boolean finished, String message, String code) {
+        this(status, finished, message, code, null);
+    }
+
+    public PaymentState(String status, boolean finished, String message, String code, Boolean canRetry) {
         this.status = status;
         this.finished = finished;
         this.message = message;
         this.code = code;
+        this.canRetry = canRetry;
     }
 
     @Schema(description = "Where the payment is in [the payment status lifecycle]" +
@@ -74,7 +83,15 @@ public class PaymentState {
     public String getCode() {
         return code;
     }
-    
+
+    @Schema(description = "If `can_retry` is `true`, you can use this agreement to try to take another recurring payment. " +
+            "If `can_retry` is `false`, you cannot take another recurring payment with this agreement. " +
+            "`can_retry` only appears on failed payments that were attempted using an agreement for recurring payments.",
+            nullable = true, accessMode = READ_ONLY)
+    public Boolean getCanRetry() {
+        return canRetry;
+    }
+
     @Override
     public String toString() {
         return "PaymentState{" +
@@ -82,6 +99,7 @@ public class PaymentState {
                 ", finished='" + finished + '\'' +
                 ", message=" + message +
                 ", code=" + code +
+                (canRetry != null ? ", canRetry=" +canRetry : "") +
                 '}';
     }
 
@@ -93,11 +111,12 @@ public class PaymentState {
         return finished == that.finished &&
                 Objects.equals(status, that.status) &&
                 Objects.equals(message, that.message) &&
-                Objects.equals(code, that.code);
+                Objects.equals(code, that.code) &&
+                Objects.equals(canRetry, that.canRetry);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(status, finished, message, code);
+        return Objects.hash(status, finished, message, code, canRetry);
     }
 }

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceCreateIT.java
@@ -444,7 +444,7 @@ public class PaymentsResourceCreateIT extends PaymentResourceITestBase {
                 .build();
 
         postPaymentResponse(paymentPayload(params))
-                .statusCode(201).log().body()
+                .statusCode(201)
                 .contentType(JSON)
                 .body("payment_id", is(CHARGE_ID))
                 .body("amount", is(minimumAmount))

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentResultBuilder.java
@@ -164,6 +164,21 @@ public abstract class PaymentResultBuilder {
         }
     }
 
+    protected static class TestPaymentRejectedState extends TestPaymentState {
+        private boolean success;
+        private boolean can_retry;
+        private String code;
+        private String message;
+
+        protected TestPaymentRejectedState(String status, String code, String message, boolean canRetry) {
+            super(status, true);
+            this.success = true;
+            this.code = code;
+            this.message = message;
+            this.can_retry = canRetry;
+        }
+    }
+
     protected static final List<TestPaymentState> states = new LinkedList<>();
 
     static {

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSearchResultBuilder.java
@@ -83,6 +83,11 @@ public class PaymentSearchResultBuilder extends PaymentResultBuilder {
         return this;
     }
 
+    public PaymentSearchResultBuilder withRejectedState(String status, String code, String message,  boolean canRetry) {
+        this.state = new TestPaymentRejectedState(status, code, message, canRetry);
+        return this;
+    }
+
     public PaymentSearchResultBuilder withDelayedCapture(boolean delayedCapture) {
         this.delayedCapture = delayedCapture;
         return this;

--- a/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSingleResultBuilder.java
+++ b/src/test/java/uk/gov/pay/api/it/fixtures/PaymentSingleResultBuilder.java
@@ -89,8 +89,10 @@ public class PaymentSingleResultBuilder extends PaymentResultBuilder {
     
     public PaymentSingleResultBuilder withState(PaymentState paymentState) {
         this.state = paymentState == null ?
-                new TestPaymentState("submitted", false) :        
-                new TestPaymentState(paymentState.getStatus(), paymentState.isFinished());
+                new TestPaymentState("submitted", false) :
+                paymentState.getCanRetry() == null ?
+                new TestPaymentState(paymentState.getStatus(), paymentState.isFinished()) :
+                new TestPaymentRejectedState(paymentState.getStatus(), paymentState.getCode(), paymentState.getMessage(), paymentState.getCanRetry());
         return this;
     }
     


### PR DESCRIPTION
## WHAT YOU DID
- add canRetry to `PaymentState`
- implement including canRetry when getting/searching transactions (if applicable)
- add test
- BAU remove forgotten debug code (`.log().body()`)
