### PR TITLE
ZD-5631868 Add payment_id to refund OpenAPI spec

### DIFF
--- a/openapi/publicapi_spec.json
+++ b/openapi/publicapi_spec.json
@@ -2500,6 +2500,12 @@
             "example" : "2017-01-10T16:52:07.855Z",
             "readOnly" : true
           },
+          "payment_id" : {
+            "type" : "string",
+            "description" : "The unique ID GOV.UK Pay automatically associated with this payment when you created it.",
+            "example" : "hu20sqlact5260q2nanm0q8u93",
+            "readOnly" : true
+          },
           "refund_id" : {
             "type" : "string",
             "description" : "The unique ID GOV.UK Pay automatically associated with this refund when you created it.",
@@ -2536,6 +2542,12 @@
             "type" : "string",
             "description" : "The date and time you created this refund. This value uses Coordinated Universal Time (UTC) and ISO 8601 format - `YYYY-MM-DDThh:mm:ss.SSSZ`.",
             "example" : "2017-01-10T16:52:07.855Z",
+            "readOnly" : true
+          },
+          "payment_id" : {
+            "type" : "string",
+            "description" : "The unique ID GOV.UK Pay automatically associated with this payment when you created it.",
+            "example" : "hu20sqlact5260q2nanm0q8u93",
             "readOnly" : true
           },
           "refund_id" : {

--- a/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/RefundForSearchRefundsResult.java
@@ -73,7 +73,9 @@ public class RefundForSearchRefundsResult {
     }
 
     @JsonProperty("payment_id")
-    @Schema(hidden = true)
+    @Schema(example = "hu20sqlact5260q2nanm0q8u93",
+            description = "The unique ID GOV.UK Pay automatically associated " +
+                    "with this payment when you created it.", accessMode = READ_ONLY)
     public String getChargeId() {
         return chargeId;
     }


### PR DESCRIPTION
The `payment_id` field is included in the refund object and documented at https://docs.payments.service.gov.uk/api_reference/search_refunds_reference/#attributes-you-ll-get-in-a-search-refunds-response but it is not included in our OpenAPI spec.

Since it’s already there and documented, people will be relying on it so the only sensible thing to do is to include it in the OpenAPI spec.

Description nabbed from the documentation and is identical to that used elsewhere in the OpenAPI spec.