### PR TITLE
 PP-12789 upgrade to pay-java-commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hamcrest.version>2.2</hamcrest.version>
-        <pay-java-commons.version>1.0.20240603094506</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20240711152628</pay-java-commons.version>
         <prometheus.version>0.16.0</prometheus.version>
         <swagger.lib.version>2.2.22</swagger.lib.version>
         <pact.version>4.6.11</pact.version>

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceCancelPactConsumerIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceCancelPactConsumerIT.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.it;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.apache.http.HttpStatus;
@@ -11,8 +11,8 @@ import uk.gov.pay.api.app.PublicApi;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.utils.ApiKeyGenerator;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
@@ -33,7 +33,7 @@ public class PaymentsResourceCancelPactConsumerIT {
     public WireMockRule publicAuth = new WireMockRule(publicAuthPort);
 
     @Rule
-    public PactProviderRule connector = new PactProviderRule("connector", this);
+    public PayPactProviderRule connector = new PayPactProviderRule("connector", this);
 
     @Rule
     public DropwizardAppRule<PublicApiConfig> app = new DropwizardAppRule<>(

--- a/src/test/java/uk/gov/pay/api/it/telephone/pact/CreateTelephonePaymentServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/it/telephone/pact/CreateTelephonePaymentServiceTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.it.telephone.pact;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
 import org.junit.Rule;
@@ -19,8 +19,8 @@ import uk.gov.pay.api.model.telephone.Supplemental;
 import uk.gov.pay.api.model.telephone.TelephonePaymentResponse;
 import uk.gov.pay.api.service.ConnectorUriGenerator;
 import uk.gov.pay.api.service.telephone.CreateTelephonePaymentService;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 import java.util.Optional;
@@ -36,7 +36,7 @@ public class CreateTelephonePaymentServiceTest {
     private static CreateTelephonePaymentRequest.Builder builder = new CreateTelephonePaymentRequest.Builder();
 
     @Rule
-    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+    public PayPactProviderRule connectorRule = new PayPactProviderRule("connector", this);
 
     @Mock
     private PublicApiConfig configuration;

--- a/src/test/java/uk/gov/pay/api/ledger/service/TransactionSearchServiceTest.java
+++ b/src/test/java/uk/gov/pay/api/ledger/service/TransactionSearchServiceTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.ledger.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,8 +20,8 @@ import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.search.card.PaymentForSearchResult;
 import uk.gov.pay.api.service.PaymentUriGenerator;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 import java.util.Map;
@@ -46,7 +46,7 @@ public class TransactionSearchServiceTest {
     private static final String CHARGE_ID = "charge97837509646393e3C";
 
     @Rule
-    public PactProviderRule ledgerRule = new PactProviderRule("ledger", this);
+    public PayPactProviderRule ledgerRule = new PayPactProviderRule("ledger", this);
 
     @Before
     public void setup() {

--- a/src/test/java/uk/gov/pay/api/service/AuthorisationServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/AuthorisationServicePactTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
@@ -14,8 +14,8 @@ import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.exception.AuthorisationRequestException;
 import uk.gov.pay.api.exception.mapper.AuthorisationRequestExceptionMapper;
 import uk.gov.pay.api.model.AuthorisationRequest;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
@@ -33,7 +33,7 @@ public class AuthorisationServicePactTest {
     private AuthorisationRequestExceptionMapper mapper;
 
     @Rule
-    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+    public PayPactProviderRule connectorRule = new PayPactProviderRule("connector", this);
 
     @Mock
     private PublicApiConfig mockConfiguration;

--- a/src/test/java/uk/gov/pay/api/service/CancelAgreementConnectorServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CancelAgreementConnectorServicePactTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
@@ -15,8 +15,8 @@ import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CancelAgreementException;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 
@@ -32,7 +32,7 @@ public class CancelAgreementConnectorServicePactTest {
     private final Account ACCOUNT = new Account("123456", TokenPaymentType.CARD, "a-token-link");
     
     @Rule
-    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+    public PayPactProviderRule connectorRule = new PayPactProviderRule("connector", this);
 
     private ConnectorService connectorService;
     @Mock

--- a/src/test/java/uk/gov/pay/api/service/CancelPaymentServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CancelPaymentServicePactTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,8 +12,8 @@ import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
@@ -30,7 +30,7 @@ public class CancelPaymentServicePactTest {
     private CancelPaymentService cancelPaymentService;
     
     @Rule
-    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+    public PayPactProviderRule connectorRule = new PayPactProviderRule("connector", this);
 
     @Mock
     private PublicApiConfig mockConfiguration;

--- a/src/test/java/uk/gov/pay/api/service/CapturePaymentServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CapturePaymentServicePactTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,8 +12,8 @@ import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.model.TokenPaymentType;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
@@ -31,7 +31,7 @@ public class CapturePaymentServicePactTest {
     private CapturePaymentService capturePaymentService;
 
     @Rule
-    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+    public PayPactProviderRule connectorRule = new PayPactProviderRule("connector", this);
 
     @Mock
     private PublicApiConfig mockConfiguration;

--- a/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServicePactTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import com.jayway.jsonassert.JsonAssert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -17,8 +17,8 @@ import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.search.PaginationDecorator;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.when;
 public class CardPaymentSearchServicePactTest {
 
     @Rule
-    public PactProviderRule ledgerRule = new PactProviderRule("ledger", this);
+    public PayPactProviderRule ledgerRule = new PayPactProviderRule("ledger", this);
 
     @Mock
     private PublicApiConfig configuration;

--- a/src/test/java/uk/gov/pay/api/service/CreateAgreementLedgerServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreateAgreementLedgerServicePactTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -16,8 +16,8 @@ import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.CreateAgreementException;
 import uk.gov.pay.api.model.CreateAgreementRequestBuilder;
 import uk.gov.pay.api.model.TokenPaymentType;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 
@@ -31,7 +31,7 @@ import static uk.gov.service.payments.commons.model.ErrorIdentifier.RECURRING_CA
 public class CreateAgreementLedgerServicePactTest {
 
     @Rule
-    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+    public PayPactProviderRule connectorRule = new PayPactProviderRule("connector", this);
 
     @Mock
     private PublicApiConfig configuration;

--- a/src/test/java/uk/gov/pay/api/service/CreatePaymentServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreatePaymentServicePactTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,8 +24,8 @@ import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 import java.util.Collections;
@@ -48,7 +48,7 @@ public class CreatePaymentServicePactTest {
     private CreatePaymentService createPaymentService;
 
     @Rule
-    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+    public PayPactProviderRule connectorRule = new PayPactProviderRule("connector", this);
 
     @Mock
     private PublicApiConfig configuration;

--- a/src/test/java/uk/gov/pay/api/service/CreateRefundServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CreateRefundServicePactTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,7 +15,7 @@ import uk.gov.pay.api.exception.CreateRefundException;
 import uk.gov.pay.api.model.CreatePaymentRefundRequest;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
 
 import javax.ws.rs.client.Client;
@@ -31,7 +31,7 @@ public class CreateRefundServicePactTest {
     private CreateRefundService createRefundService;
 
     @Rule
-    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+    public PayPactProviderRule connectorRule = new PayPactProviderRule("connector", this);
 
     @Mock
     private PublicApiConfig configuration;

--- a/src/test/java/uk/gov/pay/api/service/GetOneAgreementLedgerServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetOneAgreementLedgerServicePactTest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
-import org.hamcrest.Matchers;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -16,8 +15,8 @@ import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.exception.GetAgreementException;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.TokenPaymentType;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 
@@ -33,7 +32,7 @@ public class GetOneAgreementLedgerServicePactTest {
     private final Account ACCOUNT = new Account("3456", TokenPaymentType.CARD, "a-token-link");
 
     @Rule
-    public PactProviderRule ledgerRule = new PactProviderRule("ledger", this);
+    public PayPactProviderRule ledgerRule = new PayPactProviderRule("ledger", this);
 
     private LedgerService ledgerService;
     @Mock

--- a/src/test/java/uk/gov/pay/api/service/GetPaymentEventsServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentEventsServicePactTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -14,8 +14,8 @@ import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.PaymentEventsResponse;
 import uk.gov.pay.api.model.TokenPaymentType;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 
@@ -27,10 +27,10 @@ import static org.mockito.Mockito.when;
 public class GetPaymentEventsServicePactTest {
 
     @Rule
-    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+    public PayPactProviderRule connectorRule = new PayPactProviderRule("connector", this);
 
     @Rule
-    public PactProviderRule ledgerRule = new PactProviderRule("ledger", this);
+    public PayPactProviderRule ledgerRule = new PayPactProviderRule("ledger", this);
 
     @Mock
     private PublicApiConfig mockConfiguration;

--- a/src/test/java/uk/gov/pay/api/service/GetPaymentRefundServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentRefundServicePactTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -14,8 +14,8 @@ import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.RefundResponse;
 import uk.gov.pay.api.model.TokenPaymentType;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 
@@ -33,10 +33,10 @@ public class GetPaymentRefundServicePactTest {
     private GetPaymentRefundService getPaymentService;
 
     @Rule
-    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+    public PayPactProviderRule connectorRule = new PayPactProviderRule("connector", this);
     
     @Rule
-    public PactProviderRule ledgerRule = new PactProviderRule("ledger", this);
+    public PayPactProviderRule ledgerRule = new PayPactProviderRule("ledger", this);
 
     @Mock
     private PublicApiConfig mockConfiguration;

--- a/src/test/java/uk/gov/pay/api/service/GetPaymentRefundsServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentRefundsServicePactTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,8 +15,8 @@ import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.RefundResponse;
 import uk.gov.pay.api.model.RefundsResponse;
 import uk.gov.pay.api.model.TokenPaymentType;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 import java.util.List;
@@ -30,9 +30,9 @@ public class GetPaymentRefundsServicePactTest {
 
     private static final String ACCOUNT_ID = "123456";
     @Rule
-    public PactProviderRule ledgerRule = new PactProviderRule("ledger", this);
+    public PayPactProviderRule ledgerRule = new PayPactProviderRule("ledger", this);
     @Rule
-    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+    public PayPactProviderRule connectorRule = new PayPactProviderRule("connector", this);
     @Mock
     private PublicApiConfig mockConfiguration;
     private GetPaymentRefundsService getPaymentRefundsService;

--- a/src/test/java/uk/gov/pay/api/service/GetPaymentServiceLedgerPactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentServiceLedgerPactTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -14,7 +14,6 @@ import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
-import uk.gov.pay.api.model.CardPayment;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.Wallet;
@@ -22,8 +21,8 @@ import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 import uk.gov.pay.api.utils.mocks.ConnectorMockClient;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 import java.util.Optional;
@@ -50,7 +49,7 @@ public class GetPaymentServiceLedgerPactTest {
     public static WireMockClassRule connectorRule = new WireMockClassRule(CONNECTOR_PORT);
 
     @Rule
-    public PactProviderRule ledgerRule = new PactProviderRule("ledger", this);
+    public PayPactProviderRule ledgerRule = new PayPactProviderRule("ledger", this);
 
     @Mock
     private PublicApiConfig mockConfiguration;

--- a/src/test/java/uk/gov/pay/api/service/GetPaymentServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/GetPaymentServicePactTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,7 +12,6 @@ import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
-import uk.gov.pay.api.model.CardPayment;
 import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.Wallet;
@@ -20,8 +19,8 @@ import uk.gov.pay.api.model.links.PaymentWithAllLinks;
 import uk.gov.pay.api.model.links.PostLink;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 import java.util.Collections;
@@ -43,7 +42,7 @@ public class GetPaymentServicePactTest {
     private GetPaymentService getPaymentService;
 
     @Rule
-    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+    public PayPactProviderRule connectorRule = new PayPactProviderRule("connector", this);
 
     @Mock
     private PublicApiConfig mockConfiguration;

--- a/src/test/java/uk/gov/pay/api/service/SearchAgreementsLedgerServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/SearchAgreementsLedgerServicePactTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -16,8 +16,8 @@ import uk.gov.pay.api.ledger.model.AgreementSearchParams;
 import uk.gov.pay.api.ledger.model.SearchResults;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.TokenPaymentType;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class SearchAgreementsLedgerServicePactTest {
     @Rule
-    public PactProviderRule ledgerRule = new PactProviderRule("ledger", this);
+    public PayPactProviderRule ledgerRule = new PayPactProviderRule("ledger", this);
     @Mock
     private PublicApiConfig mockConfiguration;
 

--- a/src/test/java/uk/gov/pay/api/service/SearchDisputesServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/SearchDisputesServicePactTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
@@ -18,8 +18,8 @@ import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.search.PaginationDecorator;
 import uk.gov.pay.api.model.search.dispute.DisputeForSearchResult;
 import uk.gov.pay.api.model.search.dispute.DisputesSearchResults;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class SearchDisputesServicePactTest {
     @Rule
-    public PactProviderRule ledgerRule = new PactProviderRule("ledger", this);
+    public PayPactProviderRule ledgerRule = new PayPactProviderRule("ledger", this);
 
     @Mock
     private PublicApiConfig mockConfiguration;

--- a/src/test/java/uk/gov/pay/api/service/SearchRefundsServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/SearchRefundsServicePactTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -16,8 +16,8 @@ import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.search.PaginationDecorator;
 import uk.gov.pay.api.model.search.card.SearchRefundsResults;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 
@@ -32,9 +32,9 @@ import static org.mockito.Mockito.when;
 public class SearchRefundsServicePactTest {
 
     @Rule
-    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+    public PayPactProviderRule connectorRule = new PayPactProviderRule("connector", this);
     @Rule
-    public PactProviderRule ledgerRule = new PactProviderRule("ledger", this);
+    public PayPactProviderRule ledgerRule = new PayPactProviderRule("ledger", this);
     @Mock
     private PublicApiConfig mockConfiguration;
 

--- a/src/test/java/uk/gov/pay/api/service/SetUpAgreementWithPaymentConnectorServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/SetUpAgreementWithPaymentConnectorServicePactTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.api.service;
 
-import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.junit.PactVerification;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -11,14 +11,13 @@ import uk.gov.pay.api.app.RestClientFactory;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.app.config.RestClientConfig;
 import uk.gov.pay.api.auth.Account;
-import uk.gov.pay.api.model.CardPayment;
 import uk.gov.pay.api.model.CreateCardPaymentRequestBuilder;
 import uk.gov.pay.api.model.CreatedPaymentWithAllLinks;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.links.Link;
 import uk.gov.pay.api.model.links.PaymentWithAllLinks;
-import uk.gov.service.payments.commons.testing.pact.consumers.PactProviderRule;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
+import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
 
 import javax.ws.rs.client.Client;
 
@@ -32,7 +31,7 @@ public class SetUpAgreementWithPaymentConnectorServicePactTest {
     private final Account ACCOUNT = new Account("123456", TokenPaymentType.CARD, "a-token-link");
     
     @Rule
-    public PactProviderRule connectorRule = new PactProviderRule("connector", this);
+    public PayPactProviderRule connectorRule = new PayPactProviderRule("connector", this);
 
     private ConnectorService connectorService;
 

--- a/src/test/resources/pacts/publicapi-connector-take-a-recurring-payment.json
+++ b/src/test/resources/pacts/publicapi-connector-take-a-recurring-payment.json
@@ -81,7 +81,6 @@
             "$.amount": {
               "matchers": [{"match": "type"}]
             },
-            ,
             "$.created_date": {
               "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
             },


### PR DESCRIPTION
## WHAT YOU DID

`pay-java-commons` was upgraded to Java 21. Some of the imports needed update as they are transative dependencies.

fix pact test (unnecessary , in json file)
