### PR TITLE
PP-13429: Clarify rate limiting functionality

### DIFF
--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterKey.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterKey.java
@@ -6,11 +6,11 @@ import javax.ws.rs.container.ContainerRequestContext;
 
 public class RateLimiterKey {
 
-    private String method;
-    private String key;
-    private String keyType;
+    private final String method;
+    private final String key;
+    private final String keyType;
 
-    public RateLimiterKey(String key, String keyType, String method) {
+    private RateLimiterKey(String key, String keyType, String method) {
         this.key = key;
         this.keyType = keyType;
         this.method = method;

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/LocalRateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/LocalRateLimiterTest.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.api.app.config.RateLimiterConfig;
 import uk.gov.pay.api.filter.RateLimiterKey;
 
+import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -65,7 +66,7 @@ public class LocalRateLimiterTest {
         when(rateLimiterConfig.getPerMillis()).thenReturn(1000);
         
         String key = "key1";
-        var rateLimiterKey = new RateLimiterKey(key, "key-type", POST);
+        var rateLimiterKey = createRateLimiterKey(key, "key-type", POST);
         localRateLimiter = new LocalRateLimiter(rateLimiterConfig);
 
         localRateLimiter.checkRateOf(accountId, rateLimiterKey);
@@ -73,13 +74,13 @@ public class LocalRateLimiterTest {
     }
 
     @Test
-    public void rateLimiterSetTo_1CallPer300Millis_shouldAFailWhen2ConsecutiveCallsWithSameKeysAreMade() throws RateLimitException {
+    public void rateLimiterSetTo_1CallPer300Millis_shouldAFailWhen2ConsecutiveCallsWithSameKeysAreMade() throws Exception {
         when(rateLimiterConfig.getNoOfReqPerNode()).thenReturn(1);
         when(rateLimiterConfig.getNoOfReqForPostPerNode()).thenReturn(1);
         when(rateLimiterConfig.getPerMillis()).thenReturn(300);
         
         String key = "key2";
-        var rateLimiterKey = new RateLimiterKey(key, "key-type", POST);
+        var rateLimiterKey = createRateLimiterKey(key, "key-type", POST);
         localRateLimiter = new LocalRateLimiter(rateLimiterConfig);
 
         localRateLimiter.checkRateOf(accountId, rateLimiterKey);
@@ -99,7 +100,7 @@ public class LocalRateLimiterTest {
         when(rateLimiterConfig.getPerMillis()).thenReturn(1000);
         
         String key = "key3";
-        var rateLimiterKey = new RateLimiterKey(key, "key-type", POST);
+        var rateLimiterKey = createRateLimiterKey(key, "key-type", POST);
         localRateLimiter = new LocalRateLimiter(rateLimiterConfig);
 
         ExecutorService executor = Executors.newFixedThreadPool(3);
@@ -141,5 +142,11 @@ public class LocalRateLimiterTest {
         assertThat(successfulTasks.size(), is(3));
     }
 
+    public static RateLimiterKey createRateLimiterKey(String key, String type, String method) throws Exception {
+        Class<RateLimiterKey> clazz = RateLimiterKey.class;
+        Constructor<RateLimiterKey> constructor = clazz.getDeclaredConstructor(String.class, String.class, String.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(key, type, method);
 
+    }
 }

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimitManagerTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimitManagerTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.api.filter.ratelimit.LocalRateLimiterTest.createRateLimiterKey;
 
 @ExtendWith(MockitoExtension.class)
 public class RateLimitManagerTest {
@@ -22,8 +23,8 @@ public class RateLimitManagerTest {
     private RateLimitManager rateLimitManager;
 
     @Test
-    public void returnsNumberOfAllowedRequestsForNoAccount() {
-        var rateLimiterKey = new RateLimiterKey("path", "key-type", "PUT");
+    public void returnsNumberOfAllowedRequestsForNoAccount() throws Exception {
+        var rateLimiterKey = createRateLimiterKey("path", "key-type", "PUT");
         when(rateLimiterConfig.getNoOfReq()).thenReturn(1);
 
         rateLimitManager = new RateLimitManager(rateLimiterConfig);
@@ -31,8 +32,8 @@ public class RateLimitManagerTest {
     }
 
     @Test
-    public void returnsNumberOfAllowedRequestsForPostForAccount1() {
-        var rateLimiterKey = new RateLimiterKey("path", "key-type", "POST");
+    public void returnsNumberOfAllowedRequestsForPostForAccount1() throws Exception {
+        var rateLimiterKey = createRateLimiterKey("path", "key-type", "POST");
         when(rateLimiterConfig.getElevatedAccounts()).thenReturn(List.of("1"));
         when(rateLimiterConfig.getNoOfPostReqForElevatedAccounts()).thenReturn(4);
 
@@ -41,8 +42,8 @@ public class RateLimitManagerTest {
     }
 
     @Test
-    public void returnsNumberOfAllowedRequestsForGetForAccount1() {
-        var rateLimiterKey = new RateLimiterKey("path", "key-type", "GET");
+    public void returnsNumberOfAllowedRequestsForGetForAccount1() throws Exception {
+        var rateLimiterKey = createRateLimiterKey("path", "key-type", "GET");
         when(rateLimiterConfig.getElevatedAccounts()).thenReturn(List.of("1"));
         when(rateLimiterConfig.getNoOfReqForElevatedAccounts()).thenReturn(3);
 
@@ -51,8 +52,8 @@ public class RateLimitManagerTest {
     }
 
     @Test
-    public void returnsNumberOfAllowedRequestsForPostForAccount2() {
-        var rateLimiterKey = new RateLimiterKey("path", "key-type", "POST");
+    public void returnsNumberOfAllowedRequestsForPostForAccount2() throws Exception {
+        var rateLimiterKey = createRateLimiterKey("path", "key-type", "POST");
         when(rateLimiterConfig.getNoOfReqForPost()).thenReturn(2);
 
         rateLimitManager = new RateLimitManager(rateLimiterConfig);
@@ -60,8 +61,8 @@ public class RateLimitManagerTest {
     }
 
     @Test
-    public void returnsNumberOfAllowedRequestsForGetForAccount2() {
-        var rateLimiterKey = new RateLimiterKey("path", "key-type", "GET");
+    public void returnsNumberOfAllowedRequestsForGetForAccount2() throws Exception {
+        var rateLimiterKey = createRateLimiterKey("path", "key-type", "GET");
         when(rateLimiterConfig.getNoOfReq()).thenReturn(1);
 
         rateLimitManager = new RateLimitManager(rateLimiterConfig);
@@ -69,8 +70,8 @@ public class RateLimitManagerTest {
     }
 
     @Test
-    public void shouldReturnNumberOfAllowedPostRequestsCorrectlyForLowTrafficAccounts() {
-        var rateLimiterKey = new RateLimiterKey("path", "key-type", "POST");
+    public void shouldReturnNumberOfAllowedPostRequestsCorrectlyForLowTrafficAccounts() throws Exception {
+        var rateLimiterKey = createRateLimiterKey("path", "key-type", "POST");
         when(rateLimiterConfig.getLowTrafficAccounts()).thenReturn(List.of("10"));
         when(rateLimiterConfig.getNoOfPostReqForLowTrafficAccounts()).thenReturn(7);
 
@@ -79,8 +80,8 @@ public class RateLimitManagerTest {
     }
 
     @Test
-    public void shouldReturnNumberOfAllowedGetRequestsCorrectlyForLowTrafficAccounts() {
-        var rateLimiterKey = new RateLimiterKey("path", "key-type", "GET");
+    public void shouldReturnNumberOfAllowedGetRequestsCorrectlyForLowTrafficAccounts() throws Exception {
+        var rateLimiterKey = createRateLimiterKey("path", "key-type", "GET");
         when(rateLimiterConfig.getLowTrafficAccounts()).thenReturn(List.of("10"));
         when(rateLimiterConfig.getNoOfReqForLowTrafficAccounts()).thenReturn(100);
 

--- a/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimiterTest.java
+++ b/src/test/java/uk/gov/pay/api/filter/ratelimit/RateLimiterTest.java
@@ -10,6 +10,7 @@ import uk.gov.pay.api.filter.RateLimiterKey;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static uk.gov.pay.api.filter.ratelimit.LocalRateLimiterTest.createRateLimiterKey;
 
 @ExtendWith(MockitoExtension.class)
 public class RateLimiterTest {
@@ -25,8 +26,8 @@ public class RateLimiterTest {
     private RateLimiter rateLimiter;
 
     @BeforeEach
-    public void setup() {
-        rateLimiterKey = new RateLimiterKey("key2", "key-type", POST);
+    public void setup() throws Exception {
+        rateLimiterKey = createRateLimiterKey("key2", "key-type", POST);
         rateLimiter = new RateLimiter(localRateLimiter, redisRateLimiter);
     }
 


### PR DESCRIPTION
The rate limiting implementation can be quite to understand; hopefully adding the comments will help. Rate limiting is currently applied using discrete time blocks, but an idea for the future is to use a sliding window and do a count for requests in the last second/minute/hour window which could potentially make the logic simpler.

This commit also makes the RateLimiterKey constructor private; this is more correct as it's currently public for the sake of convenient unit testing.
