### PR TITLE
PP-13315: Deal with NON_HTTPS_RETURN_URL_NOT_ALLOWED_FOR_A_LIVE_ACCOUNT

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -22,6 +22,7 @@ import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_CARD_NUMBER_
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_CONNECTOR_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_IDEMPOTENCY_KEY_ALREADY_USED;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_MOTO_NOT_ENABLED;
+import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_NON_HTTPS_RETURN_URL_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_UNEXPECTED_FIELD_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.CREATE_PAYMENT_VALIDATION_ERROR;
 import static uk.gov.pay.api.model.RequestError.Code.GENERIC_MISSING_FIELD_ERROR_MESSAGE_FROM_CONNECTOR;
@@ -51,6 +52,11 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
         } else {
             ErrorIdentifier errorIdentifier = exception.getErrorIdentifier();
             switch (errorIdentifier) {
+                case NON_HTTPS_RETURN_URL_NOT_ALLOWED_FOR_A_LIVE_ACCOUNT:
+                    statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
+                    requestError = aRequestError("return_url", CREATE_PAYMENT_NON_HTTPS_RETURN_URL_ERROR,
+                            "Must begin with https:// for a live gateway account");
+                    break;
                 case ZERO_AMOUNT_NOT_ALLOWED:
                     statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
                     requestError = aRequestError("amount", CREATE_PAYMENT_VALIDATION_ERROR,

--- a/src/main/java/uk/gov/pay/api/model/RequestError.java
+++ b/src/main/java/uk/gov/pay/api/model/RequestError.java
@@ -28,6 +28,7 @@ public class RequestError {
         CREATE_PAYMENT_MISSING_FIELD_ERROR("P0101", "Missing mandatory attribute: %s"),
         CREATE_PAYMENT_UNEXPECTED_FIELD_ERROR("P0104", "Unexpected attribute: %s"),
         CREATE_PAYMENT_VALIDATION_ERROR("P0102", "Invalid attribute value: %s. %s"),
+        CREATE_PAYMENT_NON_HTTPS_RETURN_URL_ERROR("P0920", "Invalid attribute value: %s. %s"),
         CREATE_PAYMENT_HEADER_VALIDATION_ERROR("P0102", "%s"),
         CREATE_PAYMENT_IDEMPOTENCY_KEY_ALREADY_USED("P0191", "The `Idempotency-Key` you sent in the request header has already been used to create a payment."),
 

--- a/src/test/java/uk/gov/pay/api/it/rule/RedisDockerRule.java
+++ b/src/test/java/uk/gov/pay/api/it/rule/RedisDockerRule.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.api.it.rule;
 
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -8,7 +10,7 @@ import static uk.gov.pay.api.it.rule.RedisContainer.getConnectionUrl;
 import static uk.gov.pay.api.it.rule.RedisContainer.getOrCreateRedisContainer;
 import static uk.gov.pay.api.it.rule.RedisContainer.clearRedisCache;
 
-public class RedisDockerRule implements TestRule {
+public class RedisDockerRule implements TestRule, BeforeAllCallback {
 
     public RedisDockerRule() {
         getOrCreateRedisContainer();
@@ -24,6 +26,12 @@ public class RedisDockerRule implements TestRule {
     }
 
     public void clearCache() {
+        clearRedisCache();
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        getOrCreateRedisContainer();
         clearRedisCache();
     }
 }

--- a/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentWithHttpReturnUrlIT.java
+++ b/src/test/java/uk/gov/pay/api/it/validation/CreatePaymentWithHttpReturnUrlIT.java
@@ -1,107 +1,124 @@
 package uk.gov.pay.api.it.validation;
 
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
-import io.dropwizard.testing.junit.DropwizardAppRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.restassured.response.ValidatableResponse;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.pay.api.app.PublicApi;
 import uk.gov.pay.api.app.config.PublicApiConfig;
 import uk.gov.pay.api.it.rule.RedisDockerRule;
 import uk.gov.pay.api.utils.ApiKeyGenerator;
-import uk.gov.pay.api.utils.JsonStringBuilder;
-import uk.gov.pay.api.utils.PublicAuthMockClient;
-import uk.gov.pay.api.utils.mocks.ConnectorMockClient;
+import uk.gov.pay.api.utils.mocks.Junit5ConnectorMockClient;
 
 import java.util.Map;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static javax.ws.rs.core.HttpHeaders.ACCEPT;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
+import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.api.model.TokenPaymentType.CARD;
 import static uk.gov.pay.api.utils.mocks.CreateChargeRequestParams.CreateChargeRequestParamsBuilder.aCreateChargeRequestParams;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.NON_HTTPS_RETURN_URL_NOT_ALLOWED_FOR_A_LIVE_ACCOUNT;
 import static uk.gov.service.payments.commons.testing.port.PortFactory.findFreePort;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class CreatePaymentWithHttpReturnUrlIT {
 
     private static final String API_KEY = ApiKeyGenerator.apiKeyValueOf("TEST_BEARER_TOKEN", "qwer9yuhgf");
     private static final String GATEWAY_ACCOUNT_ID = "GATEWAY_ACCOUNT_ID";
     private static final String PAYMENTS_PATH = "/v1/payments/";
 
-    @ClassRule
+    @RegisterExtension
     public static RedisDockerRule redisDockerRule = new RedisDockerRule();
 
     private static final int CONNECTOR_PORT = findFreePort();
     private static final int PUBLIC_AUTH_PORT = findFreePort();
 
-    @ClassRule
-    public static WireMockClassRule connectorMock = new WireMockClassRule(CONNECTOR_PORT);
+    @RegisterExtension
+    public static WireMockExtension connectorMock = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(CONNECTOR_PORT))
+            .build();
 
-    @ClassRule
-    public static WireMockClassRule publicAuthMock = new WireMockClassRule(PUBLIC_AUTH_PORT);
+    @RegisterExtension
+    public static WireMockExtension publicAuthMock = WireMockExtension.newInstance()
+            .options(wireMockConfig().port(PUBLIC_AUTH_PORT))
+            .build();
 
-    @ClassRule
-    public static DropwizardAppRule<PublicApiConfig> app = new DropwizardAppRule<>(
+    private final DropwizardAppExtension<PublicApiConfig> app = new DropwizardAppExtension<>(
             PublicApi.class,
             resourceFilePath("config/test-config.yaml"),
             config("connectorUrl", "http://localhost:" + CONNECTOR_PORT),
             config("publicAuthUrl", "http://localhost:" + PUBLIC_AUTH_PORT + "/v1/auth"),
             config("redis.endpoint", redisDockerRule.getRedisUrl()),
-            config("allowHttpForReturnUrl", "true")
-    );
-
-    private final PublicAuthMockClient publicAuthMockClient = new PublicAuthMockClient(publicAuthMock);
-    private final ConnectorMockClient connectorMockClient = new ConnectorMockClient(connectorMock);
+            config("allowHttpForReturnUrl", "true")); 
     
-    @Before
-    public void setup() {
-        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID, CARD);
-    }
-    
-    @Test
-    public void createSuccessfullyWhenHttpReturnUrl() {
-        String payload = new JsonStringBuilder()
-                .add("amount", 100)
-                .add("reference", "ref")
-                .add("description", "desc")
-                .add("return_url", "http://somewhere.com")
-                .add("metadata", Map.of())
-                .build();
+    private final Junit5ConnectorMockClient connectorMockClient = new Junit5ConnectorMockClient(connectorMock);
 
-        connectorMockClient.respondCreated_whenCreateCharge(GATEWAY_ACCOUNT_ID, aCreateChargeRequestParams()
-                .withAmount(100)
-                .withDescription("desc")
-                .withReference("ref")
-                .withReturnUrl("http://somewhere.com")
-                .build());
+    private final Map<String, Object> createChargePayload = Map.of("amount", 100,
+            "reference", "ref",
+            "description", "desc",
+            "return_url", "http://somewhere.com",
+            "metadata", Map.of());
 
-        postPaymentResponse(payload).statusCode(201);
-    }
-    
-    @Test
-    public void createSuccessfullyWhenHttpsReturnUrl() {
-        String payload = new JsonStringBuilder()
-                .add("amount", 100)
-                .add("reference", "ref")
-                .add("description", "desc")
-                .add("return_url", "https://somewhere.com")
-                .add("metadata", Map.of())
-                .build();
-
-        connectorMockClient.respondCreated_whenCreateCharge(GATEWAY_ACCOUNT_ID, aCreateChargeRequestParams()
-                .withAmount(100)
-                .withDescription("desc")
-                .withReference("ref")
-                .withReturnUrl("https://somewhere.com")
-                .build());
-
-        postPaymentResponse(payload).statusCode(201);
+    @BeforeEach
+    void setup() {
+        publicAuthMock.stubFor(get("/v1/auth")
+                .withHeader(ACCEPT, matching(APPLICATION_JSON))
+                .withHeader(AUTHORIZATION, matching("Bearer " + API_KEY))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                        .withBody("{\"account_id\" : \"" + GATEWAY_ACCOUNT_ID + "\", " +
+                                "\"token_link\" : \"a-token-link\", " +
+                                "\"token_type\" : \"" + CARD.toString() + "\"}")));
     }
 
-    private ValidatableResponse postPaymentResponse(String payload) {
+    @Nested
+    class ForGatewayAccountId {
+        @Test
+        void create_payment_successfully() {
+            connectorMockClient.respondCreated_whenCreateCharge(GATEWAY_ACCOUNT_ID, aCreateChargeRequestParams()
+                    .withAmount(100)
+                    .withDescription("desc")
+                    .withReference("ref")
+                    .withReturnUrl("http://somewhere.com")
+                    .build());
+
+            postPaymentResponse(createChargePayload).statusCode(201);
+        }
+
+        @Test
+        void handle_NON_HTTPS_RETURN_URL_NOT_ALLOWED_FOR_A_LIVE_ACCOUNT_error() {
+            connectorMockClient.respondWithErrorIdentifier_whenCreateCharge(GATEWAY_ACCOUNT_ID, SC_UNPROCESSABLE_ENTITY,
+                    NON_HTTPS_RETURN_URL_NOT_ALLOWED_FOR_A_LIVE_ACCOUNT);
+
+            postPaymentResponse(createChargePayload)
+                    .statusCode(422)
+                    .body("field", is("return_url"))
+                    .body("code", is("P0920"))
+                    .body("description", is("Invalid attribute value: return_url. Must begin with https:// for a live gateway account"));
+        }
+    }
+
+    private ValidatableResponse postPaymentResponse(Map<String, Object> payload) {
         return given().port(app.getLocalPort())
                 .body(payload)
                 .accept(JSON)

--- a/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/BaseConnectorMockClient.java
@@ -1,14 +1,9 @@
 package uk.gov.pay.api.utils.mocks;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
-import com.google.common.collect.ImmutableMap;
-import com.google.gson.Gson;
 import uk.gov.pay.api.utils.JsonStringBuilder;
-
-import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -16,8 +11,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static java.lang.String.format;
-import static javax.ws.rs.HttpMethod.GET;
-import static javax.ws.rs.HttpMethod.POST;
 import static uk.gov.service.payments.commons.model.Source.CARD_API;
 
 public abstract class BaseConnectorMockClient {
@@ -31,37 +24,9 @@ public abstract class BaseConnectorMockClient {
     static String CONNECTOR_MOCK_AUTHORISATION_PATH = "/v1/api/charges/authorise";
 
     WireMockClassRule wireMockClassRule;
-    Gson gson = new Gson();
-    ObjectMapper objectMapper = new ObjectMapper();
 
     BaseConnectorMockClient(WireMockClassRule wireMockClassRule) {
         this.wireMockClassRule = wireMockClassRule;
-    }
-
-    ImmutableMap<String, String> validGetLink(String href, String rel) {
-        return ImmutableMap.of(
-                "href", href,
-                "rel", rel,
-                "method", GET);
-    }
-
-    ImmutableMap<String, Object> validPostLink(String href, String rel, String type, Map<String, String> params) {
-        return ImmutableMap.of(
-                "href", href,
-                "rel", rel,
-                "type", type,
-                "params", params,
-                "method", POST);
-    }
-
-    String chargeLocation(String accountId, String chargeId) {
-        return format(CONNECTOR_MOCK_CHARGE_PATH, accountId, chargeId);
-    }
-    
-    abstract String nextUrlPost();
-
-    String nextUrl(String tokenId) {
-        return nextUrlPost() + tokenId;
     }
 
     void whenGetCharge(String gatewayAccountId, String chargeId, ResponseDefinitionBuilder response) {

--- a/src/test/java/uk/gov/pay/api/utils/mocks/Junit5ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/Junit5ConnectorMockClient.java
@@ -1,0 +1,46 @@
+package uk.gov.pay.api.utils.mocks;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static java.lang.String.format;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.HttpHeaders.LOCATION;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.jetty.http.HttpStatus.CREATED_201;
+import static uk.gov.pay.api.utils.mocks.MockHelperFunctions.buildChargeResponse;
+import static uk.gov.pay.api.utils.mocks.MockHelperFunctions.buildErrorResponse;
+import static uk.gov.pay.api.utils.mocks.MockHelperFunctions.chargeLocation;
+import static uk.gov.pay.api.utils.mocks.MockHelperFunctions.fromCreateChargeRequestParams;
+
+public class Junit5ConnectorMockClient {
+    
+    private final WireMockExtension wireMockExtension;
+
+    public Junit5ConnectorMockClient(WireMockExtension wireMockExtension) {
+        this.wireMockExtension = wireMockExtension;
+    }
+
+    public void respondCreated_whenCreateCharge(String gatewayAccountId, CreateChargeRequestParams requestParams) {
+        var responseFromConnector = fromCreateChargeRequestParams(gatewayAccountId, requestParams);
+        var responseDefinitionBuilder = aResponse()
+                .withStatus(CREATED_201)
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                .withHeader(LOCATION, chargeLocation(gatewayAccountId, "chargeId"))
+                .withBody(buildChargeResponse(responseFromConnector));
+
+        wireMockExtension.stubFor(post(urlPathEqualTo(format("/v1/api/accounts/%s/charges", gatewayAccountId)))
+                .withHeader(CONTENT_TYPE, matching(APPLICATION_JSON)).willReturn(responseDefinitionBuilder));
+    }
+
+    public void respondWithErrorIdentifier_whenCreateCharge(String accountId, int statusCode, ErrorIdentifier errorIdentifier) {
+        ResponseDefinitionBuilder errorResponse = buildErrorResponse(statusCode, "", errorIdentifier, null);
+        wireMockExtension.stubFor(post(urlPathEqualTo(format("/v1/api/accounts/%s/charges", accountId)))
+                .withHeader(CONTENT_TYPE, matching(APPLICATION_JSON)).willReturn(errorResponse));
+    }
+}

--- a/src/test/java/uk/gov/pay/api/utils/mocks/MockHelperFunctions.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/MockHelperFunctions.java
@@ -1,0 +1,153 @@
+package uk.gov.pay.api.utils.mocks;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.google.gson.GsonBuilder;
+import uk.gov.pay.api.it.fixtures.PaymentSingleResultBuilder;
+import uk.gov.pay.api.model.Address;
+import uk.gov.pay.api.model.CardDetailsFromResponse;
+import uk.gov.pay.api.model.PaymentState;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static javax.ws.rs.HttpMethod.GET;
+import static javax.ws.rs.HttpMethod.POST;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.pay.api.it.fixtures.PaymentSingleResultBuilder.aSuccessfulSinglePayment;
+import static uk.gov.pay.api.utils.mocks.ChargeResponseFromConnector.ChargeResponseFromConnectorBuilder.aCreateOrGetChargeResponseFromConnector;
+
+public class MockHelperFunctions {
+
+    private static final DateFormat SDF = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    
+    static ChargeResponseFromConnector fromCreateChargeRequestParams(String gatewayAccountId, CreateChargeRequestParams requestParams) {
+        var responseFromConnector = aCreateOrGetChargeResponseFromConnector()
+                .withAmount(requestParams.getAmount())
+                .withChargeId("chargeId")
+                .withState(new PaymentState("created", false, null, null))
+                .withReturnUrl(requestParams.getReturnUrl())
+                .withDescription(requestParams.getDescription())
+                .withReference(requestParams.getReference())
+                .withPaymentProvider("Sandbox")
+                .withGatewayTransactionId("gatewayTransactionId")
+                .withCreatedDate(SDF.format(new Date()))
+                .withLanguage(SupportedLanguage.ENGLISH)
+                .withDelayedCapture(false)
+                .withCardDetails(new CardDetailsFromResponse("1234", "123456", "Mr. Payment", "12/19", null, "Mastercard", "debit"))
+                .withLink(validGetLink(chargeLocation(gatewayAccountId, "chargeId"), "self"))
+                .withLink(validGetLink(nextUrl("chargeTokenId"), "next_url"))
+                .withLink(validPostLink(nextUrlPost(), "next_url_post", "application/x-www-form-urlencoded", getChargeIdTokenMap("chargeTokenId", false)));
+
+        requestParams.getSetUpAgreement().ifPresent(responseFromConnector::withAgreementId);
+
+        if (!requestParams.getMetadata().isEmpty())
+            responseFromConnector.withMetadata(requestParams.getMetadata());
+
+        if (requestParams.getEmail() != null) {
+            responseFromConnector.withEmail(requestParams.getEmail());
+        }
+
+        if (requestParams.getCardholderName().isPresent() || requestParams.getAddressLine1().isPresent() ||
+                requestParams.getAddressLine2().isPresent() || requestParams.getAddressPostcode().isPresent() ||
+                requestParams.getAddressCity().isPresent() || requestParams.getAddressCountry().isPresent()) {
+            Address billingAddress = new Address(requestParams.getAddressLine1().orElse(null), requestParams.getAddressLine2().orElse(null),
+                    requestParams.getAddressPostcode().orElse(null), requestParams.getAddressCity().orElse(null), requestParams.getAddressCountry().orElse(null));
+            CardDetailsFromResponse cardDetails = new CardDetailsFromResponse(null, null, requestParams.getCardholderName().orElse(null),
+                    null, billingAddress, null, null);
+            responseFromConnector.withCardDetails(cardDetails);
+        }
+        
+        return responseFromConnector.build();
+    }
+    
+    static Map<String, String> getChargeIdTokenMap(String chargeTokenId, boolean isMotoApi) {
+        final Map<String, String> chargeTokenIdMap = new HashMap<>();
+        chargeTokenIdMap.put(isMotoApi ? "one_time_token" : "chargeTokenId", chargeTokenId);
+        return chargeTokenIdMap;
+    }
+
+    static Map<String, String> validGetLink(String href, String rel) {
+        return Map.of(
+                "href", href,
+                "rel", rel,
+                "method", GET);
+    }
+
+    static Map<String, Object> validPostLink(String href, String rel, String type, Map<String, String> params) {
+        return Map.of(
+                "href", href,
+                "rel", rel,
+                "type", type,
+                "params", params,
+                "method", POST);
+    }
+    
+    static String chargeLocation(String accountId, String chargeId) {
+        return format("/v1/api/accounts/%s/charges/%s", accountId, chargeId);
+    }
+
+    static String nextUrl(String tokenId) {
+        return nextUrlPost() + tokenId;
+    }
+    
+    static String nextUrlPost() {
+        return "http://frontend_card/charge/";
+    }
+    
+    static String buildChargeResponse(ChargeResponseFromConnector responseFromConnector) {
+        PaymentSingleResultBuilder resultBuilder = aSuccessfulSinglePayment()
+                .withChargeId(responseFromConnector.getChargeId())
+                .withAmount(responseFromConnector.getAmount())
+                .withMatchingReference(responseFromConnector.getReference())
+                .withEmail(responseFromConnector.getEmail())
+                .withDescription(responseFromConnector.getDescription())
+                .withState(responseFromConnector.getState())
+                .withReturnUrl(responseFromConnector.getReturnUrl())
+                .withCreatedDate(responseFromConnector.getCreatedDate())
+                .withLanguage(responseFromConnector.getLanguage())
+                .withPaymentProvider(responseFromConnector.getPaymentProvider())
+                .withDelayedCapture(responseFromConnector.isDelayedCapture())
+                .withMoto(responseFromConnector.isMoto())
+                .withAgreementId(responseFromConnector.getAgreementId())
+                .withLinks(responseFromConnector.getLinks())
+                .withSettlementSummary(responseFromConnector.getSettlementSummary())
+                .withAuthorisationMode(responseFromConnector.getAuthorisationMode());
+
+        ofNullable(responseFromConnector.getCardDetails()).ifPresent(resultBuilder::withCardDetails);
+        ofNullable(responseFromConnector.getRefundSummary()).ifPresent(resultBuilder::withRefundSummary);
+        ofNullable(responseFromConnector.getGatewayTransactionId()).ifPresent(resultBuilder::withGatewayTransactionId);
+        ofNullable(responseFromConnector.getCorporateCardSurcharge()).ifPresent(resultBuilder::withCorporateCardSurcharge);
+        ofNullable(responseFromConnector.getTotalAmount()).ifPresent(resultBuilder::withTotalAmount);
+        ofNullable(responseFromConnector.getFee()).ifPresent(resultBuilder::withFee);
+        ofNullable(responseFromConnector.getNetAmount()).ifPresent(resultBuilder::withNetAmount);
+        ofNullable(responseFromConnector.getAuthorisationSummary()).ifPresent(resultBuilder::withAuthorisationSummary);
+        ofNullable(responseFromConnector.getWalletType()).ifPresent(resultBuilder::withWalletType);
+        responseFromConnector.getMetadata().ifPresent(resultBuilder::withMetadata);
+
+        return resultBuilder.build();
+    }
+    
+    static ResponseDefinitionBuilder buildErrorResponse(int statusCode, String errorMsg, ErrorIdentifier errorIdentifier, String reason) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("message", List.of(errorMsg));
+        payload.put("error_identifier", errorIdentifier.toString());
+        if (reason != null) {
+            payload.put("reason", reason);
+        }
+
+        return aResponse()
+                .withStatus(statusCode)
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                .withBody(new GsonBuilder().create().toJson(payload));
+    }
+}


### PR DESCRIPTION
Deal with possible NON_HTTPS_RETURN_URL_NOT_ALLOWED_FOR_A_LIVE_ACCOUNT when creating a charge.

This commit also upgrades CreatePaymentWithHttpReturnUrlIT to a junit5 test. As part of this MockHelperFunctions is created so WireMockExtension (junit5) and WireMockClassRule (junit4) can be DRY.
