### PR TITLE
bau: Test and PaymentWithAllLinks constructor cleanup

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
+++ b/src/main/java/uk/gov/pay/api/model/links/PaymentWithAllLinks.java
@@ -25,7 +25,7 @@ public class PaymentWithAllLinks extends CardPayment {
         return links;
     }
 
-    public PaymentWithAllLinks(String chargeId, long amount, PaymentState state, String returnUrl, String description,
+    private PaymentWithAllLinks(String chargeId, long amount, PaymentState state, String returnUrl, String description,
                                String reference, String email, String paymentProvider, String createdDate, SupportedLanguage language,
                                boolean delayedCapture, boolean moto, RefundSummary refundSummary, PaymentSettlementSummary settlementSummary, CardDetails cardDetails,
                                List<PaymentConnectorResponseLink> paymentConnectorResponseLinks, URI selfLink, URI paymentEventsUri, URI paymentCancelUri,
@@ -55,38 +55,39 @@ public class PaymentWithAllLinks extends CardPayment {
                                               URI paymentRefundsUri,
                                               URI paymentsCaptureUri,
                                               URI paymentAuthorisationUri) {
-        return new PaymentWithAllLinks(
-                paymentConnector.getChargeId(),
-                paymentConnector.getAmount(),
-                paymentConnector.getState(),
-                paymentConnector.getReturnUrl(),
-                paymentConnector.getDescription(),
-                paymentConnector.getReference(),
-                paymentConnector.getEmail(),
-                paymentConnector.getPaymentProvider(),
-                paymentConnector.getCreatedDate(),
-                paymentConnector.getLanguage(),
-                paymentConnector.getDelayedCapture(),
-                paymentConnector.isMoto(),
-                paymentConnector.getRefundSummary(),
-                paymentConnector.getSettlementSummary(),
-                paymentConnector.getCardDetails(),
-                paymentConnector.getLinks(),
-                selfLink,
-                paymentEventsUri,
-                paymentCancelUri,
-                paymentRefundsUri,
-                paymentsCaptureUri,
-                paymentAuthorisationUri,
-                paymentConnector.getCorporateCardSurcharge(),
-                paymentConnector.getTotalAmount(),
-                paymentConnector.getGatewayTransactionId(),
-                paymentConnector.getMetadata().orElse(null),
-                paymentConnector.getFee(),
-                paymentConnector.getNetAmount(),
-                paymentConnector.getAuthorisationSummary(),
-                paymentConnector.getAgreementId(),
-                paymentConnector.getAuthorisationMode());
+        return new PaymentWithAllLinksBuilder()
+                .setChargeId(paymentConnector.getChargeId())
+                .setAmount(paymentConnector.getAmount())
+                .setState(paymentConnector.getState())
+                .setReturnUrl(paymentConnector.getReturnUrl())
+                .setDescription(paymentConnector.getDescription())
+                .setReference(paymentConnector.getReference())
+                .setEmail(paymentConnector.getEmail())
+                .setPaymentProvider(paymentConnector.getPaymentProvider())
+                .setCreatedDate(paymentConnector.getCreatedDate())
+                .setLanguage(paymentConnector.getLanguage())
+                .setDelayedCapture(paymentConnector.getDelayedCapture())
+                .setMoto(paymentConnector.isMoto())
+                .setRefundSummary(paymentConnector.getRefundSummary())
+                .setSettlementSummary(paymentConnector.getSettlementSummary())
+                .setCardDetails(paymentConnector.getCardDetails())
+                .setPaymentConnectorResponseLinks(paymentConnector.getLinks())
+                .setSelfLink(selfLink)
+                .setPaymentEventsUri(paymentEventsUri)
+                .setPaymentCancelUri(paymentCancelUri)
+                .setPaymentRefundsUri(paymentRefundsUri)
+                .setPaymentCaptureUri(paymentsCaptureUri)
+                .setPaymentAuthorisationUri(paymentAuthorisationUri)
+                .setCorporateCardSurcharge(paymentConnector.getCorporateCardSurcharge())
+                .setTotalAmount(paymentConnector.getTotalAmount())
+                .setProviderId(paymentConnector.getGatewayTransactionId())
+                .setMetadata(paymentConnector.getMetadata().orElse(null))
+                .setFee(paymentConnector.getFee())
+                .setNetAmount(paymentConnector.getNetAmount())
+                .setAuthorisationSummary(paymentConnector.getAuthorisationSummary())
+                .setAgreementId(paymentConnector.getAgreementId())
+                .setAuthorisationMode(paymentConnector.getAuthorisationMode())
+                .createPaymentWithAllLinks();
     }
 
     public static PaymentWithAllLinks getPaymentWithLinks(
@@ -99,5 +100,202 @@ public class PaymentWithAllLinks extends CardPayment {
             URI paymentAuthorisationUri) {
         
         return PaymentWithAllLinks.valueOf(paymentConnector, selfLink, paymentEventsUri, paymentCancelUri, paymentRefundsUri, paymentsCaptureUri, paymentAuthorisationUri);
+    }
+    
+    public static class PaymentWithAllLinksBuilder {
+        private String chargeId;
+        private long amount;
+        private PaymentState state;
+        private String returnUrl;
+        private String description;
+        private String reference;
+        private String email;
+        private String paymentProvider;
+        private String createdDate;
+        private SupportedLanguage language;
+        private boolean delayedCapture;
+        private boolean moto;
+        private RefundSummary refundSummary;
+        private PaymentSettlementSummary settlementSummary;
+        private CardDetails cardDetails;
+        private List<PaymentConnectorResponseLink> paymentConnectorResponseLinks;
+        private URI selfLink;
+        private URI paymentEventsUri;
+        private URI paymentCancelUri;
+        private URI paymentRefundsUri;
+        private URI paymentCaptureUri;
+        private URI paymentAuthorisationUri;
+        private Long corporateCardSurcharge;
+        private Long totalAmount;
+        private String providerId;
+        private ExternalMetadata metadata;
+        private Long fee;
+        private Long netAmount;
+        private AuthorisationSummary authorisationSummary;
+        private String agreementId;
+        private AuthorisationMode authorisationMode;
+
+        public PaymentWithAllLinksBuilder setChargeId(String chargeId) {
+            this.chargeId = chargeId;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setAmount(long amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setState(PaymentState state) {
+            this.state = state;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setReturnUrl(String returnUrl) {
+            this.returnUrl = returnUrl;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setReference(String reference) {
+            this.reference = reference;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setEmail(String email) {
+            this.email = email;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setPaymentProvider(String paymentProvider) {
+            this.paymentProvider = paymentProvider;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setCreatedDate(String createdDate) {
+            this.createdDate = createdDate;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setLanguage(SupportedLanguage language) {
+            this.language = language;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setDelayedCapture(boolean delayedCapture) {
+            this.delayedCapture = delayedCapture;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setMoto(boolean moto) {
+            this.moto = moto;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setRefundSummary(RefundSummary refundSummary) {
+            this.refundSummary = refundSummary;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setSettlementSummary(PaymentSettlementSummary settlementSummary) {
+            this.settlementSummary = settlementSummary;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setCardDetails(CardDetails cardDetails) {
+            this.cardDetails = cardDetails;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setPaymentConnectorResponseLinks(List<PaymentConnectorResponseLink> paymentConnectorResponseLinks) {
+            this.paymentConnectorResponseLinks = paymentConnectorResponseLinks;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setSelfLink(URI selfLink) {
+            this.selfLink = selfLink;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setPaymentEventsUri(URI paymentEventsUri) {
+            this.paymentEventsUri = paymentEventsUri;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setPaymentCancelUri(URI paymentCancelUri) {
+            this.paymentCancelUri = paymentCancelUri;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setPaymentRefundsUri(URI paymentRefundsUri) {
+            this.paymentRefundsUri = paymentRefundsUri;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setPaymentCaptureUri(URI paymentCaptureUri) {
+            this.paymentCaptureUri = paymentCaptureUri;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setPaymentAuthorisationUri(URI paymentAuthorisationUri) {
+            this.paymentAuthorisationUri = paymentAuthorisationUri;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setCorporateCardSurcharge(Long corporateCardSurcharge) {
+            this.corporateCardSurcharge = corporateCardSurcharge;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setTotalAmount(Long totalAmount) {
+            this.totalAmount = totalAmount;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setProviderId(String providerId) {
+            this.providerId = providerId;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setMetadata(ExternalMetadata metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setFee(Long fee) {
+            this.fee = fee;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setNetAmount(Long netAmount) {
+            this.netAmount = netAmount;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setAuthorisationSummary(AuthorisationSummary authorisationSummary) {
+            this.authorisationSummary = authorisationSummary;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setAgreementId(String agreementId) {
+            this.agreementId = agreementId;
+            return this;
+        }
+
+        public PaymentWithAllLinksBuilder setAuthorisationMode(AuthorisationMode authorisationMode) {
+            this.authorisationMode = authorisationMode;
+            return this;
+        }
+
+        public PaymentWithAllLinks createPaymentWithAllLinks() {
+            return new PaymentWithAllLinks(chargeId, amount, state, returnUrl, description, reference, email, 
+                    paymentProvider, createdDate, language, delayedCapture, moto, refundSummary, settlementSummary, 
+                    cardDetails, paymentConnectorResponseLinks, selfLink, paymentEventsUri, paymentCancelUri, 
+                    paymentRefundsUri, paymentCaptureUri, paymentAuthorisationUri, corporateCardSurcharge, totalAmount, 
+                    providerId, metadata, fee, netAmount, authorisationSummary, agreementId, authorisationMode);
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
+++ b/src/test/java/uk/gov/pay/api/resources/PaymentsResourceCreatePaymentTest.java
@@ -101,37 +101,38 @@ public class PaymentsResourceCreatePaymentTest {
     @NotNull
     private PaymentWithAllLinks aSuccessfullyCreatedPayment() {
         final Address cardholderAddress = new Address("123 Acacia Ave", "", "", "London", "GB");
-        return new PaymentWithAllLinks(
-                "abc123",
-                100L,
-                new PaymentState("created", false),
-                "https://somewhere.test",
-                "New Passport",
-                "my_ref",
-                "made.up@example.com",
-                "sandbox",
-                "2018-01-01T11:12:13Z",
-                SupportedLanguage.ENGLISH,
-                false,
-                false,
-                new RefundSummary(),
-                new PaymentSettlementSummary(),
-                new CardDetails("9876", "482393", "Anne Onymous", "12/20", cardholderAddress, "visa", null),
-                Collections.emptyList(),
-                URI.create(PAYMENT_URI),
-                URI.create(PAYMENT_URI + "/events"),
-                URI.create(PAYMENT_URI + "/cancel"),
-                URI.create(PAYMENT_URI + "/refunds"),
-                URI.create(PAYMENT_URI + "/capture"),
-                URI.create(PAYMENT_URI + "/auth"),
-                null,
-                null,
-                "providerId",
-                null,
-                null,
-                null,
-                null,
-                null,
-                AuthorisationMode.WEB);
+        return new PaymentWithAllLinks.PaymentWithAllLinksBuilder()
+                .setChargeId("abc123")
+                .setAmount(100L)
+                .setState(new PaymentState("created", false))
+                .setReturnUrl("https://somewhere.test")
+                .setDescription("New Passport")
+                .setReference("my_ref")
+                .setEmail("made.up@example.com")
+                .setPaymentProvider("sandbox")
+                .setCreatedDate("2018-01-01T11:12:13Z")
+                .setLanguage(SupportedLanguage.ENGLISH)
+                .setDelayedCapture(false)
+                .setMoto(false)
+                .setRefundSummary(new RefundSummary())
+                .setSettlementSummary(new PaymentSettlementSummary())
+                .setCardDetails(new CardDetails("9876", "482393", "Anne Onymous", "12/20", cardholderAddress, "visa", null))
+                .setPaymentConnectorResponseLinks(Collections.emptyList())
+                .setSelfLink(URI.create(PAYMENT_URI))
+                .setPaymentEventsUri(URI.create(PAYMENT_URI + "/events"))
+                .setPaymentCancelUri(URI.create(PAYMENT_URI + "/cancel"))
+                .setPaymentRefundsUri(URI.create(PAYMENT_URI + "/refunds"))
+                .setPaymentCaptureUri(URI.create(PAYMENT_URI + "/capture"))
+                .setPaymentAuthorisationUri(URI.create(PAYMENT_URI + "/auth"))
+                .setCorporateCardSurcharge(null)
+                .setTotalAmount(null)
+                .setProviderId("providerId")
+                .setMetadata(null)
+                .setFee(null)
+                .setNetAmount(null)
+                .setAuthorisationSummary(null)
+                .setAgreementId(null)
+                .setAuthorisationMode(AuthorisationMode.WEB)
+                .createPaymentWithAllLinks();
     }
 }


### PR DESCRIPTION
Removed JsonAssert usages in PaymentsResourceSearchIT as they weren't doing anything. Try adding the following in
`PaymentsResourceSearchIT.searchPayments_shouldOnlyReturnAllowedProperties` in the current master branch:
```
JsonAssert.with(responseBody).assertNotDefined("_links.refunds.href")
```

It should cause the test to fail but it doesn't.

Also use a builder pattern for PaymentWithAllLinks.