### PR TITLE
PP-12789 fix pact test

### DIFF
--- a/src/test/resources/pacts/publicapi-ledger-search-disputes-no-result.json
+++ b/src/test/resources/pacts/publicapi-ledger-search-disputes-no-result.json
@@ -7,7 +7,7 @@
   },
   "interactions": [
     {
-      "description": "search payments",
+      "description": "search disputed payments",
       "providerStates": [
         {
           "name": "a dispute lost transaction exists",
@@ -56,7 +56,28 @@
         },
         "matchingRules": {
           "body": {
-            "results": {
+            "$.total": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.count": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.page": {
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.results[*]": {
               "matchers": [
                 {
                   "match": "type"


### PR DESCRIPTION
## WHAT YOU DID

`publicapi-ledger-search-disputes-no-result` pact test fails provider verification on Ledger. It is due to the stricter rules introduced by pact v4 through pay-java-commons.

- fix pact descriptor file
