### PR TITLE
PP-11223: Set up prometheus metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <pay-java-commons.version>1.0.20230720152355</pay-java-commons.version>
         <junit5.version>5.9.3</junit5.version>
         <pact.version>3.6.15</pact.version>
+        <prometheus.version>0.16.0</prometheus.version>
         <swagger.lib.version>2.2.14</swagger.lib.version>
         <PACT_BROKER_URL/>
         <PACT_BROKER_USERNAME/>
@@ -33,6 +34,21 @@
     </parent>
 
     <dependencies>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_servlet</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_dropwizard</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
         <dependency>
             <groupId>uk.gov.service.payments</groupId>
             <artifactId>model</artifactId>

--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
@@ -6,6 +6,8 @@ import io.dropwizard.Configuration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.net.URI;
+import java.util.Optional;
 
 public class PublicApiConfig extends Configuration {
 
@@ -47,6 +49,9 @@ public class PublicApiConfig extends Configuration {
     @NotNull
     @JsonProperty("rateLimiter")
     private RateLimiterConfig rateLimiterConfig;
+
+    @JsonProperty("ecsContainerMetadataUriV4")
+    private URI ecsContainerMetadataUriV4;
 
     public String getBaseUrl() {
         return baseUrl;
@@ -96,4 +101,7 @@ public class PublicApiConfig extends Configuration {
         return redis;
     }
 
+    public Optional<URI> getEcsContainerMetadataUriV4() {
+        return Optional.ofNullable(ecsContainerMetadataUriV4);
+    }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -65,3 +65,5 @@ apiKeyHmacSecret: ${TOKEN_API_HMAC_SECRET}
 
 # Caching authenticator.
 authenticationCachePolicy: expireAfterWrite=1m
+
+ecsContainerMetadataUriV4: ${ECS_CONTAINER_METADATA_URI_V4:-}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -54,3 +54,5 @@ apiKeyHmacSecret: qwer9yuhgf
 
 # Caching authenticator.
 authenticationCachePolicy: expireAfterWrite=3s
+
+ecsContainerMetadataUriV4: ${ECS_CONTAINER_METADATA_URI_V4:-}


### PR DESCRIPTION
Set up a prometheus metric endpoint /metrics.
Append ECS metadata info (via the PrometheusDefaultLabelSampleBuilder class in pay-java-commons) as default labels.

Analogus to alphagov/pay-connector#4625, which has been tested.