### PR TITLE
PP-12517 Update logging for rate limiter exceptions

### DIFF
--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
@@ -11,6 +11,8 @@ import uk.gov.pay.api.filter.RateLimiterKey;
 import uk.gov.pay.api.managed.RedisClientManager;
 
 import javax.inject.Singleton;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoField;
 import java.util.concurrent.Callable;
@@ -18,6 +20,8 @@ import java.util.concurrent.Callable;
 @Singleton
 public class RedisRateLimiter {
     private static final Logger LOGGER = LoggerFactory.getLogger(RedisRateLimiter.class);
+    private static final StringWriter stringWriter = new StringWriter();
+    private static final PrintWriter printWriter = new PrintWriter(stringWriter);
     private final MetricRegistry metricsRegistry;
 
     private RateLimitManager rateLimitManager;
@@ -43,6 +47,10 @@ public class RedisRateLimiter {
             count = updateAllowance(key.getKey(), rateLimitInterval);
         } catch (Exception e) {
             LOGGER.info(String.format("Failed to update allowance. Cause of error: %s", e));
+            e.printStackTrace(printWriter);
+            LOGGER.info(stringWriter.toString());
+            stringWriter.flush();
+            
             // Exception possible if redis is unavailable or perMillis is too high        
             throw new RedisException();
         }

--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
@@ -42,7 +42,7 @@ public class RedisRateLimiter {
             int rateLimitInterval = rateLimitManager.getRateLimitInterval(accountId);
             count = updateAllowance(key.getKey(), rateLimitInterval);
         } catch (Exception e) {
-            LOGGER.info("Failed to update allowance. Cause of error: " + e.getMessage());
+            LOGGER.info(String.format("Failed to update allowance. Cause of error: %s", e));
             // Exception possible if redis is unavailable or perMillis is too high        
             throw new RedisException();
         }


### PR DESCRIPTION
## WHAT YOU DID
 - Update logging for exceptions caught on rate limiter allowance update
   - This is to help diagnose the cause of timeout errors being caught here, and may be removed once resolved
