### PR TITLE
PP-14385 Convert Account class into record

### DIFF
--- a/src/main/java/uk/gov/pay/api/agreement/resource/AgreementsApiResource.java
+++ b/src/main/java/uk/gov/pay/api/agreement/resource/AgreementsApiResource.java
@@ -87,7 +87,7 @@ public class AgreementsApiResource {
             @Valid CreateAgreementRequest createAgreementRequest)
     {
         LOGGER.info("Creating new agreement for reference {} and gateway accountID {}", 
-                createAgreementRequest.getReference(), account.getAccountId());
+                createAgreementRequest.getReference(), account.accountId());
         var agreementCreatedResponse = agreementsService.createAgreement(account, createAgreementRequest);
         var agreementLedgerResponse = agreementsService.getAgreement(account, agreementCreatedResponse.getAgreementId());
         

--- a/src/main/java/uk/gov/pay/api/auth/Account.java
+++ b/src/main/java/uk/gov/pay/api/auth/Account.java
@@ -4,32 +4,11 @@ import uk.gov.pay.api.model.TokenPaymentType;
 
 import java.security.Principal;
 
-public class Account implements Principal {
-
-    private final String accountId;
-    private final TokenPaymentType paymentType;
-    private final String tokenLink;
-
-    public Account(String accountId, TokenPaymentType paymentType, String tokenLink) {
-        this.accountId = accountId;
-        this.paymentType = paymentType;
-        this.tokenLink = tokenLink;
-    }
+public record Account(String accountId, TokenPaymentType paymentType, String tokenLink) implements Principal {
 
     @Override
     public String getName() {
-        return getAccountId();
+        return accountId();
     }
 
-    public String getTokenLink() {
-        return tokenLink;
-    }
-
-    public String getAccountId() {
-        return accountId;
-    }
-
-    public TokenPaymentType getPaymentType() {
-        return paymentType;
-    }
 }

--- a/src/main/java/uk/gov/pay/api/filter/LoggingMDCRequestFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/LoggingMDCRequestFilter.java
@@ -26,7 +26,7 @@ public class LoggingMDCRequestFilter implements ContainerRequestFilter {
     public void filter(ContainerRequestContext requestContext) {
         Optional<Account> mayBeAccount = getAccount(requestContext);
         MDC.put(GATEWAY_ACCOUNT_ID, mayBeAccount.map(Account::getName).orElse(EMPTY));
-        mayBeAccount.ifPresent(account -> MDC.put("token_link", account.getTokenLink()));
+        mayBeAccount.ifPresent(account -> MDC.put("token_link", account.tokenLink()));
 
         String clientAddress = getClientAddress(requestContext);
         MDC.put(REMOTE_ADDRESS, clientAddress);

--- a/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
+++ b/src/main/java/uk/gov/pay/api/filter/RateLimiterFilter.java
@@ -80,7 +80,7 @@ public class RateLimiterFilter implements ContainerRequestFilter {
     private String getAccountId(ContainerRequestContext requestContext) {
         Account account = (Account) requestContext.getSecurityContext().getUserPrincipal();
         return Optional.ofNullable(account)
-                .map(Account::getAccountId)
+                .map(Account::accountId)
                 .orElse(StringUtils.EMPTY);
     }
 }

--- a/src/main/java/uk/gov/pay/api/ledger/service/LedgerUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/ledger/service/LedgerUriGenerator.java
@@ -34,7 +34,7 @@ public class LedgerUriGenerator {
     public String transactionURI(Account gatewayAccountId, String paymentId, String transactionType) {
         String path = format("/v1/transaction/%s", paymentId);
         return buildLedgerUri(path, Map.of(
-                "account_id", gatewayAccountId.getAccountId(),
+                "account_id", gatewayAccountId.accountId(),
                 "transaction_type", transactionType,
                 "status_version", "1"
         ));
@@ -43,7 +43,7 @@ public class LedgerUriGenerator {
     public String transactionURI(Account gatewayAccountId, String refundId, String transactionType, String paymentId) {
         String path = format("/v1/transaction/%s", refundId);
         return buildLedgerUri(path, Map.of(
-                "account_id", gatewayAccountId.getAccountId(),
+                "account_id", gatewayAccountId.accountId(),
                 "transaction_type", transactionType,
                 "parent_external_id", paymentId,
                 "status_version", "1")
@@ -53,7 +53,7 @@ public class LedgerUriGenerator {
     public String transactionEventsURI(Account gatewayAccountId, String paymentId) {
         String path = format("/v1/transaction/%s/event", paymentId);
         return buildLedgerUri(path, Map.of(
-                "gateway_account_id", gatewayAccountId.getAccountId(),
+                "gateway_account_id", gatewayAccountId.accountId(),
                 "status_version", "1")
         );
     }
@@ -69,7 +69,7 @@ public class LedgerUriGenerator {
     public String agreementURI(Account account, String agreementId) {
         String path = format("/v1/agreement/%s", agreementId);
         return buildLedgerUri(path, Map.of(
-                "account_id", account.getAccountId()
+                "account_id", account.accountId()
         ));
     }
 

--- a/src/main/java/uk/gov/pay/api/ledger/service/TransactionSearchService.java
+++ b/src/main/java/uk/gov/pay/api/ledger/service/TransactionSearchService.java
@@ -75,7 +75,7 @@ public class TransactionSearchService {
                 searchParams.getFromSettledDate(), searchParams.getToSettledDate());
         validateSupportedSearchParams(searchParams.getQueryMap());
 
-        searchParams.setAccountId(account.getAccountId());
+        searchParams.setAccountId(account.accountId());
         String url = ledgerUriGenerator.transactionsURIWithParams(searchParams.getQueryMap());
         Response ledgerResponse = client
                 .target(url)

--- a/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
+++ b/src/main/java/uk/gov/pay/api/service/ConnectorUriGenerator.java
@@ -19,30 +19,30 @@ public class ConnectorUriGenerator {
     }
 
     String chargesURI(Account account) {
-        return buildConnectorUri(format("/v1/api/accounts/%s/charges", account.getAccountId()));
+        return buildConnectorUri(format("/v1/api/accounts/%s/charges", account.accountId()));
     }
 
     String chargeURI(Account account, String chargeId) {
-        String path = format("/v1/api/accounts/%s/charges/%s", account.getAccountId(), chargeId); //TODO rename to /payments instead /charges
+        String path = format("/v1/api/accounts/%s/charges/%s", account.accountId(), chargeId); //TODO rename to /payments instead /charges
         return buildConnectorUri(path);
     }
 
     public String chargeEventsURI(Account account, String paymentId) {
-        String path = format("/v1/api/accounts/%s/charges/%s/events", account.getAccountId(), paymentId);
+        String path = format("/v1/api/accounts/%s/charges/%s/events", account.accountId(), paymentId);
         return buildConnectorUri(path);
     }
 
     String cancelURI(Account account, String paymentId) {
-        String path = format("/v1/api/accounts/%s/charges/%s/cancel", account.getAccountId(), paymentId);
+        String path = format("/v1/api/accounts/%s/charges/%s/cancel", account.accountId(), paymentId);
         return buildConnectorUri(path, Collections.emptyMap());
     }
 
     public String telephoneChargesURI(Account account) {
-        return buildConnectorUri(format("/v1/api/accounts/%s/telephone-charges", account.getAccountId()));
+        return buildConnectorUri(format("/v1/api/accounts/%s/telephone-charges", account.accountId()));
     }
 
     String captureURI(Account account, String chargeId) {
-        String path = format("/v1/api/accounts/%s/charges/%s/capture", account.getAccountId(), chargeId);
+        String path = format("/v1/api/accounts/%s/charges/%s/capture", account.accountId(), chargeId);
         return buildConnectorUri(path);
     }
 
@@ -57,12 +57,12 @@ public class ConnectorUriGenerator {
     }
 
     public String getAgreementURI(Account account) {
-        String path = format("/v1/api/accounts/%s/agreements", account.getAccountId());
+        String path = format("/v1/api/accounts/%s/agreements", account.accountId());
         return buildConnectorUri(path);
     }
 
     public String cancelAgreementURI(Account account, String agreementId) {
-        String path = format("/v1/api/accounts/%s/agreements/%s/cancel", account.getAccountId(), agreementId);
+        String path = format("/v1/api/accounts/%s/agreements/%s/cancel", account.accountId(), agreementId);
         return buildConnectorUri(path, Collections.emptyMap());
     }
 

--- a/src/main/java/uk/gov/pay/api/service/CreateRefundService.java
+++ b/src/main/java/uk/gov/pay/api/service/CreateRefundService.java
@@ -55,7 +55,7 @@ public class CreateRefundService {
         String connectorPayload = new GsonBuilder().create().toJson(payloadMap);
 
         Response connectorResponse = client
-                .target(getConnectorUrl(format("/v1/api/accounts/%s/charges/%s/refunds", account.getAccountId(), paymentId)))
+                .target(getConnectorUrl(format("/v1/api/accounts/%s/charges/%s/refunds", account.accountId(), paymentId)))
                 .request()
                 .post(json(connectorPayload));
 

--- a/src/main/java/uk/gov/pay/api/service/GetPaymentRefundService.java
+++ b/src/main/java/uk/gov/pay/api/service/GetPaymentRefundService.java
@@ -25,7 +25,7 @@ public class GetPaymentRefundService {
     }
 
     public RefundResponse getConnectorPaymentRefund(Account account, String paymentId, String refundId) {
-        RefundFromConnector refundFromConnector = connectorService.getPaymentRefund(account.getAccountId(), paymentId, refundId);
+        RefundFromConnector refundFromConnector = connectorService.getPaymentRefund(account.accountId(), paymentId, refundId);
 
         return RefundResponse.from(
                 refundFromConnector,

--- a/src/main/java/uk/gov/pay/api/service/GetPaymentRefundsService.java
+++ b/src/main/java/uk/gov/pay/api/service/GetPaymentRefundsService.java
@@ -22,7 +22,7 @@ public class GetPaymentRefundsService {
     }
 
     public RefundsResponse getLedgerTransactionTransactions(Account account, String paymentId) {
-        RefundsFromLedger refundsFromLedger = ledgerService.getPaymentRefunds(account.getAccountId(), paymentId);
+        RefundsFromLedger refundsFromLedger = ledgerService.getPaymentRefunds(account.accountId(), paymentId);
         List<RefundResponse> refundResponses = processRefunds(paymentId, refundsFromLedger);
         
         return getRefundsResponse(paymentId, refundResponses);

--- a/src/main/java/uk/gov/pay/api/service/LedgerService.java
+++ b/src/main/java/uk/gov/pay/api/service/LedgerService.java
@@ -114,7 +114,7 @@ public class LedgerService {
 
     public SearchRefundsResponseFromLedger searchRefunds(Account account, Map<String, String> paramsAsMap) {
 
-        paramsAsMap.put(PARAM_ACCOUNT_ID, account.getAccountId());
+        paramsAsMap.put(PARAM_ACCOUNT_ID, account.accountId());
         paramsAsMap.put(PARAM_TRANSACTION_TYPE, REFUND_TRANSACTION_TYPE);
 
         Response response = client
@@ -135,7 +135,7 @@ public class LedgerService {
     }
 
     public SearchDisputesResponseFromLedger searchDisputes(Account account, Map<String, String> paramsAsMap) {
-        paramsAsMap.put(PARAM_ACCOUNT_ID, account.getAccountId());
+        paramsAsMap.put(PARAM_ACCOUNT_ID, account.accountId());
         paramsAsMap.put(PARAM_TRANSACTION_TYPE, DISPUTE_TRANSACTION_TYPE);
 
         if (paramsAsMap.containsKey("status")) {
@@ -161,7 +161,7 @@ public class LedgerService {
 
     public PaymentSearchResponse<TransactionResponse> searchPayments(Account account, Map<String, String> paramsAsMap) {
 
-        paramsAsMap.put(PARAM_ACCOUNT_ID, account.getAccountId());
+        paramsAsMap.put(PARAM_ACCOUNT_ID, account.accountId());
         paramsAsMap.put(PARAM_TRANSACTION_TYPE, PAYMENT_TRANSACTION_TYPE);
         paramsAsMap.put(PARAM_EXACT_REFERENCE_MATCH, "true");
 
@@ -201,7 +201,7 @@ public class LedgerService {
         AgreementSearchValidator.validateSearchParameters(searchParams);
 
         var params = new HashMap<>(searchParams.getQueryMap());
-        params.put(GATEWAY_ACCOUNT_ID, account.getAccountId());
+        params.put(GATEWAY_ACCOUNT_ID, account.accountId());
         params.put(PARAM_EXACT_REFERENCE_MATCH, "true");
 
         String url = ledgerUriGenerator.agreementsURIWithParams(params);

--- a/src/test/java/uk/gov/pay/api/auth/AccountAuthenticatorTest.java
+++ b/src/test/java/uk/gov/pay/api/auth/AccountAuthenticatorTest.java
@@ -95,8 +95,8 @@ public class AccountAuthenticatorTest {
         when(mockResponse.readEntity(AuthResponse.class)).thenReturn(authResponse);
         Optional<Account> maybeAccount = accountAuthenticator.authenticate(bearerToken);
         assertThat(maybeAccount.get().getName(), is(accountId));
-        assertThat(maybeAccount.get().getAccountId(), is(accountId));
-        assertThat(maybeAccount.get().getPaymentType(), is(CARD));
+        assertThat(maybeAccount.get().accountId(), is(accountId));
+        assertThat(maybeAccount.get().paymentType(), is(CARD));
         
         verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();

--- a/src/test/java/uk/gov/pay/api/service/ConnectorUriGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/api/service/ConnectorUriGeneratorTest.java
@@ -57,7 +57,7 @@ public class ConnectorUriGeneratorTest {
     @Test
     public void shouldGenerateTheRightCaptureURI() {
         String uri = connectorUriGenerator.captureURI(cardAccount, chargeId);
-        assertThat(uri, is("https://bla.test/v1/api/accounts/" + cardAccount.getAccountId() + "/charges/" + chargeId + "/capture"));
+        assertThat(uri, is("https://bla.test/v1/api/accounts/" + cardAccount.accountId() + "/charges/" + chargeId + "/capture"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/api/utils/WiremockStubbing.java
+++ b/src/test/java/uk/gov/pay/api/utils/WiremockStubbing.java
@@ -18,7 +18,7 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 public class WiremockStubbing {
     
     public static void stubPublicAuthV1ApiAuth(WireMockRule wireMockRule, Account account, String token) throws JsonProcessingException {
-        Map<String, String> entity = ImmutableMap.of("account_id", account.getAccountId(), "token_type", account.getPaymentType().name());
+        Map<String, String> entity = ImmutableMap.of("account_id", account.accountId(), "token_type", account.paymentType().name());
         String json = new ObjectMapper().writeValueAsString(entity);
         wireMockRule.stubFor(get(urlEqualTo("/v1/api/auth"))
                 .withHeader(AUTHORIZATION, equalTo("Bearer " + token))


### PR DESCRIPTION
Convert the `Account` class into a record, which gives us things like sensibly overriding `equals(…)` and `hashCode()` from Principal for free.