### PR TITLE
PP-13367 Rename redis reconnect delay config vars

### DIFF
--- a/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
+++ b/src/main/java/uk/gov/pay/api/app/config/PublicApiModule.java
@@ -87,9 +87,9 @@ public class PublicApiModule extends AbstractModule {
         ClientResources clientResources = DefaultClientResources.builder()
                 .reconnectDelay(
                         Delay.fullJitter(
-                                configuration.getRedisConfiguration().getExponentialReconnectDelayLowerBound(),
-                                configuration.getRedisConfiguration().getExponentialReconnectDelayUpperBound(),
-                                configuration.getRedisConfiguration().getReconnectDelayExponentBase(),
+                                configuration.getRedisConfiguration().getReconnectDelayLowerBound(),
+                                configuration.getRedisConfiguration().getReconnectDelayUpperBound(),
+                                configuration.getRedisConfiguration().getReconnectDelayBase(),
                                 TimeUnit.MILLISECONDS))
                 .build();
 

--- a/src/main/java/uk/gov/pay/api/app/config/RedisConfiguration.java
+++ b/src/main/java/uk/gov/pay/api/app/config/RedisConfiguration.java
@@ -29,18 +29,18 @@ public class RedisConfiguration {
 
     @Valid
     @NotNull
-    @JsonProperty("exponentialReconnectDelayLowerBound")
-    private Duration exponentialReconnectDelayLowerBound;
+    @JsonProperty("reconnectDelayLowerBound")
+    private Duration reconnectDelayLowerBound;
 
     @Valid
     @NotNull
-    @JsonProperty("exponentialReconnectDelayUpperBound")
-    private Duration exponentialReconnectDelayUpperBound;
+    @JsonProperty("reconnectDelayUpperBound")
+    private Duration reconnectDelayUpperBound;
 
     @Valid
     @NotNull
-    @JsonProperty("reconnectDelayExponentBase")
-    private long reconnectDelayExponentBase;
+    @JsonProperty("reconnectDelayBase")
+    private long reconnectDelayBase;
 
     public String getUrl() {
         return format("%s://%s", ssl ? "rediss" : "redis", endpoint);
@@ -54,15 +54,15 @@ public class RedisConfiguration {
         return connectTimeout.toMilliseconds();
     }
 
-    public Long getExponentialReconnectDelayLowerBound() {
-        return exponentialReconnectDelayLowerBound.toMilliseconds();
+    public Long getReconnectDelayLowerBound() {
+        return reconnectDelayLowerBound.toMilliseconds();
     }
 
-    public Long getExponentialReconnectDelayUpperBound() {
-        return exponentialReconnectDelayUpperBound.toMilliseconds();
+    public Long getReconnectDelayUpperBound() {
+        return reconnectDelayUpperBound.toMilliseconds();
     }
 
-    public long getReconnectDelayExponentBase() {
-        return reconnectDelayExponentBase;
+    public long getReconnectDelayBase() {
+        return reconnectDelayBase;
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -57,9 +57,9 @@ redis:
   ssl: false
   commandTimeout: ${REDIS_COMMAND_TIMEOUT:-250ms}
   connectTimeout: ${REDIS_CONNECT_TIMEOUT:-100ms}
-  exponentialReconnectDelayLowerBound: ${REDIS_RECONNECT_DELAY_LOWER_BOUND:-100ms}
-  exponentialReconnectDelayUpperBound: ${REDIS_RECONNECT_DELAY_UPPER_BOUND:-10000ms}
-  reconnectDelayExponentBase: ${REDIS_RECONNECT_DELAY_EXPONENT_BASE:-10}
+  reconnectDelayLowerBound: ${REDIS_RECONNECT_DELAY_LOWER_BOUND:-100ms}
+  reconnectDelayUpperBound: ${REDIS_RECONNECT_DELAY_UPPER_BOUND:-10000ms}
+  reconnectDelayBase: ${REDIS_RECONNECT_DELAY_BASE:-100}
 
 allowHttpForReturnUrl: ${ALLOW_HTTP_FOR_RETURN_URL:-false}
 

--- a/src/test/resources/config/empty-elevated-accounts-test-config.yaml
+++ b/src/test/resources/config/empty-elevated-accounts-test-config.yaml
@@ -44,9 +44,9 @@ redis:
   ssl: false
   commandTimeout: 250ms
   connectTimeout: 500ms
-  exponentialReconnectDelayLowerBound: 100ms
-  exponentialReconnectDelayUpperBound: 10000ms
-  reconnectDelayExponentBase: 10
+  reconnectDelayLowerBound: 100ms
+  reconnectDelayUpperBound: 10000ms
+  reconnectDelayBase: 100
 
 allowHttpForReturnUrl: false
 

--- a/src/test/resources/config/empty-low-traffic-accounts-test-config.yaml
+++ b/src/test/resources/config/empty-low-traffic-accounts-test-config.yaml
@@ -44,9 +44,9 @@ redis:
   ssl: false
   commandTimeout: 250ms
   connectTimeout: 500ms
-  exponentialReconnectDelayLowerBound: 100ms
-  exponentialReconnectDelayUpperBound: 10000ms
-  reconnectDelayExponentBase: 10
+  reconnectDelayLowerBound: 100ms
+  reconnectDelayUpperBound: 10000ms
+  reconnectDelayBase: 100
 
 allowHttpForReturnUrl: false
 

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -46,9 +46,9 @@ redis:
   ssl: false
   commandTimeout: 250ms
   connectTimeout: 100ms
-  exponentialReconnectDelayLowerBound: 100ms
-  exponentialReconnectDelayUpperBound: 10000ms
-  reconnectDelayExponentBase: 10
+  reconnectDelayLowerBound: 100ms
+  reconnectDelayUpperBound: 10000ms
+  reconnectDelayBase: 100
 
 allowHttpForReturnUrl: false
 


### PR DESCRIPTION
## WHAT
- Updated `reconnectDelay` config to match AWS docs
- Renamed Redis `reconnectDelay` variables as Full Jitter is not truly exponential. FullJitter delay uses the power of 2 during the calculation and the `base` configured is used to limit the upper bound for a specific attempt. See FullJitter reconnect delay calculation in https://github.com/redis/lettuce/blob/main/src/main/java/io/lettuce/core/resource/FullJitterDelay.java#L59-L63 (FullJitter is explained in AWS docs https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)

    Reconnect delays calculated locally (with DEBUG enabled and Redis stopped) for the FullJitter approach are as follows:

    ```
      Reconnect attempt 1, delay 100ms
      Reconnect attempt 2, delay 182ms
      Reconnect attempt 3, delay 386ms
      Reconnect attempt 4, delay 516ms
      Reconnect attempt 5, delay 1056ms
      Reconnect attempt 6, delay 3102ms
      Reconnect attempt 7, delay 4092ms
      Reconnect attempt 8, delay 5329ms
      Reconnect attempt 9, delay 9584ms
      Reconnect attempt 10, delay 5446ms
      Reconnect attempt 11, delay 7243ms
      Reconnect attempt 12, delay 9948ms
      Reconnect attempt 13, delay 8209ms
      Reconnect attempt 14, delay 9753ms
      Reconnect attempt 15, delay 6976ms
    ```

    Adds randomness so that no two client nodes (public) try to reconnect simultaneously, causing server (redis) load.
