### PR TITLE
PP-12517 Update logging for rate limiter exceptions

### DIFF
--- a/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
+++ b/src/main/java/uk/gov/pay/api/filter/ratelimit/RedisRateLimiter.java
@@ -42,7 +42,7 @@ public class RedisRateLimiter {
             int rateLimitInterval = rateLimitManager.getRateLimitInterval(accountId);
             count = updateAllowance(key.getKey(), rateLimitInterval);
         } catch (Exception e) {
-            LOGGER.info("Failed to update allowance. Cause of error: " + e.getMessage());
+            LOGGER.info(String.format("Failed to update allowance. Cause of error: %s", e));
             // Exception possible if redis is unavailable or perMillis is too high        
             throw new RedisException();
         }


### PR DESCRIPTION
## WHAT YOU DID
 - Update logging for exceptions caught on rate limiter allowance update
   - Adds logging of exception classname
   - This is to help diagnose the cause of timeout errors being caught here, and may be removed once resolved