### PR TITLE
PP-12517: Set DEBUG level for the logger io.lettuce.core.protocol again

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -16,6 +16,8 @@ server:
 
 logging:
   level: INFO
+  loggers:
+    "io.lettuce.core.protocol": DEBUG
   appenders:
     - type: logstash-console
       threshold: ALL


### PR DESCRIPTION
Same as https://github.com/alphagov/pay-publicapi/pull/2012. Setting DEBUG level again as the RedisCommandTimeoutExceptions are still occurring, albeit at a much reduced frequency (reason as yet unknown).
