### PR TITLE
PP-14434 add rcp reason to a pact test

### DIFF
--- a/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServicePactTest.java
+++ b/src/test/java/uk/gov/pay/api/service/CardPaymentSearchServicePactTest.java
@@ -16,6 +16,7 @@ import uk.gov.pay.api.exception.SearchPaymentsException;
 import uk.gov.pay.api.ledger.service.LedgerUriGenerator;
 import uk.gov.pay.api.model.TokenPaymentType;
 import uk.gov.pay.api.model.search.PaginationDecorator;
+import uk.gov.service.payments.commons.model.AgreementPaymentType;
 import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.testing.pact.consumers.Pacts;
 import uk.gov.service.payments.commons.testing.pact.consumers.PayPactProviderRule;
@@ -225,7 +226,8 @@ public class CardPaymentSearchServicePactTest {
                 .assertThat("total", is(1))
                 .assertThat("page", is(1))
                 .assertThat("results", hasSize(equalTo(1)))
-                .assertThat("results[0].authorisation_mode", is(AuthorisationMode.AGREEMENT.getName()));
+                .assertThat("results[0].authorisation_mode", is(AuthorisationMode.AGREEMENT.getName()))
+                .assertThat("results[0].agreement_payment_type", is(AgreementPaymentType.RECURRING.getName()));
     }
 
     @Test

--- a/src/test/resources/pacts/publicapi-ledger-search-payment-by-agreement-id.json
+++ b/src/test/resources/pacts/publicapi-ledger-search-payment-by-agreement-id.json
@@ -65,7 +65,8 @@
               "transaction_id": "charge97837509646393e3C",
               "payment_provider": "sandbox",
               "created_date": "2018-09-22T10:13:16.067Z",
-              "authorisation_mode": "agreement"
+              "authorisation_mode": "agreement",
+              "agreement_payment_type": "recurring"
             }
           ],
           "_links": {


### PR DESCRIPTION
## WHAT YOU DID

Update an existing Pact test between connector and ledger to verify the agreement_payment_type property.
