### PR TITLE
PP-13359 update java commons version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hamcrest.version>3.0</hamcrest.version>
-        <pay-java-commons.version>1.0.20250106092102</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20250114131848</pay-java-commons.version>
         <prometheus.version>0.16.0</prometheus.version>
         <swagger.lib.version>2.2.27</swagger.lib.version>
         <pact.version>4.6.16</pact.version>


### PR DESCRIPTION
- point to updated pay-java-commons so we can use the new `BELOW_MINIMUM_AMOUNT` error identifier necessary for restricting Stripe transactions to less than 30p.