### PR TITLE
PP-13367 Update DNS_TTL and lettuce reconnect delay

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -161,7 +161,7 @@
         "filename": "src/test/resources/config/empty-elevated-accounts-test-config.yaml",
         "hashed_secret": "3d4478f77d368235803ceb52bbd45b7240e6af62",
         "is_verified": false,
-        "line_number": 50
+        "line_number": 53
       }
     ],
     "src/test/resources/config/test-config.yaml": [
@@ -170,7 +170,7 @@
         "filename": "src/test/resources/config/test-config.yaml",
         "hashed_secret": "3d4478f77d368235803ceb52bbd45b7240e6af62",
         "is_verified": false,
-        "line_number": 52
+        "line_number": 55
       }
     ],
     "src/test/resources/pacts/publicapi-connector-get-payment-refund.json": [
@@ -192,5 +192,5 @@
       }
     ]
   },
-  "generated_at": "2024-09-10T09:28:38Z"
+  "generated_at": "2024-12-04T09:02:15Z"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM eclipse-temurin:21-jre-alpine@sha256:2a0bbb1db6d8db42c66ed00c43d954cf458066
 
 RUN ["apk", "--no-cache", "upgrade"]
 
-ARG DNS_TTL=15
+ARG DNS_TTL=10
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8

--- a/src/main/java/uk/gov/pay/api/app/config/RedisConfiguration.java
+++ b/src/main/java/uk/gov/pay/api/app/config/RedisConfiguration.java
@@ -1,15 +1,15 @@
 package uk.gov.pay.api.app.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.util.Duration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import io.dropwizard.util.Duration;
 
 import static java.lang.String.format;
 
 public class RedisConfiguration {
-    
+
     @Valid
     @NotNull
     @JsonProperty("endpoint")
@@ -18,7 +18,7 @@ public class RedisConfiguration {
     @Valid
     @JsonProperty("ssl")
     private boolean ssl;
-    
+
     @Valid
     @JsonProperty("commandTimeout")
     private Duration commandTimeout;
@@ -26,6 +26,21 @@ public class RedisConfiguration {
     @Valid
     @JsonProperty("connectTimeout")
     private Duration connectTimeout;
+
+    @Valid
+    @NotNull
+    @JsonProperty("exponentialReconnectDelayLowerBound")
+    private Duration exponentialReconnectDelayLowerBound;
+
+    @Valid
+    @NotNull
+    @JsonProperty("exponentialReconnectDelayUpperBound")
+    private Duration exponentialReconnectDelayUpperBound;
+
+    @Valid
+    @NotNull
+    @JsonProperty("reconnectDelayExponentBase")
+    private long reconnectDelayExponentBase;
 
     public String getUrl() {
         return format("%s://%s", ssl ? "rediss" : "redis", endpoint);
@@ -37,5 +52,17 @@ public class RedisConfiguration {
 
     public Long getConnectTimeout() {
         return connectTimeout.toMilliseconds();
+    }
+
+    public Long getExponentialReconnectDelayLowerBound() {
+        return exponentialReconnectDelayLowerBound.toMilliseconds();
+    }
+
+    public Long getExponentialReconnectDelayUpperBound() {
+        return exponentialReconnectDelayUpperBound.toMilliseconds();
+    }
+
+    public long getReconnectDelayExponentBase() {
+        return reconnectDelayExponentBase;
     }
 }

--- a/src/main/java/uk/gov/pay/api/managed/RedisClientManager.java
+++ b/src/main/java/uk/gov/pay/api/managed/RedisClientManager.java
@@ -16,7 +16,7 @@ public class RedisClientManager implements Managed {
     public RedisClientManager(RedisClient redisClient) {
         this.redisClient = redisClient;
     }
-    
+
     public StatefulRedisConnection getRedisConnection() {
         if (statefulRedisConnection == null) {
             statefulRedisConnection = redisClient.connect();
@@ -28,10 +28,11 @@ public class RedisClientManager implements Managed {
     public void start() throws Exception {}
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         if (statefulRedisConnection != null) {
             statefulRedisConnection.close();
         }
+        redisClient.getResources().shutdown();
         redisClient.shutdown();
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -56,7 +56,10 @@ redis:
   endpoint: ${REDIS_URL:-localhost:6379}
   ssl: false
   commandTimeout: ${REDIS_COMMAND_TIMEOUT:-250ms}
-  connectTimeout: ${REDIS_CONNECT_TIMEOUT:-500ms}
+  connectTimeout: ${REDIS_CONNECT_TIMEOUT:-100ms}
+  exponentialReconnectDelayLowerBound: ${REDIS_RECONNECT_DELAY_LOWER_BOUND:-100ms}
+  exponentialReconnectDelayUpperBound: ${REDIS_RECONNECT_DELAY_UPPER_BOUND:-10000ms}
+  reconnectDelayExponentBase: ${REDIS_RECONNECT_DELAY_EXPONENT_BASE:-10}
 
 allowHttpForReturnUrl: ${ALLOW_HTTP_FOR_RETURN_URL:-false}
 

--- a/src/test/resources/config/empty-elevated-accounts-test-config.yaml
+++ b/src/test/resources/config/empty-elevated-accounts-test-config.yaml
@@ -44,6 +44,9 @@ redis:
   ssl: false
   commandTimeout: 250ms
   connectTimeout: 500ms
+  exponentialReconnectDelayLowerBound: 100ms
+  exponentialReconnectDelayUpperBound: 10000ms
+  reconnectDelayExponentBase: 10
 
 allowHttpForReturnUrl: false
 

--- a/src/test/resources/config/empty-low-traffic-accounts-test-config.yaml
+++ b/src/test/resources/config/empty-low-traffic-accounts-test-config.yaml
@@ -44,6 +44,9 @@ redis:
   ssl: false
   commandTimeout: 250ms
   connectTimeout: 500ms
+  exponentialReconnectDelayLowerBound: 100ms
+  exponentialReconnectDelayUpperBound: 10000ms
+  reconnectDelayExponentBase: 10
 
 allowHttpForReturnUrl: false
 

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -45,7 +45,10 @@ redis:
   endpoint: localhost:6379
   ssl: false
   commandTimeout: 250ms
-  connectTimeout: 500ms
+  connectTimeout: 100ms
+  exponentialReconnectDelayLowerBound: 100ms
+  exponentialReconnectDelayUpperBound: 10000ms
+  reconnectDelayExponentBase: 10
 
 allowHttpForReturnUrl: false
 


### PR DESCRIPTION
## WHAT YOU DID

As per AWS recommendations https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/BestPractices.Clients-lettuce.html
- Updated DNS_TTL to 10s
- Updated Exponential reconnect strategy.
    - With the default lettuce config, the exponential retry strategy uses an exponential base of 2 and an upper bound of 30 seconds. So we will likely fall back to the local rate limiter for 30+ seconds (as it uses DNS cache within the first 15 seconds of retries).

    - With the new config, reconnect attempts will be at 100ms, 1000ms, 10000ms and every 10000ms.
        - so if there are any one-off issues, the Redis client can reconnect at 100ms and 1000ms. For longer timeouts (during failovers or upgrades) attempts can be every 10 seconds. This also coincides with DNS_TTL. For re-connect attempts at 10000ms, PublicAPI will get new IP addresses by requering DNS entry.

- Since we are passing `ClientResources` to RedisClient, as per [lettuce docs](https://redis.github.io/lettuce/advanced-usage/), we need to shut it down. So `Resources` is shut down before redisClient in RedisClientManager.

- Updated `connectTimeout` too but this has no impact. Env variable has been overridden in infra

