### PR TITLE
PP-12517: Set DEBUG level for the logger io.lettuce.core.protocol

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -16,6 +16,8 @@ server:
 
 logging:
   level: INFO
+  loggers:
+    "io.lettuce.core.protocol": DEBUG
   appenders:
     - type: logstash-console
       threshold: ALL


### PR DESCRIPTION
https://github.com/redis/lettuce/wiki/Frequently-Asked-Questions#im-seeing-rediscommandtimeoutexception recommends setting DEBUG level for the logger io.lettuce.core.protocol to help diagnose RedisCommandTimeoutExceptions. We've
[agreed](https://gds.slack.com/archives/C03B49R80NA/p1718201774505239?thread_ts=1718195250.871609&cid=C03B49R80NA) that we can turn DEBUG logging temporarily.