### PR TITLE
PP-11087: Use status 302 for security.txt redirect

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/SecuritytxtResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SecuritytxtResource.java
@@ -26,7 +26,12 @@ public class SecuritytxtResource {
     }
 
     private static Response redirectToCabinetOfficeSecuritytxt() {
-        return Response.temporaryRedirect(CABINET_OFFICE_SECURITY_TXT).cacheControl(CacheControl.valueOf("no-cache")).expires(new Date()).build();
+        return Response
+                .status(Response.Status.FOUND)
+                .location(CABINET_OFFICE_SECURITY_TXT)
+                .cacheControl(CacheControl.valueOf("no-cache"))
+                .expires(new Date())
+                .build();
     }
 
 }


### PR DESCRIPTION
According to https://gds-way.cloudapps.digital/standards/vulnerability-disclosure.html#security-txt, we should be redirecting with a 302 rather than a 307 when returning security.txt.