### PR TITLE
BAU — Upgrade from Dropwizard 3.0.6 to 3.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>
-                <version>3.0.6</version>
+                <version>3.0.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -242,7 +242,7 @@
         <dependency>
             <groupId>io.dropwizard.modules</groupId>
             <artifactId>dropwizard-testing-junit4</artifactId>
-            <version>3.0.6</version>
+            <version>3.0.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Dependabot has not opened a PR to do this for some reason.