### PR TITLE
PP-15767: add platform-bom and bump pay-java-commons to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hamcrest.version>3.0</hamcrest.version>
-        <pay-java-commons.version>1.0.20260817082240</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20260825154634</pay-java-commons.version>
         <prometheus.version>0.16.0</prometheus.version>
         <swagger.lib.version>2.2.54</swagger.lib.version>
         <pact.version>4.7.5</pact.version>
@@ -23,6 +23,13 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>uk.gov.service.payments</groupId>
+                <artifactId>platform-bom</artifactId>
+                <version>${pay-java-commons.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>


### PR DESCRIPTION
Add the new GOV.UK Pay platform BOM to temporarily override patch versions Dropwizard-managed dependencies. Bump pay-java-commons to version that includes the BOM.