### PR TITLE
PP-13991 refactor config to use dropwizard-sentry 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,11 +179,6 @@
             <version>3.2.2</version>
         </dependency>
         <dependency>
-            <groupId>org.dhatim</groupId>
-            <artifactId>dropwizard-sentry</artifactId>
-            <version>2.1.6</version>
-        </dependency>
-        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20250517</version>

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -25,7 +25,7 @@ logging:
       customFields:
         container: "publicapi"
         environment: ${ENVIRONMENT}
-    - type: pay-dropwizard-4-sentry
+    - type: sentry
       threshold: ERROR
       dsn: ${SENTRY_DSN:-https://example.com@dummy/1}
       environment: ${ENVIRONMENT}


### PR DESCRIPTION
## WHAT YOU DID

We can migrate to version 4.x now we use Dropwizard 4, which would allow us to remove some custom code.
