### PR TITLE
PP-13334 add a ledger as provider pact test

### DIFF
--- a/src/test/resources/pacts/publicapi-ledger-search-payment-with-charge-in-success-state-that-has-exemption-honoured.json
+++ b/src/test/resources/pacts/publicapi-ledger-search-payment-with-charge-in-success-state-that-has-exemption-honoured.json
@@ -1,0 +1,121 @@
+{
+  "consumer": {
+    "name": "publicapi"
+  },
+  "provider": {
+    "name": "ledger"
+  },
+  "interactions": [
+    {
+      "description": "search payment in success state that has honoured exemption",
+      "providerStates": [
+        {
+          "name": "a transaction with honoured corporate exemption exists",
+          "params": {
+            "transaction_external_id": "charge97837509646393e3C",
+            "gateway_account_id": "123456"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/v1/transaction",
+        "query": {
+          "state": [
+            "success"
+          ],
+          "status_version" : [
+            "1"
+          ],
+          "page" : [
+            "1"
+          ],
+          "exact_reference_match" : [
+            "true"
+          ],
+          "display_size" : [
+            "500"
+          ],
+          "transaction_type" : [
+            "PAYMENT"
+          ],
+          "account_id" : [
+            "123456"
+          ]
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "page": 1,
+          "total": 1,
+          "count": 1,
+          "results": [
+            {
+              "amount": 100,
+              "state": {
+                "finished": true,
+                "status": "success"
+              },
+              "description": "Test description",
+              "reference": "aReference",
+              "language": "en",
+              "transaction_id": "ch_123abc456xyz",
+              "return_url": "https://somewhere.gov.uk/rainbow/1",
+              "payment_provider": "sandbox",
+              "created_date": "2018-10-16T10:46:02.121Z",
+              "refund_summary": {
+                "status": "available",
+                "user_external_id": null,
+                "amount_available": 100,
+                "amount_submitted": 0
+              },
+              "settlement_summary": {
+                "capture_submit_time": null,
+                "captured_date": null
+              },
+              "delayed_capture": false,
+              "exemption": {
+                "requested": true,
+                "type": "corporate",
+                "outcome": {
+                  "result": "honoured"
+                }
+              }
+            }
+          ]
+        },
+        "matchingRules": {
+          "body": {
+              "$.results[*].reference": {
+                "matchers": [{"match": "type"}]
+              },
+              "$.results[*].description": {
+                "matchers": [{"match": "type"}]
+              },
+              "$.results[*].return_url": {
+                "matchers": [{"match": "type"}]
+              },
+              "$.results[*].created_date": {
+                "matchers": [{ "date": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" }]
+              },
+              "$.results[*].refund_summary.amount_available": {
+                "matchers": [{"match": "type"}]
+              }
+            }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
## WHAT YOU DID

Add a pact test that searches Ledger for a transaction which has an honoured corporate exemption. This test is needed because Ledger builds transactions in different ways for a get one and a search call.
