### PR TITLE
Add linting for our OpenAPI document

### DIFF
--- a/.github/workflows/lint-openapi.yml
+++ b/.github/workflows/lint-openapi.yml
@@ -1,0 +1,21 @@
+name: Lint OpenAPI specification
+
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
+
+permissions:
+  checks: write
+
+jobs:
+  build:
+    name: Run Spectral
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: stoplightio/spectral-action@latest
+        with:
+          file_glob: 'openapi/publicapi_spec.json'

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,5 @@
+extends:
+- spectral:oas
+rules:
+  oas3-valid-schema-example: warn
+  oas3-valid-media-example: warn


### PR DESCRIPTION
## WHAT YOU DID

Added support for linting our public OpenAPI documentation.

[CDDO's api-standards-linting](https://github.com/co-cddo/api-standards-linting) could be used as a ruleset to allow for other rules, but I'm not sure how well maintained it is now.

This downgrades the current errors that Spectral picks up to warnings, as they're technically find as-is, but may be worth amending at some point.

## How to test

- How should it be reviewed? 
  - View the GitHub Actions YAML
  - View the PR's checks ([example run on fork](https://github.com/jamietanna/pay-publicapi/pull/1))
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

N/A

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition