### PR TITLE
PP-13359 Handle AMOUNT_BELOW_MINIMUM

### DIFF
--- a/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapper.java
@@ -60,7 +60,12 @@ public class CreateChargeExceptionMapper implements ExceptionMapper<CreateCharge
                 case ZERO_AMOUNT_NOT_ALLOWED:
                     statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
                     requestError = aRequestError("amount", CREATE_PAYMENT_VALIDATION_ERROR,
-                            "Must be greater than or equal to 1");
+                            "Must be greater than or equal to 1. Refer to https://docs.payments.service.gov.uk/making_payments/#amount/ .");
+                    break;
+                case AMOUNT_BELOW_MINIMUM:
+                    statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;
+                    requestError = aRequestError("amount", CREATE_PAYMENT_VALIDATION_ERROR,
+                            "Must be greater than or equal to 30. Refer to https://docs.payments.service.gov.uk/making_payments/#amount/ .");
                     break;
                 case MOTO_NOT_ALLOWED:
                     statusCode = HttpStatus.UNPROCESSABLE_ENTITY_422;

--- a/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
+++ b/src/test/java/uk/gov/pay/api/exception/mapper/CreateChargeExceptionMapperTest.java
@@ -23,6 +23,7 @@ import static uk.gov.service.payments.commons.model.ErrorIdentifier.ACCOUNT_DISA
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.ACCOUNT_NOT_LINKED_WITH_PSP;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.AGREEMENT_NOT_ACTIVE;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.AGREEMENT_NOT_FOUND;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.AMOUNT_BELOW_MINIMUM;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.AUTHORISATION_API_NOT_ALLOWED;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.INCORRECT_AUTHORISATION_MODE_FOR_SAVE_PAYMENT_INSTRUMENT_TO_AGREEMENT;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.INVALID_ATTRIBUTE_VALUE;
@@ -58,7 +59,8 @@ class CreateChargeExceptionMapperTest {
 
     static Stream<Arguments> testExceptionMapping() {
         return Stream.of(
-                arguments(ZERO_AMOUNT_NOT_ALLOWED, false, "Invalid attribute value: amount. Must be greater than or equal to 1", 422, "P0102"),
+                arguments(ZERO_AMOUNT_NOT_ALLOWED, false, "Invalid attribute value: amount. Must be greater than or equal to 1. Refer to https://docs.payments.service.gov.uk/making_payments/#amount/ .", 422, "P0102"),
+                arguments(AMOUNT_BELOW_MINIMUM, false, "Invalid attribute value: amount. Must be greater than or equal to 30. Refer to https://docs.payments.service.gov.uk/making_payments/#amount/ .", 422, "P0102"),
                 arguments(MOTO_NOT_ALLOWED, false, "MOTO payments are not enabled for this account. Please contact support if you would like to process MOTO payments - https://www.payments.service.gov.uk/support/ .", 422, "P0196"),
                 arguments(ACCOUNT_DISABLED, false, "GOV.UK Pay has disabled payment and refund creation on this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ .", 403, "P0941"),
                 arguments(TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED, false, "Access to this resource is not enabled for this account. Contact support with your error code - https://www.payments.service.gov.uk/support/ .", 403, "P0930"),

--- a/src/test/java/uk/gov/pay/api/it/PaymentsResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/api/it/PaymentsResourceCreateIT.java
@@ -745,7 +745,23 @@ public class PaymentsResourceCreateIT extends PaymentResourceITestBase {
                 .contentType(JSON)
                 .body("code", is("P0102"))
                 .body("field", is("amount"))
-                .body("description", is("Invalid attribute value: amount. Must be greater than or equal to 1"));
+                .body("description", is("Invalid attribute value: amount. Must be greater than or equal to 1. Refer to https://docs.payments.service.gov.uk/making_payments/#amount/ ."));
+
+        connectorMockClient.verifyCreateChargeConnectorRequest(GATEWAY_ACCOUNT_ID, SUCCESS_PAYLOAD);
+    }
+
+    @Test
+    public void createPayment_responseWith422_whenAmountBelowMinimum() {
+        publicAuthMockClient.mapBearerTokenToAccountId(API_KEY, GATEWAY_ACCOUNT_ID);
+
+        connectorMockClient.respondAmountBelowMinimum(GATEWAY_ACCOUNT_ID);
+
+        postPaymentResponse(SUCCESS_PAYLOAD)
+                .statusCode(422)
+                .contentType(JSON)
+                .body("code", is("P0102"))
+                .body("field", is("amount"))
+                .body("description", is("Invalid attribute value: amount. Must be greater than or equal to 30. Refer to https://docs.payments.service.gov.uk/making_payments/#amount/ ."));
 
         connectorMockClient.verifyCreateChargeConnectorRequest(GATEWAY_ACCOUNT_ID, SUCCESS_PAYLOAD);
     }

--- a/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
+++ b/src/test/java/uk/gov/pay/api/utils/mocks/ConnectorMockClient.java
@@ -57,6 +57,7 @@ import static uk.gov.pay.api.utils.mocks.MockHelperFunctions.validPostLink;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.ACCOUNT_NOT_LINKED_WITH_PSP;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.AGREEMENT_NOT_ACTIVE;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.AGREEMENT_NOT_FOUND;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.AMOUNT_BELOW_MINIMUM;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.AUTHORISATION_API_NOT_ALLOWED;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_REJECTED;
 import static uk.gov.service.payments.commons.model.ErrorIdentifier.GENERIC;
@@ -345,6 +346,10 @@ public class ConnectorMockClient extends BaseConnectorMockClient {
 
     public void respondZeroAmountNotAllowed(String gatewayAccountId) {
         mockCreateCharge(gatewayAccountId, withStatusAndErrorMessage(UNPROCESSABLE_ENTITY_422, "anything", ZERO_AMOUNT_NOT_ALLOWED));
+    }
+
+    public void respondAmountBelowMinimum(String gatewayAccountId) {
+        mockCreateCharge(gatewayAccountId, withStatusAndErrorMessage(UNPROCESSABLE_ENTITY_422, "anything", AMOUNT_BELOW_MINIMUM));
     }
 
     public void respondMotoPaymentNotAllowed(String gatewayAccountId) {


### PR DESCRIPTION
- Respond appropriately to an AMOUNT_BELOW_MINIMUM response from connector in relation to a create payment request for a Stripe account (we are limiting Stripe payments to 30p or more to avoid the issues associated with fees exceeding the transaction amount).
- Include link to the 'amount' section of the tech docs in error responses for this scenario and for the zero amount not allowed scenario.
- The change to the connector logic to cover this scenario will be made subsequently.