### PR TITLE
PP-12557: Upgrade integration test redis version

### DIFF
--- a/src/test/java/uk/gov/pay/api/it/rule/RedisContainer.java
+++ b/src/test/java/uk/gov/pay/api/it/rule/RedisContainer.java
@@ -16,7 +16,7 @@ public class RedisContainer {
     
     static GenericContainer<?> getOrCreateRedisContainer() {
         if (REDIS_CONTAINER == null) {
-            REDIS_CONTAINER = new GenericContainer<>("redis:5.0.6") // elasticache engine version
+            REDIS_CONTAINER = new GenericContainer<>("redis:7") // elasticache engine version
                     .withExposedPorts(PORT)
                     .waitingFor(Wait.forLogMessage(".*Ready to accept connections.*", 1));
 


### PR DESCRIPTION
## WHAT YOU DID
Upgrade redis in the integration tests to 7. We have auto-minor version turned on in AWS so it makes sense to only pin to 7, not a specific minor and/or patch version

## How to test

- See the PR tests pass

