### PR TITLE
PP-11228: Remove graphite metrics sending and config

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -161,7 +161,7 @@
         "filename": "src/test/resources/config/empty-elevated-accounts-test-config.yaml",
         "hashed_secret": "3d4478f77d368235803ceb52bbd45b7240e6af62",
         "is_verified": false,
-        "line_number": 51
+        "line_number": 48
       }
     ],
     "src/test/resources/config/test-config.yaml": [
@@ -170,7 +170,7 @@
         "filename": "src/test/resources/config/test-config.yaml",
         "hashed_secret": "3d4478f77d368235803ceb52bbd45b7240e6af62",
         "is_verified": false,
-        "line_number": 53
+        "line_number": 50
       }
     ],
     "src/test/resources/pacts/publicapi-connector-get-payment-refund.json": [
@@ -192,5 +192,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-05T15:53:25Z"
+  "generated_at": "2023-09-06T14:26:21Z"
 }

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ Configuration of the application is performed via environment variables, some of
 | `ADMIN_PORT`                | No        | 8081           | The port number to listen for Dropwizard admin requests on.                                                |
 | `ALLOW_HTTP_FOR_RETURN_URL` | No        | false          | Whether to allow service return URLs to be non-HTTPS                                                       |
 | `CONNECTOR_URL`             | Yes       | N/A            | The URL to the [connector](https://github.com/alphagov/pay-connector) service                              |
-| `DISABLE_INTERNAL_HTTPS`    | No        | false          | The port number to send graphite metrics to.                                                               |
-| `METRICS_HOST`              | No        | localhost      | The hostname to send graphite metrics to.                                                                  |
-| `METRICS_PORT`              | No        | 8092           | The port number to send graphite metrics to.                                                               |
+| `DISABLE_INTERNAL_HTTPS`    | No        | false          | Disable secure connection for calls to internal APIs                                                       |
 | `PORT`                      | No        | 8080           | The port number to listen for requests on.                                                                 |
 | `PUBLICAPI_BASE`            | Yes       | N/A            | The base URL clients can use to reach the API. e.g. http://api.example.org:1234/                           |
 | `PUBLIC_AUTH_URL`           | Yes       | N/A            | The URL to the [publicauth](https://github.com/alphagov/pay-publicauth) service                            |

--- a/pom.xml
+++ b/pom.xml
@@ -111,11 +111,6 @@
             <version>1.16.0</version>
         </dependency>
         <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-graphite</artifactId>
-            <version>4.2.12</version>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>

--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiConfig.java
@@ -24,11 +24,6 @@ public class PublicApiConfig extends Configuration {
     private String publicAuthUrl;
 
     @NotNull
-    private String graphiteHost;
-    @NotNull
-    private String graphitePort;
-
-    @NotNull
     private Boolean allowHttpForReturnUrl;
 
     private String apiKeyHmacSecret;
@@ -67,14 +62,6 @@ public class PublicApiConfig extends Configuration {
 
     public String getPublicAuthUrl() {
         return publicAuthUrl;
-    }
-
-    public String getGraphiteHost() {
-        return graphiteHost;
-    }
-
-    public String getGraphitePort() {
-        return graphitePort;
     }
 
     public Boolean getAllowHttpForReturnUrl() {

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -33,9 +33,6 @@ connectorUrl: ${CONNECTOR_URL}
 publicAuthUrl: ${PUBLIC_AUTH_URL}
 ledgerUrl: ${LEDGER_URL}
 
-graphiteHost: ${METRICS_HOST:-localhost}
-graphitePort: ${METRICS_PORT:-8092}
-
 jerseyClientConfig:
   disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS:-false}
 

--- a/src/test/resources/config/empty-elevated-accounts-test-config.yaml
+++ b/src/test/resources/config/empty-elevated-accounts-test-config.yaml
@@ -20,9 +20,6 @@ connectorUrl: http://connector_card.url/
 publicAuthUrl: http://publicauth.url/v1/auth
 ledgerUrl: http://ledger.url/
 
-graphiteHost: ${METRICS_HOST:-localhost}
-graphitePort: ${METRICS_PORT:-8092}
-
 jerseyClientConfig:
   disabledSecureConnection: "true"
 

--- a/src/test/resources/config/empty-low-traffic-accounts-test-config.yaml
+++ b/src/test/resources/config/empty-low-traffic-accounts-test-config.yaml
@@ -20,9 +20,6 @@ connectorUrl: http://connector_card.url/
 publicAuthUrl: http://publicauth.url/v1/auth
 ledgerUrl: http://ledger.url/
 
-graphiteHost: ${METRICS_HOST:-localhost}
-graphitePort: ${METRICS_PORT:-8092}
-
 jerseyClientConfig:
   disabledSecureConnection: "true"
 

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -22,9 +22,6 @@ connectorUrl: http://connector_card.url/
 publicAuthUrl: http://publicauth.url/v1/auth
 ledgerUrl: http://ledger.url/
 
-graphiteHost: ${METRICS_HOST:-localhost}
-graphitePort: ${METRICS_PORT:-8092}
-
 jerseyClientConfig:
   disabledSecureConnection: "true"
 


### PR DESCRIPTION
## WHAT YOU DID
Remove graphite metrics configuration and sending.
Also fixed the description of DISABLE_INTERNAL_HTTPS env var in the README

## How to test

Check build passes ok 🥳 and explicitly wait for the e2e tests to pass

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [x] Updated README.md for any of the following ?

* ~Introduced any new environment variables /~ removed existing environment variable
* ~Added new API / updated existing API definition~