### PR TITLE
bau: Make publicauth endpoint clear

### DIFF
--- a/src/test/java/uk/gov/pay/api/auth/AccountAuthenticatorTest.java
+++ b/src/test/java/uk/gov/pay/api/auth/AccountAuthenticatorTest.java
@@ -79,9 +79,9 @@ public class AccountAuthenticatorTest {
         logger.setLevel(Level.INFO);
         logger.addAppender(mockAppender);
         
-        when(mockConfiguration.getPublicAuthUrl()).thenReturn("");
+        when(mockConfiguration.getPublicAuthUrl()).thenReturn("/v1/api/auth");
         accountAuthenticator = new AccountAuthenticator(publicAuthMock, mockConfiguration);
-        when(publicAuthMock.target("")).thenReturn(mockTarget);
+        when(publicAuthMock.target("/v1/api/auth")).thenReturn(mockTarget);
         when(mockTarget.request()).thenReturn(mockRequest);
         when(mockRequest.header(AUTHORIZATION, "Bearer " + bearerToken)).thenReturn(mockRequest);
         when(mockRequest.accept(MediaType.APPLICATION_JSON)).thenReturn(mockRequest);

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -19,7 +19,7 @@ logging:
 
 baseUrl: http://publicapi.url/
 connectorUrl: http://connector_card.url/
-publicAuthUrl: http://publicauth.url/v1/auth
+publicAuthUrl: http://publicauth.url/v1/api/auth
 ledgerUrl: http://ledger.url/
 
 jerseyClientConfig:


### PR DESCRIPTION
This will save some effort looking into terraform to see what the value for the PUBLIC_AUTH_URL env var is.