### PR TITLE
PP-11188 refactor agreement pact tests

### DIFF
--- a/src/test/java/uk/gov/pay/api/service/CancelAgreementConnectorServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CancelAgreementConnectorServicePactTest.java
@@ -8,21 +8,17 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.api.agreement.service.AgreementsService;
 import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CancelAgreementException;
-import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.TokenPaymentType;
-import uk.gov.pay.api.model.search.PaginationDecorator;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
 
 import javax.ws.rs.client.Client;
-import javax.ws.rs.core.Response;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasProperty;
@@ -31,35 +27,30 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class CancelAgreementsServicePactTest {
+public class CancelAgreementConnectorServicePactTest {
 
     private final Account ACCOUNT = new Account("123456", TokenPaymentType.CARD, "a-token-link");
     
     @Rule
     public PactProviderRule connectorRule = new PactProviderRule("connector", this);
 
-    private AgreementsService agreementsService;
+    private ConnectorService connectorService;
     @Mock
     private PublicApiConfig mockConfiguration;
-
 
     @Before
     public void setUp() {
         when(mockConfiguration.getConnectorUrl()).thenReturn(connectorRule.getUrl());
         ConnectorUriGenerator connectorUriGenerator = new ConnectorUriGenerator(mockConfiguration);
-        LedgerUriGenerator ledgerUriGenerator = new LedgerUriGenerator(mockConfiguration);
         Client client = RestClientFactory.buildClient(new RestClientConfig(false));
-        agreementsService = new AgreementsService(new ConnectorService(client, connectorUriGenerator),
-                new LedgerService(client, ledgerUriGenerator),
-                new PaginationDecorator(mockConfiguration));
+        connectorService = new ConnectorService(client, connectorUriGenerator);
     }
 
     @Test
     @PactVerification({"connector"})
     @Pacts(pacts = {"publicapi-connector-cancel-agreement-with-active-status"})
     public void cancelAnAgreementWithActiveStatus() {
-        Response cancelAgreementResponse = agreementsService.cancelAgreement(ACCOUNT, "agreement1234567");
-        assertThat(cancelAgreementResponse.getStatus(), is(204));
+        connectorService.cancelAgreement(ACCOUNT, "agreement1234567");
     }
 
     @Test
@@ -67,7 +58,7 @@ public class CancelAgreementsServicePactTest {
     @Pacts(pacts = {"publicapi-connector-cancel-agreement-with-cancelled-status"})
     public void cancelAnAgreementWithCancelledStatus() {
         CancelAgreementException cancelAgreementException = assertThrows(CancelAgreementException.class,
-                () -> agreementsService.cancelAgreement(ACCOUNT, "agreement9876543"));
+                () -> connectorService.cancelAgreement(ACCOUNT, "agreement9876543"));
         assertThat(cancelAgreementException, hasProperty("errorStatus", Matchers.is(400)));
         assertThat(cancelAgreementException, hasProperty("errorIdentifier", is(ErrorIdentifier.AGREEMENT_NOT_ACTIVE)));
         assertThat(cancelAgreementException.getConnectorErrorMessage(), is("Payment instrument not active."));

--- a/src/test/java/uk/gov/pay/api/service/GetOneAgreementLedgerServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetOneAgreementLedgerServicePactTest.java
@@ -8,14 +8,12 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.api.agreement.model.AgreementLedgerResponse;
-import uk.gov.pay.api.agreement.service.AgreementsService;
 import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.TokenPaymentType;
-import uk.gov.pay.api.model.search.PaginationDecorator;
 import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
 
@@ -26,34 +24,30 @@ import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class GetOneAgreementsServicePactTest {
+public class GetOneAgreementLedgerServicePactTest {
 
     private final Account ACCOUNT = new Account("3456", TokenPaymentType.CARD, "a-token-link");
 
     @Rule
     public PactProviderRule ledgerRule = new PactProviderRule("ledger", this);
 
-    private AgreementsService agreementsService;
+    private LedgerService ledgerService;
     @Mock
     private PublicApiConfig mockConfiguration;
-
 
     @Before
     public void setUp() {
         when(mockConfiguration.getLedgerUrl()).thenReturn(ledgerRule.getUrl());
-        ConnectorUriGenerator connectorUriGenerator = new ConnectorUriGenerator(mockConfiguration);
         LedgerUriGenerator ledgerUriGenerator = new LedgerUriGenerator(mockConfiguration);
         Client client = RestClientFactory.buildClient(new RestClientConfig(false));
-        agreementsService = new AgreementsService(new ConnectorService(client, connectorUriGenerator),
-                new LedgerService(client, ledgerUriGenerator),
-                new PaginationDecorator(mockConfiguration));
+        ledgerService = new LedgerService(client, ledgerUriGenerator);
     }
 
     @Test
     @PactVerification({"ledger"})
     @Pacts(pacts = {"publicapi-ledger-get-one-agreement"})
     public void getOneAgreement() {
-        AgreementLedgerResponse getAgreementResponse = agreementsService.getAgreement(ACCOUNT, "abcdefghijklmnopqrstuvwxyz");
+        AgreementLedgerResponse getAgreementResponse = ledgerService.getAgreement(ACCOUNT, "abcdefghijklmnopqrstuvwxyz");
         assertThat(getAgreementResponse.getStatus(), is("ACTIVE"));
         assertThat(getAgreementResponse.getExternalId(), is("abcdefghijklmnopqrstuvwxyz"));
         assertThat(getAgreementResponse.getPaymentInstrument().getAgreementExternalId(), is("abcdefghijklmnopqrstuvwxyz"));

--- a/src/test/java/uk/gov/pay/api/service/SearchAgreementsLedgerServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/SearchAgreementsLedgerServicePactTest.java
@@ -7,16 +7,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.api.agreement.model.AgreementSearchResults;
-import uk.gov.pay.api.agreement.service.AgreementsService;
+import uk.gov.pay.api.agreement.model.AgreementLedgerResponse;
 import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.ledger.model.AgreementSearchParams;
+import uk.gov.pay.api.ledger.model.SearchResults;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.TokenPaymentType;
-import uk.gov.pay.api.model.search.PaginationDecorator;
 import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
 
@@ -27,28 +26,24 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class SearchAgreementsServicePactTest {
+public class SearchAgreementsLedgerServicePactTest {
     @Rule
     public PactProviderRule ledgerRule = new PactProviderRule("ledger", this);
     @Mock
     private PublicApiConfig mockConfiguration;
 
-    private AgreementsService agreementsService;
+    private LedgerService ledgerService;
 
-    private static final String PUBLIC_API_URL = "http://publicapi.test.localhost/";
+    private static final String LEDGER_SERVICE_URL = "http://ledger.service.backend/";
 
     @Before
     public void setUp() {
         when(mockConfiguration.getLedgerUrl()).thenReturn(ledgerRule.getUrl());
-        when(mockConfiguration.getBaseUrl()).thenReturn(PUBLIC_API_URL);
 
         Client client = RestClientFactory.buildClient(new RestClientConfig(false));
-        ConnectorUriGenerator connectorUriGenerator = new ConnectorUriGenerator(mockConfiguration);
         LedgerUriGenerator ledgerUriGenerator = new LedgerUriGenerator(mockConfiguration);
 
-        agreementsService = new AgreementsService(new ConnectorService(client, connectorUriGenerator),
-                new LedgerService(client, ledgerUriGenerator),
-                new PaginationDecorator(mockConfiguration));
+        ledgerService = new LedgerService(client, ledgerUriGenerator);
     }
 
     @Test
@@ -57,16 +52,16 @@ public class SearchAgreementsServicePactTest {
     public void searchWithPageAndDisplaySize_shouldReturnCorrectPageAndPaginationLinks() {
         AgreementSearchParams params = new AgreementSearchParams(null, null, "2", "1");
         Account account = new Account("777", TokenPaymentType.CARD, "a-token-link");
-        AgreementSearchResults results = agreementsService.searchAgreements(account, params);
+        SearchResults<AgreementLedgerResponse> results = ledgerService.searchAgreements(account, params);
 
         assertThat(results.getResults().size(), is(1));
         assertThat(results.getCount(), is(1));
         assertThat(results.getTotal(), is(3));
         assertThat(results.getPage(), is(2));
-        assertThat(results.getLinks().getSelf().getHref(), is(PUBLIC_API_URL + "v1/agreements?display_size=1&page=2"));
-        assertThat(results.getLinks().getFirstPage().getHref(), is(PUBLIC_API_URL + "v1/agreements?display_size=1&page=1"));
-        assertThat(results.getLinks().getLastPage().getHref(), is(PUBLIC_API_URL + "v1/agreements?display_size=1&page=3"));
-        assertThat(results.getLinks().getPrevPage().getHref(), is(PUBLIC_API_URL + "v1/agreements?display_size=1&page=1"));
-        assertThat(results.getLinks().getNextPage().getHref(), is(PUBLIC_API_URL + "v1/agreements?display_size=1&page=3"));
+        assertThat(results.getLinks().getSelf().getHref(), is(LEDGER_SERVICE_URL + "v1/agreements?account_id=777&display_size=1&page=2"));
+        assertThat(results.getLinks().getFirstPage().getHref(), is(LEDGER_SERVICE_URL + "v1/agreements?account_id=777&display_size=1&page=1"));
+        assertThat(results.getLinks().getLastPage().getHref(), is(LEDGER_SERVICE_URL + "v1/agreements?account_id=777&display_size=1&page=3"));
+        assertThat(results.getLinks().getPrevPage().getHref(), is(LEDGER_SERVICE_URL + "v1/agreements?account_id=777&display_size=1&page=1"));
+        assertThat(results.getLinks().getNextPage().getHref(), is(LEDGER_SERVICE_URL + "v1/agreements?account_id=777&display_size=1&page=3"));
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- remove AgreementService from the pact tests and use the actual service that interacts with the backend to run them
- refactor tests accordingly

with @james-peacock-gds
