### PR TITLE
PP-15698: bump pay-java-commons and bump Netty dependencies with Netty BOM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
         # lettuce v7 needs refactoring on our end
         versions:
           - ">= 7"
+      - dependency-name: "io.netty:netty-bom"
     open-pull-requests-limit: 10
     labels:
       - dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.137.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>
                 <version>5.0.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hamcrest.version>3.0</hamcrest.version>
-        <pay-java-commons.version>1.0.20260727084644</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20260812081959</pay-java-commons.version>
         <prometheus.version>0.16.0</prometheus.version>
         <swagger.lib.version>2.2.52</swagger.lib.version>
         <pact.version>4.7.3</pact.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>uk.gov.pay</groupId>
-    <version>0.1-SNAPSHOT</version>
     <artifactId>pay-publicapi</artifactId>
+    <version>0.1-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -45,7 +46,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <!-- Main dependencies that are imported from one of the BOMs specified
              in <dependencyManagement> so no explicit versions needed -->


### PR DESCRIPTION
* Bumps pay-java-commons to the latest version. This version removes the transitive `io.dropwizard.metrics:metrics-graphite` dependency. That dependency is not used here.
* Conservatively overrides Netty versions to the last 4.1.x patch release. Netty dependencies are pulled in via `io.lettuce:lettuce-core` and this is currently stuck at the last 6.x release. To be addressed in [PP-15737](https://payments-platform.atlassian.net/browse/PP-15737)
* Instructs Dependabot to ignore updates to the Netty BOM. We need to keep compatible with Lettuce 6.x
* Runs `mvn tidy:pom`

[PP-15737]: https://payments-platform.atlassian.net/browse/PP-15737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ