### PR TITLE
PP-10982 add new pact test

### DIFF
--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceGetIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceGetIT.java
@@ -65,7 +65,7 @@ public class PaymentsResourceGetIT extends PaymentResourceITestBase {
     private static final PaymentState CREATED = new PaymentState("created", false, null, null);
     private static final PaymentState CAPTURED = new PaymentState("captured", false, null, null);
     public static final PaymentState AWAITING_CAPTURE_REQUEST = new PaymentState("submitted", false, null, null);
-    public static final PaymentState REJECTED = new PaymentState("declined", true, "Payment method rejected", "P0010",true);
+    public static final PaymentState REJECTED = new PaymentState("failed", true, "Payment method rejected", "P0010",true);
     private static final RefundSummary REFUND_SUMMARY = new RefundSummary("pending", 100L, 50L);
     private static final String PAYMENT_PROVIDER = "Sandbox";
     private static final String CARD_BRAND_LABEL = "Mastercard";

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceSearchIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceSearchIT.java
@@ -209,7 +209,7 @@ public class PaymentsResourceSearchIT extends PaymentResourceITestBase {
                 .withPage(2)
                 .withTotal(20)
                 .withPayments(aSuccessfulSearchPayment()
-                        .withRejectedState("declined", "P0010", "Payment method rejected", true)
+                        .withRejectedState("failed", "P0010", "Payment method rejected", true)
                         .withReference(TEST_REFERENCE)
                         .withAuthorisationMode(AuthorisationMode.AGREEMENT)
                         .withNumberOfResults(1)

--- a/src/test/java/uk/gov/pay/api/service/GetPaymentServiceLedgerTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentServiceLedgerTest.java
@@ -176,4 +176,16 @@ public class GetPaymentServiceLedgerTest {
         CardPayment payment = (CardPayment) paymentResponse.getPayment();
         assertThat(payment.getAuthorisationSummary().getThreeDSecure().isRequired(), is(true));
     }
+
+    @Test
+    @PactVerification({"ledger"})
+    @Pacts(pacts = {"publicapi-ledger-get-rejected-recurring-payment-with-can-retry-true"})
+    public void testGetRejectedPaymentWithNoRetryTrueFromLedger() {
+        Account account = new Account(ACCOUNT_ID, TokenPaymentType.CARD, tokenLink);
+
+        PaymentWithAllLinks paymentResponse = getPaymentService.getPayment(account, CHARGE_ID_NON_EXISTENT_IN_CONNECTOR);
+        CardPayment payment = (CardPayment) paymentResponse.getPayment();
+        assertThat(payment.getState().getCanRetry(), is(true));
+        assertThat(payment.getAuthorisationMode(), is(AuthorisationMode.AGREEMENT));
+    }
 }

--- a/src/test/resources/pacts/publicapi-ledger-get-rejected-recurring-payment-with-can-retry-true.json
+++ b/src/test/resources/pacts/publicapi-ledger-get-rejected-recurring-payment-with-can-retry-true.json
@@ -1,0 +1,100 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "ledger"
+  },
+  "interactions": [
+    {
+      "description": "get a recurring charge request with rejected state and can_retry equal to true",
+      "providerStates": [
+        {
+          "name": "a recurring card payment with rejected state and can_retry equal to true exists",
+          "params": {
+            "account_id": "123456",
+            "agreement_id": "123abc456agreement",
+            "charge_id": "ch_123abc456xyz"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/transaction/ch_123abc456xyz",
+        "query": {
+          "account_id": ["123456"],
+          "transaction_type": ["PAYMENT"],
+          "status_version": ["1"]
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "amount": 1000,
+          "state": {
+            "finished": true,
+            "code": "P0010",
+            "message": "Payment method rejected",
+            "can_retry": true,
+            "status": "failed"
+          },
+          "description": "Test description",
+          "reference": "aReference",
+          "language": "en",
+          "transaction_id": "ch_123abc456xyz",
+          "settlement_summary": {
+            "capture_submit_time": null,
+            "captured_date": null
+          },
+          "return_url": "https://example.org/transactions",
+          "payment_provider": "sandbox",
+          "created_date": "2020-09-19T00:00:01.000Z",
+          "refund_summary": {
+            "status": "available",
+            "user_external_id": null,
+            "amount_available": 1000,
+            "amount_submitted": 0
+          },
+          "delayed_capture": false,
+          "authorisation_mode": "agreement"
+        },
+        "matchingRules": {
+          "body": {
+            "$.amount": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.reference": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.description": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.return_url": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.created_date": {
+              "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
+            },
+            "$.refund_summary.status": {
+              "matchers": [{"match": "type"}]
+            },
+            "$.refund_summary.amount_available": {
+              "matchers": [{"match": "type"}]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
## WHAT YOU DID
- add a new pact test that verifies a rejected recurring payment with can retry true against ledger
- correct rejected state's status to the right one in tests
