### PR TITLE
PP-11407: Update docker image JRE to 11.0.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-alpine@sha256:6a7bdc6f82c73a2fa1c95c5fe7465f8dab63a8973d9eb2c9ad6157db75b9c309
+FROM eclipse-temurin:11-jre-alpine@sha256:77f7c2509dba2f346bf042e424d395b16b0c432ee1eabf0cbcc17922dc900c73
 
 RUN ["apk", "--no-cache", "upgrade"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-alpine@sha256:aea6ff5a31148a9dc80c65fad592d5681c61f73dab8ad2f5b8fb08de256899dc
+FROM eclipse-temurin:11-jre-alpine@sha256:6a7bdc6f82c73a2fa1c95c5fe7465f8dab63a8973d9eb2c9ad6157db75b9c309
 
 RUN ["apk", "--no-cache", "upgrade"]
 

--- a/m1/arm64.Dockerfile
+++ b/m1/arm64.Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre@sha256:3efc210202a0aa206aa353f7d31b36d24aa239251d6a30bdc3c25016f280c1bd
+FROM eclipse-temurin:11-jre@sha256:e12585f95f18fba9841aa3c12e6e4261f74b608cbc27b0fab61ac267b57de8f6
 
 RUN ["apt-get", "update"]
 


### PR DESCRIPTION
## WHAT YOU DID
Upgraded the pay-publicapi Java 11 Docker images from Java 11.0.19 to Java 11.0.20

## How to test

How should it be reviewed?
Will be reviewed by a colleague from the dev team

What feedback do you need?
All relevant build and pipeline stages are successful

### Documentation
As defined in:

https://payments-platform.atlassian.net/browse/PP-11407