### PR TITLE
PP-10509 Remove `status_version` from agreements URI

### DIFF
--- a/src/main/java/uk/gov/pay/api/ledger/service/LedgerUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/ledger/service/LedgerUriGenerator.java
@@ -74,7 +74,6 @@ public class LedgerUriGenerator {
     }
 
     public String agreementsURIWithParams(Map<String, String> queryParams) {
-        queryParams.put("status_version", "1");
         return buildLedgerUri("/v1/agreement", queryParams);
     }
 }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/LedgerMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/LedgerMockClient.java
@@ -226,7 +226,6 @@ public class LedgerMockClient {
                 .withQueryParam("status", equalTo("created"))
                 .withQueryParam("account_id", equalTo(gatewayAccountId))
                 .withQueryParam("exact_reference_match", equalTo("true"))
-                .withQueryParam("status_version", equalTo("1"))
                 .willReturn(aResponse()
                         .withStatus(OK_200)
                         .withHeader(CONTENT_TYPE, APPLICATION_JSON)

--- a/src/test/resources/pacts/publicapi-ledger-search-agreements-with-page-and-display-size.json
+++ b/src/test/resources/pacts/publicapi-ledger-search-agreements-with-page-and-display-size.json
@@ -27,8 +27,7 @@
             "1"
           ],
           "account_id": ["777"],
-          "exact_reference_match": ["true"],
-          "status_version": ["1"]
+          "exact_reference_match": ["true"]
         }
       },
       "response": {


### PR DESCRIPTION
## WHAT YOU DID
- Removed `status_version` from the agreements URI when querying Ledger for agreements. This field is not required for agreements
