### PR TITLE
PP-13949: Allow setting the redis ssl setting via env var REDIS_SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Configuration of the application is performed via environment variables, some of
 | `PUBLICAPI_BASE`            | Yes       | N/A            | The base URL clients can use to reach the API. e.g. http://api.example.org:1234/                           |
 | `PUBLIC_AUTH_URL`           | Yes       | N/A            | The URL to the [publicauth](https://github.com/alphagov/pay-publicauth) service                            |
 | `REDIS_URL`                 | No        | localhost:6379 | The location of the redis endpoint to store rate-limiter information in                                    |
+|  REDIS_SSL                  | No        | false          | Whether to establish TLS encrypted connections to the redis instance
 | `TOKEN_API_HMAC_SECRET`     | Yes       | N/A            | Hmac secret to be used to validate that the given token is genuine (Api Key = Token + Hmac (Token, Secret) |
 
 ## Rate limiting

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -54,7 +54,7 @@ rateLimiter:  # rate = noOfReq per perMillis
 
 redis:
   endpoint: ${REDIS_URL:-localhost:6379}
-  ssl: false
+  ssl: ${REDIS_SSL:-false}
   commandTimeout: ${REDIS_COMMAND_TIMEOUT:-250ms}
   connectTimeout: ${REDIS_CONNECT_TIMEOUT:-100ms}
   reconnectDelayLowerBound: ${REDIS_RECONNECT_DELAY_LOWER_BOUND:-100ms}


### PR DESCRIPTION
## WHAT YOU DID
We want to enable TLS encryption for connections to redis, it's already in the code, we just need to take the configuration via env var and default to false (the current value)

## How to test

Check the syntax is correct for loading via env var. See the e2e tests work

## Code review checklist

### Logging

N/A

### Documentation

- [X] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* ~Added new API / updated existing API definition~