### PR TITLE
PP-11223: Fix deploy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,11 @@
             <artifactId>dropwizard-sentry</artifactId>
             <version>2.1.2-4</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20230618</version>
+        </dependency>
         <!-- testing -->
         <dependency>
             <groupId>uk.gov.service.payments</groupId>
@@ -251,12 +255,6 @@
                     <artifactId>json</artifactId>
                 </exclusion>
             </exclusions>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20230618</version>
             <scope>test</scope>
         </dependency>
         <!-- swagger -->


### PR DESCRIPTION
Publicapi failed to deploy due to:
```
at uk.gov.pay.api.app.PublicApi.main(PublicApi.java:220)
Caused by: java.lang.ClassNotFoundException: org.json.JSONException
```
The transitive org.json:json dependency from pay-java-commons was not included due to the test scope overriding it in publicapi's pom.xml