### PR TITLE
PP-13367 Enable keepalive

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
@@ -76,13 +76,14 @@ public class PublicApiModule extends AbstractModule {
     public RateLimiterConfig getRateLimiterConfig() {
         return configuration.getRateLimiterConfig();
     }
-    
+
     @Provides
     @Singleton
     public RedisClient getRedisClient() {
         RedisClient client = RedisClient.create(configuration.getRedisConfiguration().getUrl());
         SocketOptions socketOptions = SocketOptions
                 .builder()
+                .keepAlive(true)
                 .connectTimeout(Duration.ofMillis(configuration.getRedisConfiguration().getConnectTimeout()))
                 .build();
         ClientOptions clientOptions = ClientOptions


### PR DESCRIPTION
## WHAT YOU DID
- Redis: enables keepalive to reduce the need to handle failed connections during command runtime.
- This is as recommended by AWS docs https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/BestPractices.Clients-lettuce.html

