### PR TITLE
PP-12767 Remove unnecessary logging

### DIFF
--- a/src/main/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategy.java
+++ b/src/main/java/uk/gov/pay/api/resources/GetPaymentRefundsStrategy.java
@@ -1,10 +1,14 @@
 package uk.gov.pay.api.resources;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.RefundsResponse;
 import uk.gov.pay.api.service.GetPaymentRefundsService;
 
 public class GetPaymentRefundsStrategy extends LedgerOrConnectorStrategyTemplate<RefundsResponse> {
+
+    private static final Logger logger = LoggerFactory.getLogger(GetPaymentRefundsStrategy.class);
 
     private final Account account;
     private final String paymentId;
@@ -20,6 +24,7 @@ public class GetPaymentRefundsStrategy extends LedgerOrConnectorStrategyTemplate
 
     @Override
     protected RefundsResponse executeLedgerOnlyStrategy() {
+        logger.info("Executing ledger-only strategy to get refunds");
         return getPaymentRefundsService.getLedgerTransactionTransactions(account, paymentId);
     }
 
@@ -30,6 +35,7 @@ public class GetPaymentRefundsStrategy extends LedgerOrConnectorStrategyTemplate
 
     @Override
     protected RefundsResponse executeConnectorOnlyStrategy() {
+        logger.info("Executing connector-only strategy to get refunds");
         return getPaymentRefundsService.getConnectorPaymentRefunds(account, paymentId);
     }
 }

--- a/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentRefundsResource.java
@@ -89,12 +89,9 @@ public class PaymentRefundsResource {
                                       @PathParam("paymentId") @Parameter(name = "paymentId", 
                                               description = "The unique `payment_id` of the payment you want a list of refunds for.") String paymentId,
                                       @Parameter(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
-
-        logger.info("Get refunds for payment request - paymentId={} using strategy={}", paymentId, strategyName);
-
+        
         GetPaymentRefundsStrategy strategy = new GetPaymentRefundsStrategy(strategyName, account, paymentId, getPaymentRefundsService);
         RefundsResponse refundsResponse = strategy.validateAndExecute();
-
         logger.debug("refund returned - [ {} ]", refundsResponse);
         return refundsResponse;
     }
@@ -129,13 +126,9 @@ public class PaymentRefundsResource {
                                                         "If one payment has multiple refunds, each refund has a different `refund_id`.") String refundId,
                                         @Parameter(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
 
-        logger.info("Payment refund request - paymentId={}, refundId={}", paymentId, refundId);
-
         var strategy = new GetPaymentRefundStrategy(strategyName, account, paymentId, refundId, getPaymentRefundService);
         RefundResponse refundResponse = strategy.validateAndExecute();
-
         logger.info("refund returned - [ {} ]", refundResponse);
-
         return refundResponse;
     }
 
@@ -167,8 +160,7 @@ public class PaymentRefundsResource {
                                          description = "The unique `payment_id` of the payment you want to refund.") String paymentId,
                                  @Parameter(required = true, description = "requestPayload")
                                  CreatePaymentRefundRequest requestPayload) {
-
-        logger.info("Create a refund for payment request - paymentId={}", paymentId);
+        
         RefundResponse refundResponse = createRefundService.createRefund(account, paymentId, requestPayload);
         return Response.accepted(refundResponse).build();
     }

--- a/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/PaymentsResource.java
@@ -121,11 +121,9 @@ public class PaymentsResource {
                                String paymentId,
                                @Parameter(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
 
-        logger.info("Payment request - paymentId={}", paymentId);
-
         var strategy = new GetOnePaymentStrategy(strategyName, account, paymentId, getPaymentService);
         PaymentWithAllLinks payment = strategy.validateAndExecute();
-
+        
         logger.info("Payment returned - [ {} ]", payment);
         return Response.ok(payment)
                 .header(PRAGMA, "no-cache")
@@ -162,13 +160,10 @@ public class PaymentsResource {
                                                   String paymentId,
                                                   @Parameter(hidden = true) @HeaderParam("X-Ledger") String strategyName) {
 
-        logger.info("Payment events request - payment_id={}", paymentId);
-
         var strategy = new GetPaymentEventsStrategy(strategyName, account, paymentId, getPaymentEventsService);
         PaymentEventsResponse paymentEventsResponse = strategy.validateAndExecute();
-
+        
         logger.info("Payment events returned - [ {} ]", paymentEventsResponse);
-
         return paymentEventsResponse;
     }
 
@@ -351,8 +346,6 @@ public class PaymentsResource {
                                   @Parameter(name = "paymentId", description = "The `payment_id` of the payment you’re cancelling.", example = "hu20sqlact5260q2nanm0q8u93")
                                   String paymentId) {
 
-        logger.info("Payment cancel request - payment_id=[{}]", paymentId);
-
         return cancelPaymentService.cancel(account, paymentId);
     }
 
@@ -385,15 +378,12 @@ public class PaymentsResource {
                                    @PathParam("paymentId")
                                    @Parameter(name = "paymentId", description = "The `payment_id` of the payment you’re capturing.", example = "hu20sqlact5260q2nanm0q8u93")
                                    String paymentId) {
-        logger.info("Payment capture request - payment_id=[{}]", paymentId);
-
         Response connectorResponse = capturePaymentService.capture(account, paymentId);
 
         if (connectorResponse.getStatus() == HttpStatus.SC_NO_CONTENT) {
             connectorResponse.close();
             return Response.noContent().build();
         }
-
         throw new CaptureChargeException(connectorResponse);
     }
 }

--- a/src/main/java/uk/gov/pay/api/resources/SearchDisputesResource.java
+++ b/src/main/java/uk/gov/pay/api/resources/SearchDisputesResource.java
@@ -91,11 +91,7 @@ public class SearchDisputesResource {
                                                 @QueryParam("page") String pageNumber,
                                                 @Parameter(description = "The number of disputes returned per results page. Defaults to `500`. Maximum value is `500`.")
                                                 @QueryParam("display_size") String displaySize) {
-        logger.info("Disputes search request - [ {} ]",
-                format("from_date: %s, to_date: %s, from_settled_date: %s, to_settled_date: %s, " +
-                                "status: s, page: %s, display_size: %s",
-                        fromDate, toDate, fromSettledDate, toSettledDate, status, pageNumber, displaySize));
-
+        
         DisputesSearchParams params = new DisputesSearchParams.Builder()
                 .withFromDate(fromDate)
                 .withToDate(toDate)
@@ -108,6 +104,11 @@ public class SearchDisputesResource {
 
         validateDisputeParameters(params);
 
+        logger.info("Disputes search request - [ {} ]",
+                format("from_date: %s, to_date: %s, from_settled_date: %s, to_settled_date: %s, " +
+                                "status: s, page: %s, display_size: %s",
+                        fromDate, toDate, fromSettledDate, toSettledDate, status, pageNumber, displaySize));
+        
         return searchDisputesService.searchDisputes(account, params);
     }
 }


### PR DESCRIPTION
The latest IT Healthcheck identified a number of logging statements which could potentially result in unsanitised PII being logged. In several of these cases, these logging statements were found to be unnecessary as the relevant information is already logged in the API call, so they are being removed rather than spending time investigating the risk around logging PII.

- remove unnecessary logging statements
- log the executed GetPaymentRefundsStrategy rather than logging the value of the supplied strategy parameter which could theoretically contain PII
- move logging of disputes search params to after validation to avoid risk of PII