### PR TITLE
PP-13201 implement AuthorisationSummary.ThreeDSecure not required

### DIFF
--- a/src/main/java/uk/gov/pay/api/model/Charge.java
+++ b/src/main/java/uk/gov/pay/api/model/Charge.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.api.model;
 
+import uk.gov.pay.api.utils.AuthorisationSummaryHelper;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
@@ -119,7 +120,7 @@ public class Charge {
                 chargeFromResponse.getMetadata().orElse(null),
                 chargeFromResponse.getFee(),
                 chargeFromResponse.getNetAmount(),
-                chargeFromResponse.getAuthorisationSummary(),
+                AuthorisationSummaryHelper.includeAuthorisationSummaryWhen3dsRequired(chargeFromResponse.getAuthorisationSummary()),
                 chargeFromResponse.getAgreementId(),
                 chargeFromResponse.getAuthorisationMode()
         );
@@ -151,7 +152,7 @@ public class Charge {
                 transactionResponse.getMetadata().orElse(null),
                 transactionResponse.getFee(),
                 transactionResponse.getNetAmount(),
-                transactionResponse.getAuthorisationSummary(),
+                AuthorisationSummaryHelper.includeAuthorisationSummaryWhen3dsRequired(transactionResponse.getAuthorisationSummary()),
                 null,
                 transactionResponse.getAuthorisationMode());
     }

--- a/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
+++ b/src/main/java/uk/gov/pay/api/model/search/card/PaymentForSearchResult.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import uk.gov.pay.api.model.AuthorisationSummary;
 import uk.gov.pay.api.model.CardDetails;
-import uk.gov.pay.api.model.CardDetailsFromResponse;
 import uk.gov.pay.api.model.CardPayment;
 import uk.gov.pay.api.model.PaymentConnectorResponseLink;
 import uk.gov.pay.api.model.PaymentSettlementSummary;
@@ -12,6 +11,7 @@ import uk.gov.pay.api.model.PaymentState;
 import uk.gov.pay.api.model.RefundSummary;
 import uk.gov.pay.api.model.TransactionResponse;
 import uk.gov.pay.api.model.links.PaymentLinksForSearch;
+import uk.gov.pay.api.utils.AuthorisationSummaryHelper;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
@@ -85,7 +85,7 @@ public class PaymentForSearchResult extends CardPayment {
                 paymentResult.getMetadata().orElse(null),
                 paymentResult.getFee(),
                 paymentResult.getNetAmount(),
-                paymentResult.getAuthorisationSummary(),
+                AuthorisationSummaryHelper.includeAuthorisationSummaryWhen3dsRequired(paymentResult.getAuthorisationSummary()),
                 paymentResult.getAuthorisationMode());
     }
 

--- a/src/main/java/uk/gov/pay/api/utils/AuthorisationSummaryHelper.java
+++ b/src/main/java/uk/gov/pay/api/utils/AuthorisationSummaryHelper.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.api.utils;
+
+import uk.gov.pay.api.model.AuthorisationSummary;
+
+public class AuthorisationSummaryHelper {
+    public static AuthorisationSummary includeAuthorisationSummaryWhen3dsRequired(AuthorisationSummary authorisationSummary) {
+        if (authorisationSummary != null &&
+                authorisationSummary.getThreeDSecure() != null &&
+                authorisationSummary.getThreeDSecure().isRequired()) {
+            return authorisationSummary;
+        }
+        return null;
+    }
+}

--- a/src/test/java/uk/gov/pay/api/utils/AuthorisationSummaryHelperTest.java
+++ b/src/test/java/uk/gov/pay/api/utils/AuthorisationSummaryHelperTest.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.api.utils;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.api.model.AuthorisationSummary;
+import uk.gov.pay.api.model.ThreeDSecure;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static uk.gov.pay.api.utils.AuthorisationSummaryHelper.includeAuthorisationSummaryWhen3dsRequired;
+
+class AuthorisationSummaryHelperTest {
+    @Test
+    void shouldReturnNullWhenAuthorisationSummaryIsNull() {
+        assertThat(includeAuthorisationSummaryWhen3dsRequired(null), is(nullValue()));
+    }
+
+    @Test
+    void shouldReturnNullWhenThreeDSecureRequiredIsNull() {
+        AuthorisationSummary authorisationSummary = new AuthorisationSummary(null);
+        assertThat(includeAuthorisationSummaryWhen3dsRequired(authorisationSummary), is(nullValue()));
+    }
+
+    @Test
+    void shouldReturnNullWhenThreeDSecureRequiredIsFalse() {
+        AuthorisationSummary authorisationSummary = new AuthorisationSummary(new ThreeDSecure(false));
+        assertThat(includeAuthorisationSummaryWhen3dsRequired(authorisationSummary), is(nullValue()));
+    }
+
+    @Test
+    void shouldReturnAuthorisationSummaryWhenThreeDSecureRequiredIsTrue() {
+        AuthorisationSummary authorisationSummary = new AuthorisationSummary(new ThreeDSecure(true));
+        assertThat(includeAuthorisationSummaryWhen3dsRequired(authorisationSummary), is(authorisationSummary));
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID

Only include authorisation summary in public API responses if 3D Secure was required.

- add a helper class that determines whether we need to include AuthorisationSummary to the return API call objects
